### PR TITLE
Fix wasm loader malloc(0) issue which returns NULL is some platforms

### DIFF
--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -1691,8 +1691,14 @@ init_function_local_offsets(WASMFunction *func,
     uint32 i, local_offset = 0;
     uint64 total_size = sizeof(uint16) * ((uint64)param_count + local_count);
 
-    if (!(func->local_offsets =
-                loader_malloc(total_size, error_buf, error_buf_size))) {
+    /*
+     * Only allocate memory when total_size is not 0,
+     * or the return value of malloc(0) might be NULL on some platforms,
+     * which causes wasm loader return false.
+     */
+    if (total_size > 0
+        && !(func->local_offsets =
+               loader_malloc(total_size, error_buf, error_buf_size))) {
         return false;
     }
 

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -853,8 +853,9 @@ init_function_local_offsets(WASMFunction *func,
     uint32 i, local_offset = 0;
     uint64 total_size = sizeof(uint16) * ((uint64)param_count + local_count);
 
-    if (!(func->local_offsets =
-                loader_malloc(total_size, error_buf, error_buf_size))) {
+    if (total_size > 0
+        && !(func->local_offsets =
+               loader_malloc(total_size, error_buf, error_buf_size))) {
         return false;
     }
 


### PR DESCRIPTION
Detail can be found in comments.

Signed-off-by: Huang Qi <huangqi3@xiaomi.com>