### PR TITLE
Fix a build on alpine, whose libc is musl

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -2160,8 +2160,8 @@ static void convert_timestamp(
     struct timespec *out
 ) {
   // Store sub-second remainder.
-#ifndef __APPLE__
-  out->tv_nsec = (__syscall_slong_t)(in % 1000000000);
+#if defined(__SYSCALL_SLONG_TYPE)
+  out->tv_nsec = (__SYSCALL_SLONG_TYPE)(in % 1000000000);
 #else
   out->tv_nsec = (long)(in % 1000000000);
 #endif


### PR DESCRIPTION
__syscall_slong_t/__SYSCALL_SLONG_TYPE and friends are
glibc specific as far as I know.