### PR TITLE
fix exec_env not checked issue, export __heap_base and __data_end

### DIFF
--- a/core/iwasm/common/wasm_exec_env.c
+++ b/core/iwasm/common/wasm_exec_env.c
@@ -84,15 +84,16 @@ WASMExecEnv *
 wasm_exec_env_create(struct WASMModuleInstanceCommon *module_inst,
                      uint32 stack_size)
 {
-    WASMExecEnv *exec_env = wasm_exec_env_create_internal(module_inst,
-                                                          stack_size);
+    WASMExecEnv *exec_env =
+        wasm_exec_env_create_internal(module_inst, stack_size);
+
+    if (!exec_env)
+        return NULL;
+
     /* Set the aux_stack_boundary to 0 */
     exec_env->aux_stack_boundary = 0;
 #if WASM_ENABLE_THREAD_MGR != 0
     WASMCluster *cluster;
-
-    if (!exec_env)
-        return NULL;
 
     /* Create a new cluster for this exec_env */
     cluster = wasm_cluster_create(exec_env);

--- a/core/iwasm/common/wasm_native.c
+++ b/core/iwasm/common/wasm_native.c
@@ -335,14 +335,14 @@ wasm_native_init()
 #if WASM_ENABLE_LIBC_BUILTIN != 0
     n_native_symbols = get_libc_builtin_export_apis(&native_symbols);
     if (!wasm_native_register_natives("env",
-                                       native_symbols, n_native_symbols))
+                                      native_symbols, n_native_symbols))
         return false;
 #endif /* WASM_ENABLE_LIBC_BUILTIN */
 
 #if WASM_ENABLE_SPEC_TEST
     n_native_symbols = get_spectest_export_apis(&native_symbols);
     if (!wasm_native_register_natives("spectest",
-                                       native_symbols, n_native_symbols))
+                                      native_symbols, n_native_symbols))
         return false;
 #endif /* WASM_ENABLE_SPEC_TEST */
 

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -1365,14 +1365,6 @@ wasm_runtime_init_wasi(WASMModuleInstanceCommon *module_inst,
         goto fail;
     }
 
-    wasi_ctx->curfds_offset = offset_curfds;
-    wasi_ctx->prestats_offset = offset_prestats;
-    wasi_ctx->argv_environ_offset = offset_argv_environ;
-    wasi_ctx->argv_buf_offset = offset_argv_buf;
-    wasi_ctx->argv_offsets_offset = offset_argv_offsets;
-    wasi_ctx->env_buf_offset = offset_env_buf;
-    wasi_ctx->env_offsets_offset = offset_env_offsets;
-
     if (!fd_table_init(curfds)) {
         set_error_buf(error_buf, error_buf_size,
                       "Init wasi environment failed: "
@@ -1433,6 +1425,14 @@ wasm_runtime_init_wasi(WASMModuleInstanceCommon *module_inst,
         fd_table_insert_existing(curfds, wasm_fd, raw_fd);
         fd_prestats_insert(prestats, dir_list[i], wasm_fd);
     }
+
+    wasi_ctx->curfds_offset = offset_curfds;
+    wasi_ctx->prestats_offset = offset_prestats;
+    wasi_ctx->argv_environ_offset = offset_argv_environ;
+    wasi_ctx->argv_buf_offset = offset_argv_buf;
+    wasi_ctx->argv_offsets_offset = offset_argv_offsets;
+    wasi_ctx->env_buf_offset = offset_env_buf;
+    wasi_ctx->env_offsets_offset = offset_env_offsets;
 
     return true;
 

--- a/samples/simple/build.sh
+++ b/samples/simple/build.sh
@@ -153,6 +153,7 @@ OUT_FILE=${i%.*}.wasm
         -Wl,--export=on_request -Wl,--export=on_response \
         -Wl,--export=on_sensor_event -Wl,--export=on_timer_callback \
         -Wl,--export=on_connection_data \
+        -Wl,--export=__heap_base -Wl,--export=__data_end \
         -o ${OUT_DIR}/wasm-apps/${OUT_FILE} ${APP_SRC}
 if [ -f ${OUT_DIR}/wasm-apps/${OUT_FILE} ]; then
         echo "build ${OUT_FILE} success"


### PR DESCRIPTION
- fix exec_env not checked issue 
- export __heap_base and __data_end in sample to decrease memory usage
- fix some coding styles