### PR TITLE
Cancel the return value check of dwarf_gen_location and fix typos

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -14,7 +14,7 @@
 #endif
 #if WASM_ENABLE_AOT != 0
 #include "../aot/aot_runtime.h"
-#if WASM_ENABLE_AOT_DEBUG != 0
+#if WASM_ENABLE_DEBUG_AOT != 0
 #include "../aot/debug/jit_debug.h"
 #endif
 #endif
@@ -134,7 +134,7 @@ wasm_runtime_env_init()
         goto fail6;
     }
 #endif
-#if WASM_ENABLE_AOT_DEBUG != 0
+#if WASM_ENABLE_DEBUG_AOT != 0
     if (!jit_debug_engine_init()) {
         goto fail7;
     }
@@ -153,7 +153,7 @@ wasm_runtime_env_init()
 fail8:
 #endif
 #if WASM_ENABLE_AOT != 0
-#if WASM_ENABLE_AOT_DEBUG != 0
+#if WASM_ENABLE_DEBUG_AOT != 0
     jit_debug_engine_destroy();
 fail7:
 #endif
@@ -216,7 +216,7 @@ wasm_runtime_destroy()
 #endif
 
 #if WASM_ENABLE_AOT != 0
-#if WASM_ENABLE_AOT_DEBUG != 0
+#if WASM_ENABLE_DEBUG_AOT != 0
     jit_debug_engine_destroy();
 #endif
 #ifdef OS_ENABLE_HW_BOUND_CHECK

--- a/core/iwasm/compilation/aot_compiler.c
+++ b/core/iwasm/compilation/aot_compiler.c
@@ -171,10 +171,6 @@ aot_compile_func(AOTCompContext *comp_ctx, uint32 func_index)
       comp_ctx, func_ctx,
       (frame_ip - 1) - comp_ctx->comp_data->wasm_module->buf_code
     );
-    if (!location) {
-        aot_set_last_error("dwarf generate location failed");
-        return false;
-    }
     LLVMSetCurrentDebugLocation2(comp_ctx->builder, location);
 #endif
 

--- a/core/iwasm/compilation/aot_emit_control.c
+++ b/core/iwasm/compilation/aot_emit_control.c
@@ -175,10 +175,6 @@ handle_next_reachable_block(AOTCompContext *comp_ctx,
       comp_ctx, func_ctx,
       (*p_frame_ip - 1) - comp_ctx->comp_data->wasm_module->buf_code
     );
-    if (!return_location) {
-        aot_set_last_error("dwarf generate location failed");
-        return false;
-    }
 #endif
     if (block->label_type == LABEL_TYPE_IF
         && block->llvm_else_block
@@ -1068,10 +1064,6 @@ aot_compile_op_return(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
       comp_ctx, func_ctx,
       (*p_frame_ip - 1) - comp_ctx->comp_data->wasm_module->buf_code
     );
-    if (!return_location) {
-        aot_set_last_error("dwarf generate location failed");
-        return false;
-    }
 #endif
     if (block_func->result_count) {
         /* Store extra result values to function parameters */

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -640,10 +640,6 @@ aot_create_func_context(AOTCompData *comp_data, AOTCompContext *comp_ctx,
 
 #if WASM_ENABLE_DEBUG_AOT != 0
     func_ctx->debug_func = dwarf_gen_func_info(comp_ctx, func_ctx);
-    if (!func_ctx->debug_func) {
-        aot_set_last_error("dwarf generate func info failed");
-        goto fail;
-    }
 #endif
 
     aot_block_stack_push(&func_ctx->block_stack, aot_block);


### PR DESCRIPTION
Wasm modules compiled by clang/emcc have some extra functions like `__wasm_call_ctors` and `__original_main`, but there is no corresponding information in dwarf.

So, I cancelled the return value check of `dwarf_gen_location` and `dwarf_gen_func_info`.

Besides, I fix some macro typos.