### PR TITLE
Update URL to lvgl repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ The WAMR [samples](./samples) integrate the iwasm VM core, application manager a
 
 - [**Basic**](./samples/basic): Demonstrating how host runtime calls WASM function as well as WASM function calls native function.
 - **[Simple](./samples/simple/README.md)**: The runtime is integrated with most of the WAMR APP libraries, and a few WASM applications are provided for testing the WAMR APP API set. It uses **built-in libc** and executes apps in **interpreter** mode by default.
-- **[littlevgl](./samples/littlevgl/README.md)**: Demonstrating the graphic user interface application usage on WAMR. The whole [LittlevGL](https://github.com/littlevgl/) 2D user graphic library and the UI application is built into WASM application.  It uses **WASI libc** and executes apps in **AoT mode** by default.
-- **[gui](./samples/gui/README.md)**: Moved the [LittlevGL](https://github.com/littlevgl/) library into the runtime and defined a WASM application interface by wrapping the littlevgl API. It uses **WASI libc** and executes apps in **interpreter** mode by default.
+- **[littlevgl](./samples/littlevgl/README.md)**: Demonstrating the graphic user interface application usage on WAMR. The whole [LittlevGL](https://github.com/lvgl/) 2D user graphic library and the UI application is built into WASM application.  It uses **WASI libc** and executes apps in **AoT mode** by default.
+- **[gui](./samples/gui/README.md)**: Moved the [LittlevGL](https://github.com/lvgl/) library into the runtime and defined a WASM application interface by wrapping the littlevgl API. It uses **WASI libc** and executes apps in **interpreter** mode by default.
 - **[wasm-c-api](./samples/wasm-c-api/README.md)**: they are samples from [wasm-c-api proposal](https://github.com/WebAssembly/wasm-c-api) and show supported APIs.
 
 


### PR DESCRIPTION
The `lvgl` project appears to have changed their project name & repository URL.

This commit updates the URLs so the links don't go to a 404 error page.

The project name is now "Light and Versatile Embedded Graphics Library" but I haven't updated the name anywhere.