### PR TITLE
make fixed width integer use stdint

### DIFF
--- a/core/app-framework/base/app/bh_platform.h
+++ b/core/app-framework/base/app/bh_platform.h
@@ -7,13 +7,16 @@
 #define DEPS_IWASM_APP_LIBS_BASE_BH_PLATFORM_H_
 
 #include <stdbool.h>
+#include <stdint.h>
 
-typedef unsigned char uint8;
-typedef char int8;
-typedef unsigned short uint16;
-typedef short int16;
-typedef unsigned int uint32;
-typedef int int32;
+typedef uint8_t uint8;
+typedef int8_t int8;
+typedef uint16_t uint16;
+typedef int16_t int16;
+typedef uint32_t uint32;
+typedef int32_t int32;
+typedef float float32;
+typedef double float64;
 
 #ifndef NULL
 #  define NULL ((void*) 0)

--- a/core/shared/platform/include/bh_types.h
+++ b/core/shared/platform/include/bh_types.h
@@ -7,13 +7,14 @@
 #define _BH_TYPES_H
 
 #include "bh_config.h"
+#include <stdint.h>
 
-typedef unsigned char uint8;
-typedef char int8;
-typedef unsigned short uint16;
-typedef short int16;
-typedef unsigned int uint32;
-typedef int int32;
+typedef uint8_t uint8;
+typedef int8_t int8;
+typedef uint16_t uint16;
+typedef int16_t int16;
+typedef uint32_t uint32;
+typedef int32_t int32;
 typedef float float32;
 typedef double float64;
 


### PR DESCRIPTION
All platforms use: `typedef uint64_t uint64;` so the rest should be defined the same way
or 
use stdint fixed width types instead without defining own types  (since stdint fixed width types is part of C since C99  and iwasm depends on them anyway on all platforms)

`grep -r 'typedef .* uint64': `

    core/shared/platform/android/bh_platform.h:typedef uint64_t uint64;
    core/shared/platform/riot/bh_platform.h:typedef uint64_t uint64;
    core/shared/platform/zephyr/bh_platform.h:typedef uint64_t uint64;
    core/shared/platform/linux/bh_platform.h:typedef uint64_t uint64;
    core/shared/platform/vxworks/bh_platform.h:typedef uint64_t uint64;
    core/shared/platform/linux-sgx/bh_platform.h:typedef uint64_t uint64;
    core/shared/platform/darwin/bh_platform.h:typedef uint64_t uint64;
    core/shared/platform/alios/bh_platform.h:typedef uint64_t uint64;
