### PR TITLE
Missing SGX SDK Include fixed

### DIFF
--- a/core/shared/platform/linux-sgx/shared_platform.cmake
+++ b/core/shared/platform/linux-sgx/shared_platform.cmake
@@ -7,11 +7,16 @@ add_definitions(-DBH_PLATFORM_LINUX_SGX)
 
 include_directories(${PLATFORM_SHARED_DIR})
 include_directories(${PLATFORM_SHARED_DIR}/../include)
-if(NOT EXISTS ${SGX_SDK_PATH})
-    set(SGX_SDK_PATH /opt/intel/sgxsdk)
-endif()
-include_directories(${SGX_SDK_PATH}/include)
 
+if ("$ENV{SGX_SDK}" STREQUAL "")
+  set (SGX_SDK_DIR "/opt/intel/sgxsdk")
+else()
+  set (SGX_SDK_DIR $ENV{SGX_SDK})
+endif()
+
+include_directories (${SGX_SDK_DIR}/include
+                     ${SGX_SDK_DIR}/include/tlibc
+                     ${SGX_SDK_DIR}/include/libcxx)
 
 file (GLOB_RECURSE source_all ${PLATFORM_SHARED_DIR}/*.c)
 

--- a/core/shared/platform/linux-sgx/shared_platform.cmake
+++ b/core/shared/platform/linux-sgx/shared_platform.cmake
@@ -7,6 +7,10 @@ add_definitions(-DBH_PLATFORM_LINUX_SGX)
 
 include_directories(${PLATFORM_SHARED_DIR})
 include_directories(${PLATFORM_SHARED_DIR}/../include)
+if(NOT EXISTS ${SGX_SDK_PATH})
+    set(SGX_SDK_PATH /opt/intel/sgxsdk)
+endif()
+include_directories(${SGX_SDK_PATH}/include)
 
 
 file (GLOB_RECURSE source_all ${PLATFORM_SHARED_DIR}/*.c)


### PR DESCRIPTION
Hi, 
If I use `set(WAMR_BUILD_PLATFORM linux-sgx)` and `include(${WAMR_ROOT_DIR}/build-scripts/runtime_lib.cmake)` in order to build the wamr-lib for linux-sgx, I get an error message, that my compiler can't find `"sgx_thread.h"`. The following lines fixed that issue. 

Best regards,
Joshua