### PR TITLE
fix wasm-c-api sample AOT mode.

### DIFF
--- a/samples/wasm-c-api/CMakeLists.txt
+++ b/samples/wasm-c-api/CMakeLists.txt
@@ -124,13 +124,13 @@ foreach(EX ${EXAMPLES})
   if(${WAMR_BUILD_AOT} EQUAL 1)
     if(EXISTS ${WAMRC})
       add_custom_target(${EX}_AOT ALL
-		  COMMAND ${WAMRC} -o ${PROJECT_BINARY_DIR}/${EX}.aot
-			${PROJECT_BINARY_DIR}/${EX}.wasm
-		  DEPENDS ${PROJECT_BINARY_DIR}/${EX}.wasm
-          BYPRODUCTS ${PROJECT_BINARY_DIR}/${EX}.aot
-          VERBATIM
-          SOURCES ${SRC}
-          COMMENT "generate a aot file ${PROJECT_BINARY_DIR}/${EX}.aot"
+        COMMAND ${WAMRC} -o ${PROJECT_BINARY_DIR}/${EX}.aot
+          ${PROJECT_BINARY_DIR}/${EX}.wasm
+        DEPENDS ${PROJECT_BINARY_DIR}/${EX}.wasm
+        BYPRODUCTS ${PROJECT_BINARY_DIR}/${EX}.aot
+        VERBATIM
+        SOURCES ${SRC}
+        COMMENT "generate a aot file ${PROJECT_BINARY_DIR}/${EX}.aot"
       )
     endif()
   endif()

--- a/samples/wasm-c-api/CMakeLists.txt
+++ b/samples/wasm-c-api/CMakeLists.txt
@@ -31,11 +31,7 @@ if(NOT DEFINED WAMR_BUILD_INTERP)
 endif()
 
 if(NOT DEFINED WAMR_BUILD_AOT)
-  set(WAMR_BUILD_AOT 0)
-endif()
-
-if(${WAMR_BUILD_AOT} EQUAL 1)
-  add_definitions(-DWAMR_BUILD_AOT)
+  set(WAMR_BUILD_AOT 1)
 endif()
 
 if(NOT DEFINED WAMR_BUILD_JIT)

--- a/samples/wasm-c-api/CMakeLists.txt
+++ b/samples/wasm-c-api/CMakeLists.txt
@@ -31,7 +31,11 @@ if(NOT DEFINED WAMR_BUILD_INTERP)
 endif()
 
 if(NOT DEFINED WAMR_BUILD_AOT)
-  set(WAMR_BUILD_AOT 1)
+  set(WAMR_BUILD_AOT 0)
+endif()
+
+if(${WAMR_BUILD_AOT} EQUAL 1)
+  add_definitions(-DWAMR_BUILD_AOT)
 endif()
 
 if(NOT DEFINED WAMR_BUILD_JIT)
@@ -119,6 +123,21 @@ foreach(EX ${EXAMPLES})
     VERBATIM
     SOURCES ${SRC}
   )
