### PR TITLE
Implement Inclavare Containers PAL interface in WAMR Linux-SGX

### DIFF
--- a/product-mini/platforms/linux-sgx/enclave-sample/App/README.md
+++ b/product-mini/platforms/linux-sgx/enclave-sample/App/README.md
@@ -1,0 +1,166 @@
+# WAMR as an Enclave Runtime for Rune
+
+## Build WAMR vmcore (iwasm) for Linux-SGX
+
+### SIM Mode
+
+The default SGX mode in WAMR is the SIM mode. Build the source code and enclave example, please refer to [this guild](https://github.com/bytecodealliance/wasm-micro-runtime/blob/main/doc/linux_sgx.md#build-wamr-vmcore-iwasm-for-linux-sgx).
+
+### HW Mode
+
+Please do the following changes before execute [this guild](https://github.com/bytecodealliance/wasm-micro-runtime/blob/main/doc/linux_sgx.md#build-wamr-vmcore-iwasm-for-linux-sgx).
+
+```shell
+diff --git a/product-mini/platforms/linux-sgx/enclave-sample/Makefile b/product-mini/platforms/linux-sgx/enclave-sample/Makefile
+index f06b5b8..f247f3e 100644
+--- a/product-mini/platforms/linux-sgx/enclave-sample/Makefile
++++ b/product-mini/platforms/linux-sgx/enclave-sample/Makefile
+@@ -4,7 +4,7 @@
+ ######## SGX SDK Settings ########
+
+ SGX_SDK ?= /opt/intel/sgxsdk
+-SGX_MODE ?= SIM
++SGX_MODE ?= HW
+ SGX_ARCH ?= x64
+ SGX_DEBUG ?= 0
+ SPEC_TEST ?= 0
+```
+
+```shell
+diff --git a/product-mini/platforms/linux-sgx/enclave-sample/Makefile_minimal b/product-mini/platforms/linux-sgx/enclave-sample/Makefile_minimal
+index a64d577..747d995 100644
+--- a/product-mini/platforms/linux-sgx/enclave-sample/Makefile_minimal
++++ b/product-mini/platforms/linux-sgx/enclave-sample/Makefile_minimal
+@@ -4,7 +4,7 @@
+ ######## SGX SDK Settings ########
+
+ SGX_SDK ?= /opt/intel/sgxsdk
+-SGX_MODE ?= SIM
++SGX_MODE ?= HW
+ SGX_ARCH ?= x64
+ SGX_DEBUG ?= 0
+ SPEC_TEST ?= 0
+
+```
+
+After building, please sign enclave.so to generate enclave.signed.so which is needed in PAL
+
+```shell
+/opt/intel/sgxsdk/bin/x64/sgx_sign sign -key Enclave/Enclave_private.pem -enclave enclave.so -out enclave.signed.so -config Enclave/Enclave.config.xml
+```
+
+---
+
+## Build PAL dynamically linked shared object
+
+To build WAMR as an Enclave Runtime for [Inclavare Containers](https://github.com/alibaba/inclavare-containers), we should implement the [PAL interface](https://github.com/alibaba/inclavare-containers/blob/master/rune/libenclave/internal/runtime/pal/spec_v2.md) in WAMR for rune to call the PAL to create the enclave with WAMR and run applications.
+
+```shell
+g++ -shared -fPIC -o libwamr.so App/*.o libvmlib_untrusted.a -L/opt/intel/sgxsdk/lib64 -lsgx_urts -lpthread -lssl -lcrypto
+```
+
+Note: /opt/intel/sgxsdk/ is where you installed the SGX SDK
+
+---
+
+## Build WAMR container image
+
+Under the `enclave-sample` directory, to create the WAMR docker images to load the `enclave.signed.so` and target application wasm files, please type the following commands to create a `Dockerfile`:
+
+For centos:
+
+```shell
+cat >Dockerfile <<EOF
+FROM centos:8.1.1911
+
+RUN mkdir -p /run/rune
+WORKDIR /run/rune
+
+COPY enclave.signed.so .
+EOF
+```
+
+ For ubuntu:
+
+```shell
+cat > Dockerfile <<EOF
+FROM ubuntu:18.04
+
+RUN mkdir -p /run/rune
+WORKDIR /run/rune
+
+COPY enclave.signed.so .
+EOF
+```
+
+Then build the WAMR container image with the command:
+
+```shell
+docker build . -t wamr-app
+```
+
+---
+
+## Create WAMR Application bundle
+
+In order to use `rune` you must have your container image in the format of an OCI bundle. If you have Docker installed you can use its `export` method to acquire a root filesystem from an existing WAMR application container image.
+
+```shell
+# create the top most bundle directory
+mkdir -p "$HOME/rune_workdir"
+cd "$HOME/rune_workdir"
+mkdir rune-container
+cd rune-container
+
+# create the rootfs directory
+mkdir rootfs
+
+# export wamr application image via Docker into the rootfs directory
+docker export $(docker create ${wamr_application_image}) | sudo tar -C rootfs -xvf -
+```
+
+After a root filesystem is populated you just generate a spec in the format of a config.json file inside your bundle. `rune` provides a spec command which is similar to `runc` to generate a template file that you are then able to edit.
+
+```shell
+rune spec
+```
+
+To find features and documentation for fields in the spec please refer to the [specs](https://github.com/opencontainers/runtime-spec) repository.
+
+In order to run the hello world demo program in WAMR with `rune`, you need to change the entrypoint from `sh` to `/bin/hello_world`
+
+```yaml
+  "process": {
+      "args": [
+          "/bin/hello_world"
+      ],
+  }
+```
+
+and then configure enclave runtime as following:
+
+```yaml
+  "annotations": {
+      "enclave.type": "intelSgx",
+      "enclave.runtime.path": "/usr/lib/wamr-pal.so",
+      "enclave.runtime.args": "./"
+  }
+```
+
+where:
+
+- @enclave.type: specify the type of enclave hardware to use, such as `intelSgx`.
+- @enclave.runtime.path: specify the path to enclave runtime to launch. For an WAMR application, you need to specify the path to `libwamr-pal.so`.
+- @enclave.runtime.args: specify the specific arguments to enclave runtime, separated by the comma.
+
+---
+
+## Run WAMR Application
+
+Assuming you have an OCI bundle from the previous step you can execute the container in this way.
+
+```shell
+cd "$HOME/rune_workdir/rune-container"
+sudo rune run ${wamr_application_container_name}
+```
+

--- a/product-mini/platforms/linux-sgx/enclave-sample/App/pal_api.h
+++ b/product-mini/platforms/linux-sgx/enclave-sample/App/pal_api.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2019 Intel Corporation.  All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
 #ifndef __WAMR_PAL_API_H__
 #define __WAMR_PAL_API_H__
 
@@ -33,9 +38,9 @@ typedef struct wamr_pal_attr {
     const char     *log_level;
 } wamr_pal_attr_t;
 
-#define WAMR_PAL_ATTR_INITVAL         { \
-    .instance_dir = ".",                 \
-    .log_level = 2                        \
+#define WAMR_PAL_ATTR_INITVAL { \
+    .instance_dir = ".",        \
+    .log_level = 2              \
 }
 
 /*
@@ -62,14 +67,15 @@ struct wamr_pal_create_process_args {
     // Argments array pass to new process.
     //
     // The arguments to the command. By convention, the argv[0] should be the program name.
-    // And the array must be NULL terminated.
+    // And the last element of the array must be NULL to indicate the length of array.
     //
     // Mandatory field. Must not be NULL.
     const char **argv;
 
     // Untrusted environment variable array pass to new process.
     //
-    // The untrusted env vars to the command. The array must be NULL terminated.
+    // The untrusted env vars to the command. And the last element of the array must be
+    // NULL to indicate the length of array.
     //
     // Optional field.
     const char **env;
@@ -109,20 +115,15 @@ struct wamr_pal_exec_args {
     int *exit_value;
 };
 
-int
-wamr_pal_init(const struct wamr_pal_attr *args);
+int wamr_pal_init(const struct wamr_pal_attr *args);
 
-int
-wamr_pal_create_process(struct wamr_pal_create_process_args *args);
+int wamr_pal_create_process(struct wamr_pal_create_process_args *args);
 
-int
-wamr_pal_destroy(void);
+int wamr_pal_destroy(void);
 
-int
-wamr_pal_exec(struct wamr_pal_exec_args *args);
+int wamr_pal_exec(struct wamr_pal_exec_args *args);
 
-int
-wamr_pal_kill(int pid, int sig);
+int wamr_pal_kill(int pid, int sig);
 
 int pal_get_version(void);
 

--- a/product-mini/platforms/linux-sgx/enclave-sample/App/pal_api.h
+++ b/product-mini/platforms/linux-sgx/enclave-sample/App/pal_api.h
@@ -1,0 +1,145 @@
+#ifndef __WAMR_PAL_API_H__
+#define __WAMR_PAL_API_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * WAMR PAL API version number
+ */
+#define WAMR_PAL_VERSION 2
+
+/*
+ * @brief Get version of WAMR PAL API
+ *
+ * @retval If > 0, then success; otherwise, it is an invalid version.
+ */
+int wamr_pal_get_version(void);
+
+/*
+ * WAMR PAL attributes
+ */
+typedef struct wamr_pal_attr {
+    // WAMR instance directory.
+    //
+    // The default value is "."; that is, the current working directory
+    const char     *instance_dir;
+    // Log level.
+    //
+    // Specifies the log verbose level (0 to 5, default is 2)
+    // large level with more log
+    //
+    const char     *log_level;
+} wamr_pal_attr_t;
+
+#define WAMR_PAL_ATTR_INITVAL         { \
+    .instance_dir = ".",                 \
+    .log_level = 2                        \
+}
+
+/*
+ * The struct which consists of file descriptors of standard I/O
+ */
+typedef struct wamr_stdio_fds {
+    int stdin_fd;
+    int stdout_fd;
+    int stderr_fd;
+} wamr_stdio_fds_t;
+
+/*
+ * The struct which consists of arguments needed by wamr_pal_create_process
+ */
+struct wamr_pal_create_process_args {
+
+    // Path to new process.
+    //
+    // The path of the command which will be created as a new process.
+    //
+    // Mandatory field. Must not be NULL.
+    const char *path;
+
+    // Argments array pass to new process.
+    //
+    // The arguments to the command. By convention, the argv[0] should be the program name.
+    // And the array must be NULL terminated.
+    //
+    // Mandatory field. Must not be NULL.
+    const char **argv;
+
+    // Untrusted environment variable array pass to new process.
+    //
+    // The untrusted env vars to the command. The array must be NULL terminated.
+    //
+    // Optional field.
+    const char **env;
+
+    // File descriptors of the redirected standard I/O (i.e., stdin, stdout, stderr)
+    //
+    // If set to NULL, will use the original standard I/O file descriptors.
+    //
+    // Optional field.
+    const struct wamr_stdio_fds *stdio;
+
+    // Output. Pid of new process in libos.
+    //
+    // If wamr_pal_create_process returns success, pid of the new process will
+    // be updated.
+    //
+    // Mandatory field. Must not be NULL.
+    int *pid;
+};
+
+/*
+ * The struct which consists of arguments needed by wamr_pal_exec
+ */
+struct wamr_pal_exec_args {
+    // Pid of new process created with wamr_pal_create_process.
+    //
+    // Mandatory field.
+    int pid;
+
+    // Output. The exit status of the command. The semantic of
+    // this value follows the one described in wait(2) man
+    // page. For example, if the program terminated normally,
+    // then WEXITSTATUS(exit_status) gives the value returned
+    // from a main function.
+    //
+    // Mandatory field. Must not be NULL.
+    int *exit_value;
+};
+
+int
+wamr_pal_init(const struct wamr_pal_attr *args);
+
+int
+wamr_pal_create_process(struct wamr_pal_create_process_args *args);
+
+int
+wamr_pal_destroy(void);
+
+int
+wamr_pal_exec(struct wamr_pal_exec_args *args);
+
+int
+wamr_pal_kill(int pid, int sig);
+
+int pal_get_version(void);
+
+int pal_init(const struct wamr_pal_attr *attr);
+
+int pal_create_process(struct wamr_pal_create_process_args *args);
+
+int pal_exec(struct wamr_pal_exec_args *args);
+
+int pal_kill(int pid, int sig);
+
+int pal_destroy(void);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __WAMR_PAL_API_H__ */
+

--- a/product-mini/platforms/linux-sgx/enclave-sample/App/wamr-bundle.md
+++ b/product-mini/platforms/linux-sgx/enclave-sample/App/wamr-bundle.md
@@ -1,0 +1,65 @@
+# Run WAMR bundle for Rune
+
+## Create WAMR Application bundle
+
+In order to use `rune` you must have your container image in the format of an OCI bundle. If you have Docker installed you can use its `export` method to acquire a root filesystem from an existing WAMR application container image.
+
+```shell
+# create the top most bundle directory
+mkdir -p "$HOME/rune_workdir"
+cd "$HOME/rune_workdir"
+mkdir rune-container
+cd rune-container
+
+# create the rootfs directory
+mkdir rootfs
+
+# export wamr application image via Docker into the rootfs directory
+docker export $(docker create ${wamr_application_image}) | sudo tar -C rootfs -xvf -
+```
+
+After a root filesystem is populated you just generate a spec in the format of a config.json file inside your bundle. `rune` provides a spec command which is similar to `runc` to generate a template file that you are then able to edit.
+
+```shell
+rune spec
+```
+
+To find features and documentation for fields in the spec please refer to the [specs](https://github.com/opencontainers/runtime-spec) repository.
+
+In order to run the target applications in WAMR with `rune`, you need to change the entrypoint from `sh` to `/run/rune/${wasm_app1.wasm}`, and in order to run multi-applications in one runtime with enclave, change it to `/run/rune/${wasm_app1.aot}`, `/run/rune/${wasm_app2.aot}` ... 
+
+```yaml
+  "process": {
+      "args": [
+          "/run/rune/demo.aot"
+      ],
+  }
+```
+
+and then configure enclave runtime as following:
+
+```yaml
+  "annotations": {
+      "enclave.type": "intelSgx",
+      "enclave.runtime.path": "/usr/lib/libwamr-pal.so",
+      "enclave.runtime.args": "./"
+  }
+```
+
+where:
+
+- @enclave.type: specify the type of enclave hardware to use, such as `intelSgx`.
+- @enclave.runtime.path: specify the path to enclave runtime to launch. For an WAMR application, you need to specify the path to `libwamr-pal.so`.
+- @enclave.runtime.args: specify the specific arguments to enclave runtime, separated by the comma.
+
+---
+
+## Run WAMR Application
+
+Assuming you have an OCI bundle from the previous step you can execute the container in this way.
+
+```shell
+cd "$HOME/rune_workdir/rune-container"
+sudo rune run ${wamr_application_container_name}
+```
+


### PR DESCRIPTION
This patch is the implemtation of the PAL interface [spec_v2](https://github.com/alibaba/inclavare-containers/blob/master/rune/libenclave/internal/runtime/pal/spec_v2.md)
And it enables WAMR as a enclave runtime backend for Inclavare Containers.
I also draft a guide for how to use it.

In the future, I will add extra arguments support and divide the workflow into the standard PAL processions.