### PR TITLE
sgx: fix the build warning

### DIFF
--- a/product-mini/platforms/linux-sgx/enclave-sample/App/App.cpp
+++ b/product-mini/platforms/linux-sgx/enclave-sample/App/App.cpp
@@ -97,11 +97,12 @@ enclave_init(sgx_enclave_id_t *p_eid)
      */
     /* try to get the token saved in $HOME */
     home_dir = getpwuid(getuid())->pw_dir;
+    size_t home_dir_len = home_dir ? strlen(home_dir) : 0;
 
     if (home_dir != NULL &&
-        (strlen(home_dir) + strlen("/") + sizeof(TOKEN_FILENAME) + 1) <= MAX_PATH) {
+        home_dir_len <= MAX_PATH - 1 - sizeof(TOKEN_FILENAME) - strlen("/")) {
         /* compose the token path */
-        strncpy(token_path, home_dir, strlen(home_dir));
+        strncpy(token_path, home_dir, MAX_PATH);
         strncat(token_path, "/", strlen("/"));
         strncat(token_path, TOKEN_FILENAME, sizeof(TOKEN_FILENAME) + 1);
     }
@@ -756,6 +757,7 @@ wamr_pal_init(const struct wamr_pal_attr *args)
         std::cout << "Fail to initialize enclave." << std::endl;
         return 1;
     }
+    return 0;
 }
 
 int


### PR DESCRIPTION
fix the warnings as below:
```

App/App.cpp: In function ‘int wamr_pal_init(const wamr_pal_attr*)’:
App/App.cpp:759:1: warning: control reaches end of non-void function [-Wreturn-type]
  759 | }
      | ^
In file included from /usr/include/string.h:495,
                 from App/App.cpp:9:
In function ‘char* strncpy(char*, const char*, size_t)’,
    inlined from ‘int enclave_init(sgx_enclave_id_t*)’ at App/App.cpp:104:16:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:34: warning: ‘char* __builtin___strncpy_chk(char*, const char*, long unsigned int, long unsigned int)’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
App/App.cpp: In function ‘int enclave_init(sgx_enclave_id_t*)’:
App/App.cpp:102:16: note: length computed here
  102 |         (strlen(home_dir) + strlen("/") + sizeof(TOKEN_FILENAME) + 1) <= MAX_PATH) {
      |          ~~~~~~^~~~~~~~~~
```

After
```
platforms/linux-sgx/enclave-sample ‹main*› » make                                                                                                                      
GEN  =>  App/Enclave_u.c
CC   <=  App/Enclave_u.c
CXX  <=  App/App.cpp
CP libvmlib_untrusted.a  <=  ../build/libvmlib_untrusted.a
LINK =>  iwasm
GEN  =>  Enclave/Enclave_t.c
CC   <=  Enclave/Enclave_t.c
CXX  <=  Enclave/Enclave.cpp
CP libvmlib.a  <=  ../build/libvmlib.a
LINK =>  enclave.so
<!-- Please refer to User's Guide for the explanation of each field -->
<EnclaveConfiguration>
    <ProdID>0</ProdID>
    <ISVSVN>0</ISVSVN>
    <StackMaxSize>0x100000</StackMaxSize>
    <HeapMaxSize>0x2000000</HeapMaxSize>
    <ReservedMemMaxSize>0x1000000</ReservedMemMaxSize>
    <ReservedMemExecutable>1</ReservedMemExecutable>
    <TCSNum>10</TCSNum>
    <TCSPolicy>1</TCSPolicy>
    <DisableDebug>0</DisableDebug>
    <MiscSelect>0</MiscSelect>
    <MiscMask>0xFFFFFFFF</MiscMask>
</EnclaveConfiguration>
tcs_num 10, tcs_max_num 10, tcs_min_pool 1
The required memory is 72093696B.
The required memory is 0x44c1000, 70404 KB.
Succeed.
SIGN =>  enclave.signed.so
```
Signed-off-by: LiFeng <lifeng68@huawei.com>