### PR TITLE
Change whence_t constant values to match pre-existing agreed-upon values.

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/include/wasmtime_ssp.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/include/wasmtime_ssp.h
@@ -275,9 +275,9 @@ typedef uint64_t __wasi_timestamp_t;
 typedef uint64_t __wasi_userdata_t;
 
 typedef uint8_t __wasi_whence_t;
-#define __WASI_WHENCE_CUR (0)
-#define __WASI_WHENCE_END (1)
-#define __WASI_WHENCE_SET (2)
+#define __WASI_WHENCE_SET (0)
+#define __WASI_WHENCE_CUR (1)
+#define __WASI_WHENCE_END (2)
 
 typedef uint8_t __wasi_preopentype_t;
 #define __WASI_PREOPENTYPE_DIR              (0)


### PR DESCRIPTION
Hello,

After reviewing the specs provided by WASI, I noticed that the `__wasi_whence`_t constants were outdated. Indeed, the specs changed the values, according to this change request on the official WASI repo: https://github.com/WebAssembly/WASI/pull/106.

This pull request updates the `__wasi_whence` constants according to the latest specs.