### PR TITLE
Update wasm_c_api to use vector types.

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -4104,6 +4104,7 @@ wasm_runtime_invoke_c_api_native(WASMModuleInstanceCommon *module_inst,
     wasm_val_t *params = params_buf, *results = results_buf;
     wasm_trap_t *trap = NULL;
     bool ret = false;
+    wasm_val_vec_t params_vec, results_vec;
 
     if (func_type->param_count > 16
         && !(params = wasm_runtime_malloc(sizeof(wasm_val_t)
@@ -4124,14 +4125,24 @@ wasm_runtime_invoke_c_api_native(WASMModuleInstanceCommon *module_inst,
         goto fail;
     }
 
+    params_vec.data = params;
+    params_vec.num_elems = func_type->param_count;
+    params_vec.size = func_type->param_count;
+    params_vec.size_of_elem = sizeof(wasm_val_t);
+
+    results_vec.data = results;
+    results_vec.num_elems = 0;
+    results_vec.size = func_type->result_count;
+    results_vec.size_of_elem = sizeof(wasm_val_t);
+
     if (!with_env) {
         wasm_func_callback_t callback = (wasm_func_callback_t)func_ptr;
-        trap = callback(params, results);
+        trap = callback(&params_vec, &results_vec);
     }
     else {
         wasm_func_callback_with_env_t callback =
           (wasm_func_callback_with_env_t)func_ptr;
-        trap = callback(wasm_c_api_env, params, results);
+        trap = callback(wasm_c_api_env, &params_vec, &results_vec);
     }
 
     if (trap) {
@@ -4155,7 +4166,7 @@ wasm_runtime_invoke_c_api_native(WASMModuleInstanceCommon *module_inst,
         wasm_runtime_set_exception(module_inst, "unsupported result type");
         goto fail;
     }
-
+    results_vec.num_elems = func_type->result_count;
     ret = true;
 
 fail:

--- a/core/iwasm/include/wasm_c_api.h
+++ b/core/iwasm/include/wasm_c_api.h
@@ -467,9 +467,9 @@ WASM_API_EXTERN own wasm_module_t* wasm_module_deserialize(wasm_store_t*, const 
 WASM_DECLARE_REF(func)
 
 typedef own wasm_trap_t* (*wasm_func_callback_t)(
-  const wasm_val_t args[], own wasm_val_t results[]);
+  const wasm_val_vec_t* args, own wasm_val_vec_t *results);
 typedef own wasm_trap_t* (*wasm_func_callback_with_env_t)(
-  void* env, const wasm_val_t args[], wasm_val_t results[]);
+  void* env, const wasm_val_vec_t *args, wasm_val_vec_t *results);
 
 WASM_API_EXTERN own wasm_func_t* wasm_func_new(
   wasm_store_t*, const wasm_functype_t*, wasm_func_callback_t);
@@ -482,7 +482,7 @@ WASM_API_EXTERN size_t wasm_func_param_arity(const wasm_func_t*);
 WASM_API_EXTERN size_t wasm_func_result_arity(const wasm_func_t*);
 
 WASM_API_EXTERN own wasm_trap_t* wasm_func_call(
-  const wasm_func_t*, const wasm_val_t args[], wasm_val_t results[]);
+  const wasm_func_t*, const wasm_val_vec_t* args, wasm_val_vec_t* results);
 
 
 // Global Instances
@@ -569,13 +569,13 @@ WASM_API_EXTERN const wasm_memory_t* wasm_extern_as_memory_const(const wasm_exte
 WASM_DECLARE_REF(instance)
 
 WASM_API_EXTERN own wasm_instance_t* wasm_instance_new(
-  wasm_store_t*, const wasm_module_t*, const wasm_extern_t *const imports[],
+  wasm_store_t*, const wasm_module_t*, const wasm_extern_vec_t *imports,
   own wasm_trap_t**
 );
 
 // please refer to wasm_runtime_instantiate(...) in core/iwasm/include/wasm_export.h
 WASM_API_EXTERN own wasm_instance_t* wasm_instance_new_with_args(
-  wasm_store_t*, const wasm_module_t*, const wasm_extern_t *const imports[],
+  wasm_store_t*, const wasm_module_t*, const wasm_extern_vec_t *imports,
   own wasm_trap_t**, const uint32_t stack_size, const uint32_t heap_size
 );
 

--- a/samples/wasm-c-api/src/global.c
+++ b/samples/wasm-c-api/src/global.c
@@ -39,9 +39,10 @@ wasm_func_t* get_export_func(const wasm_extern_vec_t* exports, size_t i) {
 
 #define check_call(func, type, expected) \
   { \
-    wasm_val_t results[1]; \
-    wasm_func_call(func, NULL, results); \
-    check(results[0], type, expected); \
+    wasm_val_vec_t results; \
+    wasm_val_vec_new_uninitialized(&results, 1); \
+    wasm_func_call(func, NULL, &results); \
+    check(results.data[0], type, expected); \
   }
 
 
@@ -115,14 +116,21 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  const wasm_extern_t* imports[] = {
+  /*const wasm_extern_t* imports1[] = {
     wasm_global_as_extern(const_f32_import),
     wasm_global_as_extern(const_i64_import),
     wasm_global_as_extern(var_f32_import),
     wasm_global_as_extern(var_i64_import)
-  };
+    };*/
+  wasm_extern_vec_t imports;
+  wasm_extern_vec_new(&imports, 4, (wasm_extern_t* []) {
+      wasm_global_as_extern(const_f32_import),
+      wasm_global_as_extern(const_i64_import),
+      wasm_global_as_extern(var_f32_import),
+      wasm_global_as_extern(var_i64_import)
+    });
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, imports, NULL);
+    wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -200,14 +208,18 @@ int main(int argc, const char* argv[]) {
   check_call(get_var_i64_export, i64, 38);
 
   // Modify variables through calls and check again.
-  wasm_val_t args73[] = { WASM_F32_VAL(73) };
-  wasm_func_call(set_var_f32_import, args73, NULL);
-  wasm_val_t args74[] = { WASM_I64_VAL(74) };
-  wasm_func_call(set_var_i64_import, args74, NULL);
-  wasm_val_t args77[] = { WASM_F32_VAL(77) };
-  wasm_func_call(set_var_f32_export, args77, NULL);
-  wasm_val_t args78[] = { WASM_I64_VAL(78) };
-  wasm_func_call(set_var_i64_export, args78, NULL);
+  wasm_val_vec_t args73;
+  wasm_val_vec_new(&args73, 1, (wasm_val_t []){ WASM_F32_VAL(73) });
+  wasm_func_call(set_var_f32_import, &args73, NULL);
+  wasm_val_vec_t args74;
+  wasm_val_vec_new(&args74, 1, (wasm_val_t []){ WASM_I64_VAL(74) });
+  wasm_func_call(set_var_i64_import, &args74, NULL);
+  wasm_val_vec_t args77;
+  wasm_val_vec_new(&args77, 1, (wasm_val_t []){ WASM_F32_VAL(77) });
+  wasm_func_call(set_var_f32_export, &args77, NULL);
+  wasm_val_vec_t args78;
+  wasm_val_vec_new(&args78, 1, (wasm_val_t []){ WASM_I64_VAL(78) });
+  wasm_func_call(set_var_i64_export, &args78, NULL);
 
   check_global(var_f32_import, f32, 73);
   check_global(var_i64_import, i64, 74);

--- a/samples/wasm-c-api/src/globalexportimport.c
+++ b/samples/wasm-c-api/src/globalexportimport.c
@@ -52,9 +52,10 @@ wasm_func_t* get_export_func(const wasm_extern_vec_t* exports, size_t i) {
 
 #define check_call(func, type, expected) \
   { \
-    wasm_val_t results[1]; \
-    wasm_func_call(func, NULL, results); \
-    check(results[0], type, expected); \
+    wasm_val_vec_t results; \
+    wasm_val_vec_new_uninitialized(&results, 1); \
+    wasm_func_call(func, NULL, &results); \
+    check(results.data[0], type, expected); \
   }
 
 wasm_module_t * create_module_from_file(wasm_store_t* store, const char * filename)
@@ -146,16 +147,18 @@ int main(int argc, const char* argv[]) {
 
   // Modify variables through calls and check again.
   printf("Modify the variable to 77.0...\n");
-  wasm_val_t args77[] = { {.kind = WASM_F32, .of = {.f32 = 77.}} };
-  wasm_func_call(set_var_f32_export, args77, NULL); //Call to module export
+  wasm_val_vec_t args77;
+  wasm_val_vec_new(&args77, 1, (wasm_val_t []){ {.kind = WASM_F32, .of = {.f32 = 77.0}} });
+  wasm_func_call(set_var_f32_export, &args77, NULL); //Call to module export
   check_call(get_var_f32_export, f32, 77.0);          //Call to module export
   check_global(var_f32_export, f32, 77.0);    //Failed here, still 37
   check_call(get_var_f32_import, f32, 77.0); //Call to module import  Failed here, still 37
 
 
   printf("Modify the variable to 78.0...\n");
-  wasm_val_t args78[] = { {.kind = WASM_F32, .of = {.f32 = 78.0}} };
-  wasm_func_call(set_var_f32_import, args78, NULL);
+  wasm_val_vec_t args78;
+  wasm_val_vec_new(&args78, 1, (wasm_val_t []){ {.kind = WASM_F32, .of = {.f32 = 78.0}} });
+  wasm_func_call(set_var_f32_import, &args78, NULL);
   check_global(var_f32_export, f32, 78.0);
   check_call(get_var_f32_export, f32, 78.0); //Call to module export Failed here, still 77
   check_call(get_var_f32_import, f32, 78.0); //Call to module import

--- a/samples/wasm-c-api/src/hello.c
+++ b/samples/wasm-c-api/src/hello.c
@@ -9,7 +9,7 @@
 
 // A function to be called from Wasm code.
 own wasm_trap_t* hello_callback(
-  const wasm_val_t args[], wasm_val_t results[]
+  const wasm_val_vec_t* args, wasm_val_vec_t* results
 ) {
   printf("Calling back...\n");
   printf("> Hello World!\n");
@@ -66,9 +66,11 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  const wasm_extern_t* imports[] = { wasm_func_as_extern(hello_func) };
+  wasm_extern_vec_t imports;
+  wasm_extern_vec_new(&imports, 1, (wasm_extern_t* []) { wasm_func_as_extern(hello_func) });
+
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, imports, NULL);
+    wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;

--- a/samples/wasm-c-api/src/memory.c
+++ b/samples/wasm-c-api/src/memory.c
@@ -33,8 +33,13 @@ void check(bool success) {
 }
 
 void check_call(wasm_func_t* func, int i, wasm_val_t args[], int32_t expected) {
-  wasm_val_t results[1] = { WASM_INIT_VAL };
-  if (wasm_func_call(func, args, results) || results[0].of.i32 != expected) {
+  wasm_val_vec_t args_vec;
+  wasm_val_vec_t results_vec;
+  if (args)
+    wasm_val_vec_new(&args_vec, i, args);
+  wasm_val_vec_new(&results_vec, 1, (wasm_val_t []){ WASM_INIT_VAL });
+  if (wasm_func_call(func, args ? &args_vec : NULL, &results_vec)
+      || results_vec.data[0].of.i32 != expected) {
     printf("> Error on result\n");
     exit(1);
   }
@@ -55,7 +60,9 @@ void check_call2(wasm_func_t* func, int32_t arg1, int32_t arg2, int32_t expected
 }
 
 void check_ok(wasm_func_t* func, int i, wasm_val_t args[]) {
-  if (wasm_func_call(func, args, NULL)) {
+  wasm_val_vec_t args_vec;
+  wasm_val_vec_new(&args_vec, i, args);
+  if (wasm_func_call(func, &args_vec, NULL)) {
     printf("> Error on result, expected empty\n");
     exit(1);
   }
@@ -67,8 +74,10 @@ void check_ok2(wasm_func_t* func, int32_t arg1, int32_t arg2) {
 }
 
 void check_trap(wasm_func_t* func, int i, wasm_val_t args[]) {
-  wasm_val_t results[1] = { WASM_INIT_VAL };
-  own wasm_trap_t* trap = wasm_func_call(func, args, results);
+  wasm_val_vec_t args_vec, results_vec;
+  wasm_val_vec_new(&args_vec, i, args);
+  wasm_val_vec_new(&results_vec, 1, (wasm_val_t []){ WASM_INIT_VAL });
+  own wasm_trap_t* trap = wasm_func_call(func, &args_vec, &results_vec);
   if (! trap) {
     printf("> Error on result, expected trap\n");
     exit(1);

--- a/samples/wasm-c-api/src/table.c
+++ b/samples/wasm-c-api/src/table.c
@@ -9,11 +9,11 @@
 
 // A function to be called from Wasm code.
 own wasm_trap_t* neg_callback(
-  const wasm_val_t args[], wasm_val_t results[]
+  const wasm_val_vec_t* args, wasm_val_vec_t* results
 ) {
   printf("Calling back...\n");
-  results[0].kind = WASM_I32;
-  results[0].of.i32 = -args[0].of.i32;
+  results->data[0].kind = WASM_I32;
+  results->data[0].of.i32 = -args->data[0].of.i32;
   return NULL;
 }
 
@@ -49,18 +49,20 @@ void check_table(wasm_table_t* table, int32_t i, bool expect_set) {
 }
 
 void check_call(wasm_func_t* func, int32_t arg1, int32_t arg2, int32_t expected) {
-  wasm_val_t args[2] = { WASM_I32_VAL(arg1), WASM_I32_VAL(arg2) };
-  wasm_val_t results[1] = { WASM_INIT_VAL };
-  if (wasm_func_call(func, args, results) || results[0].of.i32 != expected) {
+  wasm_val_vec_t args, results;
+  wasm_val_vec_new(&args, 2, (wasm_val_t []){ WASM_I32_VAL(arg1), WASM_I32_VAL(arg2) });
+  wasm_val_vec_new(&results, 1, (wasm_val_t []){ WASM_INIT_VAL });
+  if (wasm_func_call(func, &args, &results) || results.data[0].of.i32 != expected) {
     printf("> Error on result\n");
     exit(1);
   }
 }
 
 void check_trap(wasm_func_t* func, int32_t arg1, int32_t arg2) {
-  wasm_val_t args[2] = { WASM_I32_VAL(arg1), WASM_I32_VAL(arg2) };
-  wasm_val_t results[1] = { WASM_INIT_VAL };
-  own wasm_trap_t* trap = wasm_func_call(func, args, results);
+  wasm_val_vec_t args, results;
+  wasm_val_vec_new(&args, 2, (wasm_val_t []){ WASM_I32_VAL(arg1), WASM_I32_VAL(arg2) });
+  wasm_val_vec_new(&results, 1, (wasm_val_t []){ WASM_INIT_VAL });
+  own wasm_trap_t* trap = wasm_func_call(func, &args, &results);
   if (! trap) {
     printf("> Error on result, expected trap\n");
     exit(1);

--- a/samples/wasm-c-api/src/trap.c
+++ b/samples/wasm-c-api/src/trap.c
@@ -9,7 +9,7 @@
 
 // A function to be called from Wasm code.
 own wasm_trap_t* fail_callback(
-  void* env, const wasm_val_t args[], wasm_val_t results[]
+  void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results
 ) {
   printf("Calling back...\n");
   own wasm_name_t message;
@@ -80,9 +80,10 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  const wasm_extern_t* imports[] = { wasm_func_as_extern(fail_func) };
+  wasm_extern_vec_t imports;
+  wasm_extern_vec_new(&imports, 1, (wasm_extern_t* []) { wasm_func_as_extern(fail_func) });
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, imports, NULL);
+    wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -111,8 +112,10 @@ int main(int argc, const char* argv[]) {
     }
 
     printf("Calling export %d...\n", i);
-    wasm_val_t results[1]; \
-    own wasm_trap_t* trap = wasm_func_call(func, NULL, results);
+
+    wasm_val_vec_t results;
+    wasm_val_vec_new_uninitialized(&results, 1);
+    own wasm_trap_t* trap = wasm_func_call(func, NULL, &results);
     if (!trap) {
       printf("> Error calling function, expected trap!\n");
       return 1;


### PR DESCRIPTION
The WASM C API now requires the use of vector types in certain apis.
Switching WAMR to use the new call signatures improves "drop in"
compilation compatibility between between WAMR and other implementations
from a C-api embedding program's perspective.

* wasm_func_callback_t type has been updated to use wasm_val_vec_t
* wasm_func_callback_with_env_t type has been updated to use wasm_val_vec_t
* wasm_func_call() has been updated to use wasm_val_vec_t
* wasm_instance_new() has been updated to use wasm_extern_vec_t*
* wasm_instance_new_with_args() has been updated to use wasm_extern_vec_t*
* wasm_runtime_invoke_c_api_native() has been updated to support vector types
  in native callbacks without modifying the contract with the interpreter code.
* All users of the modified functions (including samples/wasm-c-api/src/*.c)
  have been appropriately updated