### PR TITLE
Fix issues when use linux-sgx as cmake subdirectory

### DIFF
--- a/product-mini/platforms/linux-sgx/CMakeLists.txt
+++ b/product-mini/platforms/linux-sgx/CMakeLists.txt
@@ -64,11 +64,17 @@ set (APP_FRAMEWORK_DIR ${WAMR_ROOT_DIR}/core/app-framework)
 # include the build config template file
 include (${WAMR_ROOT_DIR}/build-scripts/config_common.cmake)
 
+if ("$ENV{SGX_SDK}" STREQUAL "")
+  set (SGX_SDK_DIR "/opt/intel/sgxsdk")
+else()
+  set (SGX_SDK_DIR $ENV{SGX_SDK})
+endif()
+
 include_directories (${SHARED_DIR}/include
                      ${IWASM_DIR}/include
-                     $ENV{SGX_SDK}/include
-                     $ENV{SGX_SDK}/include/tlibc
-                     $ENV{SGX_SDK}/include/libcxx)
+                     ${SGX_SDK_DIR}/include
+                     ${SGX_SDK_DIR}/include/tlibc
+                     ${SGX_SDK_DIR}/include/libcxx)
 
 enable_language (ASM)
 
@@ -107,7 +113,3 @@ add_library (vmlib
              ${IWASM_COMPL_SOURCE})
 
 add_library (extlib ext_lib_export.c)
-
-set (copy_libs_cmd cp -a libvmlib.a libextlib.a ../enclave-sample/)
-add_custom_target (copy_libs_to_enclave ALL COMMAND ${copy_libs_cmd} DEPENDS vmlib extlib)
-

--- a/product-mini/platforms/linux-sgx/enclave-sample/Makefile
+++ b/product-mini/platforms/linux-sgx/enclave-sample/Makefile
@@ -170,6 +170,14 @@ Enclave/%.o: Enclave/%.cpp
 	@$(CXX) $(Enclave_Cpp_Flags) -c $< -o $@
 	@echo "CXX  <=  $<"
 
+libvmlib.a: ../build/libvmlib.a
+	@cp $< $@
+	@echo "CP $@  <=  $<"
+
+libextlib.a: ../build/libextlib.a
+	@cp $< $@
+	@echo "CP $@  <=  $<"
+
 $(Enclave_Name): Enclave/Enclave_t.o $(Enclave_Cpp_Objects) libvmlib.a libextlib.a
 	@$(CXX) $^ -o $@ $(Enclave_Link_Flags)
 	@echo "LINK =>  $@"


### PR DESCRIPTION
1. Remove the copy of libvmlib.a and libextlib.a to ../enclave_example,
   which doesn't exist in other project.
2. Use default SGX_SDK path to avoid "source $SGX_SDK/environment".

Signed-off-by: Junxian.Xiao <junxian.xjx@antfin.com>