### PR TITLE
include headers follow strict protoype rule

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -852,7 +852,7 @@ wasm_runtime_destroy_exec_env(WASMExecEnv *exec_env)
 }
 
 bool
-wasm_runtime_init_thread_env()
+wasm_runtime_init_thread_env(void)
 {
 #ifdef BH_PLATFORM_WINDOWS
     if (os_thread_env_init() != 0)
@@ -873,7 +873,7 @@ wasm_runtime_init_thread_env()
 }
 
 void
-wasm_runtime_destroy_thread_env()
+wasm_runtime_destroy_thread_env(void)
 {
 #if WASM_ENABLE_AOT != 0
 #ifdef OS_ENABLE_HW_BOUND_CHECK

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -421,13 +421,13 @@ wasm_runtime_destroy_exec_env(wasm_exec_env_t exec_env);
  * @return true if success, false otherwise
  */
 WASM_RUNTIME_API_EXTERN bool
-wasm_runtime_init_thread_env();
+wasm_runtime_init_thread_env(void);
 
 /**
  * Destroy thread environment
  */
 WASM_RUNTIME_API_EXTERN void
-wasm_runtime_destroy_thread_env();
+wasm_runtime_destroy_thread_env(void);
 
 /**
  * Get WASM module instance from execution environment


### PR DESCRIPTION
I use an embedded OS that compiles using -Wstrict-prototypes. When i compile files that include I get headers the following 

Warning:

warning: function declaration isn’t a prototype [-Wstrict-prototypes]
wasm_runtime_init_thread_env(void);

I think i would be reasonable to provide the include headers in a form does not produce a warning.

see #331 