### PR TITLE
Fix compile warnings with arm-none-eabi-gcc 9.3.1

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -2300,7 +2300,7 @@ invoke_wasm_c_api_native(AOTModuleInstance *module_inst, void *func_ptr,
     }
     if (trap) {
         if (trap->message->data) {
-            snprintf(fmt, sizeof(fmt), "%%.%us", (uint32)trap->message->size);
+            snprintf(fmt, sizeof(fmt), "%%.%"PRIu32"s", (uint32)trap->message->size);
             snprintf(module_inst->cur_exception,
                      sizeof(module_inst->cur_exception),
                      fmt, trap->message->data);

--- a/core/iwasm/aot/arch/aot_reloc_thumb.c
+++ b/core/iwasm/aot/arch/aot_reloc_thumb.c
@@ -304,7 +304,7 @@ apply_relocation(AOTModule *module,
             if (error_buf != NULL)
                 snprintf(error_buf, error_buf_size,
                          "Load relocation section failed: "
-                         "invalid relocation type %d.",
+                         "invalid relocation type %"PRIu32".",
                          reloc_type);
             return false;
     }

--- a/core/iwasm/common/wasm_application.c
+++ b/core/iwasm/common/wasm_application.c
@@ -423,7 +423,7 @@ wasm_application_execute_func(WASMModuleInstanceCommon *module_inst,
         char *endptr = NULL;
         bh_assert(argv[i] != NULL);
         if (argv[i][0] == '\0') {
-            snprintf(buf, sizeof(buf), "invalid input argument %d", i);
+            snprintf(buf, sizeof(buf), "invalid input argument %"PRId32"", i);
             wasm_runtime_set_exception(module_inst, buf);
             goto fail;
         }
@@ -554,7 +554,7 @@ wasm_application_execute_func(WASMModuleInstanceCommon *module_inst,
                 break;
         }
         if (endptr && *endptr != '\0' && *endptr != '_') {
-            snprintf(buf, sizeof(buf), "invalid input argument %d: %s",
+            snprintf(buf, sizeof(buf), "invalid input argument %"PRId32": %s",
                      i, argv[i]);
             wasm_runtime_set_exception(module_inst, buf);
             goto fail;
@@ -573,7 +573,7 @@ wasm_application_execute_func(WASMModuleInstanceCommon *module_inst,
         switch (type->types[type->param_count + j]) {
             case VALUE_TYPE_I32:
             {
-                os_printf("0x%x:i32", argv1[k]);
+                os_printf("0x%"PRIx32":i32", argv1[k]);
                 k++;
                 break;
             }

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -3388,7 +3388,7 @@ wasm_interp_call_wasm(WASMModuleInstance *module_inst,
     if (argc != function->param_cell_num) {
         char buf[128];
         snprintf(buf, sizeof(buf),
-                 "invalid argument count %d, expected %d",
+                 "invalid argument count %"PRIu32", expected %d",
                  argc, function->param_cell_num);
         wasm_set_exception(module_inst, buf);
         return;

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -3456,7 +3456,7 @@ wasm_interp_call_wasm(WASMModuleInstance *module_inst,
     if (argc != function->param_cell_num) {
         char buf[128];
         snprintf(buf, sizeof(buf),
-                 "invalid argument count %d, expected %d",
+                 "invalid argument count %"PRIu32", expected %d",
                  argc, function->param_cell_num);
         wasm_set_exception(module_inst, buf);
         return;

--- a/core/iwasm/libraries/libc-builtin/libc_builtin_wrapper.c
+++ b/core/iwasm/libraries/libc-builtin/libc_builtin_wrapper.c
@@ -762,7 +762,7 @@ exit_wrapper(wasm_exec_env_t exec_env, int32 status)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     char buf[32];
-    snprintf(buf, sizeof(buf), "env.exit(%i)", status);
+    snprintf(buf, sizeof(buf), "env.exit(%"PRIi32")", status);
     wasm_runtime_set_exception(module_inst, buf);
 }
 
@@ -1015,7 +1015,7 @@ abort_wrapper(wasm_exec_env_t exec_env, int32 code)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     char buf[32];
-    snprintf(buf, sizeof(buf), "env.abort(%i)", code);
+    snprintf(buf, sizeof(buf), "env.abort(%"PRIi32")", code);
     wasm_runtime_set_exception(module_inst, buf);
 }
 
@@ -1024,7 +1024,7 @@ abortStackOverflow_wrapper(wasm_exec_env_t exec_env, int32 code)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     char buf[32];
-    snprintf(buf, sizeof(buf), "env.abortStackOverflow(%i)", code);
+    snprintf(buf, sizeof(buf), "env.abortStackOverflow(%"PRIi32")", code);
     wasm_runtime_set_exception(module_inst, buf);
 }
 
@@ -1033,7 +1033,7 @@ nullFunc_X_wrapper(wasm_exec_env_t exec_env, int32 code)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     char buf[32];
-    snprintf(buf, sizeof(buf), "env.nullFunc_X(%i)", code);
+    snprintf(buf, sizeof(buf), "env.nullFunc_X(%"PRIi32")", code);
     wasm_runtime_set_exception(module_inst, buf);
 }
 

--- a/core/shared/mem-alloc/ems/ems_alloc.c
+++ b/core/shared/mem-alloc/ems/ems_alloc.c
@@ -729,7 +729,7 @@ void
 gc_dump_heap_stats(gc_heap_t *heap)
 {
     os_printf("heap: %p, heap start: %p\n", heap, heap->base_addr);
-    os_printf("total free: %u, current: %u, highmark: %u\n",
+    os_printf("total free: %"PRIu32", current: %"PRIu32", highmark: %"PRIu32"\n",
               heap->total_free_size, heap->current_size, heap->highmark_size);
     os_printf("g_total_malloc=%lu, g_total_free=%lu, occupied=%lu\n",
               g_total_malloc, g_total_free, g_total_malloc - g_total_free);
@@ -772,7 +772,7 @@ gci_dump(gc_heap_t *heap)
             return;
         }
 
-        os_printf("#%d %08x %x %x %d %c %d\n",
+        os_printf("#%d %08"PRIx32" %x %x %d %c %"PRId32"\n",
                   i, (int32)((char*) cur - (char*) heap->base_addr),
                   ut, p, mark, inuse, (int32)hmu_obj_size(size));
 #if BH_ENABLE_GC_VERIFY != 0

--- a/core/shared/mem-alloc/ems/ems_kfc.c
+++ b/core/shared/mem-alloc/ems/ems_kfc.c
@@ -59,7 +59,7 @@ gc_init_with_pool(char *buf, gc_size_t buf_size)
     gc_size_t heap_max_size;
 
     if (buf_size < APP_HEAP_SIZE_MIN) {
-        os_printf("[GC_ERROR]heap init buf size (%u) < %u\n",
+        os_printf("[GC_ERROR]heap init buf size (%"PRIu32") < %u\n",
                   buf_size, APP_HEAP_SIZE_MIN);
         return NULL;
     }
@@ -92,7 +92,7 @@ gc_init_with_struct_and_pool(char *struct_buf, gc_size_t struct_buf_size,
     }
 
     if (struct_buf_size < sizeof(gc_handle_t)) {
-        os_printf("[GC_ERROR]heap init struct buf size (%u) < %zu\n",
+        os_printf("[GC_ERROR]heap init struct buf size (%"PRIu32") < %zu\n",
                   struct_buf_size, sizeof(gc_handle_t));
         return NULL;
     }
@@ -103,7 +103,7 @@ gc_init_with_struct_and_pool(char *struct_buf, gc_size_t struct_buf_size,
     }
 
     if (pool_buf_size < APP_HEAP_SIZE_MIN) {
-        os_printf("[GC_ERROR]heap init buf size (%u) < %u\n",
+        os_printf("[GC_ERROR]heap init buf size (%"PRIu32") < %u\n",
                   pool_buf_size, APP_HEAP_SIZE_MIN);
         return NULL;
     }

--- a/core/shared/utils/bh_log.c
+++ b/core/shared/utils/bh_log.c
@@ -39,9 +39,10 @@ bh_log(LogLevel log_level, const char *file, int line, const char *fmt, ...)
     s = t % 60;
     mills = (uint32)(usec % 1000);
 
-    snprintf(buf, sizeof(buf), "%02u:%02u:%02u:%03u", h, m, s, mills);
+    snprintf(buf, sizeof(buf), "%02"PRIu32":%02"PRIu32":%02"PRIu32":%03"PRIu32"",
+             h, m, s, mills);
 
-    os_printf("[%s - %X]: ", buf, (uint32)(uintptr_t)self);
+    os_printf("[%s - %"PRIX32"]: ", buf, (uint32)(uintptr_t)self);
 
     if (file)
         os_printf("%s, line %d, ", file, line);
@@ -71,7 +72,7 @@ bh_print_time(const char *prompt)
 
     total_time_ms += curr_time_ms - last_time_ms;
 
-    os_printf("%-48s time of last stage: %u ms, total time: %u ms\n",
+    os_printf("%-48s time of last stage: %"PRIu32" ms, total time: %"PRIu32" ms\n",
               prompt, curr_time_ms - last_time_ms, total_time_ms);
 
     last_time_ms = curr_time_ms;


### PR DESCRIPTION
## Summary

- This PR fixes compile warnings with arm-none-eabi-gcc

## Impact

- None

## Testing

- Tested with sabre-6quad (Cortex-A9/NuttX/QEMU)
- Tested with ubuntu20.04 x86_64