### PR TITLE
Fixed macro expansion conflict

### DIFF
--- a/core/shared/platform/include/platform_api_vmcore.h
+++ b/core/shared/platform/include/platform_api_vmcore.h
@@ -49,10 +49,13 @@ void os_free(void *ptr);
  *       Refer to wasm_runtime_full_init().
  */
 
-
+#ifndef os_printf
 int os_printf(const char *format, ...);
+#endif
 
+#ifndef os_vprintf
 int os_vprintf(const char *format, va_list ap);
+#endif
 
 /**
  * Get microseconds after boot.


### PR DESCRIPTION
On linux:
The declaration of `os_printf` defined in `core/shared/platform/include/platform_api_vmcore.h`

was conflicting with the macro defined in `core/shared/platform/linux/platform_internal.h`

When trying to build wasm-compiler.