+
+  # generate .aot file
+  if(${WAMR_BUILD_AOT} EQUAL 1)
+    if(EXISTS ${WAMRC})
+      add_custom_target(${EX}_AOT ALL
+		  COMMAND ${WAMRC} -o ${PROJECT_BINARY_DIR}/${EX}.aot
+			${PROJECT_BINARY_DIR}/${EX}.wasm
+		  DEPENDS ${PROJECT_BINARY_DIR}/${EX}.wasm
+          BYPRODUCTS ${PROJECT_BINARY_DIR}/${EX}.aot
+          VERBATIM
+          SOURCES ${SRC}
+          COMMENT "generate a aot file ${PROJECT_BINARY_DIR}/${EX}.aot"
+      )
+    endif()
+  endif()
 endforeach()
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/samples/wasm-c-api/src/callback.c
+++ b/samples/wasm-c-api/src/callback.c
@@ -68,7 +68,7 @@ int main(int argc, const char* argv[]) {
 
   // Load binary.
   printf("Loading binary...\n");
-#ifdef WAMR_BUILD_AOT
+#if WASM_ENABLE_AOT != 0 && WASM_ENABLE_INTERP == 0
   FILE* file = fopen("callback.aot", "rb");
 #else
   FILE* file = fopen("callback.wasm", "rb");

--- a/samples/wasm-c-api/src/callback.c
+++ b/samples/wasm-c-api/src/callback.c
@@ -68,7 +68,11 @@ int main(int argc, const char* argv[]) {
 
   // Load binary.
   printf("Loading binary...\n");
+#ifdef WAMR_BUILD_AOT
+  FILE* file = fopen("callback.aot", "rb");
+#else
   FILE* file = fopen("callback.wasm", "rb");
+#endif
   if (!file) {
     printf("> Error loading module!\n");
     return 1;

--- a/samples/wasm-c-api/src/global.c
+++ b/samples/wasm-c-api/src/global.c
@@ -53,7 +53,7 @@ int main(int argc, const char* argv[]) {
 
   // Load binary.
   printf("Loading binary...\n");
-#ifdef WAMR_BUILD_AOT
+#if WASM_ENABLE_AOT != 0 && WASM_ENABLE_INTERP == 0
   FILE* file = fopen("global.aot", "rb");
 #else
   FILE* file = fopen("global.wasm", "rb");

--- a/samples/wasm-c-api/src/global.c
+++ b/samples/wasm-c-api/src/global.c
@@ -53,7 +53,11 @@ int main(int argc, const char* argv[]) {
 
   // Load binary.
   printf("Loading binary...\n");
+#ifdef WAMR_BUILD_AOT
+  FILE* file = fopen("global.aot", "rb");
+#else
   FILE* file = fopen("global.wasm", "rb");
+#endif
   if (!file) {
     printf("> Error loading module!\n");
     return 1;

--- a/samples/wasm-c-api/src/hello.c
+++ b/samples/wasm-c-api/src/hello.c
@@ -25,7 +25,7 @@ int main(int argc, const char* argv[]) {
 
   // Load binary.
   printf("Loading binary...\n");
-#ifdef WAMR_BUILD_AOT
+#if WASM_ENABLE_AOT != 0 && WASM_ENABLE_INTERP == 0
   FILE* file = fopen("hello.aot", "rb");
 #else
   FILE* file = fopen("hello.wasm", "rb");

--- a/samples/wasm-c-api/src/hello.c
+++ b/samples/wasm-c-api/src/hello.c
@@ -25,7 +25,11 @@ int main(int argc, const char* argv[]) {
 
   // Load binary.
   printf("Loading binary...\n");
+#ifdef WAMR_BUILD_AOT
+  FILE* file = fopen("hello.aot", "rb");
+#else
   FILE* file = fopen("hello.wasm", "rb");
+#endif
   if (!file) {
     printf("> Error loading module!\n");
     return 1;

--- a/samples/wasm-c-api/src/reflect.c
+++ b/samples/wasm-c-api/src/reflect.c
@@ -90,7 +90,7 @@ int main(int argc, const char* argv[]) {
 
   // Load binary.
   printf("Loading binary...\n");
-#ifdef WAMR_BUILD_AOT
+#if WASM_ENABLE_AOT != 0 && WASM_ENABLE_INTERP == 0
   FILE* file = fopen("reflect.aot", "rb");
 #else
   FILE* file = fopen("reflect.wasm", "rb");

--- a/samples/wasm-c-api/src/reflect.c
+++ b/samples/wasm-c-api/src/reflect.c
@@ -90,7 +90,11 @@ int main(int argc, const char* argv[]) {
 
   // Load binary.
   printf("Loading binary...\n");
+#ifdef WAMR_BUILD_AOT
+  FILE* file = fopen("reflect.aot", "rb");
+#else
   FILE* file = fopen("reflect.wasm", "rb");
+#endif
   if (!file) {
     printf("> Error loading module!\n");
     return 1;

--- a/samples/wasm-c-api/src/trap.c
+++ b/samples/wasm-c-api/src/trap.c
@@ -27,7 +27,11 @@ int main(int argc, const char* argv[]) {
 
   // Load binary.
   printf("Loading binary...\n");
+#ifdef WAMR_BUILD_AOT
+  FILE* file = fopen("trap.aot", "rb");
+#else
   FILE* file = fopen("trap.wasm", "rb");
+#endif
   if (!file) {
     printf("> Error loading module!\n");
     return 1;

--- a/samples/wasm-c-api/src/trap.c
+++ b/samples/wasm-c-api/src/trap.c
@@ -27,7 +27,7 @@ int main(int argc, const char* argv[]) {
 
   // Load binary.
   printf("Loading binary...\n");
-#ifdef WAMR_BUILD_AOT
+#if WASM_ENABLE_AOT != 0 && WASM_ENABLE_INTERP == 0
   FILE* file = fopen("trap.aot", "rb");
 #else
   FILE* file = fopen("trap.wasm", "rb");


### PR DESCRIPTION
Make the AOT mode works, as it shows in the README.
https://github.com/bytecodealliance/wasm-micro-runtime/tree/main/samples/wasm-c-api#readme

I found `generate .aot file` is removed in this commit, but I don't know why, maybe it's removed by accident?
https://github.com/bytecodealliance/wasm-micro-runtime/commit/4787b150b86ff1153559fbcc99c45df17a64a507#diff-cf97a015de62a1053255010d90c88d2e908ce26c9413b0636443fc1ebaf26da5L103