### PR TITLE
fix error while building project with RT-Thread Studio.

### DIFF
--- a/build-scripts/SConscript_config
+++ b/build-scripts/SConscript_config
@@ -32,24 +32,23 @@ if rtconfig.ARCH == 'arm':
     if re.match('^cortex-m.*', rtconfig.CPU):
         print('[WAMR] using thumbv4t')
         CPPDEFINES += ['BUILD_TARGET_THUMB']
-        CPPDEFINES += [r'BUILD_TARGET=\"thumbv4t\"']
+        CPPDEFINES += ['RTT_WAMR_BUILD_TARGET_THUMB']
     elif re.match('^cortex-a.*', rtconfig.CPU):
         print('[WAMR] using armv7')
         CPPDEFINES += ['BUILD_TARGET_ARM']
-        CPPDEFINES += [r'BUILD_TARGET=\"armv7\"']
+        CPPDEFINES += ['RTT_WAMR_BUILD_TARGET_ARMV7']
     elif re.match('^cortex-r.*', rtconfig.CPU):
         print('[WAMR] using armv7')
         CPPDEFINES += ['BUILD_TARGET_ARM']
-        CPPDEFINES += [r'BUILD_TARGET=\"armv7\"']
+        CPPDEFINES += ['RTT_WAMR_BUILD_TARGET_ARMV7']
     elif rtconfig.CPU == 'armv6':
         print('[WAMR] using armv6')
         CPPDEFINES += ['BUILD_TARGET_ARM']
-        CPPDEFINES += [r'BUILD_TARGET=\"armv6\"']
+        CPPDEFINES += ['RTT_WAMR_BUILD_TARGET_ARMV6']
     elif re.match('^arm9*', rtconfig.CPU):
         print('[WAMR] using armv4')
         CPPDEFINES += ['BUILD_TARGET_ARM']
-        CPPDEFINES += [r'BUILD_TARGET=\"armv4\"']
-
+        CPPDEFINES += ['RTT_WAMR_BUILD_TARGET_ARMV4']
 else:
     print("[WAMR] unknown arch", rtconfig.ARCH)
 

--- a/core/shared/platform/rt-thread/platform_internal.h
+++ b/core/shared/platform/rt-thread/platform_internal.h
@@ -16,6 +16,20 @@
 #include <stdint.h>
 #include <ctype.h>
 
+#if defined(WASM_ENABLE_AOT)
+#if defined(RTT_WAMR_BUILD_TARGET_THUMB)
+#define BUILD_TARGET "thumbv4t"
+#elif defined(RTT_WAMR_BUILD_TARGET_ARMV7)
+#define BUILD_TARGET "armv7"
+#elif defined(RTT_WAMR_BUILD_TARGET_ARMV6)
+#define BUILD_TARGET "armv6"
+#elif defined(RTT_WAMR_BUILD_TARGET_ARMV4)
+#define BUILD_TARGET "armv4"
+#else
+#error "unsupported aot platform."
+#endif
+#endif /* WASM_ENABLE_AOT */
+
 typedef rt_thread_t korp_tid;
 typedef struct rt_mutex korp_mutex;
 typedef struct rt_thread korp_cond;


### PR DESCRIPTION
I'm sorry for such a bother, there is something wrong while building project with RT-Thread Studio because of the definition of `BUILD_TARGET` in scons scripts, to avoid this error, I remove the definition in `build-scripts/SConscript_config` and set it in `platform/rt-thread/platform_internal.h`.

by the way, I add some macro to control the exporting of native method of rt-thread.