### PR TITLE
Rename log_level enums

### DIFF
--- a/core/shared/utils/bh_log.c
+++ b/core/shared/utils/bh_log.c
@@ -9,7 +9,7 @@
  * The verbose level of the log system.  Only those verbose logs whose
  * levels are less than or equal to this value are outputed.
  */
-static uint32 log_verbose_level = LOG_LEVEL_WARNING;
+static uint32 log_verbose_level = BH_LOG_LEVEL_WARNING;
 
 void
 bh_log_set_verbose_level(uint32 level)

--- a/core/shared/utils/bh_log.h
+++ b/core/shared/utils/bh_log.h
@@ -28,11 +28,11 @@ extern "C" {
 #endif
 
 typedef enum {
-    LOG_LEVEL_FATAL = 0,
-    LOG_LEVEL_ERROR = 1,
-    LOG_LEVEL_WARNING = 2,
-    LOG_LEVEL_DEBUG = 3,
-    LOG_LEVEL_VERBOSE = 4
+    BH_LOG_LEVEL_FATAL = 0,
+    BH_LOG_LEVEL_ERROR = 1,
+    BH_LOG_LEVEL_WARNING = 2,
+    BH_LOG_LEVEL_DEBUG = 3,
+    BH_LOG_LEVEL_VERBOSE = 4
 } LogLevel;
 
 void
@@ -41,11 +41,11 @@ bh_log_set_verbose_level(uint32 level);
 void
 bh_log(LogLevel log_level, const char *file, int line, const char *fmt, ...);
 
-#define LOG_FATAL(...)   bh_log(LOG_LEVEL_FATAL, __FILE__, __LINE__, __VA_ARGS__)
-#define LOG_ERROR(...)   bh_log(LOG_LEVEL_ERROR, NULL, 0, __VA_ARGS__)
-#define LOG_DEBUG(...)   bh_log(LOG_LEVEL_DEBUG, __FILE__, __LINE__, 0, __VA_ARGS__)
-#define LOG_WARNING(...) bh_log(LOG_LEVEL_WARNING, NULL, 0, __VA_ARGS__)
-#define LOG_VERBOSE(...) bh_log(LOG_LEVEL_VERBOSE, NULL, 0, __VA_ARGS__)
+#define LOG_FATAL(...)   bh_log(BH_LOG_LEVEL_FATAL, __FILE__, __LINE__, __VA_ARGS__)
+#define LOG_ERROR(...)   bh_log(BH_LOG_LEVEL_ERROR, NULL, 0, __VA_ARGS__)
+#define LOG_DEBUG(...)   bh_log(BH_LOG_LEVEL_DEBUG, __FILE__, __LINE__, 0, __VA_ARGS__)
+#define LOG_WARNING(...) bh_log(BH_LOG_LEVEL_WARNING, NULL, 0, __VA_ARGS__)
+#define LOG_VERBOSE(...) bh_log(BH_LOG_LEVEL_VERBOSE, NULL, 0, __VA_ARGS__)
 
 void
 bh_print_time(const char *prompt);


### PR DESCRIPTION
When I was trying to port wamr to other platforms, their header files contain the same enum definitations which causes "redeclaration of enumerator" error.

Since names of log_level enums are intuitional and common, should we rename them with bh_log_level, so that we can get rid of such problem.