### PR TITLE
Fix the build issues on mac for some samples

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -2137,7 +2137,11 @@ static void convert_timestamp(
     struct timespec *out
 ) {
   // Store sub-second remainder.
+#ifndef __APPLE__
   out->tv_nsec = (__syscall_slong_t)(in % 1000000000);
+#else
+  out->tv_nsec = (long)(in % 1000000000);
+#endif
   in /= 1000000000;
 
   // Clamp to the maximum in case it would overflow our system's time_t.

--- a/samples/basic/CMakeLists.txt
+++ b/samples/basic/CMakeLists.txt
@@ -6,7 +6,10 @@ cmake_minimum_required (VERSION 2.8)
 project (basic)
 
 ################  runtime settings  ################
-set (WAMR_BUILD_PLATFORM "linux")
+string (TOLOWER ${CMAKE_HOST_SYSTEM_NAME} WAMR_BUILD_PLATFORM)
+if (APPLE)
+  add_definitions(-DBH_PLATFORM_DARWIN)
+endif ()
 
 # Reset default linker flags
 set (CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
@@ -23,9 +26,16 @@ set (WAMR_BUILD_LIBC_WASI 1)
 set (WAMR_BUILD_FAST_INTERP 0)
 
 # linker flags
-set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections -pie -fPIE")
+set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie -fPIE")
+if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))
+  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
+endif ()
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security")
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mindirect-branch-register")
+if (WAMR_BUILD_TARGET MATCHES "X86_.*" OR WAMR_BUILD_TARGET STREQUAL "AMD_64")
+  if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mindirect-branch-register")
+  endif ()
+endif ()
 
 # build out vmlib
 set (WAMR_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR}/../..)
@@ -39,4 +49,8 @@ include (${SHARED_DIR}/utils/uncommon/shared_uncommon.cmake)
 
 add_executable (basic src/main.c src/native_impl.c ${UNCOMMON_SHARED_SOURCE})
 
-target_link_libraries (basic vmlib -lm -ldl -lpthread -lrt)
+if (APPLE)
+  target_link_libraries (basic vmlib -lm -ldl -lpthread)
+else ()
+  target_link_libraries (basic vmlib -lm -ldl -lpthread -lrt)
+endif ()

--- a/samples/multi-module/CMakeLists.txt
+++ b/samples/multi-module/CMakeLists.txt
@@ -5,7 +5,10 @@ cmake_minimum_required(VERSION 2.8)
 project(multi_module)
 
 ################  runtime settings  ################
-set(WAMR_BUILD_PLATFORM "linux")
+string (TOLOWER ${CMAKE_HOST_SYSTEM_NAME} WAMR_BUILD_PLATFORM)
+if (APPLE)
+  add_definitions(-DBH_PLATFORM_DARWIN)
+endif ()
 
 # Resetdefault linker flags
 set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
@@ -22,8 +25,16 @@ set(WAMR_BUILD_FAST_INTERP 0)
 set(WAMR_BUILD_MULTI_MODULE 1)
 
 # compiling and linking flags
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections -pie -fPIE")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security -mindirect-branch-register")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie -fPIE")
+if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))
+  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
+endif ()
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security")
+if (WAMR_BUILD_TARGET MATCHES "X86_.*" OR WAMR_BUILD_TARGET STREQUAL "AMD_64")
+  if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mindirect-branch-register")
+  endif ()
+endif ()
 
 # build out vmlib
 set(WAMR_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR}/../..)

--- a/samples/multi-thread/CMakeLists.txt
+++ b/samples/multi-thread/CMakeLists.txt
@@ -5,7 +5,10 @@ cmake_minimum_required(VERSION 2.8)
 project(pthread)
 
 ################  runtime settings  ################
-set(WAMR_BUILD_PLATFORM "linux")
+string (TOLOWER ${CMAKE_HOST_SYSTEM_NAME} WAMR_BUILD_PLATFORM)
+if (APPLE)
+  add_definitions(-DBH_PLATFORM_DARWIN)
+endif ()
 
 # Resetdefault linker flags
 set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
