### PR TITLE
refine the aot call function procedure and fix timer overflow issue

### DIFF
--- a/core/config.h
+++ b/core/config.h
@@ -267,6 +267,9 @@
    stack overflow exception if the guard boudary is reached */
 #define RESERVED_BYTES_TO_NATIVE_STACK_BOUNDARY (512)
 
+/* Guard page count for stack overflow check with hardware trap */
+#define STACK_OVERFLOW_CHECK_GUARD_PAGE_COUNT 3
+
 /* Default wasm block address cache size and conflict list size */
 #ifndef BLOCK_ADDR_CACHE_SIZE
 #define BLOCK_ADDR_CACHE_SIZE 64

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -1122,9 +1122,6 @@ wasm_runtime_call_wasm(WASMExecEnv *exec_env,
         return false;
     }
 
-    /* set thread handle and stack boundary */
-    wasm_exec_env_set_thread_info(exec_env);
-
 #if WASM_ENABLE_REF_TYPES != 0
     wasm_runtime_prepare_call_function(exec_env, function);
 #endif

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1647,6 +1647,10 @@ wasm_call_function(WASMExecEnv *exec_env,
                    unsigned argc, uint32 argv[])
 {
     WASMModuleInstance *module_inst = (WASMModuleInstance*)exec_env->module_inst;
+
+    /* set thread handle and stack boundary */
+    wasm_exec_env_set_thread_info(exec_env);
+
     wasm_interp_call_wasm(module_inst, exec_env, function, argc, argv);
     (void)clear_wasi_proc_exit_exception(module_inst);
     return !wasm_get_exception(module_inst) ? true : false;
@@ -1674,8 +1678,6 @@ wasm_create_exec_env_and_call_function(WASMModuleInstance *module_inst,
             return false;
         }
 
-        /* set thread handle and stack boundary */
-        wasm_exec_env_set_thread_info(exec_env);
 #if WASM_ENABLE_THREAD_MGR != 0
     }
 #endif

--- a/core/shared/platform/android/platform_init.c
+++ b/core/shared/platform/android/platform_init.c
@@ -20,6 +20,9 @@ bh_platform_init()
 void
 bh_platform_destroy()
 {
+#ifdef OS_ENABLE_HW_BOUND_CHECK
+    os_thread_destroy_stack_guard_pages();
+#endif
 }
 
 int os_printf(const char *fmt, ...)

--- a/core/shared/platform/android/platform_internal.h
+++ b/core/shared/platform/android/platform_internal.h
@@ -56,6 +56,8 @@ typedef pthread_mutex_t korp_mutex;
 typedef pthread_cond_t korp_cond;
 typedef pthread_t korp_thread;
 
+#define os_thread_local_attribute __thread
+
 #if WASM_DISABLE_HW_BOUND_CHECK == 0
 #if defined(BUILD_TARGET_X86_64) \
     || defined(BUILD_TARGET_AMD_64) \
@@ -65,8 +67,6 @@ typedef pthread_t korp_thread;
 
 #define OS_ENABLE_HW_BOUND_CHECK
 
-#define os_thread_local_attribute __thread
-
 typedef jmp_buf korp_jmpbuf;
 
 #define os_setjmp setjmp
@@ -74,6 +74,10 @@ typedef jmp_buf korp_jmpbuf;
 #define os_alloca alloca
 
 #define os_getpagesize getpagesize
+
+bool os_thread_init_stack_guard_pages();
+
+void os_thread_destroy_stack_guard_pages();
 
 typedef void (*os_signal_handler)(void *sig_addr);
 

--- a/core/shared/platform/darwin/platform_init.c
+++ b/core/shared/platform/darwin/platform_init.c
@@ -14,6 +14,9 @@ bh_platform_init()
 void
 bh_platform_destroy()
 {
+#ifdef OS_ENABLE_HW_BOUND_CHECK
+    os_thread_destroy_stack_guard_pages();
+#endif
 }
 
 int

--- a/core/shared/platform/darwin/platform_internal.h
+++ b/core/shared/platform/darwin/platform_internal.h
@@ -57,6 +57,8 @@ typedef pthread_mutex_t korp_mutex;
 typedef pthread_cond_t korp_cond;
 typedef pthread_t korp_thread;
 
+#define os_thread_local_attribute __thread
+
 #if WASM_DISABLE_HW_BOUND_CHECK == 0
 #if defined(BUILD_TARGET_X86_64) \
     || defined(BUILD_TARGET_AMD_64) \
