### PR TITLE
Fixed an issue where conflicting target names caused broken pdb files to be generated

### DIFF
--- a/product-mini/platforms/windows/CMakeLists.txt
+++ b/product-mini/platforms/windows/CMakeLists.txt
@@ -124,7 +124,7 @@ add_library (libiwasm SHARED ${WAMR_RUNTIME_LIB_SOURCE})
 
 install (TARGETS libiwasm DESTINATION lib)
 
-set_target_properties (libiwasm PROPERTIES OUTPUT_NAME iwasm)
+set_target_properties (libiwasm PROPERTIES OUTPUT_NAME libiwasm)
 
 target_link_libraries (libiwasm ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS})
 


### PR DESCRIPTION
The `OUTPUT_NAME` of the libwasm library should be unique, otherwise some of the files from two different targets (iwasm and libiwasm) will overwrite each other and produce corrupted output files. Currently windows debugging is broken due to the corrupted pdb files, and this PR fixed the issue.