### PR TITLE
make include headers follow strict protoype rule 

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -81,7 +81,7 @@ set_error_buf_v(char *error_buf, uint32 error_buf_size, const char *format,
 
 /* See wasm_export.h for description */
 bool
-wasm_runtime_init();
+wasm_runtime_init(void);
 
 /* See wasm_export.h for description */
 bool
@@ -89,7 +89,7 @@ wasm_runtime_full_init(RuntimeInitArgs *init_args);
 
 /* See wasm_export.h for description */
 void
-wasm_runtime_destroy();
+wasm_runtime_destroy(void);
 
 /* See wasm_export.h for description */
 PackageType

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -124,7 +124,7 @@ typedef struct RuntimeInitArgs {
  * @return true if success, false otherwise
  */
 bool
-wasm_runtime_init();
+wasm_runtime_init(void);
 
 /**
  * Initialize the WASM runtime environment, and also initialize
@@ -142,7 +142,7 @@ wasm_runtime_full_init(RuntimeInitArgs *init_args);
  * Destroy the WASM runtime environment.
  */
 void
-wasm_runtime_destroy();
+wasm_runtime_destroy(void);
 
 /**
  * Allocate memory from runtime memory environment.

--- a/core/shared/platform/include/platform_api_vmcore.h
+++ b/core/shared/platform/include/platform_api_vmcore.h
@@ -25,13 +25,13 @@ extern "C" {
  *
  * @return 0 if success
  */
-int bh_platform_init();
+int bh_platform_init(void);
 
 /**
  * Destroy the platform internal resources if needed,
  * this function is called by wasm_runtime_destroy()
  */
-void bh_platform_destroy();
+void bh_platform_destroy(void);
 
 /**
  ******** memory allocator APIs **********


### PR DESCRIPTION
I use an embedded OS that compiles using -Wstrict-prototypes. When i compile files that include I get  headers the following  Warning:

warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  127 | wasm_runtime_init();

I think i would be reasonable to provide the include headers in a form does not produce a warning.