### PR TITLE
Fix AoT on Win32 & Win64

### DIFF
--- a/core/iwasm/aot/aot_reloc.h
+++ b/core/iwasm/aot/aot_reloc.h
@@ -37,19 +37,6 @@ typedef struct {
 #define REG_AOT_TRACE_SYM()
 #endif
 
-#if (defined(_WIN32) || defined(_WIN32_)) && defined(NDEBUG)
-#define REG_COMMON_SYMBOLS                \
-    REG_SYM(aot_set_exception_with_id),   \
-    REG_SYM(aot_invoke_native),           \
-    REG_SYM(aot_call_indirect),           \
-    REG_SYM(wasm_runtime_enlarge_memory), \
-    REG_SYM(wasm_runtime_set_exception),  \
-    {"memset", (void*)aot_memset},        \
-    {"memmove", (void*)aot_memmove},      \
-    REG_BULK_MEMORY_SYM()                 \
-    REG_ATOMIC_WAIT_SYM()                 \
-    REG_AOT_TRACE_SYM()
-#else /* else of (defined(_WIN32) || defined(_WIN32_)) && defined(NDEBUG) */
 #define REG_COMMON_SYMBOLS                \
     REG_SYM(aot_set_exception_with_id),   \
     REG_SYM(aot_invoke_native),           \
@@ -73,7 +60,6 @@ typedef struct {
     REG_BULK_MEMORY_SYM()                 \
     REG_ATOMIC_WAIT_SYM()                 \
     REG_AOT_TRACE_SYM()
-#endif /* end of (defined(_WIN32) || defined(_WIN32_)) && defined(NDEBUG) */
 
 #define CHECK_RELOC_OFFSET(data_size) do {                                  \
     if (!check_reloc_offset(target_section_size, reloc_offset, data_size,   \

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -2264,7 +2264,7 @@ aot_get_module_inst_mem_consumption(const AOTModuleInstance *module_inst,
         mem_conspn->memories_size +=
             mem_inst->num_bytes_per_page * mem_inst->cur_page_count;
         mem_conspn->app_heap_size =
-            mem_inst->heap_data_end.ptr - mem_inst->heap_data.ptr;
+            (uint8_t *) mem_inst->heap_data_end.ptr - (uint8_t *) mem_inst->heap_data.ptr;
         /* size of app heap structure */
         mem_conspn->memories_size +=
             mem_allocator_get_heap_struct_size();

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -2264,7 +2264,7 @@ aot_get_module_inst_mem_consumption(const AOTModuleInstance *module_inst,
         mem_conspn->memories_size +=
             mem_inst->num_bytes_per_page * mem_inst->cur_page_count;
         mem_conspn->app_heap_size =
-            (uint8_t *) mem_inst->heap_data_end.ptr - (uint8_t *) mem_inst->heap_data.ptr;
+            (uint8 *) mem_inst->heap_data_end.ptr - (uint8 *) mem_inst->heap_data.ptr;
         /* size of app heap structure */
         mem_conspn->memories_size +=
             mem_allocator_get_heap_struct_size();

--- a/core/iwasm/aot/arch/aot_reloc_x86_32.c
+++ b/core/iwasm/aot/arch/aot_reloc_x86_32.c
@@ -8,20 +8,43 @@
 #define R_386_32        1   /* Direct 32 bit  */
 #define R_386_PC32      2   /* PC relative 32 bit */
 
+#if !defined(_WIN32) && !defined(_WIN32_)
 void __divdi3();
 void __udivdi3();
 void __moddi3();
 void __umoddi3();
+#else
+#pragma function (floor)
+#pragma function (ceil)
+
+int64_t __divdi3(int64_t a, int64_t b)
+{
+    return a / b;
+}
+
+uint64_t __udivdi3(uint64_t a, uint64_t b)
+{
+    return a / b;
+}
+
+int64_t __moddi3(int64_t a, int64_t b)
+{
+    return a % b;
+}
+
+uint64_t __umoddi3(uint64_t a, uint64_t b)
+{
+    return a % b;
+}
+#endif
 
 static SymbolMap target_sym_map[] = {
     REG_COMMON_SYMBOLS
-#if !defined(_WIN32) && !defined(_WIN32_)
     /* compiler-rt symbols that come from compiler(e.g. gcc) */
     REG_SYM(__divdi3),
     REG_SYM(__udivdi3),
     REG_SYM(__moddi3),
     REG_SYM(__umoddi3)
-#endif
 };
 
 static void

--- a/core/iwasm/aot/arch/aot_reloc_x86_32.c
+++ b/core/iwasm/aot/arch/aot_reloc_x86_32.c
@@ -17,22 +17,26 @@ void __umoddi3();
 #pragma function (floor)
 #pragma function (ceil)
 
-int64_t __divdi3(int64_t a, int64_t b)
+static int64
+__divdi3(int64 a, int64 b)
 {
     return a / b;
 }
 
-uint64_t __udivdi3(uint64_t a, uint64_t b)
+static uint64
+__udivdi3(uint64 a, uint64 b)
 {
     return a / b;
 }
 
-int64_t __moddi3(int64_t a, int64_t b)
+static int64
+__moddi3(int64 a, int64 b)
 {
     return a % b;
 }
 
-uint64_t __umoddi3(uint64_t a, uint64_t b)
+static uint64
+__umoddi3(uint64 a, uint64 b)
 {
     return a % b;
 }

--- a/core/iwasm/aot/arch/aot_reloc_x86_64.c
+++ b/core/iwasm/aot/arch/aot_reloc_x86_64.c
@@ -14,10 +14,35 @@
 #define IMAGE_REL_AMD64_REL32 4 /* The 32-bit relative address from
                                    the byte following the relocation */
 
+#if !defined(_WIN64) && !defined(_WIN64_)
 void __divdi3();
 void __udivdi3();
 void __moddi3();
 void __umoddi3();
+#else
+#pragma function (floor)
+#pragma function (ceil)
+
+int64_t __divdi3(int64_t a, int64_t b)
+{
+    return a / b;
+}
+
+uint64_t __udivdi3(uint64_t a, uint64_t b)
+{
+    return a / b;
+}
+
+int64_t __moddi3(int64_t a, int64_t b)
+{
+    return a % b;
+}
+
+uint64_t __umoddi3(uint64_t a, uint64_t b)
+{
+    return a % b;
+}
+#endif
 
 static SymbolMap target_sym_map[] = {
     REG_COMMON_SYMBOLS

--- a/core/iwasm/aot/arch/aot_reloc_x86_64.c
+++ b/core/iwasm/aot/arch/aot_reloc_x86_64.c
@@ -14,36 +14,11 @@
 #define IMAGE_REL_AMD64_REL32 4 /* The 32-bit relative address from
                                    the byte following the relocation */
 
-#if !defined(_WIN64) && !defined(_WIN64_)
-void __divdi3();
-void __udivdi3();
-void __moddi3();
-void __umoddi3();
-#else
+#if defined(_WIN64) || defined(_WIN64_)
 #pragma function (floor)
 #pragma function (ceil)
 #pragma function (floorf)
 #pragma function (ceilf)
-
-int64_t __divdi3(int64_t a, int64_t b)
-{
-    return a / b;
-}
-
-uint64_t __udivdi3(uint64_t a, uint64_t b)
-{
-    return a / b;
-}
-
-int64_t __moddi3(int64_t a, int64_t b)
-{
-    return a % b;
-}
-
-uint64_t __umoddi3(uint64_t a, uint64_t b)
-{
-    return a % b;
-}
 #endif
 
 static SymbolMap target_sym_map[] = {

--- a/core/iwasm/aot/arch/aot_reloc_x86_64.c
+++ b/core/iwasm/aot/arch/aot_reloc_x86_64.c
@@ -22,6 +22,8 @@ void __umoddi3();
 #else
 #pragma function (floor)
 #pragma function (ceil)
+#pragma function (floorf)
+#pragma function (ceilf)
 
 int64_t __divdi3(int64_t a, int64_t b)
 {

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -1525,9 +1525,9 @@ wasm_runtime_get_app_addr_range(WASMModuleInstanceCommon *module_inst,
 
 bool
 wasm_runtime_get_native_addr_range(WASMModuleInstanceCommon *module_inst,
-                                   uint8_t *native_ptr,
-                                   uint8_t **p_native_start_addr,
-                                   uint8_t **p_native_end_addr)
+                                   uint8 *native_ptr,
+                                   uint8 **p_native_start_addr,
+                                   uint8 **p_native_end_addr)
 {
 #if WASM_ENABLE_INTERP != 0
     if (module_inst->module_type == Wasm_Module_Bytecode)

--- a/product-mini/platforms/windows/main.c
+++ b/product-mini/platforms/windows/main.c
@@ -194,7 +194,7 @@ module_reader_callback(const char *module_name, uint8 **p_buffer,
 
     snprintf(wasm_file_name, sz, format, module_search_path, module_name);
 
-    *p_buffer = (uint8_t *)bh_read_file_to_buffer(wasm_file_name, p_size);
+    *p_buffer = (uint8 *)bh_read_file_to_buffer(wasm_file_name, p_size);
 
     wasm_runtime_free(wasm_file_name);
     return *p_buffer != NULL;


### PR DESCRIPTION
This fixes #531 and implements the missing functions that were patched out in PR #322. Allows AoT to work on Windows.