### PR TITLE
Fix struct stat fields for darwin

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
@@ -86,9 +86,9 @@
 #endif
 
 #ifdef __APPLE__
-#define st_atimespec st_atim
-#define st_mtimespec st_mtim
-#define st_ctimespec st_ctim
+#define st_atim st_atimespec
+#define st_ctim st_ctimespec
+#define st_mtim st_mtimespec
 #endif
 
 #ifdef __APPLE__


### PR DESCRIPTION
I'm creating [a wamr binding library for Swift](https://github.com/kateinoigakukun/wamr-swift) and I faced the following errors

```
$ swift build --target wamr-demo
./wamr-swift/Sources/wamr-core-darwin/wamr/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c:2100:40: error: no member named 'st_atsim' in 'struct stat'
      .st_atim = convert_timespec(&in->st_atsim),
                                   ~~  ^
./wamr-swift/Sources/wamr-core-darwin/wamr/core/iwasm/libraries/libc-wasi/: error: no member named 'st_mtim' in 'struct stat'
      .st_mtim = convert_timespec(&in->st_mtim),
                                   ~~  ^
./wamr-swift/Sources/wamr-core-darwin/wamr/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c:2102:40: error: no member named 'st_ctim' in 'struct stat'
      .st_ctim = convert_timespec(&in->st_ctim),

```

These `no member` errors are only reproducible when building with `-fmodule` because darwin doesn't support POSIX compatible stat fields when `-fmodule`. So I added macros for platform compatibility.