### PR TITLE
declare invokeNative as function not as nothing on arm

### DIFF
--- a/core/iwasm/common/arch/invokeNative_aarch64.s
+++ b/core/iwasm/common/arch/invokeNative_aarch64.s
@@ -6,7 +6,7 @@
         .align  2
 #ifndef BH_PLATFORM_DARWIN
         .globl invokeNative
-        .type   invokeNative, @function
+        .type  invokeNative, function
 invokeNative:
 #else
         .globl _invokeNative

--- a/core/iwasm/common/arch/invokeNative_arm.s
+++ b/core/iwasm/common/arch/invokeNative_arm.s
@@ -6,7 +6,7 @@
         .align  2
 #ifndef BH_PLATFORM_DARWIN
         .globl invokeNative
-        .type   invokeNative, @function
+        .type  invokeNative, function
 invokeNative:
 #else
         .globl _invokeNative

--- a/core/iwasm/common/arch/invokeNative_arm_vfp.s
+++ b/core/iwasm/common/arch/invokeNative_arm_vfp.s
@@ -6,7 +6,7 @@
         .align  2
 #ifndef BH_PLATFORM_DARWIN
         .globl invokeNative
-        .type   invokeNative, @function
+        .type  invokeNative, function
 invokeNative:
 #else
         .globl _invokeNative

--- a/core/iwasm/common/arch/invokeNative_thumb.s
+++ b/core/iwasm/common/arch/invokeNative_thumb.s
@@ -6,7 +6,7 @@
         .align  2
 #ifndef BH_PLATFORM_DARWIN
         .globl invokeNative
-        .type   invokeNative, @function
+        .type  invokeNative, function
 invokeNative:
 #else
         .globl _invokeNative

--- a/core/iwasm/common/arch/invokeNative_thumb_vfp.s
+++ b/core/iwasm/common/arch/invokeNative_thumb_vfp.s
@@ -6,7 +6,7 @@
         .align  2
 #ifndef BH_PLATFORM_DARWIN
         .globl invokeNative
-        .type   invokeNative, @function
+        .type  invokeNative, function
 invokeNative:
 #else
         .globl _invokeNative


### PR DESCRIPTION
#395 introduced an error for non Darwin builds for arm architectures  it declared invokeNative of no type since @function is seen as a comment.
This PR changes it back to "function" as it was declared before  ( other options would be #function or %function as one can see in #414)



i think the error got introduced while testing testing various options to build for Darwin since Darwin does no require this line 

fixes issue #414