### PR TITLE
Adapt AssemblyScript's new/pin/unpin APIs(0.18).

### DIFF
--- a/assembly-script/package.json
+++ b/assembly-script/package.json
@@ -5,16 +5,16 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build:request_handler": "asc samples/request_handler.ts -b build/request_handler.wasm -t build/request_handler.wat --sourceMap --optimize --use abort=",
-    "build:request_sender": "asc samples/request_sender.ts -b build/request_sender.wasm -t build/request_sender.wat --sourceMap --optimize --use abort=",
-    "build:timer": "asc samples/timer.ts -b build/timer.wasm -t build/timer.wat --sourceMap --optimize --use abort=",
-    "build:publisher": "asc samples/event_publisher.ts -b build/event_publisher.wasm -t build/event_publisher.wat --sourceMap --optimize --use abort=",
-    "build:subscriber": "asc samples/event_subscriber.ts -b build/event_subscriber.wasm -t build/event_subscriber.wat --sourceMap --optimize --use abort=",
+    "build:request_handler": "asc samples/request_handler.ts -b build/request_handler.wasm -t build/request_handler.wat --sourceMap --optimize --exportRuntime --use abort=",
+    "build:request_sender": "asc samples/request_sender.ts -b build/request_sender.wasm -t build/request_sender.wat --sourceMap --optimize --exportRuntime --use abort=",
+    "build:timer": "asc samples/timer.ts -b build/timer.wasm -t build/timer.wat --sourceMap --optimize --exportRuntime --use abort=",
+    "build:publisher": "asc samples/event_publisher.ts -b build/event_publisher.wasm -t build/event_publisher.wat --sourceMap --optimize --exportRuntime --use abort=",
+    "build:subscriber": "asc samples/event_subscriber.ts -b build/event_subscriber.wasm -t build/event_subscriber.wat --sourceMap --optimize --exportRuntime --use abort=",
     "build:all": "npm run build:request_handler; npm run build:request_sender; npm run build:timer; npm run build:subscriber; npm run build:publisher"
   },
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "assemblyscript": "^0.17.4"
+    "assemblyscript": "^0.18.15"
   }
 }

