### PR TITLE
Fixed typecast error when compiling in C++

### DIFF
--- a/core/iwasm/include/lib_export.h
+++ b/core/iwasm/include/lib_export.h
@@ -15,8 +15,8 @@ typedef struct NativeSymbol {
     void *func_ptr;
 } NativeSymbol;
 
-#define EXPORT_WASM_API(symbol)  {#symbol, symbol}
-#define EXPORT_WASM_API2(symbol) {#symbol, symbol##_wrapper}
+#define EXPORT_WASM_API(symbol)  {#symbol, (void*)symbol}
+#define EXPORT_WASM_API2(symbol) {#symbol, (void*)symbol##_wrapper}
 
 /**
  * Get the exported APIs of base lib


### PR DESCRIPTION
When embedding in a C++ project and compiling using clang++, we get the following error:

```
wtest.cpp:853:19: error: cannot initialize a member subobject of type 'void *' with an lvalue of type 'int (wasm_exec_env_t, int, int)' (aka 'int (WASMExecEnv *, int, int)')
                EXPORT_WASM_API(setReturn),
                                ^~~~~~~~~
../external/wasm-micro-runtime/core/iwasm/include/lib_export.h:18:44: note: expanded from macro 'EXPORT_WASM_API'
#define EXPORT_WASM_API(symbol)  {#symbol, symbol}

```
This commit fixes that issue.