### PR TITLE
Fix memory alloc failed report when malloc(0) returns NULL.

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -1498,7 +1498,8 @@ load_relocation_section(const uint8 *buf, const uint8 *buf_end,
 
     /* Allocate memory for relocation groups */
     size = sizeof(AOTRelocationGroup) * (uint64)group_count;
-    if (!(groups = loader_malloc(size, error_buf, error_buf_size))) {
+    if (!(groups = loader_malloc(size, error_buf, error_buf_size))
+        && (size != 0)) {
         goto fail;
     }
 

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -1734,7 +1734,8 @@ wasm_runtime_init_wasi(WASMModuleInstanceCommon *module_inst,
     if (total_size >= UINT32_MAX
         || !(env_list = wasm_runtime_malloc((uint32)total_size))
         || env_buf_size >= UINT32_MAX
-        || !(env_buf = wasm_runtime_malloc((uint32)env_buf_size))) {
+        || (!(env_buf = wasm_runtime_malloc((uint32)env_buf_size))
+            && (env_buf_size != 0))) {
         set_error_buf(error_buf, error_buf_size,
                       "Init wasi environment failed: allocate memory failed");
         goto fail;

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -2148,8 +2148,9 @@ load_table_segment_section(const uint8 *buf, const uint8 *buf_end, WASMModule *m
             read_leb_uint32(p, p_end, function_count);
             table_segment->function_count = function_count;
             total_size = sizeof(uint32) * (uint64)function_count;
-            if (!(table_segment->func_indexes = (uint32 *)
-                    loader_malloc(total_size, error_buf, error_buf_size))) {
+            if (!(table_segment->func_indexes = (uint32 *)loader_malloc(
+                    total_size, error_buf, error_buf_size))
+                && (total_size != 0)) {
                 return false;
             }
             for (j = 0; j < function_count; j++) {
@@ -7710,11 +7711,12 @@ fail_data_cnt_sec_require:
         goto re_scan;
 
     func->const_cell_num = loader_ctx->const_cell_num;
-    if (!(func->consts = func_const =
-                loader_malloc(func->const_cell_num * 4,
-                              error_buf, error_buf_size))) {
-        goto fail;
-    }
+    if (func->const_cell_num != 0)
+        if (!(func->consts = func_const =
+                    loader_malloc(func->const_cell_num * 4,
+                                error_buf, error_buf_size))) {
+            goto fail;
+        }
     func_const_end = func->consts + func->const_cell_num * 4;
     /* reverse the const buf */
     for (int i = loader_ctx->num_const - 1; i >= 0; i--) {


### PR DESCRIPTION
Since malloc(0) is an undefined behavior, NULL or a valid piece of memory may be returned.

When NULL returned, we should check the memory size requested, instead of just raise an error.