### PR TITLE
wamr-test-suites fixes

### DIFF
--- a/tests/wamr-test-suites/spec-test-script/all.sh
+++ b/tests/wamr-test-suites/spec-test-script/all.sh
@@ -18,7 +18,8 @@ DEBUG set -xevu
 readonly SPEC_TEST_DIR="spec/test/core"
 readonly WAST2WASM_CMD="./wabt/out/gcc/Release/wat2wasm"
 readonly WAMRC_CMD="../../../wamr-compiler/build/wamrc"
-IWASM_CMD="../../../product-mini/platforms/linux/build/iwasm"
+PLATFORM=$(uname -s | tr A-Z a-z)
+IWASM_CMD="../../../product-mini/platforms/${PLATFORM}/build/iwasm"
 
 # "imports" and "linking" are only avilable when enabling multi modules
 # "comments" is for runtest.py

--- a/tests/wamr-test-suites/spec-test-script/runtest.py
+++ b/tests/wamr-test-suites/spec-test-script/runtest.py
@@ -142,6 +142,11 @@ class Runner():
             except OSError:
                 pass
             self.p = None
+            self.stdin.close()
+            if self.stdin != self.stdout:
+                self.stdout.close()
+            self.stdin = None
+            self.stdout = None
             sys.exc_clear()
 
 def assert_prompt(runner, prompts, timeout, is_need_execute_result):

--- a/tests/wamr-test-suites/spec-test-script/runtest.py
+++ b/tests/wamr-test-suites/spec-test-script/runtest.py
@@ -979,24 +979,27 @@ def create_tmpfiles(wast_name):
     if not os.path.exists(temp_file_directory):
         os.mkdir(temp_file_directory)
 
+    def makefile(name):
+        open(name, "w").close()
+
     # create temporal file with particular name
     temp_wast_file = os.path.join(temp_file_directory, ""+ wast_name + ".wast")
     if not os.path.exists(temp_wast_file):
-        os.mknod(temp_wast_file)
+        makefile(temp_wast_file)
     tempfiles.append(temp_wast_file)
 
     # now we define the same file name as wast for wasm & aot
     wasm_file = wast_name +".wasm"
     temp_wasm_file = os.path.join(temp_file_directory, wasm_file)
     if not os.path.exists(temp_wasm_file):
-        os.mknod(temp_wasm_file)
+        makefile(temp_wasm_file)
     tempfiles.append(temp_wasm_file)
 
     if test_aot:
         aot_file = wast_name +".aot"
         temp_aot_file =os.path.join(temp_file_directory, aot_file)
         if not os.path.exists(temp_aot_file):
-            os.mknod(temp_aot_file)
+            makefile(temp_aot_file)
         tempfiles.append(temp_aot_file)
 
     # add these temp file to temporal repo, will be deleted when finishing the test

--- a/tests/wamr-test-suites/spec-test-script/runtest.py
+++ b/tests/wamr-test-suites/spec-test-script/runtest.py
@@ -105,6 +105,9 @@ class Runner():
             [outs,_,_] = select([self.stdout], [], [], 1)
             if self.stdout in outs:
                 new_data = self.stdout.read(1)
+                if not new_data:
+                    # EOF on macOS ends up here.
+                    break
                 new_data = new_data.decode("utf-8") if IS_PY_3 else new_data
                 #print("new_data: '%s'" % new_data)
                 debug(new_data)

--- a/tests/wamr-test-suites/test_wamr.sh
+++ b/tests/wamr-test-suites/test_wamr.sh
@@ -40,6 +40,7 @@ SGX_OPT=""
 # enable reference-types and bulk-memory by default
 # as they are finished and merged into spec
 ENABLE_REF_TYPES=1
+PLATFORM=$(uname -s | tr A-Z a-z)
 
 while getopts ":s:cabt:m:MCpSxr" opt
 do
@@ -145,8 +146,8 @@ if [[ ${SGX_OPT} == "--sgx" ]];then
     readonly IWASM_LINUX_ROOT_DIR="${WAMR_DIR}/product-mini/platforms/linux-sgx"
     readonly IWASM_CMD="${WAMR_DIR}/product-mini/platforms/linux-sgx/enclave-sample/iwasm"
 else
-    readonly IWASM_LINUX_ROOT_DIR="${WAMR_DIR}/product-mini/platforms/linux"
-    readonly IWASM_CMD="${WAMR_DIR}/product-mini/platforms/linux/build/iwasm"
+    readonly IWASM_LINUX_ROOT_DIR="${WAMR_DIR}/product-mini/platforms/${PLATFORM}"
+    readonly IWASM_CMD="${WAMR_DIR}/product-mini/platforms/${PLATFORM}/build/iwasm"
 fi
 
 readonly WAMRC_CMD="${WAMR_DIR}/wamr-compiler/build/wamrc"
@@ -322,14 +323,26 @@ function spec_test()
         echo "download a binary release and install"
         local WAT2WASM=${WORK_DIR}/wabt/out/gcc/Release/wat2wasm
         if [ ! -f ${WAT2WASM} ]; then
-            if [ ! -f /tmp/wabt-1.0.23-ubuntu.tar.gz ]; then
+            case ${PLATFORM} in
+                linux)
+                    WABT_PLATFORM=ubuntu
+                    ;;
+                darwin)
+                    WABT_PLATFORM=macos
+                    ;;
+                *)
+                    echo "wabt platform for ${PLATFORM} in unknown"
+                    exit 1
+                    ;;
+            esac
+            if [ ! -f /tmp/wabt-1.0.23-${WABT_PLATFORM}.tar.gz ]; then
                 wget \
-                    https://github.com/WebAssembly/wabt/releases/download/1.0.23/wabt-1.0.23-ubuntu.tar.gz \
+                    https://github.com/WebAssembly/wabt/releases/download/1.0.23/wabt-1.0.23-${WABT_PLATFORM}.tar.gz \
                     -P /tmp
             fi
 
             cd /tmp \
-            && tar zxf wabt-1.0.23-ubuntu.tar.gz \
+            && tar zxf wabt-1.0.23-${WABT_PLATFORM}.tar.gz \
             && mkdir -p ${WORK_DIR}/wabt/out/gcc/Release/ \
             && install wabt-1.0.23/bin/wa* ${WORK_DIR}/wabt/out/gcc/Release/ \
             && cd -
@@ -469,7 +482,7 @@ function build_iwasm_with_cfg()
         && make clean \
         && make SPEC_TEST=1
     else
-        cd ${WAMR_DIR}/product-mini/platforms/linux \
+        cd ${WAMR_DIR}/product-mini/platforms/${PLATFORM} \
         && if [ -d build ]; then rm -rf build/*; else mkdir build; fi \
         && cd build \
         && cmake $* .. \

--- a/tests/wamr-test-suites/test_wamr.sh
+++ b/tests/wamr-test-suites/test_wamr.sh
@@ -322,7 +322,7 @@ function spec_test()
         echo "download a binary release and install"
         local WAT2WASM=${WORK_DIR}/wabt/out/gcc/Release/wat2wasm
         if [ ! -f ${WAT2WASM} ]; then
-            if [ ! -f /tmp/wabt-1.0.23-linux.tar.gz ]; then
+            if [ ! -f /tmp/wabt-1.0.23-ubuntu.tar.gz ]; then
                 wget \
                     https://github.com/WebAssembly/wabt/releases/download/1.0.23/wabt-1.0.23-ubuntu.tar.gz \
                     -P /tmp


### PR DESCRIPTION
"./test_wamr.sh -s spec -t fast-interp -b" tested on macOS and ubuntu.