### PR TITLE
NFC: fix typo in invokeNative_aarch64.s comment

### DIFF
--- a/core/iwasm/common/arch/invokeNative_aarch64.s
+++ b/core/iwasm/common/arch/invokeNative_aarch64.s
@@ -37,7 +37,7 @@ _invokeNative:
         ldp     d4, d5, [x20], #16 /* d4 = argv[4], d5 = argv[5] */
         ldp     d6, d7, [x20], #16 /* d6 = argv[6], d7 = argv[7] */
 
-        /* Fill inteter registers */
+        /* Fill integer registers */
         ldp     x0, x1, [x20], #16 /* x0 = argv[8] = exec_env, x1 = argv[9] */
         ldp     x2, x3, [x20], #16 /* x2 = argv[10], x3 = argv[11] */
         ldp     x4, x5, [x20], #16 /* x4 = argv[12], x5 = argv[13] */


### PR DESCRIPTION
`inteter` -> `integer`