### PR TITLE
Allow calling pure C functions directly

### DIFF
--- a/core/iwasm/common/wasm_native.h
+++ b/core/iwasm/common/wasm_native.h
@@ -52,7 +52,7 @@ wasm_native_lookup_libc_builtin_global(const char *module_name,
 void*
 wasm_native_resolve_symbol(const char *module_name, const char *field_name,
                            const WASMType *func_type, const char **p_signature,
-                           void **p_attachment, bool *p_call_conv_raw);
+                           void **p_attachment, bool *p_call_conv_raw, bool *p_use_wrapper);
 
 bool
 wasm_native_register_natives(const char *module_name,

--- a/core/iwasm/include/lib_export.h
+++ b/core/iwasm/include/lib_export.h
@@ -19,6 +19,8 @@ typedef struct NativeSymbol {
     /* attachment which can be retrieved in native API by
        calling wasm_runtime_get_function_attachment(exec_env) */
     void *attachment;
+    /* prepend wasm_exec_env_t as first argument, todo: merge with WASMFunctionImport */
+    bool use_wrapper; //  prepend wasm_exec_env_t as first argument
 } NativeSymbol;
 
 #define EXPORT_WASM_API(symbol)  {#symbol, (void*)symbol, NULL, NULL}

--- a/core/iwasm/interpreter/wasm.h
+++ b/core/iwasm/interpreter/wasm.h
@@ -182,6 +182,9 @@ typedef struct WASMFunctionImport {
     /* attachment */
     void *attachment;
     bool call_conv_raw;
+    /* prepend wasm_exec_env_t as first argument, todo: merge with NativeSymbol */
+    bool use_wrapper; 
+
 #if WASM_ENABLE_MULTI_MODULE != 0
     WASMModule *import_module;
     WASMFunction *import_func_linked;

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -1058,6 +1058,8 @@ load_function_import(const uint8 **p_buf, const uint8 *buf_end,
     void *linked_attachment = NULL;
     bool linked_call_conv_raw = false;
     bool is_native_symbol = false;
+    bool linked_use_wrapper = true;
+
 
 
     CHECK_BUF(p, p_end, 1);
@@ -1083,7 +1085,9 @@ load_function_import(const uint8 **p_buf, const uint8 *buf_end,
                                              declare_func_type,
                                              &linked_signature,
                                              &linked_attachment,
-                                             &linked_call_conv_raw);
+                                             &linked_call_conv_raw,
+                                             &linked_use_wrapper
+                                             );
     if (linked_func) {
         is_native_symbol = true;
     }
@@ -1112,6 +1116,7 @@ load_function_import(const uint8 **p_buf, const uint8 *buf_end,
     function->signature = linked_signature;
     function->attachment = linked_attachment;
     function->call_conv_raw = linked_call_conv_raw;
+    function->use_wrapper = linked_use_wrapper;
 #if WASM_ENABLE_MULTI_MODULE != 0
     function->import_module = is_native_symbol ? NULL : sub_module;
     function->import_func_linked = is_native_symbol ? NULL : linked_func;

--- a/core/shared/platform/common/posix/posix_thread.c
+++ b/core/shared/platform/common/posix/posix_thread.c
@@ -334,8 +334,8 @@ static os_thread_local_attribute uint8 *sigalt_stack_base_addr;
 #pragma clang optimize off
 #endif
 #if defined(__GNUC__)
-#pragma GCC push_options
-#pragma GCC optimize("O0")
+//#pragma GCC push_options
+//#pragma GCC optimize("O0")
 __attribute__((no_sanitize_address))
 #endif
 static uint32
@@ -355,7 +355,7 @@ touch_pages(uint8 *stack_min_addr, uint32 page_size)
     return sum;
 }
 #if defined(__GNUC__)
-#pragma GCC pop_options
+//#pragma GCC pop_options
 #endif
 #if defined(__clang__)
 #pragma clang optimize on

--- a/core/shared/utils/runtime_timer.c
+++ b/core/shared/utils/runtime_timer.c
@@ -18,7 +18,7 @@ typedef struct _app_timer {
     uint64 expiry;
     bool is_periodic;
 } app_timer_t;
-
+//#pragma "-Wno-typedef-redefinition"
 typedef struct _timer_ctx {
     app_timer_t *app_timers;
     app_timer_t *idle_timers;


### PR DESCRIPTION
 Added use_wrapper to structure NativeSymbol and corresponding methods to enable linking to pure C functions,  without prepending wasm_exec_env_t as first argument

example:
```
int square(int a) {
	return a * a;
}

static NativeSymbol native_symbols[] = {
				{       "square",  (void *) square,  "(i)i", NULL, /*use_wrapper*/ false}
};
```