### PR TITLE
core/shared: Add guard to avoid redefine macro

### DIFF
--- a/core/shared/platform/include/platform_common.h
+++ b/core/shared/platform/include/platform_common.h
@@ -47,9 +47,19 @@ void BH_FREE(void *ptr);
 #endif
 
 #ifndef __cplusplus
+
+#ifndef true
 #define true 1
+#endif
+
+#ifndef false
 #define false 0
+#endif
+
+#ifndef inline
 #define inline __inline
+#endif
+
 #endif
 
 /* Return the offset of the given field in the given type */

--- a/core/shared/utils/bh_log.h
+++ b/core/shared/utils/bh_log.h
@@ -41,6 +41,16 @@ bh_log_set_verbose_level(uint32 level);
 void
 bh_log(LogLevel log_level, const char *file, int line, const char *fmt, ...);
 
+#ifdef BH_PLATFORM_NUTTX
+
+#undef LOG_FATAL
+#undef LOG_ERROR
+#undef LOG_WARNING
+#undef LOG_VERBOSE
+#undef LOG_DEBUG
+
+#endif
+
 #if BH_DEBUG == 1
 #define LOG_FATAL(...)   bh_log(BH_LOG_LEVEL_FATAL, __FILE__, __LINE__, __VA_ARGS__)
 #else


### PR DESCRIPTION
true/false already defined on some platform like NuttX,

LOG_DEBUG series macro is also easy to conflict with exists. 