### PR TITLE
Enhance the readability of WAMR SGX docs

### DIFF
--- a/doc/linux_sgx.md
+++ b/doc/linux_sgx.md
@@ -17,8 +17,6 @@ cmake ..
 make
 ```
 
-**Note:** By default, the generated SGX application assumes it is signed with production key and running on simulation mode. In order to build a debug enclave on hardware-based SGX platform, execute `make SGX_DEBUG=1 SGX_MODE=HW` instead.
-
 This builds two libraries required by SGX application:
  - libvmlib.a for Enclave part
  - libvmlib_untrusted.a for App part
@@ -31,6 +29,8 @@ source <SGX_SDK dir>/environment
 cd enclave-sample
 make
 ```
+
+**Note:** By default, the generated SGX application assumes it is signed with production key and running on simulation mode. The user can explicitly specify the relative variables in commandline to overwrite the default settings. For example, to build a debug enclave, please build the enclave with `make SGX_DEBUG=1`. To build the enclave running on a hardware-based SGX platform, execute `make SGX_MODE=HW`.
 
 The binary file iwasm will be generated. To run the sample:
 

--- a/product-mini/platforms/linux-sgx/enclave-sample/App/wamr-bundle.md
+++ b/product-mini/platforms/linux-sgx/enclave-sample/App/wamr-bundle.md
@@ -1,15 +1,15 @@
-# Run WAMR bundle for Rune
+# Run WAMR enclave runtime with bundle
 
 ## Create WAMR Application bundle
 
-In order to use `rune` you must have your container image in the format of an OCI bundle. If you have Docker installed you can use its `export` method to acquire a root filesystem from an existing WAMR application container image.
+`rune` can directly launch an OCI bundle converted from docker image. If you have Docker installed you can use its `export` sub-command to acquire a root filesystem from an existing WAMR application docker image.
 
 ```shell
 # create the top most bundle directory
 mkdir -p "$HOME/rune_workdir"
 cd "$HOME/rune_workdir"
-mkdir rune-container
-cd rune-container
+mkdir wamr-sgx-bundle
+cd warmr-sgx-bundle
 
 # create the rootfs directory
 mkdir rootfs
@@ -26,23 +26,23 @@ rune spec
 
 To find features and documentation for fields in the spec please refer to the [specs](https://github.com/opencontainers/runtime-spec) repository.
 
-In order to run the target applications in WAMR with `rune`, you need to change the entrypoint from `sh` to `/run/rune/${wasm_app1.wasm}`, and in order to run multi-applications in one runtime with enclave, change it to `/run/rune/${wasm_app1.aot}`, `/run/rune/${wasm_app2.aot}` ... 
+In order to run the target application in WAMR with `rune`, you need to change the entrypoint from `sh` to the target application, and in order to run multi-applications in one runtime with enclave, change it to `/run/rune/${wasm_app1.aot}`, `/run/rune/${wasm_app2.aot}` ... 
 
-```yaml
+```json
   "process": {
       "args": [
-          "/run/rune/demo.aot"
+          "/run/rune/${wasm_app}"
       ],
   }
 ```
 
 and then configure enclave runtime as following:
 
-```yaml
+```json
   "annotations": {
       "enclave.type": "intelSgx",
       "enclave.runtime.path": "/usr/lib/libwamr-pal.so",
-      "enclave.runtime.args": "./"
+      "enclave.runtime.args": "debug"
   }
 ```
 
@@ -59,7 +59,6 @@ where:
 Assuming you have an OCI bundle from the previous step you can execute the container in this way.
 
 ```shell
-cd "$HOME/rune_workdir/rune-container"
-sudo rune run ${wamr_application_container_name}
+cd "$HOME/rune_workdir/wamr-sgx-bundle"
+sudo rune run wamr-sgx-app
 ```
-


### PR DESCRIPTION
The global doc/linux_sgx.md needs to explicitly describe the methods to
build a debug enclave and hardware running mode. Because using debug key
to signing enclave image rather than production key is still not trivial
in reality.

For the adaption of Inclavare Containers part, add a prolog and give
more details in order to enhance the readability.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>