### PR TITLE
Fixed C compiler detection error in CMakeList.txt

### DIFF
--- a/product-mini/platforms/linux/CMakeLists.txt
+++ b/product-mini/platforms/linux/CMakeLists.txt
@@ -63,7 +63,7 @@ set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security")
 # set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wconversion -Wsign-conversion")
 
 if (WAMR_BUILD_TARGET MATCHES "X86_.*" OR WAMR_BUILD_TARGET STREQUAL "AMD_64")
-  if (NOT (${CMAKE_C_COMPILER} MATCHES ".*clang.*"))
+  if (NOT (CMAKE_C_COMPILER_ID STREQUAL "Clang"))
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mindirect-branch-register")
   endif ()
 endif ()

--- a/product-mini/platforms/linux/CMakeLists.txt
+++ b/product-mini/platforms/linux/CMakeLists.txt
@@ -63,7 +63,7 @@ set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security")
 # set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wconversion -Wsign-conversion")
 
 if (WAMR_BUILD_TARGET MATCHES "X86_.*" OR WAMR_BUILD_TARGET STREQUAL "AMD_64")
-  if (NOT (CMAKE_C_COMPILER_ID STREQUAL "Clang"))
+  if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mindirect-branch-register")
   endif ()
 endif ()


### PR DESCRIPTION
On *nix systems, (${CMAKE_C_COMPILER} resolves to /usr/bin/cc, which is usually a symlink to gcc or clang
The check in its present will not detect if it is a symlink to clang, and the flag gets added, which results in an error message from clang.
Checking if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang") is a better option.