### PR TITLE
optimize: get_current_target for AOT thumb loader

### DIFF
--- a/core/iwasm/aot/arch/aot_reloc_thumb.c
+++ b/core/iwasm/aot/arch/aot_reloc_thumb.c
@@ -118,32 +118,32 @@ get_target_symbol_map(uint32 *sym_num)
 }
 
 
-#define BUILD_TARGET_V4 "thumbv4t"
+#define BUILD_TARGET_THUMB_V4T "thumbv4t"
 void
 get_current_target(char *target_buf, uint32 target_buf_size)
 {
     const char * s =  BUILD_TARGET;
     size_t s_size = sizeof(BUILD_TARGET);
+    char *d = target_buf;
 
-    //check if wenn need to add some subarchitecture specification
-    //this is some kind of thumb since we are in ...thumb.c
-    if(sizeof(BUILD_TARGET) == sizeof("thumb")){
-        s = BUILD_TARGET_V4;
-        s_size = sizeof(BUILD_TARGET_V4);
+    /* Set to "thumbv4t" by default if sub version isn't specified */
+    if (strcmp(s, "THUMB") == 0) {
+        s = BUILD_TARGET_THUMB_V4T;
+        s_size = sizeof(BUILD_TARGET_THUMB_V4T);
     }
     if(target_buf_size < s_size){
         s_size = target_buf_size;
     }
-    char *d = target_buf;
     while (--s_size) {
         if (*s >= 'A' && *s <= 'Z')
             *d++ = *s++ + 'a' - 'A';
         else
             *d++ = *s++ ;
     }
-    *d=0;//allways set the end last byte 0
+   /* Ensure the string is null byte ('\0') terminated */
+    *d = '\0';
 }
-#undef BUILD_TARGET_V4
+#undef BUILD_TARGET_THUMB_V4T
 
 uint32
 get_plt_item_size()

--- a/core/iwasm/aot/arch/aot_reloc_thumb.c
+++ b/core/iwasm/aot/arch/aot_reloc_thumb.c
@@ -117,7 +117,6 @@ get_target_symbol_map(uint32 *sym_num)
     return target_sym_map;
 }
 
-
 #define BUILD_TARGET_THUMB_V4T "thumbv4t"
 void
 get_current_target(char *target_buf, uint32 target_buf_size)
@@ -140,7 +139,7 @@ get_current_target(char *target_buf, uint32 target_buf_size)
         else
             *d++ = *s++ ;
     }
-   /* Ensure the string is null byte ('\0') terminated */
+    /* Ensure the string is null byte ('\0') terminated */
     *d = '\0';
 }
 #undef BUILD_TARGET_THUMB_V4T

--- a/core/iwasm/aot/arch/aot_reloc_thumb.c
+++ b/core/iwasm/aot/arch/aot_reloc_thumb.c
@@ -117,22 +117,33 @@ get_target_symbol_map(uint32 *sym_num)
     return target_sym_map;
 }
 
+
+#define BUILD_TARGET_V4 "thumbv4t"
 void
 get_current_target(char *target_buf, uint32 target_buf_size)
 {
-    char *build_target = BUILD_TARGET;
-    char *p = target_buf, *p_end;
-    snprintf(target_buf, target_buf_size, "%s", build_target);
-    p_end = p + strlen(target_buf);
-    while (p < p_end) {
-        if (*p >= 'A' && *p <= 'Z')
-            *p++ += 'a' - 'A';
-        else
-            p++;
+    const char * s =  BUILD_TARGET;
+    size_t s_size = sizeof(BUILD_TARGET);
+
+    //check if wenn need to add some subarchitecture specification
+    //this is some kind of thumb since we are in ...thumb.c
+    if(sizeof(BUILD_TARGET) == sizeof("thumb")){
+        s = BUILD_TARGET_V4;
+        s_size = sizeof(BUILD_TARGET_V4);
     }
-    if (!strcmp(target_buf, "thumb"))
-        snprintf(target_buf, target_buf_size, "thumbv4t");
+    if(target_buf_size < s_size){
+        s_size = target_buf_size;
+    }
+    char *d = target_buf;
+    while (--s_size) {
+        if (*s >= 'A' && *s <= 'Z')
+            *d++ = *s++ + 'a' - 'A';
+        else
+            *d++ = *s++ ;
+    }
+    *d=0;//allways set the end last byte 0
 }
+#undef BUILD_TARGET_V4
 
 uint32
 get_plt_item_size()


### PR DESCRIPTION
debugging i found myself in the AOT loader part and saw there was a massive amount of string and format printing used for that simple function so i went to solve it.

(it had 2 format string and 1 string length calls to basically copy a constant)
i checked with godbolt but no compiler (and option) did get rid of these calls all of them made it into the assembler
sadly i cold net get the case conversion removed from the result.

i would do the same for aarch64 and arm if u like