### PR TITLE
Make sp 8 byte aligned in invokeNative on ARM

### DIFF
--- a/core/iwasm/common/arch/invokeNative_arm_vfp.s
+++ b/core/iwasm/common/arch/invokeNative_arm_vfp.s
@@ -22,6 +22,7 @@ _invokeNative:
  */
 
         stmfd   sp!, {r4, r5, r6, r7, lr}
+        sub     sp, sp, #4      /* make sp 8 byte aligned */
         mov     ip, r0          /* ip = function ptr */
         mov     r4, r1          /* r4 = argv */
         mov     r5, r2          /* r5 = nstacks */
@@ -79,6 +80,7 @@ call_func:
         mov     sp, r6          /* restore sp */
 
 return:
+        add     sp, sp, #4      /* make sp 8 byte aligned */
         ldmfd   sp!, {r4, r5, r6, r7, lr}
         bx      lr
 

--- a/core/iwasm/common/arch/invokeNative_thumb.s
+++ b/core/iwasm/common/arch/invokeNative_thumb.s
@@ -23,6 +23,7 @@ _invokeNative:
 
         push    {r4, r5, r6, r7}
         push    {lr}
+        sub     sp, sp, #4      /* make sp 8 byte aligned */
         mov     ip, r0          /* ip = function ptr */
         mov     r4, r1          /* r4 = argv */
         mov     r5, r2          /* r5 = argc */
@@ -83,6 +84,7 @@ call_func:
         add     sp, sp, r6       /* restore sp */
 
 return:
+        add     sp, sp, #4      /* make sp 8 byte aligned */
         pop     {r3}
         pop     {r4, r5, r6, r7}
         mov     lr, r3

--- a/core/iwasm/common/arch/invokeNative_thumb_vfp.s
+++ b/core/iwasm/common/arch/invokeNative_thumb_vfp.s
@@ -23,6 +23,7 @@ _invokeNative:
 
         push    {r4, r5, r6, r7}
         push    {lr}
+        sub     sp, sp, #4      /* make sp 8 byte aligned */
         mov     ip, r0          /* ip = function ptr */
         mov     r4, r1          /* r4 = argv */
         mov     r5, r2          /* r5 = nstacks */
@@ -91,6 +92,7 @@ call_func:
         mov     sp, r7          /* restore sp */
 
 return:
+        add     sp, sp, #4      /* make sp 8 byte aligned */
         pop     {r3}
         pop     {r4, r5, r6, r7}
         mov     lr, r3


### PR DESCRIPTION
Fix potential bugs on ARM platform such as `va_arg(ap, double)` get value from wrong address