### PR TITLE
Add support for Apple Silicon on macOS

### DIFF
--- a/product-mini/platforms/darwin/CMakeLists.txt
+++ b/product-mini/platforms/darwin/CMakeLists.txt
@@ -14,7 +14,10 @@ set (CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
 # Set WAMR_BUILD_TARGET, currently values supported:
 # "X86_64", "AMD_64", "X86_32", "ARM[sub]", "THUMB[sub]", "MIPS", "XTENSA"
 if (NOT DEFINED WAMR_BUILD_TARGET)
-  if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+  if ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "arm64")
+    # Handle Apple Silicon
+    set (WAMR_BUILD_TARGET "AARCH64")
+  elseif (CMAKE_SIZEOF_VOID_P EQUAL 8)
     # Build as X86_64 by default in 64-bit platform
     set (WAMR_BUILD_TARGET "X86_64")
   else ()

--- a/product-mini/platforms/darwin/CMakeLists.txt
+++ b/product-mini/platforms/darwin/CMakeLists.txt
@@ -14,7 +14,7 @@ set (CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
 # Set WAMR_BUILD_TARGET, currently values supported:
 # "X86_64", "AMD_64", "X86_32", "ARM[sub]", "THUMB[sub]", "MIPS", "XTENSA"
 if (NOT DEFINED WAMR_BUILD_TARGET)
-  if ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "arm64")
+  if (CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
     # Handle Apple Silicon
     set (WAMR_BUILD_TARGET "AARCH64")
   elseif (CMAKE_SIZEOF_VOID_P EQUAL 8)


### PR DESCRIPTION
Without this change in a corresponding `CMakeLists.txt` it attempts to build `invokeNative` assembly for `X86_64` on Macs with Apple Silicon.