### PR TITLE
[fix] failed to loading wasm byte-code

### DIFF
--- a/core/shared/platform/rt-thread/rtt_platform.c
+++ b/core/shared/platform/rt-thread/rtt_platform.c
@@ -28,10 +28,6 @@ void *os_malloc(unsigned size)
     void *buf_fixed;
     rt_ubase_t *addr_field;
 
-    if (size == 0)
-    {
-        return RT_NULL;
-    }
     buf_origin = rt_malloc(size + 8 + sizeof(rt_ubase_t));
     buf_fixed = buf_origin + sizeof(void*);
     if ((rt_ubase_t)buf_fixed & 0x7)


### PR DESCRIPTION
 failed to load wasm byte-code if return `NULL` in `os_malloc` while size == 0.