@@ -66,8 +68,6 @@ typedef pthread_t korp_thread;
 
 #define OS_ENABLE_HW_BOUND_CHECK
 
-#define os_thread_local_attribute __thread
-
 typedef jmp_buf korp_jmpbuf;
 
 #define os_setjmp setjmp
@@ -75,6 +75,10 @@ typedef jmp_buf korp_jmpbuf;
 #define os_alloca alloca
 
 #define os_getpagesize getpagesize
+
+bool os_thread_init_stack_guard_pages();
+
+void os_thread_destroy_stack_guard_pages();
 
 typedef void (*os_signal_handler)(void *sig_addr);
 

--- a/core/shared/platform/linux/platform_init.c
+++ b/core/shared/platform/linux/platform_init.c
@@ -14,6 +14,9 @@ bh_platform_init()
 void
 bh_platform_destroy()
 {
+#ifdef OS_ENABLE_HW_BOUND_CHECK
+    os_thread_destroy_stack_guard_pages();
+#endif
 }
 
 int

--- a/core/shared/platform/linux/platform_internal.h
+++ b/core/shared/platform/linux/platform_internal.h
@@ -56,6 +56,8 @@ typedef pthread_mutex_t korp_mutex;
 typedef pthread_cond_t korp_cond;
 typedef pthread_t korp_thread;
 
+#define os_thread_local_attribute __thread
+
 #if WASM_DISABLE_HW_BOUND_CHECK == 0
 #if defined(BUILD_TARGET_X86_64) \
     || defined(BUILD_TARGET_AMD_64) \
@@ -65,8 +67,6 @@ typedef pthread_t korp_thread;
 
 #define OS_ENABLE_HW_BOUND_CHECK
 
-#define os_thread_local_attribute __thread
-
 typedef jmp_buf korp_jmpbuf;
 
 #define os_setjmp setjmp
@@ -74,6 +74,10 @@ typedef jmp_buf korp_jmpbuf;
 #define os_alloca alloca
 
 #define os_getpagesize getpagesize
+
+bool os_thread_init_stack_guard_pages();
+
+void os_thread_destroy_stack_guard_pages();
 
 typedef void (*os_signal_handler)(void *sig_addr);
 

--- a/core/shared/platform/vxworks/platform_init.c
+++ b/core/shared/platform/vxworks/platform_init.c
@@ -14,6 +14,9 @@ bh_platform_init()
 void
 bh_platform_destroy()
 {
+#ifdef OS_ENABLE_HW_BOUND_CHECK
+    os_thread_destroy_stack_guard_pages();
+#endif
 }
 
 int

--- a/core/shared/platform/vxworks/platform_internal.h
+++ b/core/shared/platform/vxworks/platform_internal.h
@@ -55,6 +55,8 @@ typedef pthread_mutex_t korp_mutex;
 typedef pthread_cond_t korp_cond;
 typedef pthread_t korp_thread;
 
+#define os_thread_local_attribute __thread
+
 #if WASM_DISABLE_HW_BOUND_CHECK == 0
 #if defined(BUILD_TARGET_X86_64) \
     || defined(BUILD_TARGET_AMD_64) \
@@ -64,8 +66,6 @@ typedef pthread_t korp_thread;
 
 #define OS_ENABLE_HW_BOUND_CHECK
 
-#define os_thread_local_attribute __thread
-
 typedef jmp_buf korp_jmpbuf;
 
 #define os_setjmp setjmp
@@ -73,6 +73,10 @@ typedef jmp_buf korp_jmpbuf;
 #define os_alloca alloca
 
 #define os_getpagesize getpagesize
+
+bool os_thread_init_stack_guard_pages();
+
+void os_thread_destroy_stack_guard_pages();
 
 typedef void (*os_signal_handler)(void *sig_addr);
 

--- a/core/shared/platform/zephyr/zephyr_time.c
+++ b/core/shared/platform/zephyr/zephyr_time.c
@@ -8,6 +8,6 @@
 uint64
 os_time_get_boot_microsecond()
 {
-    return k_uptime_get_32() * 1000;
+    return k_uptime_get() * 1000;
 }
 


### PR DESCRIPTION
1. Refine the aot call function procedure

2. fix timer overflow issue on zephyr platform

3. move wasm_exec_env_set_thread_info into lower layer