### PR TITLE
Use macro instead of enum to define MEM_ALLOCATOR for better compatibility

### DIFF
--- a/core/config.h
+++ b/core/config.h
@@ -43,12 +43,8 @@
 #define BH_DEBUG 0
 #endif
 
-enum {
-    /* Memory allocator ems */
-    MEM_ALLOCATOR_EMS = 0,
-    /* Memory allocator tlsf */
-    MEM_ALLOCATOR_TLSF
-};
+#define MEM_ALLOCATOR_EMS  0
+#define MEM_ALLOCATOR_TLSF 1
 
 /* Default memory allocator */
 #define DEFAULT_MEM_ALLOCATOR MEM_ALLOCATOR_EMS


### PR DESCRIPTION
Some compiler would raise a warning when pre-processing, like:
```
In file included from wamr/core/shared/utils/../platform/include/platform_common.h:13,
                 from wamr/core/shared/utils/bh_platform.h:9,
                 from wamr/core/shared/mem-alloc/mem_alloc.h:9,
                 from wamr/core/shared/mem-alloc/mem_alloc.c:6:
wamr/core/shared/utils/../platform/include/../../../config.h:57:31: warning: "MEM_ALLOCATOR_EMS" is not defined, evaluates to 0 [-Wundef]
   57 | #define DEFAULT_MEM_ALLOCATOR MEM_ALLOCATOR_EMS
      |                               ^~~~~~~~~~~~~~~~~
wamr/core/shared/mem-alloc/mem_alloc.c:8:5: note: in expansion of macro 'DEFAULT_MEM_ALLOCATOR'
    8 | #if DEFAULT_MEM_ALLOCATOR == MEM_ALLOCATOR_EMS
      |     ^~~~~~~~~~~~~~~~~~~~~
wamr/core/shared/mem-alloc/mem_alloc.c:8:30: warning: "MEM_ALLOCATOR_EMS" is not defined, evaluates to 0 [-Wundef]
    8 | #if DEFAULT_MEM_ALLOCATOR == MEM_ALLOCATOR_EMS
```