@@ -21,7 +24,10 @@ set(WAMR_BUILD_FAST_INTERP 1)
 set(WAMR_BUILD_LIB_PTHREAD 1)
 
 # compiling and linking flags
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections -pie -fPIE")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie -fPIE")
+if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))
+  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
+endif ()
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security")
 
 # build out vmlib

--- a/samples/multi-thread/wasm-apps/CMakeLists.txt
+++ b/samples/multi-thread/wasm-apps/CMakeLists.txt
@@ -6,7 +6,11 @@ project(wasm-apps)
 
 set(WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 
-set(CMAKE_SYSTEM_NAME Linux)
+if (APPLE)
+    set (HAVE_FLAG_SEARCH_PATHS_FIRST 0)
+    set (CMAKE_C_LINK_FLAGS "")
+    set (CMAKE_CXX_LINK_FLAGS "")
+endif ()
 set(CMAKE_SYSTEM_PROCESSOR wasm32)
 set (CMAKE_SYSROOT                  ${WAMR_ROOT_DIR}/wamr-sdk/app/libc-builtin-sysroot)
 

--- a/samples/spawn-thread/CMakeLists.txt
+++ b/samples/spawn-thread/CMakeLists.txt
@@ -5,7 +5,10 @@ cmake_minimum_required(VERSION 2.8)
 project(spawn_thread)
 
 ################  runtime settings  ################
-set(WAMR_BUILD_PLATFORM "linux")
+string (TOLOWER ${CMAKE_HOST_SYSTEM_NAME} WAMR_BUILD_PLATFORM)
+if (APPLE)
+  add_definitions(-DBH_PLATFORM_DARWIN)
+endif ()
 
 # Resetdefault linker flags
 set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
@@ -21,7 +24,10 @@ set(WAMR_BUILD_FAST_INTERP 1)
 set(WAMR_BUILD_LIB_PTHREAD 1)
 
 # compiling and linking flags
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections -pie -fPIE")
+set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie -fPIE")
+if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))
+  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
+endif ()
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security")
 
 # build out vmlib

--- a/samples/spawn-thread/wasm-apps/CMakeLists.txt
+++ b/samples/spawn-thread/wasm-apps/CMakeLists.txt
@@ -6,7 +6,11 @@ project(wasm-apps)
 
 set(WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 
-set(CMAKE_SYSTEM_NAME Linux)
+if (APPLE)
+    set (HAVE_FLAG_SEARCH_PATHS_FIRST 0)
+    set (CMAKE_C_LINK_FLAGS "")
+    set (CMAKE_CXX_LINK_FLAGS "")
+endif ()
 set(CMAKE_SYSTEM_PROCESSOR wasm32)
 set (CMAKE_SYSROOT                  ${WAMR_ROOT_DIR}/wamr-sdk/app/libc-builtin-sysroot)
 

--- a/samples/wasm-c-api/CMakeLists.txt
+++ b/samples/wasm-c-api/CMakeLists.txt
@@ -8,7 +8,10 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 ################  runtime settings  ################
-set(WAMR_BUILD_PLATFORM "linux")
+string (TOLOWER ${CMAKE_HOST_SYSTEM_NAME} WAMR_BUILD_PLATFORM)
+if (APPLE)
+  add_definitions(-DBH_PLATFORM_DARWIN)
+endif ()
 
 # Resetdefault linker flags
 set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
@@ -37,8 +40,16 @@ if(NOT DEFINED WAMR_BUILD_FAST_INTERP)
 endif()
 
 # compiling and linking flags
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections -pie -fPIE")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security -mindirect-branch-register")
+set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie -fPIE")
+if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))
+  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
+endif ()
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security")
+if (WAMR_BUILD_TARGET MATCHES "X86_.*" OR WAMR_BUILD_TARGET STREQUAL "AMD_64")
+  if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mindirect-branch-register")
+  endif ()
+endif ()
 
 # build out vmlib
 set(WAMR_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR}/../..)


### PR DESCRIPTION
Fix the build issues on mac for basic/multi-module/multi-thread/simple/spawn-thread/wasm-c-api under samples.
And all these samples could be run as expected.