--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -1743,7 +1743,7 @@ load_from_sections(AOTModule *module, AOTSection *sections,
                     export_tmp = module->exports;
                     for (j = 0; j < module->export_count; j++, export_tmp++) {
                         if ((export_tmp->kind == EXPORT_KIND_FUNC)
-                            && (!strcmp(export_tmp->name, "__retain"))) {
+                            && (!strcmp(export_tmp->name, "__pin"))) {
                             func_index = export_tmp->index
                                             - module->import_func_count;
                             func_type_index =
@@ -1771,7 +1771,7 @@ load_from_sections(AOTModule *module, AOTSection *sections,
                 }
             }
             else if ((!strcmp(exports[i].name, "free"))
-                     || (!strcmp(exports[i].name, "__release"))) {
+                     || (!strcmp(exports[i].name, "__unpin"))) {
                 func_index = exports[i].index - module->import_func_count;
                 func_type_index = module->func_type_indexes[func_index];
                 func_type = module->func_types[func_type_index];

--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -1743,7 +1743,8 @@ load_from_sections(AOTModule *module, AOTSection *sections,
                     export_tmp = module->exports;
                     for (j = 0; j < module->export_count; j++, export_tmp++) {
                         if ((export_tmp->kind == EXPORT_KIND_FUNC)
-                            && (!strcmp(export_tmp->name, "__pin"))) {
+                            && (!strcmp(export_tmp->name, "__retain")
+                                || !strcmp(export_tmp->name, "__pin"))) {
                             func_index = export_tmp->index
                                             - module->import_func_count;
                             func_type_index =
@@ -1771,6 +1772,7 @@ load_from_sections(AOTModule *module, AOTSection *sections,
                 }
             }
             else if ((!strcmp(exports[i].name, "free"))
+                     || (!strcmp(exports[i].name, "__release"))
                      || (!strcmp(exports[i].name, "__unpin"))) {
                 func_index = exports[i].index - module->import_func_count;
                 func_type_index = module->func_type_indexes[func_index];

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -1575,7 +1575,7 @@ aot_module_free(AOTModuleInstance *module_inst, uint32 ptr)
             }
             free_func =
                 aot_lookup_function(module_inst, free_func_name, "(i)i");
-            if (!free_func)
+            if (!free_func && module->retain_func_index != (uint32)-1)
                 free_func = aot_lookup_function(module_inst, "__unpin", "(i)i");
 
             bh_assert(free_func);

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -1501,7 +1501,9 @@ aot_module_malloc(AOTModuleInstance *module_inst, uint32 size,
             malloc_func_name = "__new";
             malloc_func_sig = "(ii)i";
             retain_func =
-                aot_lookup_function(module_inst, "__pin", "(i)i");
+                aot_lookup_function(module_inst, "__retain", "(i)i");
+            if (!retain_func)
+                retain_func = aot_lookup_function(module_inst, "__pin", "(i)i");
             bh_assert(retain_func);
         }
         else {
@@ -1566,13 +1568,15 @@ aot_module_free(AOTModuleInstance *module_inst, uint32 ptr)
             char *free_func_name;
 
             if (module->retain_func_index != (uint32)-1) {
-                free_func_name = "__unpin";
+                free_func_name = "__release";
             }
             else {
                 free_func_name = "free";
             }
             free_func =
                 aot_lookup_function(module_inst, free_func_name, "(i)i");
+            if (!free_func)
+                free_func = aot_lookup_function(module_inst, "__unpin", "(i)i");
 
             bh_assert(free_func);
             execute_free_function(module_inst, free_func, ptr);

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -1501,7 +1501,7 @@ aot_module_malloc(AOTModuleInstance *module_inst, uint32 size,
             malloc_func_name = "__new";
             malloc_func_sig = "(ii)i";
             retain_func =
-                aot_lookup_function(module_inst, "__retain", "(i)i");
+                aot_lookup_function(module_inst, "__pin", "(i)i");
             bh_assert(retain_func);
         }
         else {
@@ -1566,7 +1566,7 @@ aot_module_free(AOTModuleInstance *module_inst, uint32 ptr)
             char *free_func_name;
 
             if (module->retain_func_index != (uint32)-1) {
-                free_func_name = "__release";
+                free_func_name = "__unpin";
             }
             else {
                 free_func_name = "free";

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -2789,7 +2789,8 @@ load_from_sections(WASMModule *module, WASMSection *sections,
                     export_tmp = module->exports;
                     for (j = 0; j < module->export_count; j++, export_tmp++) {
                         if ((export_tmp->kind == EXPORT_KIND_FUNC)
-                            && (!strcmp(export_tmp->name, "__pin"))
+                            && (!strcmp(export_tmp->name, "__retain")
+                                || (!strcmp(export_tmp->name, "__pin")))
                             && (export_tmp->index
                                 >= module->import_function_count)) {
                             func_index = export_tmp->index
@@ -2818,6 +2819,7 @@ load_from_sections(WASMModule *module, WASMSection *sections,
                 }
             }
             else if (((!strcmp(export->name, "free"))
+                      || (!strcmp(export->name, "__release"))
                       || (!strcmp(export->name, "__unpin")))
                      && export->index >= module->import_function_count) {
                 func_index = export->index - module->import_function_count;

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -2768,7 +2768,7 @@ load_from_sections(WASMModule *module, WASMSection *sections,
             }
             else if (!strcmp(export->name, "__new")
                      && export->index >= module->import_function_count) {
-                /* __new && __retain for AssemblyScript */
+                /* __new && __pin for AssemblyScript */
                 func_index = export->index - module->import_function_count;
                 func_type = module->functions[func_index]->func_type;
                 if (func_type->param_count == 2
@@ -2789,7 +2789,7 @@ load_from_sections(WASMModule *module, WASMSection *sections,
                     export_tmp = module->exports;
                     for (j = 0; j < module->export_count; j++, export_tmp++) {
                         if ((export_tmp->kind == EXPORT_KIND_FUNC)
-                            && (!strcmp(export_tmp->name, "__retain"))
+                            && (!strcmp(export_tmp->name, "__pin"))
                             && (export_tmp->index
                                 >= module->import_function_count)) {
                             func_index = export_tmp->index
@@ -2818,7 +2818,7 @@ load_from_sections(WASMModule *module, WASMSection *sections,
                 }
             }
             else if (((!strcmp(export->name, "free"))
-                      || (!strcmp(export->name, "__release")))
+                      || (!strcmp(export->name, "__unpin")))
                      && export->index >= module->import_function_count) {
                 func_index = export->index - module->import_function_count;
                 func_type = module->functions[func_index]->func_type;

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -1664,7 +1664,7 @@ load_from_sections(WASMModule *module, WASMSection *sections,
             }
             else if (!strcmp(export->name, "__new")
                      && export->index >= module->import_function_count) {
-                /* __new && __retain for AssemblyScript */
+                /* __new && __pin for AssemblyScript */
                 func_index = export->index - module->import_function_count;
                 func_type = module->functions[func_index]->func_type;
                 if (func_type->param_count == 2
@@ -1685,7 +1685,7 @@ load_from_sections(WASMModule *module, WASMSection *sections,
                     export_tmp = module->exports;
                     for (j = 0; j < module->export_count; j++, export_tmp++) {
                         if ((export_tmp->kind == EXPORT_KIND_FUNC)
-                            && (!strcmp(export_tmp->name, "__retain"))
+                            && (!strcmp(export_tmp->name, "__pin"))
                             && (export_tmp->index
                                 >= module->import_function_count)) {
                             func_index = export_tmp->index
@@ -1714,7 +1714,7 @@ load_from_sections(WASMModule *module, WASMSection *sections,
                 }
             }
             else if (((!strcmp(export->name, "free"))
-                      || (!strcmp(export->name, "__release")))
+                      || (!strcmp(export->name, "__unpin")))
                      && export->index >= module->import_function_count) {
                 func_index = export->index - module->import_function_count;
                 func_type = module->functions[func_index]->func_type;

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -1685,7 +1685,8 @@ load_from_sections(WASMModule *module, WASMSection *sections,
                     export_tmp = module->exports;
                     for (j = 0; j < module->export_count; j++, export_tmp++) {
                         if ((export_tmp->kind == EXPORT_KIND_FUNC)
-                            && (!strcmp(export_tmp->name, "__pin"))
+                            && (!strcmp(export_tmp->name, "__retain")
+                                || !strcmp(export_tmp->name, "__pin"))
                             && (export_tmp->index
                                 >= module->import_function_count)) {
                             func_index = export_tmp->index
@@ -1714,6 +1715,7 @@ load_from_sections(WASMModule *module, WASMSection *sections,
                 }
             }
             else if (((!strcmp(export->name, "free"))
+                      || (!strcmp(export->name, "__release"))
                       || (!strcmp(export->name, "__unpin")))
                      && export->index >= module->import_function_count) {
                 func_index = export->index - module->import_function_count;


### PR DESCRIPTION
Hi, In AssemblyScript 0.17, there exist a memory leak problem which I had opened a [issue](https://github.com/bytecodealliance/wasm-micro-runtime/issues/542) which caused by AssemblyScript lib, and this problem is solved in AssemblyScript 0.18. But I noticed that runtime is using the [deprecated api](https://www.assemblyscript.org/runtime.html), so I update it to adapt AssemblyScript 0.18 and have tested it in my wasm app.

ps: [AssemblyScript 0.18 GC API Doc](https://www.assemblyscript.org/garbage-collection.html#runtime-interface)