### PR TITLE
Apply clang-format for core/iwasm compilation and libraries

### DIFF
--- a/.github/workflows/compilation_on_android_ubuntu_macos.yml
+++ b/.github/workflows/compilation_on_android_ubuntu_macos.yml
@@ -399,6 +399,7 @@ jobs:
           cmake --build . --config Release --parallel 4
           ./callback
           ./callback_chain
+          ./empty_imports
           ./global
           ./hello
           ./hostref

--- a/.github/workflows/spec_test.yml
+++ b/.github/workflows/spec_test.yml
@@ -6,6 +6,7 @@ on:
   # will be triggered on PR events
   pull_request:
     paths:
+      - "core/config.h"
       - "core/iwasm/**"
       - "core/shared/**"
       - "wamr-compiler/**"
@@ -13,6 +14,7 @@ on:
   # will be triggered on push events
   push:
     paths:
+      - "core/config.h"
       - "core/iwasm/**"
       - "core/shared/**"
       - "wamr-compiler/**"

--- a/core/config.h
+++ b/core/config.h
@@ -6,6 +6,7 @@
 #ifndef _CONFIG_H_
 #define _CONFIG_H_
 
+/* clang-format off */
 #if !defined(BUILD_TARGET_X86_64) \
     && !defined(BUILD_TARGET_AMD_64) \
     && !defined(BUILD_TARGET_AARCH64) \
@@ -21,6 +22,7 @@
     && !defined(BUILD_TARGET_RISCV32_ILP32D) \
     && !defined(BUILD_TARGET_RISCV32_ILP32) \
     && !defined(BUILD_TARGET_ARC)
+/* clang-format on */
 #if defined(__x86_64__) || defined(__x86_64)
 #define BUILD_TARGET_X86_64
 #elif defined(__amd64__) || defined(__amd64)
@@ -54,7 +56,7 @@
 #define BH_DEBUG 0
 #endif
 
-#define MEM_ALLOCATOR_EMS  0
+#define MEM_ALLOCATOR_EMS 0
 #define MEM_ALLOCATOR_TLSF 1
 
 /* Default memory allocator */
@@ -268,8 +270,8 @@
 #define APP_THREAD_STACK_SIZE_DEFAULT (6 * 1024)
 #define APP_THREAD_STACK_SIZE_MIN (4 * 1024)
 #elif defined(PTHREAD_STACK_DEFAULT) && defined(PTHREAD_STACK_MIN)
-#define APP_THREAD_STACK_SIZE_DEFAULT   PTHREAD_STACK_DEFAULT
-#define APP_THREAD_STACK_SIZE_MIN       PTHREAD_STACK_MIN
+#define APP_THREAD_STACK_SIZE_DEFAULT PTHREAD_STACK_DEFAULT
+#define APP_THREAD_STACK_SIZE_MIN PTHREAD_STACK_MIN
 #else
 #define APP_THREAD_STACK_SIZE_DEFAULT (32 * 1024)
 #define APP_THREAD_STACK_SIZE_MIN (24 * 1024)
@@ -312,4 +314,3 @@
 #endif
 
 #endif /* end of _CONFIG_H_ */
-

--- a/core/iwasm/compilation/aot.c
+++ b/core/iwasm/compilation/aot.c
@@ -5,13 +5,12 @@
 
 #include "aot.h"
 
-
 static char aot_error[128];
 
-char*
+char *
 aot_get_last_error()
 {
-  return aot_error[0] == '\0' ? "" : aot_error;
+    return aot_error[0] == '\0' ? "" : aot_error;
 }
 
 void
@@ -26,558 +25,561 @@ aot_set_last_error_v(const char *format, ...)
 void
 aot_set_last_error(const char *error)
 {
-  if (error)
-    snprintf(aot_error, sizeof(aot_error), "Error: %s", error);
-  else
-    aot_error[0] = '\0';
+    if (error)
+        snprintf(aot_error, sizeof(aot_error), "Error: %s", error);
+    else
+        aot_error[0] = '\0';
 }
 
 static void
 aot_destroy_mem_init_data_list(AOTMemInitData **data_list, uint32 count)
 {
-  uint32 i;
-  for (i = 0; i < count; i++)
-    if (data_list[i])
-      wasm_runtime_free(data_list[i]);
-  wasm_runtime_free(data_list);
+    uint32 i;
+    for (i = 0; i < count; i++)
+        if (data_list[i])
+            wasm_runtime_free(data_list[i]);
+    wasm_runtime_free(data_list);
 }
 
 static AOTMemInitData **
 aot_create_mem_init_data_list(const WASMModule *module)
 {
-  AOTMemInitData **data_list;
-  uint64 size;
-  uint32 i;
+    AOTMemInitData **data_list;
+    uint64 size;
+    uint32 i;
 
-  /* Allocate memory */
-  size = sizeof(AOTMemInitData *) * (uint64)module->data_seg_count;
-  if (size >= UINT32_MAX
-      || !(data_list = wasm_runtime_malloc((uint32)size))) {
-    aot_set_last_error("allocate memory failed.");
-    return NULL;
-  }
-
-  memset(data_list, 0, size);
-
-  /* Create each memory data segment */
-  for (i = 0; i < module->data_seg_count; i++) {
-    size = offsetof(AOTMemInitData, bytes) +
-                (uint64)module->data_segments[i]->data_length;
+    /* Allocate memory */
+    size = sizeof(AOTMemInitData *) * (uint64)module->data_seg_count;
     if (size >= UINT32_MAX
-        || !(data_list[i] = wasm_runtime_malloc((uint32)size))) {
-      aot_set_last_error("allocate memory failed.");
-      goto fail;
+        || !(data_list = wasm_runtime_malloc((uint32)size))) {
+        aot_set_last_error("allocate memory failed.");
+        return NULL;
     }
 
-#if WASM_ENABLE_BULK_MEMORY != 0
-    data_list[i]->is_passive = module->data_segments[i]->is_passive;
-    data_list[i]->memory_index = module->data_segments[i]->memory_index;
-#endif
-    data_list[i]->offset = module->data_segments[i]->base_offset;
-    data_list[i]->byte_count = module->data_segments[i]->data_length;
-    memcpy(data_list[i]->bytes, module->data_segments[i]->data,
-           module->data_segments[i]->data_length);
-  }
+    memset(data_list, 0, size);
 
-  return data_list;
+    /* Create each memory data segment */
+    for (i = 0; i < module->data_seg_count; i++) {
+        size = offsetof(AOTMemInitData, bytes)
+               + (uint64)module->data_segments[i]->data_length;
+        if (size >= UINT32_MAX
+            || !(data_list[i] = wasm_runtime_malloc((uint32)size))) {
+            aot_set_last_error("allocate memory failed.");
+            goto fail;
+        }
+
+#if WASM_ENABLE_BULK_MEMORY != 0
+        data_list[i]->is_passive = module->data_segments[i]->is_passive;
+        data_list[i]->memory_index = module->data_segments[i]->memory_index;
+#endif
+        data_list[i]->offset = module->data_segments[i]->base_offset;
+        data_list[i]->byte_count = module->data_segments[i]->data_length;
+        memcpy(data_list[i]->bytes, module->data_segments[i]->data,
+               module->data_segments[i]->data_length);
+    }
+
+    return data_list;
 
 fail:
-  aot_destroy_mem_init_data_list(data_list, module->data_seg_count);
-  return NULL;
+    aot_destroy_mem_init_data_list(data_list, module->data_seg_count);
+    return NULL;
 }
 
 static void
 aot_destroy_table_init_data_list(AOTTableInitData **data_list, uint32 count)
 {
-  uint32 i;
-  for (i = 0; i < count; i++)
-    if (data_list[i])
-      wasm_runtime_free(data_list[i]);
-  wasm_runtime_free(data_list);
+    uint32 i;
+    for (i = 0; i < count; i++)
+        if (data_list[i])
+            wasm_runtime_free(data_list[i]);
+    wasm_runtime_free(data_list);
 }
 
 static AOTTableInitData **
 aot_create_table_init_data_list(const WASMModule *module)
 {
-  AOTTableInitData **data_list;
-  uint64 size;
-  uint32 i;
+    AOTTableInitData **data_list;
+    uint64 size;
+    uint32 i;
 
-  /* Allocate memory */
-  size = sizeof(AOTTableInitData *) * (uint64)module->table_seg_count;
-  if (size >= UINT32_MAX
-      || !(data_list = wasm_runtime_malloc((uint32)size))) {
-    aot_set_last_error("allocate memory failed.");
-    return NULL;
-  }
-
-  memset(data_list, 0, size);
-
-  /* Create each table data segment */
-  for (i = 0; i < module->table_seg_count; i++) {
-    size = offsetof(AOTTableInitData, func_indexes) +
-           sizeof(uint32) * (uint64)module->table_segments[i].function_count;
+    /* Allocate memory */
+    size = sizeof(AOTTableInitData *) * (uint64)module->table_seg_count;
     if (size >= UINT32_MAX
-        || !(data_list[i] = wasm_runtime_malloc((uint32)size))) {
-      aot_set_last_error("allocate memory failed.");
-      goto fail;
+        || !(data_list = wasm_runtime_malloc((uint32)size))) {
+        aot_set_last_error("allocate memory failed.");
+        return NULL;
     }
 
-    data_list[i]->offset = module->table_segments[i].base_offset;
-    data_list[i]->func_index_count = module->table_segments[i].function_count;
-    data_list[i]->mode = module->table_segments[i].mode;
-    data_list[i]->elem_type = module->table_segments[i].elem_type;
-    /* runtime control it */
-    data_list[i]->is_dropped = false;
-    data_list[i]->table_index = module->table_segments[i].table_index;
-    bh_memcpy_s(&data_list[i]->offset, sizeof(AOTInitExpr),
-                &module->table_segments[i].base_offset, sizeof(AOTInitExpr));
-    data_list[i]->func_index_count = module->table_segments[i].function_count;
-    bh_memcpy_s(data_list[i]->func_indexes,
-                sizeof(uint32) * module->table_segments[i].function_count,
-                module->table_segments[i].func_indexes,
-                sizeof(uint32) * module->table_segments[i].function_count);
-  }
+    memset(data_list, 0, size);
 
-  return data_list;
+    /* Create each table data segment */
+    for (i = 0; i < module->table_seg_count; i++) {
+        size =
+            offsetof(AOTTableInitData, func_indexes)
+            + sizeof(uint32) * (uint64)module->table_segments[i].function_count;
+        if (size >= UINT32_MAX
+            || !(data_list[i] = wasm_runtime_malloc((uint32)size))) {
+            aot_set_last_error("allocate memory failed.");
+            goto fail;
+        }
+
+        data_list[i]->offset = module->table_segments[i].base_offset;
+        data_list[i]->func_index_count =
+            module->table_segments[i].function_count;
+        data_list[i]->mode = module->table_segments[i].mode;
+        data_list[i]->elem_type = module->table_segments[i].elem_type;
+        /* runtime control it */
+        data_list[i]->is_dropped = false;
+        data_list[i]->table_index = module->table_segments[i].table_index;
+        bh_memcpy_s(&data_list[i]->offset, sizeof(AOTInitExpr),
+                    &module->table_segments[i].base_offset,
+                    sizeof(AOTInitExpr));
+        data_list[i]->func_index_count =
+            module->table_segments[i].function_count;
+        bh_memcpy_s(data_list[i]->func_indexes,
+                    sizeof(uint32) * module->table_segments[i].function_count,
+                    module->table_segments[i].func_indexes,
+                    sizeof(uint32) * module->table_segments[i].function_count);
+    }
+
+    return data_list;
 
 fail:
-  aot_destroy_table_init_data_list(data_list, module->table_seg_count);
-  return NULL;
+    aot_destroy_table_init_data_list(data_list, module->table_seg_count);
+    return NULL;
 }
 
 static AOTImportGlobal *
 aot_create_import_globals(const WASMModule *module,
                           uint32 *p_import_global_data_size)
 {
-  AOTImportGlobal *import_globals;
-  uint64 size;
-  uint32 i, data_offset = 0;
+    AOTImportGlobal *import_globals;
+    uint64 size;
+    uint32 i, data_offset = 0;
 
-  /* Allocate memory */
-  size = sizeof(AOTImportGlobal) * (uint64)module->import_global_count;
-  if (size >= UINT32_MAX
-      || !(import_globals = wasm_runtime_malloc((uint32)size))) {
-    aot_set_last_error("allocate memory failed.");
-    return NULL;
-  }
+    /* Allocate memory */
+    size = sizeof(AOTImportGlobal) * (uint64)module->import_global_count;
+    if (size >= UINT32_MAX
+        || !(import_globals = wasm_runtime_malloc((uint32)size))) {
+        aot_set_last_error("allocate memory failed.");
+        return NULL;
+    }
 
-  memset(import_globals, 0, (uint32)size);
+    memset(import_globals, 0, (uint32)size);
 
-  /* Create each import global */
-  for (i = 0; i < module->import_global_count; i++) {
-    WASMGlobalImport *import_global = &module->import_globals[i].u.global;
-    import_globals[i].module_name = import_global->module_name;
-    import_globals[i].global_name = import_global->field_name;
-    import_globals[i].type = import_global->type;
-    import_globals[i].is_mutable = import_global->is_mutable;
-    import_globals[i].global_data_linked = import_global->global_data_linked;
-    import_globals[i].size = wasm_value_type_size(import_global->type);
-    /* Calculate data offset */
-    import_globals[i].data_offset = data_offset;
-    data_offset += wasm_value_type_size(import_global->type);
-  }
+    /* Create each import global */
+    for (i = 0; i < module->import_global_count; i++) {
+        WASMGlobalImport *import_global = &module->import_globals[i].u.global;
+        import_globals[i].module_name = import_global->module_name;
+        import_globals[i].global_name = import_global->field_name;
+        import_globals[i].type = import_global->type;
+        import_globals[i].is_mutable = import_global->is_mutable;
+        import_globals[i].global_data_linked =
+            import_global->global_data_linked;
+        import_globals[i].size = wasm_value_type_size(import_global->type);
+        /* Calculate data offset */
+        import_globals[i].data_offset = data_offset;
+        data_offset += wasm_value_type_size(import_global->type);
+    }
 
-  *p_import_global_data_size = data_offset;
-  return import_globals;
+    *p_import_global_data_size = data_offset;
+    return import_globals;
 }
 
 static AOTGlobal *
-aot_create_globals(const WASMModule *module,
-                   uint32 global_data_start_offset,
+aot_create_globals(const WASMModule *module, uint32 global_data_start_offset,
                    uint32 *p_global_data_size)
 {
-  AOTGlobal *globals;
-  uint64 size;
-  uint32 i, data_offset = global_data_start_offset;
+    AOTGlobal *globals;
+    uint64 size;
+    uint32 i, data_offset = global_data_start_offset;
 
-  /* Allocate memory */
-  size = sizeof(AOTGlobal) * (uint64)module->global_count;
-  if (size >= UINT32_MAX
-      || !(globals = wasm_runtime_malloc((uint32)size))) {
-    aot_set_last_error("allocate memory failed.");
-    return NULL;
-  }
+    /* Allocate memory */
+    size = sizeof(AOTGlobal) * (uint64)module->global_count;
+    if (size >= UINT32_MAX || !(globals = wasm_runtime_malloc((uint32)size))) {
+        aot_set_last_error("allocate memory failed.");
+        return NULL;
+    }
 
-  memset(globals, 0, (uint32)size);
+    memset(globals, 0, (uint32)size);
 
-  /* Create each global */
-  for (i = 0; i < module->global_count; i++) {
-    WASMGlobal *global = &module->globals[i];
-    globals[i].type = global->type;
-    globals[i].is_mutable = global->is_mutable;
-    globals[i].size = wasm_value_type_size(global->type);
-    memcpy(&globals[i].init_expr, &global->init_expr,
-           sizeof(global->init_expr));
-    /* Calculate data offset */
-    globals[i].data_offset = data_offset;
-    data_offset += wasm_value_type_size(global->type);
-  }
+    /* Create each global */
+    for (i = 0; i < module->global_count; i++) {
+        WASMGlobal *global = &module->globals[i];
+        globals[i].type = global->type;
+        globals[i].is_mutable = global->is_mutable;
+        globals[i].size = wasm_value_type_size(global->type);
+        memcpy(&globals[i].init_expr, &global->init_expr,
+               sizeof(global->init_expr));
+        /* Calculate data offset */
+        globals[i].data_offset = data_offset;
+        data_offset += wasm_value_type_size(global->type);
+    }
 
-  *p_global_data_size = data_offset - global_data_start_offset;
-  return globals;
+    *p_global_data_size = data_offset - global_data_start_offset;
+    return globals;
 }
 
 static void
 aot_destroy_func_types(AOTFuncType **func_types, uint32 count)
 {
-  uint32 i;
-  for (i = 0; i < count; i++)
-    if (func_types[i])
-      wasm_runtime_free(func_types[i]);
-  wasm_runtime_free(func_types);
+    uint32 i;
+    for (i = 0; i < count; i++)
+        if (func_types[i])
+            wasm_runtime_free(func_types[i]);
+    wasm_runtime_free(func_types);
 }
 
 static AOTFuncType **
 aot_create_func_types(const WASMModule *module)
 {
-  AOTFuncType **func_types;
-  uint64 size;
-  uint32 i;
+    AOTFuncType **func_types;
+    uint64 size;
+    uint32 i;
 
-  /* Allocate memory */
-  size = sizeof(AOTFuncType*) * (uint64)module->type_count;
-  if (size >= UINT32_MAX
-      || !(func_types = wasm_runtime_malloc((uint32)size))) {
-    aot_set_last_error("allocate memory failed.");
-    return NULL;
-  }
-
-  memset(func_types, 0, size);
-
-  /* Create each function type */
-  for (i = 0; i < module->type_count; i++) {
-    size = offsetof(AOTFuncType, types) +
-           (uint64)module->types[i]->param_count +
-           (uint64)module->types[i]->result_count;
+    /* Allocate memory */
+    size = sizeof(AOTFuncType *) * (uint64)module->type_count;
     if (size >= UINT32_MAX
-        || !(func_types[i] = wasm_runtime_malloc((uint32)size))) {
-      aot_set_last_error("allocate memory failed.");
-      goto fail;
+        || !(func_types = wasm_runtime_malloc((uint32)size))) {
+        aot_set_last_error("allocate memory failed.");
+        return NULL;
     }
-    memcpy(func_types[i], module->types[i], size);
-  }
 
-  return func_types;
+    memset(func_types, 0, size);
+
+    /* Create each function type */
+    for (i = 0; i < module->type_count; i++) {
+        size = offsetof(AOTFuncType, types)
+               + (uint64)module->types[i]->param_count
+               + (uint64)module->types[i]->result_count;
+        if (size >= UINT32_MAX
+            || !(func_types[i] = wasm_runtime_malloc((uint32)size))) {
+            aot_set_last_error("allocate memory failed.");
+            goto fail;
+        }
+        memcpy(func_types[i], module->types[i], size);
+    }
+
+    return func_types;
 
 fail:
-  aot_destroy_func_types(func_types, module->type_count);
-  return NULL;
+    aot_destroy_func_types(func_types, module->type_count);
+    return NULL;
 }
 
 static AOTImportFunc *
 aot_create_import_funcs(const WASMModule *module)
 {
-  AOTImportFunc *import_funcs;
-  uint64 size;
-  uint32 i, j;
+    AOTImportFunc *import_funcs;
+    uint64 size;
+    uint32 i, j;
 
-  /* Allocate memory */
-  size = sizeof(AOTImportFunc) * (uint64)module->import_function_count;
-  if (size >= UINT32_MAX
-      || !(import_funcs = wasm_runtime_malloc((uint32)size))) {
-    aot_set_last_error("allocate memory failed.");
-    return NULL;
-  }
+    /* Allocate memory */
+    size = sizeof(AOTImportFunc) * (uint64)module->import_function_count;
+    if (size >= UINT32_MAX
+        || !(import_funcs = wasm_runtime_malloc((uint32)size))) {
+        aot_set_last_error("allocate memory failed.");
+        return NULL;
+    }
 
-  /* Create each import function */
-  for (i = 0; i < module->import_function_count; i++) {
-    WASMFunctionImport *import_func = &module->import_functions[i].u.function;
-    import_funcs[i].module_name = import_func->module_name;
-    import_funcs[i].func_name = import_func->field_name;
-    import_funcs[i].func_ptr_linked = import_func->func_ptr_linked;
-    import_funcs[i].func_type = import_func->func_type;
-    import_funcs[i].signature = import_func->signature;
-    import_funcs[i].attachment = import_func->attachment;
-    import_funcs[i].call_conv_raw = import_func->call_conv_raw;
-    import_funcs[i].call_conv_wasm_c_api = false;
-    /* Resolve function type index */
-    for (j = 0; j < module->type_count; j++)
-      if (import_func->func_type == module->types[j]) {
-        import_funcs[i].func_type_index = j;
-        break;
-      }
-  }
+    /* Create each import function */
+    for (i = 0; i < module->import_function_count; i++) {
+        WASMFunctionImport *import_func =
+            &module->import_functions[i].u.function;
+        import_funcs[i].module_name = import_func->module_name;
+        import_funcs[i].func_name = import_func->field_name;
+        import_funcs[i].func_ptr_linked = import_func->func_ptr_linked;
+        import_funcs[i].func_type = import_func->func_type;
+        import_funcs[i].signature = import_func->signature;
+        import_funcs[i].attachment = import_func->attachment;
+        import_funcs[i].call_conv_raw = import_func->call_conv_raw;
+        import_funcs[i].call_conv_wasm_c_api = false;
+        /* Resolve function type index */
+        for (j = 0; j < module->type_count; j++)
+            if (import_func->func_type == module->types[j]) {
+                import_funcs[i].func_type_index = j;
+                break;
+            }
+    }
 
-  return import_funcs;
+    return import_funcs;
 }
 
 static void
 aot_destroy_funcs(AOTFunc **funcs, uint32 count)
 {
-  uint32 i;
+    uint32 i;
 
-  for (i = 0; i < count; i++)
-    if (funcs[i])
-      wasm_runtime_free(funcs[i]);
-  wasm_runtime_free(funcs);
+    for (i = 0; i < count; i++)
+        if (funcs[i])
+            wasm_runtime_free(funcs[i]);
+    wasm_runtime_free(funcs);
 }
 
 static AOTFunc **
 aot_create_funcs(const WASMModule *module)
 {
-  AOTFunc **funcs;
-  uint64 size;
-  uint32 i, j;
+    AOTFunc **funcs;
+    uint64 size;
+    uint32 i, j;
 
-  /* Allocate memory */
-  size = sizeof(AOTFunc*) * (uint64)module->function_count;
-  if (size >= UINT32_MAX
-      || !(funcs = wasm_runtime_malloc((uint32)size))) {
-    aot_set_last_error("allocate memory failed.");
-    return NULL;
-  }
-
-  memset(funcs, 0, size);
-
-  /* Create each function */
-  for (i = 0; i < module->function_count; i++) {
-    WASMFunction *func = module->functions[i];
-    size = sizeof (AOTFunc);
-    if (!(funcs[i] = wasm_runtime_malloc((uint32)size))) {
-      aot_set_last_error("allocate memory failed.");
-      goto fail;
+    /* Allocate memory */
+    size = sizeof(AOTFunc *) * (uint64)module->function_count;
+    if (size >= UINT32_MAX || !(funcs = wasm_runtime_malloc((uint32)size))) {
+        aot_set_last_error("allocate memory failed.");
+        return NULL;
     }
 
-    funcs[i]->func_type = func->func_type;
+    memset(funcs, 0, size);
 
-    /* Resolve function type index */
-    for (j = 0; j < module->type_count; j++)
-      if (func->func_type == module->types[j]) {
-        funcs[i]->func_type_index = j;
-        break;
-      }
+    /* Create each function */
+    for (i = 0; i < module->function_count; i++) {
+        WASMFunction *func = module->functions[i];
+        size = sizeof(AOTFunc);
+        if (!(funcs[i] = wasm_runtime_malloc((uint32)size))) {
+            aot_set_last_error("allocate memory failed.");
+            goto fail;
+        }
 
-    /* Resolve local variable info and code info */
-    funcs[i]->local_count = func->local_count;
-    funcs[i]->local_types = func->local_types;
-    funcs[i]->param_cell_num = func->param_cell_num;
-    funcs[i]->local_cell_num = func->local_cell_num;
-    funcs[i]->code = func->code;
-    funcs[i]->code_size = func->code_size;
-  }
+        funcs[i]->func_type = func->func_type;
 
-  return funcs;
+        /* Resolve function type index */
+        for (j = 0; j < module->type_count; j++)
+            if (func->func_type == module->types[j]) {
+                funcs[i]->func_type_index = j;
+                break;
+            }
+
+        /* Resolve local variable info and code info */
+        funcs[i]->local_count = func->local_count;
+        funcs[i]->local_types = func->local_types;
+        funcs[i]->param_cell_num = func->param_cell_num;
+        funcs[i]->local_cell_num = func->local_cell_num;
+        funcs[i]->code = func->code;
+        funcs[i]->code_size = func->code_size;
+    }
+
+    return funcs;
 
 fail:
-  aot_destroy_funcs(funcs, module->function_count);
-  return NULL;
+    aot_destroy_funcs(funcs, module->function_count);
+    return NULL;
 }
 
-AOTCompData*
+AOTCompData *
 aot_create_comp_data(WASMModule *module)
 {
-  AOTCompData *comp_data;
-  uint32 import_global_data_size = 0, global_data_size = 0, i, j;
-  uint64 size;
+    AOTCompData *comp_data;
+    uint32 import_global_data_size = 0, global_data_size = 0, i, j;
+    uint64 size;
 
-  /* Allocate memory */
-  if (!(comp_data = wasm_runtime_malloc(sizeof(AOTCompData)))) {
-    aot_set_last_error("create compile data failed.\n");
-    return NULL;
-  }
-
-  memset(comp_data, 0, sizeof(AOTCompData));
-
-  comp_data->memory_count = module->import_memory_count + module->memory_count;
-
-  /* TODO: create import memories */
-
-  /* Allocate memory for memory array, reserve one AOTMemory space at least */
-  if (!comp_data->memory_count)
-    comp_data->memory_count = 1;
-
-  size = (uint64)comp_data->memory_count * sizeof(AOTMemory);
-  if (size >= UINT32_MAX
-      || !(comp_data->memories = wasm_runtime_malloc((uint32)size))) {
-    aot_set_last_error("create memories array failed.\n");
-    goto fail;
-  }
-  memset(comp_data->memories, 0, size);
-
-  if (!(module->import_memory_count + module->memory_count)) {
-      comp_data->memories[0].num_bytes_per_page = DEFAULT_NUM_BYTES_PER_PAGE;
-  }
-
-  /* Set memory page count */
-  for (i = 0; i < module->import_memory_count + module->memory_count; i++) {
-    if (i < module->import_memory_count) {
-      comp_data->memories[i].memory_flags =
-        module->import_memories[i].u.memory.flags;
-      comp_data->memories[i].num_bytes_per_page =
-        module->import_memories[i].u.memory.num_bytes_per_page;
-      comp_data->memories[i].mem_init_page_count =
-        module->import_memories[i].u.memory.init_page_count;
-      comp_data->memories[i].mem_max_page_count =
-        module->import_memories[i].u.memory.max_page_count;
-      comp_data->memories[i].num_bytes_per_page =
-        module->import_memories[i].u.memory.num_bytes_per_page;
+    /* Allocate memory */
+    if (!(comp_data = wasm_runtime_malloc(sizeof(AOTCompData)))) {
+        aot_set_last_error("create compile data failed.\n");
+        return NULL;
     }
-    else {
-      j = i - module->import_memory_count;
-      comp_data->memories[i].memory_flags =
-                    module->memories[j].flags;
-      comp_data->memories[i].num_bytes_per_page =
-                    module->memories[j].num_bytes_per_page;
-      comp_data->memories[i].mem_init_page_count =
-                    module->memories[j].init_page_count;
-      comp_data->memories[i].mem_max_page_count =
-                    module->memories[j].max_page_count;
-      comp_data->memories[i].num_bytes_per_page =
-                    module->memories[j].num_bytes_per_page;
-    }
-  }
 
-  /* Create memory data segments */
-  comp_data->mem_init_data_count = module->data_seg_count;
-  if (comp_data->mem_init_data_count > 0
-      && !(comp_data->mem_init_data_list =
-            aot_create_mem_init_data_list(module)))
-    goto fail;
+    memset(comp_data, 0, sizeof(AOTCompData));
 
-  /* Create tables */
-  comp_data->table_count = module->import_table_count + module->table_count;
+    comp_data->memory_count =
+        module->import_memory_count + module->memory_count;
 
-  if (comp_data->table_count > 0) {
-    size = sizeof(AOTTable) * (uint64)comp_data->table_count;
+    /* TODO: create import memories */
+
+    /* Allocate memory for memory array, reserve one AOTMemory space at least */
+    if (!comp_data->memory_count)
+        comp_data->memory_count = 1;
+
+    size = (uint64)comp_data->memory_count * sizeof(AOTMemory);
     if (size >= UINT32_MAX
-        || !(comp_data->tables = wasm_runtime_malloc((uint32)size))) {
-      aot_set_last_error("create memories array failed.\n");
-      goto fail;
+        || !(comp_data->memories = wasm_runtime_malloc((uint32)size))) {
+        aot_set_last_error("create memories array failed.\n");
+        goto fail;
     }
-    memset(comp_data->tables, 0, size);
-    for (i = 0; i < comp_data->table_count; i++) {
-      if (i < module->import_table_count) {
-        comp_data->tables[i].elem_type =
-            module->import_tables[i].u.table.elem_type;
-        comp_data->tables[i].table_flags =
-            module->import_tables[i].u.table.flags;
-        comp_data->tables[i].table_init_size =
-            module->import_tables[i].u.table.init_size;
-        comp_data->tables[i].table_max_size =
-            module->import_tables[i].u.table.max_size;
-        comp_data->tables[i].possible_grow =
-            module->import_tables[i].u.table.possible_grow;
-      }
-      else {
-        j = i - module->import_table_count;
-        comp_data->tables[i].elem_type = module->tables[j].elem_type;
-        comp_data->tables[i].table_flags = module->tables[j].flags;
-        comp_data->tables[i].table_init_size = module->tables[j].init_size;
-        comp_data->tables[i].table_max_size = module->tables[j].max_size;
-        comp_data->tables[i].possible_grow = module->tables[j].possible_grow;
-      }
+    memset(comp_data->memories, 0, size);
+
+    if (!(module->import_memory_count + module->memory_count)) {
+        comp_data->memories[0].num_bytes_per_page = DEFAULT_NUM_BYTES_PER_PAGE;
     }
-  }
 
-  /* Create table data segments */
-  comp_data->table_init_data_count = module->table_seg_count;
-  if (comp_data->table_init_data_count > 0
-      && !(comp_data->table_init_data_list =
-            aot_create_table_init_data_list(module)))
-    goto fail;
+    /* Set memory page count */
+    for (i = 0; i < module->import_memory_count + module->memory_count; i++) {
+        if (i < module->import_memory_count) {
+            comp_data->memories[i].memory_flags =
+                module->import_memories[i].u.memory.flags;
+            comp_data->memories[i].num_bytes_per_page =
+                module->import_memories[i].u.memory.num_bytes_per_page;
+            comp_data->memories[i].mem_init_page_count =
+                module->import_memories[i].u.memory.init_page_count;
+            comp_data->memories[i].mem_max_page_count =
+                module->import_memories[i].u.memory.max_page_count;
+            comp_data->memories[i].num_bytes_per_page =
+                module->import_memories[i].u.memory.num_bytes_per_page;
+        }
+        else {
+            j = i - module->import_memory_count;
+            comp_data->memories[i].memory_flags = module->memories[j].flags;
+            comp_data->memories[i].num_bytes_per_page =
+                module->memories[j].num_bytes_per_page;
+            comp_data->memories[i].mem_init_page_count =
+                module->memories[j].init_page_count;
+            comp_data->memories[i].mem_max_page_count =
+                module->memories[j].max_page_count;
+            comp_data->memories[i].num_bytes_per_page =
+                module->memories[j].num_bytes_per_page;
+        }
+    }
 
-  /* Create import globals */
-  comp_data->import_global_count = module->import_global_count;
-  if (comp_data->import_global_count > 0
-      && !(comp_data->import_globals =
-        aot_create_import_globals(module, &import_global_data_size)))
-    goto fail;
+    /* Create memory data segments */
+    comp_data->mem_init_data_count = module->data_seg_count;
+    if (comp_data->mem_init_data_count > 0
+        && !(comp_data->mem_init_data_list =
+                 aot_create_mem_init_data_list(module)))
+        goto fail;
 
-  /* Create globals */
-  comp_data->global_count = module->global_count;
-  if (comp_data->global_count
-      && !(comp_data->globals = aot_create_globals
-            (module, import_global_data_size, &global_data_size)))
-    goto fail;
+    /* Create tables */
+    comp_data->table_count = module->import_table_count + module->table_count;
 
-  comp_data->global_data_size = import_global_data_size +
-                                global_data_size;
+    if (comp_data->table_count > 0) {
+        size = sizeof(AOTTable) * (uint64)comp_data->table_count;
+        if (size >= UINT32_MAX
+            || !(comp_data->tables = wasm_runtime_malloc((uint32)size))) {
+            aot_set_last_error("create memories array failed.\n");
+            goto fail;
+        }
+        memset(comp_data->tables, 0, size);
+        for (i = 0; i < comp_data->table_count; i++) {
+            if (i < module->import_table_count) {
+                comp_data->tables[i].elem_type =
+                    module->import_tables[i].u.table.elem_type;
+                comp_data->tables[i].table_flags =
+                    module->import_tables[i].u.table.flags;
+                comp_data->tables[i].table_init_size =
+                    module->import_tables[i].u.table.init_size;
+                comp_data->tables[i].table_max_size =
+                    module->import_tables[i].u.table.max_size;
+                comp_data->tables[i].possible_grow =
+                    module->import_tables[i].u.table.possible_grow;
+            }
+            else {
+                j = i - module->import_table_count;
+                comp_data->tables[i].elem_type = module->tables[j].elem_type;
+                comp_data->tables[i].table_flags = module->tables[j].flags;
+                comp_data->tables[i].table_init_size =
+                    module->tables[j].init_size;
+                comp_data->tables[i].table_max_size =
+                    module->tables[j].max_size;
+                comp_data->tables[i].possible_grow =
+                    module->tables[j].possible_grow;
+            }
+        }
+    }
 
-  /* Create function types */
-  comp_data->func_type_count = module->type_count;
-  if (comp_data->func_type_count
-      && !(comp_data->func_types = aot_create_func_types(module)))
-    goto fail;
+    /* Create table data segments */
+    comp_data->table_init_data_count = module->table_seg_count;
+    if (comp_data->table_init_data_count > 0
+        && !(comp_data->table_init_data_list =
+                 aot_create_table_init_data_list(module)))
+        goto fail;
 
-  /* Create import functions */
-  comp_data->import_func_count = module->import_function_count;
-  if (comp_data->import_func_count
-      && !(comp_data->import_funcs = aot_create_import_funcs(module)))
-    goto fail;
+    /* Create import globals */
+    comp_data->import_global_count = module->import_global_count;
+    if (comp_data->import_global_count > 0
+        && !(comp_data->import_globals =
+                 aot_create_import_globals(module, &import_global_data_size)))
+        goto fail;
 
-  /* Create functions */
-  comp_data->func_count = module->function_count;
-  if (comp_data->func_count
-      && !(comp_data->funcs = aot_create_funcs(module)))
-    goto fail;
+    /* Create globals */
+    comp_data->global_count = module->global_count;
+    if (comp_data->global_count
+        && !(comp_data->globals = aot_create_globals(
+                 module, import_global_data_size, &global_data_size)))
+        goto fail;
 
-  /* Create aux data/heap/stack information */
-  comp_data->aux_data_end_global_index = module->aux_data_end_global_index;
-  comp_data->aux_data_end = module->aux_data_end;
-  comp_data->aux_heap_base_global_index = module->aux_heap_base_global_index;
-  comp_data->aux_heap_base = module->aux_heap_base;
-  comp_data->aux_stack_top_global_index = module->aux_stack_top_global_index;
-  comp_data->aux_stack_bottom = module->aux_stack_bottom;
-  comp_data->aux_stack_size = module->aux_stack_size;
+    comp_data->global_data_size = import_global_data_size + global_data_size;
 
-  comp_data->start_func_index = module->start_function;
-  comp_data->malloc_func_index = module->malloc_function;
-  comp_data->free_func_index = module->free_function;
-  comp_data->retain_func_index = module->retain_function;
+    /* Create function types */
+    comp_data->func_type_count = module->type_count;
+    if (comp_data->func_type_count
+        && !(comp_data->func_types = aot_create_func_types(module)))
+        goto fail;
 
-  comp_data->wasm_module = module;
+    /* Create import functions */
+    comp_data->import_func_count = module->import_function_count;
+    if (comp_data->import_func_count
+        && !(comp_data->import_funcs = aot_create_import_funcs(module)))
+        goto fail;
 
-  return comp_data;
+    /* Create functions */
+    comp_data->func_count = module->function_count;
+    if (comp_data->func_count && !(comp_data->funcs = aot_create_funcs(module)))
+        goto fail;
+
+    /* Create aux data/heap/stack information */
+    comp_data->aux_data_end_global_index = module->aux_data_end_global_index;
+    comp_data->aux_data_end = module->aux_data_end;
+    comp_data->aux_heap_base_global_index = module->aux_heap_base_global_index;
+    comp_data->aux_heap_base = module->aux_heap_base;
+    comp_data->aux_stack_top_global_index = module->aux_stack_top_global_index;
+    comp_data->aux_stack_bottom = module->aux_stack_bottom;
+    comp_data->aux_stack_size = module->aux_stack_size;
+
+    comp_data->start_func_index = module->start_function;
+    comp_data->malloc_func_index = module->malloc_function;
+    comp_data->free_func_index = module->free_function;
+    comp_data->retain_func_index = module->retain_function;
+
+    comp_data->wasm_module = module;
+
+    return comp_data;
 
 fail:
 
-  aot_destroy_comp_data(comp_data);
-  return NULL;
+    aot_destroy_comp_data(comp_data);
+    return NULL;
 }
 
 void
 aot_destroy_comp_data(AOTCompData *comp_data)
 {
-  if (!comp_data)
-    return;
+    if (!comp_data)
+        return;
 
-  if (comp_data->import_memories)
-    wasm_runtime_free(comp_data->import_memories);
+    if (comp_data->import_memories)
+        wasm_runtime_free(comp_data->import_memories);
 
-  if (comp_data->memories)
-    wasm_runtime_free(comp_data->memories);
+    if (comp_data->memories)
+        wasm_runtime_free(comp_data->memories);
 
-  if (comp_data->mem_init_data_list)
-    aot_destroy_mem_init_data_list(comp_data->mem_init_data_list,
-                                   comp_data->mem_init_data_count);
+    if (comp_data->mem_init_data_list)
+        aot_destroy_mem_init_data_list(comp_data->mem_init_data_list,
+                                       comp_data->mem_init_data_count);
 
-  if (comp_data->import_tables)
-    wasm_runtime_free(comp_data->import_tables);
+    if (comp_data->import_tables)
+        wasm_runtime_free(comp_data->import_tables);
 
-  if (comp_data->tables)
-    wasm_runtime_free(comp_data->tables);
+    if (comp_data->tables)
+        wasm_runtime_free(comp_data->tables);
 
-  if (comp_data->table_init_data_list)
-    aot_destroy_table_init_data_list(comp_data->table_init_data_list,
-                                     comp_data->table_init_data_count);
+    if (comp_data->table_init_data_list)
+        aot_destroy_table_init_data_list(comp_data->table_init_data_list,
+                                         comp_data->table_init_data_count);
 
-  if (comp_data->import_globals)
-    wasm_runtime_free(comp_data->import_globals);
+    if (comp_data->import_globals)
+        wasm_runtime_free(comp_data->import_globals);
 
-  if (comp_data->globals)
-    wasm_runtime_free(comp_data->globals);
+    if (comp_data->globals)
+        wasm_runtime_free(comp_data->globals);
 
-  if (comp_data->func_types)
-    aot_destroy_func_types(comp_data->func_types,
-                           comp_data->func_type_count);
+    if (comp_data->func_types)
+        aot_destroy_func_types(comp_data->func_types,
+                               comp_data->func_type_count);
 
-  if (comp_data->import_funcs)
-    wasm_runtime_free(comp_data->import_funcs);
+    if (comp_data->import_funcs)
+        wasm_runtime_free(comp_data->import_funcs);
 
-  if (comp_data->funcs)
-    aot_destroy_funcs(comp_data->funcs, comp_data->func_count);
+    if (comp_data->funcs)
+        aot_destroy_funcs(comp_data->funcs, comp_data->func_count);
 
-  wasm_runtime_free(comp_data);
+    wasm_runtime_free(comp_data);
 }
-

--- a/core/iwasm/compilation/aot.h
+++ b/core/iwasm/compilation/aot.h
@@ -22,54 +22,54 @@ typedef WASMType AOTFuncType;
 typedef WASMExport AOTExport;
 
 #if WASM_ENABLE_DEBUG_AOT != 0
-typedef void * dwar_extractor_handle_t;
+typedef void *dwar_extractor_handle_t;
 #endif
 
 typedef enum AOTIntCond {
-  INT_EQZ = 0,
-  INT_EQ,
-  INT_NE,
-  INT_LT_S,
-  INT_LT_U,
-  INT_GT_S,
-  INT_GT_U,
-  INT_LE_S,
-  INT_LE_U,
-  INT_GE_S,
-  INT_GE_U
+    INT_EQZ = 0,
+    INT_EQ,
+    INT_NE,
+    INT_LT_S,
+    INT_LT_U,
+    INT_GT_S,
+    INT_GT_U,
+    INT_LE_S,
+    INT_LE_U,
+    INT_GE_S,
+    INT_GE_U
 } AOTIntCond;
 
 typedef enum AOTFloatCond {
-  FLOAT_EQ = 0,
-  FLOAT_NE,
-  FLOAT_LT,
-  FLOAT_GT,
-  FLOAT_LE,
-  FLOAT_GE,
-  FLOAT_UNO
+    FLOAT_EQ = 0,
+    FLOAT_NE,
+    FLOAT_LT,
+    FLOAT_GT,
+    FLOAT_LE,
+    FLOAT_GE,
+    FLOAT_UNO
 } AOTFloatCond;
 
 /**
  * Import memory
  */
 typedef struct AOTImportMemory {
-  char *module_name;
-  char *memory_name;
-  uint32 memory_flags;
-  uint32 num_bytes_per_page;
-  uint32 mem_init_page_count;
-  uint32 mem_max_page_count;
+    char *module_name;
+    char *memory_name;
+    uint32 memory_flags;
+    uint32 num_bytes_per_page;
+    uint32 mem_init_page_count;
+    uint32 mem_max_page_count;
 } AOTImportMemory;
 
 /**
  * Memory information
  */
 typedef struct AOTMemory {
-  /* memory info */
-  uint32 memory_flags;
-  uint32 num_bytes_per_page;
-  uint32 mem_init_page_count;
-  uint32 mem_max_page_count;
+    /* memory info */
+    uint32 memory_flags;
+    uint32 num_bytes_per_page;
+    uint32 mem_init_page_count;
+    uint32 mem_max_page_count;
 } AOTMemory;
 
 /**
@@ -77,202 +77,202 @@ typedef struct AOTMemory {
  */
 typedef struct AOTMemInitData {
 #if WASM_ENABLE_BULK_MEMORY != 0
-  /* Passive flag */
-  bool is_passive;
-  /* memory index */
-  uint32 memory_index;
+    /* Passive flag */
+    bool is_passive;
+    /* memory index */
+    uint32 memory_index;
 #endif
-  /* Start address of init data */
-  AOTInitExpr offset;
-  /* Byte count */
-  uint32 byte_count;
-  /* Byte array */
-  uint8 bytes[1];
+    /* Start address of init data */
+    AOTInitExpr offset;
+    /* Byte count */
+    uint32 byte_count;
+    /* Byte array */
+    uint8 bytes[1];
 } AOTMemInitData;
 
 /**
  * Import table
  */
 typedef struct AOTImportTable {
-  char *module_name;
-  char *table_name;
-  uint32 table_flags;
-  uint32 table_init_size;
-  uint32 table_max_size;
-  bool possible_grow;
+    char *module_name;
+    char *table_name;
+    uint32 table_flags;
+    uint32 table_init_size;
+    uint32 table_max_size;
+    bool possible_grow;
 } AOTImportTable;
 
 /**
  * Table
  */
 typedef struct AOTTable {
-  uint32 elem_type;
-  uint32 table_flags;
-  uint32 table_init_size;
-  uint32 table_max_size;
-  bool possible_grow;
+    uint32 elem_type;
+    uint32 table_flags;
+    uint32 table_init_size;
+    uint32 table_max_size;
+    bool possible_grow;
 } AOTTable;
 
 /**
  * A segment of table init data
  */
 typedef struct AOTTableInitData {
-  /* 0 to 7 */
-  uint32 mode;
-  /* funcref or externref, elemkind will be considered as funcref */
-  uint32 elem_type;
-  bool is_dropped;
-  /* optional, only for active */
-  uint32 table_index;
-  /* Start address of init data */
-  AOTInitExpr offset;
-  /* Function index count */
-  uint32 func_index_count;
-  /* Function index array */
-  uint32 func_indexes[1];
+    /* 0 to 7 */
+    uint32 mode;
+    /* funcref or externref, elemkind will be considered as funcref */
+    uint32 elem_type;
+    bool is_dropped;
+    /* optional, only for active */
+    uint32 table_index;
+    /* Start address of init data */
+    AOTInitExpr offset;
+    /* Function index count */
+    uint32 func_index_count;
+    /* Function index array */
+    uint32 func_indexes[1];
 } AOTTableInitData;
 
 /**
  * Import global variable
  */
 typedef struct AOTImportGlobal {
-  char *module_name;
-  char *global_name;
-  /* VALUE_TYPE_I32/I64/F32/F64 */
-  uint8 type;
-  bool is_mutable;
-  uint32 size;
-  /* The data offset of current global in global data */
-  uint32 data_offset;
-  /* global data after linked */
-  WASMValue global_data_linked;
+    char *module_name;
+    char *global_name;
+    /* VALUE_TYPE_I32/I64/F32/F64 */
+    uint8 type;
+    bool is_mutable;
+    uint32 size;
+    /* The data offset of current global in global data */
+    uint32 data_offset;
+    /* global data after linked */
+    WASMValue global_data_linked;
 } AOTImportGlobal;
 
 /**
  * Global variable
  */
 typedef struct AOTGlobal {
-  /* VALUE_TYPE_I32/I64/F32/F64 */
-  uint8 type;
-  bool is_mutable;
-  uint32 size;
-  /* The data offset of current global in global data */
-  uint32 data_offset;
-  AOTInitExpr init_expr;
+    /* VALUE_TYPE_I32/I64/F32/F64 */
+    uint8 type;
+    bool is_mutable;
+    uint32 size;
+    /* The data offset of current global in global data */
+    uint32 data_offset;
+    AOTInitExpr init_expr;
 } AOTGlobal;
 
 /**
  * Import function
  */
 typedef struct AOTImportFunc {
-  char *module_name;
-  char *func_name;
-  AOTFuncType *func_type;
-  uint32 func_type_index;
-  /* function pointer after linked */
-  void *func_ptr_linked;
-  /* signature from registered native symbols */
-  const char *signature;
-  /* attachment */
-  void *attachment;
-  bool call_conv_raw;
-  bool call_conv_wasm_c_api;
-  bool wasm_c_api_with_env;
+    char *module_name;
+    char *func_name;
+    AOTFuncType *func_type;
+    uint32 func_type_index;
+    /* function pointer after linked */
+    void *func_ptr_linked;
+    /* signature from registered native symbols */
+    const char *signature;
+    /* attachment */
+    void *attachment;
+    bool call_conv_raw;
+    bool call_conv_wasm_c_api;
+    bool wasm_c_api_with_env;
 } AOTImportFunc;
 
 /**
  * Function
  */
 typedef struct AOTFunc {
-  AOTFuncType *func_type;
-  uint32 func_type_index;
-  uint32 local_count;
-  uint8 *local_types;
-  uint16 param_cell_num;
-  uint16 local_cell_num;
-  uint32 code_size;
-  uint8 *code;
+    AOTFuncType *func_type;
+    uint32 func_type_index;
+    uint32 local_count;
+    uint8 *local_types;
+    uint16 param_cell_num;
+    uint16 local_cell_num;
+    uint32 code_size;
+    uint8 *code;
 } AOTFunc;
 
 typedef struct AOTCompData {
-  /* Import memories */
-  uint32 import_memory_count;
-  AOTImportMemory *import_memories;
+    /* Import memories */
+    uint32 import_memory_count;
+    AOTImportMemory *import_memories;
 
-  /* Memories */
-  uint32 memory_count;
-  AOTMemory *memories;
+    /* Memories */
+    uint32 memory_count;
+    AOTMemory *memories;
 
-  /* Memory init data info */
-  uint32 mem_init_data_count;
-  AOTMemInitData **mem_init_data_list;
+    /* Memory init data info */
+    uint32 mem_init_data_count;
+    AOTMemInitData **mem_init_data_list;
 
-  /* Import tables */
-  uint32 import_table_count;
-  AOTImportTable *import_tables;
+    /* Import tables */
+    uint32 import_table_count;
+    AOTImportTable *import_tables;
 
-  /* Tables */
-  uint32 table_count;
-  AOTTable *tables;
+    /* Tables */
+    uint32 table_count;
+    AOTTable *tables;
 
-  /* Table init data info */
-  uint32 table_init_data_count;
-  AOTTableInitData **table_init_data_list;
+    /* Table init data info */
+    uint32 table_init_data_count;
+    AOTTableInitData **table_init_data_list;
 
-  /* Import globals */
-  uint32 import_global_count;
-  AOTImportGlobal *import_globals;
+    /* Import globals */
+    uint32 import_global_count;
+    AOTImportGlobal *import_globals;
 
-  /* Globals */
-  uint32 global_count;
-  AOTGlobal *globals;
+    /* Globals */
+    uint32 global_count;
+    AOTGlobal *globals;
 
-  /* Function types */
-  uint32 func_type_count;
-  AOTFuncType **func_types;
+    /* Function types */
+    uint32 func_type_count;
+    AOTFuncType **func_types;
 
-  /* Import functions */
-  uint32 import_func_count;
-  AOTImportFunc *import_funcs;
+    /* Import functions */
+    uint32 import_func_count;
+    AOTImportFunc *import_funcs;
 
-  /* Functions */
-  uint32 func_count;
-  AOTFunc **funcs;
+    /* Functions */
+    uint32 func_count;
+    AOTFunc **funcs;
 
-  uint32 global_data_size;
+    uint32 global_data_size;
 
-  uint32 start_func_index;
-  uint32 malloc_func_index;
-  uint32 free_func_index;
-  uint32 retain_func_index;
+    uint32 start_func_index;
+    uint32 malloc_func_index;
+    uint32 free_func_index;
+    uint32 retain_func_index;
 
-  uint32 aux_data_end_global_index;
-  uint32 aux_data_end;
-  uint32 aux_heap_base_global_index;
-  uint32 aux_heap_base;
-  uint32 aux_stack_top_global_index;
-  uint32 aux_stack_bottom;
-  uint32 aux_stack_size;
+    uint32 aux_data_end_global_index;
+    uint32 aux_data_end;
+    uint32 aux_heap_base_global_index;
+    uint32 aux_heap_base;
+    uint32 aux_stack_top_global_index;
+    uint32 aux_stack_bottom;
+    uint32 aux_stack_size;
 
-  WASMModule *wasm_module;
+    WASMModule *wasm_module;
 #if WASM_ENABLE_DEBUG_AOT != 0
-  dwar_extractor_handle_t extractor;
+    dwar_extractor_handle_t extractor;
 #endif
 } AOTCompData;
 
 typedef struct AOTNativeSymbol {
-  bh_list_link link;
-  const char *symbol;
-  int32 index;
+    bh_list_link link;
+    const char *symbol;
+    int32 index;
 } AOTNativeSymbol;
 
-AOTCompData*
+AOTCompData *
 aot_create_comp_data(WASMModule *module);
 
 void
 aot_destroy_comp_data(AOTCompData *comp_data);
 
-char*
+char *
 aot_get_last_error();
 
 void
@@ -282,14 +282,16 @@ void
 aot_set_last_error_v(const char *format, ...);
 
 #if BH_DEBUG != 0
-#define HANDLE_FAILURE(callee) do {                          \
-    aot_set_last_error_v("call %s failed in %s:%d", (callee),\
-                         __FUNCTION__, __LINE__);            \
-  } while (0)
+#define HANDLE_FAILURE(callee)                                    \
+    do {                                                          \
+        aot_set_last_error_v("call %s failed in %s:%d", (callee), \
+                             __FUNCTION__, __LINE__);             \
+    } while (0)
 #else
-#define HANDLE_FAILURE(callee) do {                          \
-    aot_set_last_error_v("call %s failed", (callee));        \
-  } while (0)
+#define HANDLE_FAILURE(callee)                            \
+    do {                                                  \
+        aot_set_last_error_v("call %s failed", (callee)); \
+    } while (0)
 #endif
 
 static inline uint32
@@ -309,4 +311,3 @@ aot_get_imp_tbl_data_slots(const AOTImportTable *tbl)
 #endif
 
 #endif /* end of _AOT_H_ */
-

--- a/core/iwasm/compilation/aot_compiler.c
+++ b/core/iwasm/compilation/aot_compiler.c
@@ -36,2500 +36,2573 @@
 #include "debug/dwarf_extractor.h"
 #endif
 
-#define CHECK_BUF(buf, buf_end, length) do {                \
-  if (buf + length > buf_end) {                             \
-    aot_set_last_error("read leb failed: unexpected end."); \
-    return false;                                           \
-  }                                                         \
-} while (0)
+#define CHECK_BUF(buf, buf_end, length)                             \
+    do {                                                            \
+        if (buf + length > buf_end) {                               \
+            aot_set_last_error("read leb failed: unexpected end."); \
+            return false;                                           \
+        }                                                           \
+    } while (0)
 
 static bool
-read_leb(const uint8 *buf, const uint8 *buf_end,
-         uint32 *p_offset, uint32 maxbits,
-         bool sign, uint64 *p_result)
+read_leb(const uint8 *buf, const uint8 *buf_end, uint32 *p_offset,
+         uint32 maxbits, bool sign, uint64 *p_result)
 {
-  uint64 result = 0;
-  uint32 shift = 0;
-  uint32 bcnt = 0;
-  uint64 byte;
+    uint64 result = 0;
+    uint32 shift = 0;
+    uint32 bcnt = 0;
+    uint64 byte;
 
-  while (true) {
-    CHECK_BUF(buf, buf_end, 1);
-    byte = buf[*p_offset];
-    *p_offset += 1;
-    result |= ((byte & 0x7f) << shift);
-    shift += 7;
-    if ((byte & 0x80) == 0) {
-      break;
+    while (true) {
+        CHECK_BUF(buf, buf_end, 1);
+        byte = buf[*p_offset];
+        *p_offset += 1;
+        result |= ((byte & 0x7f) << shift);
+        shift += 7;
+        if ((byte & 0x80) == 0) {
+            break;
+        }
+        bcnt += 1;
     }
-    bcnt += 1;
-  }
-  if (bcnt > (((maxbits + 8) >> 3) - (maxbits + 8))) {
-    aot_set_last_error("read leb failed: unsigned leb overflow.");
-    return false;
-  }
-  if (sign && (shift < maxbits) && (byte & 0x40)) {
-    /* Sign extend */
-    result |= (~((uint64)0)) << shift;
-  }
-  *p_result = result;
-  return true;
+    if (bcnt > (((maxbits + 8) >> 3) - (maxbits + 8))) {
+        aot_set_last_error("read leb failed: unsigned leb overflow.");
+        return false;
+    }
+    if (sign && (shift < maxbits) && (byte & 0x40)) {
+        /* Sign extend */
+        result |= (~((uint64)0)) << shift;
+    }
+    *p_result = result;
+    return true;
 }
 
-#define read_leb_uint32(p, p_end, res) do {         \
-  uint32 off = 0;                                   \
-  uint64 res64;                                     \
-  if (!read_leb(p, p_end, &off, 32, false, &res64)) \
-    return false;                                   \
-  p += off;                                         \
-  res = (uint32)res64;                              \
-} while (0)
+#define read_leb_uint32(p, p_end, res)                    \
+    do {                                                  \
+        uint32 off = 0;                                   \
+        uint64 res64;                                     \
+        if (!read_leb(p, p_end, &off, 32, false, &res64)) \
+            return false;                                 \
+        p += off;                                         \
+        res = (uint32)res64;                              \
+    } while (0)
 
-#define read_leb_int32(p, p_end, res) do {          \
-  uint32 off = 0;                                   \
-  uint64 res64;                                     \
-  if (!read_leb(p, p_end, &off, 32, true, &res64))  \
-    return false;                                   \
-  p += off;                                         \
-  res = (int32)res64;                              \
-} while (0)
+#define read_leb_int32(p, p_end, res)                    \
+    do {                                                 \
+        uint32 off = 0;                                  \
+        uint64 res64;                                    \
+        if (!read_leb(p, p_end, &off, 32, true, &res64)) \
+            return false;                                \
+        p += off;                                        \
+        res = (int32)res64;                              \
+    } while (0)
 
-#define read_leb_int64(p, p_end, res) do {          \
-  uint32 off = 0;                                   \
-  uint64 res64;                                     \
-  if (!read_leb(p, p_end, &off, 64, true, &res64))  \
-    return false;                                   \
-  p += off;                                         \
-  res = (int64)res64;                               \
-} while (0)
+#define read_leb_int64(p, p_end, res)                    \
+    do {                                                 \
+        uint32 off = 0;                                  \
+        uint64 res64;                                    \
+        if (!read_leb(p, p_end, &off, 64, true, &res64)) \
+            return false;                                \
+        p += off;                                        \
+        res = (int64)res64;                              \
+    } while (0)
 
-#define COMPILE_ATOMIC_RMW(OP, NAME)                            \
-  case WASM_OP_ATOMIC_RMW_I32_##NAME:                           \
-    bytes = 4;                                                  \
-    op_type = VALUE_TYPE_I32;                                   \
-    goto OP_ATOMIC_##OP;                                        \
-  case WASM_OP_ATOMIC_RMW_I64_##NAME:                           \
-    bytes = 8;                                                  \
-    op_type = VALUE_TYPE_I64;                                   \
-    goto OP_ATOMIC_##OP;                                        \
-  case WASM_OP_ATOMIC_RMW_I32_##NAME##8_U:                      \
-    bytes = 1;                                                  \
-    op_type = VALUE_TYPE_I32;                                   \
-    goto OP_ATOMIC_##OP;                                        \
-  case WASM_OP_ATOMIC_RMW_I32_##NAME##16_U:                     \
-    bytes = 2;                                                  \
-    op_type = VALUE_TYPE_I32;                                   \
-    goto OP_ATOMIC_##OP;                                        \
-  case WASM_OP_ATOMIC_RMW_I64_##NAME##8_U:                      \
-    bytes = 1;                                                  \
-    op_type = VALUE_TYPE_I64;                                   \
-    goto OP_ATOMIC_##OP;                                        \
-  case WASM_OP_ATOMIC_RMW_I64_##NAME##16_U:                     \
-    bytes = 2;                                                  \
-    op_type = VALUE_TYPE_I64;                                   \
-    goto OP_ATOMIC_##OP;                                        \
-  case WASM_OP_ATOMIC_RMW_I64_##NAME##32_U:                     \
-    bytes = 4;                                                  \
-    op_type = VALUE_TYPE_I64;                                   \
-OP_ATOMIC_##OP:                                                 \
-    bin_op = LLVMAtomicRMWBinOp##OP;                            \
-    goto build_atomic_rmw;
+#define COMPILE_ATOMIC_RMW(OP, NAME)                      \
+    case WASM_OP_ATOMIC_RMW_I32_##NAME:                   \
+        bytes = 4;                                        \
+        op_type = VALUE_TYPE_I32;                         \
+        goto OP_ATOMIC_##OP;                              \
+    case WASM_OP_ATOMIC_RMW_I64_##NAME:                   \
+        bytes = 8;                                        \
+        op_type = VALUE_TYPE_I64;                         \
+        goto OP_ATOMIC_##OP;                              \
+    case WASM_OP_ATOMIC_RMW_I32_##NAME##8_U:              \
+        bytes = 1;                                        \
+        op_type = VALUE_TYPE_I32;                         \
+        goto OP_ATOMIC_##OP;                              \
+    case WASM_OP_ATOMIC_RMW_I32_##NAME##16_U:             \
+        bytes = 2;                                        \
+        op_type = VALUE_TYPE_I32;                         \
+        goto OP_ATOMIC_##OP;                              \
+    case WASM_OP_ATOMIC_RMW_I64_##NAME##8_U:              \
+        bytes = 1;                                        \
+        op_type = VALUE_TYPE_I64;                         \
+        goto OP_ATOMIC_##OP;                              \
+    case WASM_OP_ATOMIC_RMW_I64_##NAME##16_U:             \
+        bytes = 2;                                        \
+        op_type = VALUE_TYPE_I64;                         \
+        goto OP_ATOMIC_##OP;                              \
+    case WASM_OP_ATOMIC_RMW_I64_##NAME##32_U:             \
+        bytes = 4;                                        \
+        op_type = VALUE_TYPE_I64;                         \
+        OP_ATOMIC_##OP : bin_op = LLVMAtomicRMWBinOp##OP; \
+        goto build_atomic_rmw;
 
 static bool
 aot_compile_func(AOTCompContext *comp_ctx, uint32 func_index)
 {
-  AOTFuncContext *func_ctx = comp_ctx->func_ctxes[func_index];
-  uint8 *frame_ip = func_ctx->aot_func->code, opcode, *p_f32, *p_f64;
-  uint8 *frame_ip_end = frame_ip + func_ctx->aot_func->code_size;
-  uint8 *param_types = NULL;
-  uint8 *result_types = NULL;
-  uint8 value_type;
-  uint16 param_count;
-  uint16 result_count;
-  uint32 br_depth, *br_depths, br_count;
-  uint32 func_idx, type_idx, mem_idx, local_idx, global_idx, i;
-  uint32 bytes = 4, align, offset;
-  uint32 type_index;
-  bool sign = true;
-  int32 i32_const;
-  int64 i64_const;
-  float32 f32_const;
-  float64 f64_const;
-  AOTFuncType *func_type = NULL;
+    AOTFuncContext *func_ctx = comp_ctx->func_ctxes[func_index];
+    uint8 *frame_ip = func_ctx->aot_func->code, opcode, *p_f32, *p_f64;
+    uint8 *frame_ip_end = frame_ip + func_ctx->aot_func->code_size;
+    uint8 *param_types = NULL;
+    uint8 *result_types = NULL;
+    uint8 value_type;
+    uint16 param_count;
+    uint16 result_count;
+    uint32 br_depth, *br_depths, br_count;
+    uint32 func_idx, type_idx, mem_idx, local_idx, global_idx, i;
+    uint32 bytes = 4, align, offset;
+    uint32 type_index;
+    bool sign = true;
+    int32 i32_const;
+    int64 i64_const;
+    float32 f32_const;
+    float64 f64_const;
+    AOTFuncType *func_type = NULL;
 #if WASM_ENABLE_DEBUG_AOT != 0
-  LLVMMetadataRef location;
+    LLVMMetadataRef location;
 #endif
 
-  /* Start to translate the opcodes */
-  LLVMPositionBuilderAtEnd(comp_ctx->builder,
-                           func_ctx->block_stack.block_list_head
-                                   ->llvm_entry_block);
-  while (frame_ip < frame_ip_end) {
-    opcode = *frame_ip++;
+    /* Start to translate the opcodes */
+    LLVMPositionBuilderAtEnd(
+        comp_ctx->builder,
+        func_ctx->block_stack.block_list_head->llvm_entry_block);
+    while (frame_ip < frame_ip_end) {
+        opcode = *frame_ip++;
 
 #if WASM_ENABLE_DEBUG_AOT != 0
-    location = dwarf_gen_location(
-      comp_ctx, func_ctx,
-      (frame_ip - 1) - comp_ctx->comp_data->wasm_module->buf_code
-    );
-    LLVMSetCurrentDebugLocation2(comp_ctx->builder, location);
+        location = dwarf_gen_location(
+            comp_ctx, func_ctx,
+            (frame_ip - 1) - comp_ctx->comp_data->wasm_module->buf_code);
+        LLVMSetCurrentDebugLocation2(comp_ctx->builder, location);
 #endif
 
-    switch (opcode) {
-      case WASM_OP_UNREACHABLE:
-        if (!aot_compile_op_unreachable(comp_ctx, func_ctx, &frame_ip))
-          return false;
-        break;
+        switch (opcode) {
+            case WASM_OP_UNREACHABLE:
+                if (!aot_compile_op_unreachable(comp_ctx, func_ctx, &frame_ip))
+                    return false;
+                break;
 
-      case WASM_OP_NOP:
-        break;
+            case WASM_OP_NOP:
+                break;
 
-      case WASM_OP_BLOCK:
-      case WASM_OP_LOOP:
-      case WASM_OP_IF:
-        value_type = *frame_ip++;
-        if (value_type == VALUE_TYPE_I32
-            || value_type == VALUE_TYPE_I64
-            || value_type == VALUE_TYPE_F32
-            || value_type == VALUE_TYPE_F64
-            || value_type == VALUE_TYPE_V128
-            || value_type == VALUE_TYPE_VOID
-            || value_type == VALUE_TYPE_FUNCREF
-            || value_type == VALUE_TYPE_EXTERNREF) {
-          param_count = 0;
-          param_types = NULL;
-          if (value_type == VALUE_TYPE_VOID) {
-            result_count = 0;
-            result_types = NULL;
-          }
-          else {
-            result_count = 1;
-            result_types = &value_type;
-          }
-        }
-        else {
-          frame_ip--;
-          read_leb_uint32(frame_ip, frame_ip_end, type_index);
-          func_type = comp_ctx->comp_data->func_types[type_index];
-          param_count = func_type->param_count;
-          param_types = func_type->types;
-          result_count = func_type->result_count;
-          result_types = func_type->types + param_count;
-        }
-        if (!aot_compile_op_block(comp_ctx, func_ctx,
-                                  &frame_ip, frame_ip_end,
-                                  (uint32)(LABEL_TYPE_BLOCK + opcode - WASM_OP_BLOCK),
-                                  param_count, param_types,
-                                  result_count, result_types))
-          return false;
-        break;
+            case WASM_OP_BLOCK:
+            case WASM_OP_LOOP:
+            case WASM_OP_IF:
+                value_type = *frame_ip++;
+                if (value_type == VALUE_TYPE_I32 || value_type == VALUE_TYPE_I64
+                    || value_type == VALUE_TYPE_F32
+                    || value_type == VALUE_TYPE_F64
+                    || value_type == VALUE_TYPE_V128
+                    || value_type == VALUE_TYPE_VOID
+                    || value_type == VALUE_TYPE_FUNCREF
+                    || value_type == VALUE_TYPE_EXTERNREF) {
+                    param_count = 0;
+                    param_types = NULL;
+                    if (value_type == VALUE_TYPE_VOID) {
+                        result_count = 0;
+                        result_types = NULL;
+                    }
+                    else {
+                        result_count = 1;
+                        result_types = &value_type;
+                    }
+                }
+                else {
+                    frame_ip--;
+                    read_leb_uint32(frame_ip, frame_ip_end, type_index);
+                    func_type = comp_ctx->comp_data->func_types[type_index];
+                    param_count = func_type->param_count;
+                    param_types = func_type->types;
+                    result_count = func_type->result_count;
+                    result_types = func_type->types + param_count;
+                }
+                if (!aot_compile_op_block(
+                        comp_ctx, func_ctx, &frame_ip, frame_ip_end,
+                        (uint32)(LABEL_TYPE_BLOCK + opcode - WASM_OP_BLOCK),
+                        param_count, param_types, result_count, result_types))
+                    return false;
+                break;
 
-      case WASM_OP_ELSE:
-        if (!aot_compile_op_else(comp_ctx, func_ctx, &frame_ip))
-          return false;
-        break;
+            case WASM_OP_ELSE:
+                if (!aot_compile_op_else(comp_ctx, func_ctx, &frame_ip))
+                    return false;
+                break;
 
-      case WASM_OP_END:
-        if (!aot_compile_op_end(comp_ctx, func_ctx, &frame_ip))
-          return false;
-        break;
+            case WASM_OP_END:
+                if (!aot_compile_op_end(comp_ctx, func_ctx, &frame_ip))
+                    return false;
+                break;
 
-      case WASM_OP_BR:
-        read_leb_uint32(frame_ip, frame_ip_end, br_depth);
-        if (!aot_compile_op_br(comp_ctx, func_ctx, br_depth, &frame_ip))
-          return false;
-        break;
+            case WASM_OP_BR:
+                read_leb_uint32(frame_ip, frame_ip_end, br_depth);
+                if (!aot_compile_op_br(comp_ctx, func_ctx, br_depth, &frame_ip))
+                    return false;
+                break;
 
-      case WASM_OP_BR_IF:
-        read_leb_uint32(frame_ip, frame_ip_end, br_depth);
-        if (!aot_compile_op_br_if(comp_ctx, func_ctx, br_depth, &frame_ip))
-          return false;
-        break;
+            case WASM_OP_BR_IF:
+                read_leb_uint32(frame_ip, frame_ip_end, br_depth);
+                if (!aot_compile_op_br_if(comp_ctx, func_ctx, br_depth,
+                                          &frame_ip))
+                    return false;
+                break;
 
-      case WASM_OP_BR_TABLE:
-        read_leb_uint32(frame_ip, frame_ip_end, br_count);
-        if (!(br_depths =
-                wasm_runtime_malloc((uint32)sizeof(uint32) * (br_count + 1)))) {
-          aot_set_last_error("allocate memory failed.");
-          goto fail;
-        }
-        for (i = 0; i <= br_count; i++)
-          read_leb_uint32(frame_ip, frame_ip_end, br_depths[i]);
+            case WASM_OP_BR_TABLE:
+                read_leb_uint32(frame_ip, frame_ip_end, br_count);
+                if (!(br_depths = wasm_runtime_malloc((uint32)sizeof(uint32)
+                                                      * (br_count + 1)))) {
+                    aot_set_last_error("allocate memory failed.");
+                    goto fail;
+                }
+                for (i = 0; i <= br_count; i++)
+                    read_leb_uint32(frame_ip, frame_ip_end, br_depths[i]);
 
-        if (!aot_compile_op_br_table(comp_ctx, func_ctx,
-                                     br_depths, br_count, &frame_ip)) {
-          wasm_runtime_free(br_depths);
-          return false;
-        }
+                if (!aot_compile_op_br_table(comp_ctx, func_ctx, br_depths,
+                                             br_count, &frame_ip)) {
+                    wasm_runtime_free(br_depths);
+                    return false;
+                }
 
-        wasm_runtime_free(br_depths);
-        break;
+                wasm_runtime_free(br_depths);
+                break;
 
-      case WASM_OP_RETURN:
-        if (!aot_compile_op_return(comp_ctx, func_ctx, &frame_ip))
-          return false;
-        break;
+            case WASM_OP_RETURN:
+                if (!aot_compile_op_return(comp_ctx, func_ctx, &frame_ip))
+                    return false;
+                break;
 
-      case WASM_OP_CALL:
-        read_leb_uint32(frame_ip, frame_ip_end, func_idx);
-        if (!aot_compile_op_call(comp_ctx, func_ctx, func_idx, false))
-          return false;
-        break;
+            case WASM_OP_CALL:
+                read_leb_uint32(frame_ip, frame_ip_end, func_idx);
+                if (!aot_compile_op_call(comp_ctx, func_ctx, func_idx, false))
+                    return false;
+                break;
 
-      case WASM_OP_CALL_INDIRECT:
-      {
-        uint32 tbl_idx;
+            case WASM_OP_CALL_INDIRECT:
+            {
+                uint32 tbl_idx;
 
-        read_leb_uint32(frame_ip, frame_ip_end, type_idx);
+                read_leb_uint32(frame_ip, frame_ip_end, type_idx);
 
 #if WASM_ENABLE_REF_TYPES != 0
-        if (comp_ctx->enable_ref_types) {
-          read_leb_uint32(frame_ip, frame_ip_end, tbl_idx);
-        }
-        else
+                if (comp_ctx->enable_ref_types) {
+                    read_leb_uint32(frame_ip, frame_ip_end, tbl_idx);
+                }
+                else
 #endif
-        {
-          frame_ip++;
-          tbl_idx = 0;
-        }
+                {
+                    frame_ip++;
+                    tbl_idx = 0;
+                }
 
-        if (!aot_compile_op_call_indirect(comp_ctx, func_ctx, type_idx,
-                                          tbl_idx))
-          return false;
-        break;
-      }
+                if (!aot_compile_op_call_indirect(comp_ctx, func_ctx, type_idx,
+                                                  tbl_idx))
+                    return false;
+                break;
+            }
 
 #if WASM_ENABLE_TAIL_CALL != 0
-      case WASM_OP_RETURN_CALL:
-        if (!comp_ctx->enable_tail_call) {
-          aot_set_last_error("unsupported opcode");
-          return false;
-        }
-        read_leb_uint32(frame_ip, frame_ip_end, func_idx);
-        if (!aot_compile_op_call(comp_ctx, func_ctx, func_idx, true))
-          return false;
-        if (!aot_compile_op_return(comp_ctx, func_ctx, &frame_ip))
-          return false;
-        break;
+            case WASM_OP_RETURN_CALL:
+                if (!comp_ctx->enable_tail_call) {
+                    aot_set_last_error("unsupported opcode");
+                    return false;
+                }
+                read_leb_uint32(frame_ip, frame_ip_end, func_idx);
+                if (!aot_compile_op_call(comp_ctx, func_ctx, func_idx, true))
+                    return false;
+                if (!aot_compile_op_return(comp_ctx, func_ctx, &frame_ip))
+                    return false;
+                break;
 
-      case WASM_OP_RETURN_CALL_INDIRECT:
-      {
-        uint32 tbl_idx;
+            case WASM_OP_RETURN_CALL_INDIRECT:
+            {
+                uint32 tbl_idx;
 
-        if (!comp_ctx->enable_tail_call) {
-          aot_set_last_error("unsupported opcode");
-          return false;
-        }
+                if (!comp_ctx->enable_tail_call) {
+                    aot_set_last_error("unsupported opcode");
+                    return false;
+                }
 
-        read_leb_uint32(frame_ip, frame_ip_end, type_idx);
+                read_leb_uint32(frame_ip, frame_ip_end, type_idx);
 #if WASM_ENABLE_REF_TYPES != 0
-        if (comp_ctx->enable_ref_types) {
-          read_leb_uint32(frame_ip, frame_ip_end, tbl_idx);
-        }
-        else
+                if (comp_ctx->enable_ref_types) {
+                    read_leb_uint32(frame_ip, frame_ip_end, tbl_idx);
+                }
+                else
 #endif
-        {
-          frame_ip++;
-          tbl_idx = 0;
-        }
+                {
+                    frame_ip++;
+                    tbl_idx = 0;
+                }
 
-        if (!aot_compile_op_call_indirect(comp_ctx, func_ctx, type_idx,
-                                          tbl_idx))
-          return false;
-        if (!aot_compile_op_return(comp_ctx, func_ctx, &frame_ip))
-          return false;
-        break;
-      }
+                if (!aot_compile_op_call_indirect(comp_ctx, func_ctx, type_idx,
+                                                  tbl_idx))
+                    return false;
+                if (!aot_compile_op_return(comp_ctx, func_ctx, &frame_ip))
+                    return false;
+                break;
+            }
 #endif /* end of WASM_ENABLE_TAIL_CALL */
 
-      case WASM_OP_DROP:
-        if (!aot_compile_op_drop(comp_ctx, func_ctx, true))
-          return false;
-        break;
+            case WASM_OP_DROP:
+                if (!aot_compile_op_drop(comp_ctx, func_ctx, true))
+                    return false;
+                break;
 
-      case WASM_OP_DROP_64:
-        if (!aot_compile_op_drop(comp_ctx, func_ctx, false))
-          return false;
-        break;
+            case WASM_OP_DROP_64:
+                if (!aot_compile_op_drop(comp_ctx, func_ctx, false))
+                    return false;
+                break;
 
-      case WASM_OP_SELECT:
-        if (!aot_compile_op_select(comp_ctx, func_ctx, true))
-          return false;
-        break;
+            case WASM_OP_SELECT:
+                if (!aot_compile_op_select(comp_ctx, func_ctx, true))
+                    return false;
+                break;
 
-      case WASM_OP_SELECT_64:
-        if (!aot_compile_op_select(comp_ctx, func_ctx, false))
-          return false;
-        break;
+            case WASM_OP_SELECT_64:
+                if (!aot_compile_op_select(comp_ctx, func_ctx, false))
+                    return false;
+                break;
 
 #if WASM_ENABLE_REF_TYPES != 0
-      case WASM_OP_SELECT_T:
-      {
-        uint32 vec_len;
+            case WASM_OP_SELECT_T:
+            {
+                uint32 vec_len;
 
-        if (!comp_ctx->enable_ref_types) {
-          goto unsupport_ref_types;
-        }
+                if (!comp_ctx->enable_ref_types) {
+                    goto unsupport_ref_types;
+                }
 
-        read_leb_uint32(frame_ip, frame_ip_end, vec_len);
-        bh_assert(vec_len == 1);
-        vec_len = vec_len;
+                read_leb_uint32(frame_ip, frame_ip_end, vec_len);
+                bh_assert(vec_len == 1);
+                (void)vec_len;
 
-        type_idx = *frame_ip++;
-        if (!aot_compile_op_select(comp_ctx, func_ctx,
-                                   (type_idx != VALUE_TYPE_I64)
-                                     && (type_idx != VALUE_TYPE_F64)))
-          return false;
-        break;
-      }
-      case WASM_OP_TABLE_GET:
-      {
-        uint32 tbl_idx;
+                type_idx = *frame_ip++;
+                if (!aot_compile_op_select(comp_ctx, func_ctx,
+                                           (type_idx != VALUE_TYPE_I64)
+                                               && (type_idx != VALUE_TYPE_F64)))
+                    return false;
+                break;
+            }
+            case WASM_OP_TABLE_GET:
+            {
+                uint32 tbl_idx;
 
-        if (!comp_ctx->enable_ref_types) {
-          goto unsupport_ref_types;
-        }
+                if (!comp_ctx->enable_ref_types) {
+                    goto unsupport_ref_types;
+                }
 
-        read_leb_uint32(frame_ip, frame_ip_end, tbl_idx);
-        if (!aot_compile_op_table_get(comp_ctx, func_ctx, tbl_idx))
-          return false;
-        break;
-      }
-      case WASM_OP_TABLE_SET:
-      {
-        uint32 tbl_idx;
+                read_leb_uint32(frame_ip, frame_ip_end, tbl_idx);
+                if (!aot_compile_op_table_get(comp_ctx, func_ctx, tbl_idx))
+                    return false;
+                break;
+            }
+            case WASM_OP_TABLE_SET:
+            {
+                uint32 tbl_idx;
 
-        if (!comp_ctx->enable_ref_types) {
-          goto unsupport_ref_types;
-        }
+                if (!comp_ctx->enable_ref_types) {
+                    goto unsupport_ref_types;
+                }
 
-        read_leb_uint32(frame_ip, frame_ip_end, tbl_idx);
-        if (!aot_compile_op_table_set(comp_ctx, func_ctx, tbl_idx))
-          return false;
-        break;
-      }
-      case WASM_OP_REF_NULL:
-      {
-        uint32 type;
+                read_leb_uint32(frame_ip, frame_ip_end, tbl_idx);
+                if (!aot_compile_op_table_set(comp_ctx, func_ctx, tbl_idx))
+                    return false;
+                break;
+            }
+            case WASM_OP_REF_NULL:
+            {
+                uint32 type;
 
-        if (!comp_ctx->enable_ref_types) {
-          goto unsupport_ref_types;
-        }
+                if (!comp_ctx->enable_ref_types) {
+                    goto unsupport_ref_types;
+                }
 
-        read_leb_uint32(frame_ip, frame_ip_end, type);
+                read_leb_uint32(frame_ip, frame_ip_end, type);
 
-        if (!aot_compile_op_ref_null(comp_ctx, func_ctx))
-          return false;
+                if (!aot_compile_op_ref_null(comp_ctx, func_ctx))
+                    return false;
 
-        (void)type;
-        break;
-      }
-      case WASM_OP_REF_IS_NULL:
-      {
-        if (!comp_ctx->enable_ref_types) {
-          goto unsupport_ref_types;
-        }
+                (void)type;
+                break;
+            }
+            case WASM_OP_REF_IS_NULL:
+            {
+                if (!comp_ctx->enable_ref_types) {
+                    goto unsupport_ref_types;
+                }
 
-        if (!aot_compile_op_ref_is_null(comp_ctx, func_ctx))
-          return false;
-        break;
-      }
-      case WASM_OP_REF_FUNC:
-      {
-        uint32 func_idx;
+                if (!aot_compile_op_ref_is_null(comp_ctx, func_ctx))
+                    return false;
+                break;
+            }
+            case WASM_OP_REF_FUNC:
+            {
+                uint32 func_idx;
 
-        if (!comp_ctx->enable_ref_types) {
-          goto unsupport_ref_types;
-        }
+                if (!comp_ctx->enable_ref_types) {
+                    goto unsupport_ref_types;
+                }
 
-        read_leb_uint32(frame_ip, frame_ip_end, func_idx);
-        if (!aot_compile_op_ref_func(comp_ctx, func_ctx, func_idx))
-          return false;
-        break;
-      }
+                read_leb_uint32(frame_ip, frame_ip_end, func_idx);
+                if (!aot_compile_op_ref_func(comp_ctx, func_ctx, func_idx))
+                    return false;
+                break;
+            }
 #endif
 
-      case WASM_OP_GET_LOCAL:
-        read_leb_uint32(frame_ip, frame_ip_end, local_idx);
-        if (!aot_compile_op_get_local(comp_ctx, func_ctx, local_idx))
-          return false;
-        break;
-
-      case WASM_OP_SET_LOCAL:
-        read_leb_uint32(frame_ip, frame_ip_end, local_idx);
-        if (!aot_compile_op_set_local(comp_ctx, func_ctx, local_idx))
-          return false;
-        break;
-
-      case WASM_OP_TEE_LOCAL:
-        read_leb_uint32(frame_ip, frame_ip_end, local_idx);
-        if (!aot_compile_op_tee_local(comp_ctx, func_ctx, local_idx))
-          return false;
-        break;
-
-      case WASM_OP_GET_GLOBAL:
-        read_leb_uint32(frame_ip, frame_ip_end, global_idx);
-        if (!aot_compile_op_get_global(comp_ctx, func_ctx, global_idx))
-          return false;
-        break;
-
-      case WASM_OP_SET_GLOBAL:
-      case WASM_OP_SET_GLOBAL_64:
-      case WASM_OP_SET_GLOBAL_AUX_STACK:
-        read_leb_uint32(frame_ip, frame_ip_end, global_idx);
-        if (!aot_compile_op_set_global(comp_ctx, func_ctx, global_idx,
-                                       opcode == WASM_OP_SET_GLOBAL_AUX_STACK
-                                       ? true : false))
-          return false;
-        break;
-
-      case WASM_OP_I32_LOAD:
-        bytes = 4;
-        sign = true;
-        goto op_i32_load;
-      case WASM_OP_I32_LOAD8_S:
-      case WASM_OP_I32_LOAD8_U:
-        bytes = 1;
-        sign = (opcode == WASM_OP_I32_LOAD8_S) ? true : false;
-        goto op_i32_load;
-      case WASM_OP_I32_LOAD16_S:
-      case WASM_OP_I32_LOAD16_U:
-        bytes = 2;
-        sign = (opcode == WASM_OP_I32_LOAD16_S) ? true : false;
-    op_i32_load:
-        read_leb_uint32(frame_ip, frame_ip_end, align);
-        read_leb_uint32(frame_ip, frame_ip_end, offset);
-        if (!aot_compile_op_i32_load(comp_ctx, func_ctx, align, offset,
-                                     bytes, sign, false))
-          return false;
-        break;
-
-      case WASM_OP_I64_LOAD:
-        bytes = 8;
-        sign = true;
-        goto op_i64_load;
-      case WASM_OP_I64_LOAD8_S:
-      case WASM_OP_I64_LOAD8_U:
-        bytes = 1;
-        sign = (opcode == WASM_OP_I64_LOAD8_S) ? true : false;
-        goto op_i64_load;
-      case WASM_OP_I64_LOAD16_S:
-      case WASM_OP_I64_LOAD16_U:
-        bytes = 2;
-        sign = (opcode == WASM_OP_I64_LOAD16_S) ? true : false;
-        goto op_i64_load;
-      case WASM_OP_I64_LOAD32_S:
-      case WASM_OP_I64_LOAD32_U:
-        bytes = 4;
-        sign = (opcode == WASM_OP_I64_LOAD32_S) ? true : false;
-    op_i64_load:
-        read_leb_uint32(frame_ip, frame_ip_end, align);
-        read_leb_uint32(frame_ip, frame_ip_end, offset);
-        if (!aot_compile_op_i64_load(comp_ctx, func_ctx, align, offset,
-                                     bytes, sign, false))
-          return false;
-        break;
-
-      case WASM_OP_F32_LOAD:
-        read_leb_uint32(frame_ip, frame_ip_end, align);
-        read_leb_uint32(frame_ip, frame_ip_end, offset);
-        if (!aot_compile_op_f32_load(comp_ctx, func_ctx, align, offset))
-          return false;
-        break;
-
-      case WASM_OP_F64_LOAD:
-        read_leb_uint32(frame_ip, frame_ip_end, align);
-        read_leb_uint32(frame_ip, frame_ip_end, offset);
-        if (!aot_compile_op_f64_load(comp_ctx, func_ctx, align, offset))
-          return false;
-        break;
-
-      case WASM_OP_I32_STORE:
-        bytes = 4;
-        goto op_i32_store;
-      case WASM_OP_I32_STORE8:
-        bytes = 1;
-        goto op_i32_store;
-      case WASM_OP_I32_STORE16:
-        bytes = 2;
-    op_i32_store:
-        read_leb_uint32(frame_ip, frame_ip_end, align);
-        read_leb_uint32(frame_ip, frame_ip_end, offset);
-        if (!aot_compile_op_i32_store(comp_ctx, func_ctx, align,
-                                      offset, bytes, false))
-          return false;
-        break;
-
-      case WASM_OP_I64_STORE:
-        bytes = 8;
-        goto op_i64_store;
-      case WASM_OP_I64_STORE8:
-        bytes = 1;
-        goto op_i64_store;
-      case WASM_OP_I64_STORE16:
-        bytes = 2;
-        goto op_i64_store;
-      case WASM_OP_I64_STORE32:
-        bytes = 4;
-    op_i64_store:
-        read_leb_uint32(frame_ip, frame_ip_end, align);
-        read_leb_uint32(frame_ip, frame_ip_end, offset);
-        if (!aot_compile_op_i64_store(comp_ctx, func_ctx, align,
-                                      offset, bytes, false))
-          return false;
-        break;
-
-      case WASM_OP_F32_STORE:
-        read_leb_uint32(frame_ip, frame_ip_end, align);
-        read_leb_uint32(frame_ip, frame_ip_end, offset);
-        if (!aot_compile_op_f32_store(comp_ctx, func_ctx, align, offset))
-          return false;
-        break;
-
-      case WASM_OP_F64_STORE:
-        read_leb_uint32(frame_ip, frame_ip_end, align);
-        read_leb_uint32(frame_ip, frame_ip_end, offset);
-        if (!aot_compile_op_f64_store(comp_ctx, func_ctx, align, offset))
-          return false;
-        break;
-
-      case WASM_OP_MEMORY_SIZE:
-        read_leb_uint32(frame_ip, frame_ip_end, mem_idx);
-        if (!aot_compile_op_memory_size(comp_ctx, func_ctx))
-          return false;
-        (void)mem_idx;
-        break;
-
-      case WASM_OP_MEMORY_GROW:
-        read_leb_uint32(frame_ip, frame_ip_end, mem_idx);
-        if (!aot_compile_op_memory_grow(comp_ctx, func_ctx))
-          return false;
-        break;
-
-      case WASM_OP_I32_CONST:
-        read_leb_int32(frame_ip, frame_ip_end, i32_const);
-        if (!aot_compile_op_i32_const(comp_ctx, func_ctx, i32_const))
-          return false;
-        break;
-
-      case WASM_OP_I64_CONST:
-        read_leb_int64(frame_ip, frame_ip_end, i64_const);
-        if (!aot_compile_op_i64_const(comp_ctx, func_ctx, i64_const))
-          return false;
-        break;
-
-      case WASM_OP_F32_CONST:
-        p_f32 = (uint8 *)&f32_const;
-        for (i = 0; i < sizeof(float32); i++)
-          *p_f32++ = *frame_ip++;
-        if (!aot_compile_op_f32_const(comp_ctx, func_ctx, f32_const))
-          return false;
-        break;
-
-      case WASM_OP_F64_CONST:
-        p_f64 = (uint8 *)&f64_const;
-        for (i = 0; i < sizeof(float64); i++)
-          *p_f64++ = *frame_ip++;
-        if (!aot_compile_op_f64_const(comp_ctx, func_ctx, f64_const))
-          return false;
-        break;
-
-      case WASM_OP_I32_EQZ:
-      case WASM_OP_I32_EQ:
-      case WASM_OP_I32_NE:
-      case WASM_OP_I32_LT_S:
-      case WASM_OP_I32_LT_U:
-      case WASM_OP_I32_GT_S:
-      case WASM_OP_I32_GT_U:
-      case WASM_OP_I32_LE_S:
-      case WASM_OP_I32_LE_U:
-      case WASM_OP_I32_GE_S:
-      case WASM_OP_I32_GE_U:
-        if (!aot_compile_op_i32_compare(comp_ctx, func_ctx,
-                                        INT_EQZ + opcode - WASM_OP_I32_EQZ))
-          return false;
-        break;
-
-      case WASM_OP_I64_EQZ:
-      case WASM_OP_I64_EQ:
-      case WASM_OP_I64_NE:
-      case WASM_OP_I64_LT_S:
-      case WASM_OP_I64_LT_U:
-      case WASM_OP_I64_GT_S:
-      case WASM_OP_I64_GT_U:
-      case WASM_OP_I64_LE_S:
-      case WASM_OP_I64_LE_U:
-      case WASM_OP_I64_GE_S:
-      case WASM_OP_I64_GE_U:
-        if (!aot_compile_op_i64_compare(comp_ctx, func_ctx,
-                                        INT_EQZ + opcode - WASM_OP_I64_EQZ))
-          return false;
-        break;
-
-      case WASM_OP_F32_EQ:
-      case WASM_OP_F32_NE:
-      case WASM_OP_F32_LT:
-      case WASM_OP_F32_GT:
-      case WASM_OP_F32_LE:
-      case WASM_OP_F32_GE:
-        if (!aot_compile_op_f32_compare(comp_ctx, func_ctx,
-                                        FLOAT_EQ + opcode - WASM_OP_F32_EQ))
-          return false;
-        break;
-
-      case WASM_OP_F64_EQ:
-      case WASM_OP_F64_NE:
-      case WASM_OP_F64_LT:
-      case WASM_OP_F64_GT:
-      case WASM_OP_F64_LE:
-      case WASM_OP_F64_GE:
-        if (!aot_compile_op_f64_compare(comp_ctx, func_ctx,
-                                        FLOAT_EQ + opcode - WASM_OP_F64_EQ))
-          return false;
-        break;
-
-      case WASM_OP_I32_CLZ:
-        if (!aot_compile_op_i32_clz(comp_ctx, func_ctx))
-          return false;
-        break;
-
-      case WASM_OP_I32_CTZ:
-        if (!aot_compile_op_i32_ctz(comp_ctx, func_ctx))
-          return false;
-        break;
-
-      case WASM_OP_I32_POPCNT:
-        if (!aot_compile_op_i32_popcnt(comp_ctx, func_ctx))
-          return false;
-        break;
-
-      case WASM_OP_I32_ADD:
-      case WASM_OP_I32_SUB:
-      case WASM_OP_I32_MUL:
-      case WASM_OP_I32_DIV_S:
-      case WASM_OP_I32_DIV_U:
-      case WASM_OP_I32_REM_S:
-      case WASM_OP_I32_REM_U:
-        if (!aot_compile_op_i32_arithmetic(comp_ctx, func_ctx,
-                                           INT_ADD + opcode - WASM_OP_I32_ADD,
-                                           &frame_ip))
-          return false;
-        break;
-
-      case WASM_OP_I32_AND:
-      case WASM_OP_I32_OR:
-      case WASM_OP_I32_XOR:
-        if (!aot_compile_op_i32_bitwise(comp_ctx, func_ctx,
-                                        INT_SHL + opcode - WASM_OP_I32_AND))
-          return false;
-        break;
-
-      case WASM_OP_I32_SHL:
-      case WASM_OP_I32_SHR_S:
-      case WASM_OP_I32_SHR_U:
-      case WASM_OP_I32_ROTL:
-      case WASM_OP_I32_ROTR:
-        if (!aot_compile_op_i32_shift(comp_ctx, func_ctx,
-                                      INT_SHL + opcode - WASM_OP_I32_SHL))
-          return false;
-        break;
-
-      case WASM_OP_I64_CLZ:
-        if (!aot_compile_op_i64_clz(comp_ctx, func_ctx))
-          return false;
-        break;
-
-      case WASM_OP_I64_CTZ:
-        if (!aot_compile_op_i64_ctz(comp_ctx, func_ctx))
-          return false;
-        break;
-
-      case WASM_OP_I64_POPCNT:
-        if (!aot_compile_op_i64_popcnt(comp_ctx, func_ctx))
-          return false;
-        break;
-
-      case WASM_OP_I64_ADD:
-      case WASM_OP_I64_SUB:
-      case WASM_OP_I64_MUL:
-      case WASM_OP_I64_DIV_S:
-      case WASM_OP_I64_DIV_U:
-      case WASM_OP_I64_REM_S:
-      case WASM_OP_I64_REM_U:
-        if (!aot_compile_op_i64_arithmetic(comp_ctx, func_ctx,
-                                           INT_ADD + opcode - WASM_OP_I64_ADD,
-                                           &frame_ip))
-          return false;
-        break;
-
-      case WASM_OP_I64_AND:
-      case WASM_OP_I64_OR:
-      case WASM_OP_I64_XOR:
-        if (!aot_compile_op_i64_bitwise(comp_ctx, func_ctx,
-                                        INT_SHL + opcode - WASM_OP_I64_AND))
-          return false;
-        break;
-
-      case WASM_OP_I64_SHL:
-      case WASM_OP_I64_SHR_S:
-      case WASM_OP_I64_SHR_U:
-      case WASM_OP_I64_ROTL:
-      case WASM_OP_I64_ROTR:
-        if (!aot_compile_op_i64_shift(comp_ctx, func_ctx,
-                                      INT_SHL + opcode - WASM_OP_I64_SHL))
-          return false;
-        break;
-
-      case WASM_OP_F32_ABS:
-      case WASM_OP_F32_NEG:
-      case WASM_OP_F32_CEIL:
-      case WASM_OP_F32_FLOOR:
-      case WASM_OP_F32_TRUNC:
-      case WASM_OP_F32_NEAREST:
-      case WASM_OP_F32_SQRT:
-        if (!aot_compile_op_f32_math(comp_ctx, func_ctx,
-                                     FLOAT_ABS + opcode - WASM_OP_F32_ABS))
-          return false;
-        break;
-
-      case WASM_OP_F32_ADD:
-      case WASM_OP_F32_SUB:
-      case WASM_OP_F32_MUL:
-      case WASM_OP_F32_DIV:
-      case WASM_OP_F32_MIN:
-      case WASM_OP_F32_MAX:
-        if (!aot_compile_op_f32_arithmetic(comp_ctx, func_ctx,
-                                           FLOAT_ADD + opcode - WASM_OP_F32_ADD))
-          return false;
-        break;
-
-      case WASM_OP_F32_COPYSIGN:
-        if (!aot_compile_op_f32_copysign(comp_ctx, func_ctx))
-          return false;
-        break;
-
-      case WASM_OP_F64_ABS:
-      case WASM_OP_F64_NEG:
-      case WASM_OP_F64_CEIL:
-      case WASM_OP_F64_FLOOR:
-      case WASM_OP_F64_TRUNC:
-      case WASM_OP_F64_NEAREST:
-      case WASM_OP_F64_SQRT:
-        if (!aot_compile_op_f64_math(comp_ctx, func_ctx,
-                                     FLOAT_ABS + opcode - WASM_OP_F64_ABS))
-          return false;
-        break;
-
-      case WASM_OP_F64_ADD:
-      case WASM_OP_F64_SUB:
-      case WASM_OP_F64_MUL:
-      case WASM_OP_F64_DIV:
-      case WASM_OP_F64_MIN:
-      case WASM_OP_F64_MAX:
-        if (!aot_compile_op_f64_arithmetic(comp_ctx, func_ctx,
-                                           FLOAT_ADD + opcode - WASM_OP_F64_ADD))
-          return false;
-        break;
-
-      case WASM_OP_F64_COPYSIGN:
-        if (!aot_compile_op_f64_copysign(comp_ctx, func_ctx))
-          return false;
-        break;
-
-      case WASM_OP_I32_WRAP_I64:
-        if (!aot_compile_op_i32_wrap_i64(comp_ctx, func_ctx))
-          return false;
-        break;
-
-      case WASM_OP_I32_TRUNC_S_F32:
-      case WASM_OP_I32_TRUNC_U_F32:
-        sign = (opcode == WASM_OP_I32_TRUNC_S_F32) ? true : false;
-        if (!aot_compile_op_i32_trunc_f32(comp_ctx, func_ctx, sign, false))
-          return false;
-        break;
-
-      case WASM_OP_I32_TRUNC_S_F64:
-      case WASM_OP_I32_TRUNC_U_F64:
-        sign = (opcode == WASM_OP_I32_TRUNC_S_F64) ? true : false;
-        if (!aot_compile_op_i32_trunc_f64(comp_ctx, func_ctx, sign, false))
-          return false;
-        break;
-
-      case WASM_OP_I64_EXTEND_S_I32:
-      case WASM_OP_I64_EXTEND_U_I32:
-        sign = (opcode == WASM_OP_I64_EXTEND_S_I32) ? true : false;
-        if (!aot_compile_op_i64_extend_i32(comp_ctx, func_ctx, sign))
-          return false;
-        break;
-
-      case WASM_OP_I64_TRUNC_S_F32:
-      case WASM_OP_I64_TRUNC_U_F32:
-        sign = (opcode == WASM_OP_I64_TRUNC_S_F32) ? true : false;
-        if (!aot_compile_op_i64_trunc_f32(comp_ctx, func_ctx, sign, false))
-          return false;
-        break;
-
-      case WASM_OP_I64_TRUNC_S_F64:
-      case WASM_OP_I64_TRUNC_U_F64:
-        sign = (opcode == WASM_OP_I64_TRUNC_S_F64) ? true : false;
-        if (!aot_compile_op_i64_trunc_f64(comp_ctx, func_ctx, sign, false))
-          return false;
-        break;
-
-      case WASM_OP_F32_CONVERT_S_I32:
-      case WASM_OP_F32_CONVERT_U_I32:
-        sign = (opcode == WASM_OP_F32_CONVERT_S_I32) ? true : false;
-        if (!aot_compile_op_f32_convert_i32(comp_ctx, func_ctx, sign))
-          return false;
-        break;
-
-      case WASM_OP_F32_CONVERT_S_I64:
-      case WASM_OP_F32_CONVERT_U_I64:
-        sign = (opcode == WASM_OP_F32_CONVERT_S_I64) ? true : false;
-        if (!aot_compile_op_f32_convert_i64(comp_ctx, func_ctx, sign))
-          return false;
-        break;
-
-      case WASM_OP_F32_DEMOTE_F64:
-        if (!aot_compile_op_f32_demote_f64(comp_ctx, func_ctx))
-          return false;
-        break;
-
-      case WASM_OP_F64_CONVERT_S_I32:
-      case WASM_OP_F64_CONVERT_U_I32:
-        sign = (opcode == WASM_OP_F64_CONVERT_S_I32) ? true : false;
-        if (!aot_compile_op_f64_convert_i32(comp_ctx, func_ctx, sign))
-          return false;
-        break;
-
-      case WASM_OP_F64_CONVERT_S_I64:
-      case WASM_OP_F64_CONVERT_U_I64:
-        sign = (opcode == WASM_OP_F64_CONVERT_S_I64) ? true : false;
-        if (!aot_compile_op_f64_convert_i64(comp_ctx, func_ctx, sign))
-          return false;
-        break;
-
-      case WASM_OP_F64_PROMOTE_F32:
-        if (!aot_compile_op_f64_promote_f32(comp_ctx, func_ctx))
-          return false;
-        break;
-
-      case WASM_OP_I32_REINTERPRET_F32:
-        if (!aot_compile_op_i32_reinterpret_f32(comp_ctx, func_ctx))
-          return false;
-        break;
-
-      case WASM_OP_I64_REINTERPRET_F64:
-        if (!aot_compile_op_i64_reinterpret_f64(comp_ctx, func_ctx))
-          return false;
-        break;
-
-      case WASM_OP_F32_REINTERPRET_I32:
-        if (!aot_compile_op_f32_reinterpret_i32(comp_ctx, func_ctx))
-          return false;
-        break;
-
-      case WASM_OP_F64_REINTERPRET_I64:
-        if (!aot_compile_op_f64_reinterpret_i64(comp_ctx, func_ctx))
-          return false;
-        break;
-
-      case WASM_OP_I32_EXTEND8_S:
-        if (!aot_compile_op_i32_extend_i32(comp_ctx, func_ctx, 8))
-          return false;
-        break;
-
-      case WASM_OP_I32_EXTEND16_S:
-        if (!aot_compile_op_i32_extend_i32(comp_ctx, func_ctx, 16))
-          return false;
-        break;
-
-      case WASM_OP_I64_EXTEND8_S:
-        if (!aot_compile_op_i64_extend_i64(comp_ctx, func_ctx, 8))
-          return false;
-        break;
-
-      case WASM_OP_I64_EXTEND16_S:
-        if (!aot_compile_op_i64_extend_i64(comp_ctx, func_ctx, 16))
-          return false;
-        break;
-
-      case WASM_OP_I64_EXTEND32_S:
-        if (!aot_compile_op_i64_extend_i64(comp_ctx, func_ctx, 32))
-          return false;
-        break;
-
-      case WASM_OP_MISC_PREFIX:
-      {
-        uint32 opcode1;
-
-        read_leb_uint32(frame_ip, frame_ip_end, opcode1);
-        opcode = (uint32)opcode1;
-
-        //TODO: --enable-bulk-memory ?
+            case WASM_OP_GET_LOCAL:
+                read_leb_uint32(frame_ip, frame_ip_end, local_idx);
+                if (!aot_compile_op_get_local(comp_ctx, func_ctx, local_idx))
+                    return false;
+                break;
+
+            case WASM_OP_SET_LOCAL:
+                read_leb_uint32(frame_ip, frame_ip_end, local_idx);
+                if (!aot_compile_op_set_local(comp_ctx, func_ctx, local_idx))
+                    return false;
+                break;
+
+            case WASM_OP_TEE_LOCAL:
+                read_leb_uint32(frame_ip, frame_ip_end, local_idx);
+                if (!aot_compile_op_tee_local(comp_ctx, func_ctx, local_idx))
+                    return false;
+                break;
+
+            case WASM_OP_GET_GLOBAL:
+                read_leb_uint32(frame_ip, frame_ip_end, global_idx);
+                if (!aot_compile_op_get_global(comp_ctx, func_ctx, global_idx))
+                    return false;
+                break;
+
+            case WASM_OP_SET_GLOBAL:
+            case WASM_OP_SET_GLOBAL_64:
+            case WASM_OP_SET_GLOBAL_AUX_STACK:
+                read_leb_uint32(frame_ip, frame_ip_end, global_idx);
+                if (!aot_compile_op_set_global(
+                        comp_ctx, func_ctx, global_idx,
+                        opcode == WASM_OP_SET_GLOBAL_AUX_STACK ? true : false))
+                    return false;
+                break;
+
+            case WASM_OP_I32_LOAD:
+                bytes = 4;
+                sign = true;
+                goto op_i32_load;
+            case WASM_OP_I32_LOAD8_S:
+            case WASM_OP_I32_LOAD8_U:
+                bytes = 1;
+                sign = (opcode == WASM_OP_I32_LOAD8_S) ? true : false;
+                goto op_i32_load;
+            case WASM_OP_I32_LOAD16_S:
+            case WASM_OP_I32_LOAD16_U:
+                bytes = 2;
+                sign = (opcode == WASM_OP_I32_LOAD16_S) ? true : false;
+            op_i32_load:
+                read_leb_uint32(frame_ip, frame_ip_end, align);
+                read_leb_uint32(frame_ip, frame_ip_end, offset);
+                if (!aot_compile_op_i32_load(comp_ctx, func_ctx, align, offset,
+                                             bytes, sign, false))
+                    return false;
+                break;
+
+            case WASM_OP_I64_LOAD:
+                bytes = 8;
+                sign = true;
+                goto op_i64_load;
+            case WASM_OP_I64_LOAD8_S:
+            case WASM_OP_I64_LOAD8_U:
+                bytes = 1;
+                sign = (opcode == WASM_OP_I64_LOAD8_S) ? true : false;
+                goto op_i64_load;
+            case WASM_OP_I64_LOAD16_S:
+            case WASM_OP_I64_LOAD16_U:
+                bytes = 2;
+                sign = (opcode == WASM_OP_I64_LOAD16_S) ? true : false;
+                goto op_i64_load;
+            case WASM_OP_I64_LOAD32_S:
+            case WASM_OP_I64_LOAD32_U:
+                bytes = 4;
+                sign = (opcode == WASM_OP_I64_LOAD32_S) ? true : false;
+            op_i64_load:
+                read_leb_uint32(frame_ip, frame_ip_end, align);
+                read_leb_uint32(frame_ip, frame_ip_end, offset);
+                if (!aot_compile_op_i64_load(comp_ctx, func_ctx, align, offset,
+                                             bytes, sign, false))
+                    return false;
+                break;
+
+            case WASM_OP_F32_LOAD:
+                read_leb_uint32(frame_ip, frame_ip_end, align);
+                read_leb_uint32(frame_ip, frame_ip_end, offset);
+                if (!aot_compile_op_f32_load(comp_ctx, func_ctx, align, offset))
+                    return false;
+                break;
+
+            case WASM_OP_F64_LOAD:
+                read_leb_uint32(frame_ip, frame_ip_end, align);
+                read_leb_uint32(frame_ip, frame_ip_end, offset);
+                if (!aot_compile_op_f64_load(comp_ctx, func_ctx, align, offset))
+                    return false;
+                break;
+
+            case WASM_OP_I32_STORE:
+                bytes = 4;
+                goto op_i32_store;
+            case WASM_OP_I32_STORE8:
+                bytes = 1;
+                goto op_i32_store;
+            case WASM_OP_I32_STORE16:
+                bytes = 2;
+            op_i32_store:
+                read_leb_uint32(frame_ip, frame_ip_end, align);
+                read_leb_uint32(frame_ip, frame_ip_end, offset);
+                if (!aot_compile_op_i32_store(comp_ctx, func_ctx, align, offset,
+                                              bytes, false))
+                    return false;
+                break;
+
+            case WASM_OP_I64_STORE:
+                bytes = 8;
+                goto op_i64_store;
+            case WASM_OP_I64_STORE8:
+                bytes = 1;
+                goto op_i64_store;
+            case WASM_OP_I64_STORE16:
+                bytes = 2;
+                goto op_i64_store;
+            case WASM_OP_I64_STORE32:
+                bytes = 4;
+            op_i64_store:
+                read_leb_uint32(frame_ip, frame_ip_end, align);
+                read_leb_uint32(frame_ip, frame_ip_end, offset);
+                if (!aot_compile_op_i64_store(comp_ctx, func_ctx, align, offset,
+                                              bytes, false))
+                    return false;
+                break;
+
+            case WASM_OP_F32_STORE:
+                read_leb_uint32(frame_ip, frame_ip_end, align);
+                read_leb_uint32(frame_ip, frame_ip_end, offset);
+                if (!aot_compile_op_f32_store(comp_ctx, func_ctx, align,
+                                              offset))
+                    return false;
+                break;
+
+            case WASM_OP_F64_STORE:
+                read_leb_uint32(frame_ip, frame_ip_end, align);
+                read_leb_uint32(frame_ip, frame_ip_end, offset);
+                if (!aot_compile_op_f64_store(comp_ctx, func_ctx, align,
+                                              offset))
+                    return false;
+                break;
+
+            case WASM_OP_MEMORY_SIZE:
+                read_leb_uint32(frame_ip, frame_ip_end, mem_idx);
+                if (!aot_compile_op_memory_size(comp_ctx, func_ctx))
+                    return false;
+                (void)mem_idx;
+                break;
+
+            case WASM_OP_MEMORY_GROW:
+                read_leb_uint32(frame_ip, frame_ip_end, mem_idx);
+                if (!aot_compile_op_memory_grow(comp_ctx, func_ctx))
+                    return false;
+                break;
+
+            case WASM_OP_I32_CONST:
+                read_leb_int32(frame_ip, frame_ip_end, i32_const);
+                if (!aot_compile_op_i32_const(comp_ctx, func_ctx, i32_const))
+                    return false;
+                break;
+
+            case WASM_OP_I64_CONST:
+                read_leb_int64(frame_ip, frame_ip_end, i64_const);
+                if (!aot_compile_op_i64_const(comp_ctx, func_ctx, i64_const))
+                    return false;
+                break;
+
+            case WASM_OP_F32_CONST:
+                p_f32 = (uint8 *)&f32_const;
+                for (i = 0; i < sizeof(float32); i++)
+                    *p_f32++ = *frame_ip++;
+                if (!aot_compile_op_f32_const(comp_ctx, func_ctx, f32_const))
+                    return false;
+                break;
+
+            case WASM_OP_F64_CONST:
+                p_f64 = (uint8 *)&f64_const;
+                for (i = 0; i < sizeof(float64); i++)
+                    *p_f64++ = *frame_ip++;
+                if (!aot_compile_op_f64_const(comp_ctx, func_ctx, f64_const))
+                    return false;
+                break;
+
+            case WASM_OP_I32_EQZ:
+            case WASM_OP_I32_EQ:
+            case WASM_OP_I32_NE:
+            case WASM_OP_I32_LT_S:
+            case WASM_OP_I32_LT_U:
+            case WASM_OP_I32_GT_S:
+            case WASM_OP_I32_GT_U:
+            case WASM_OP_I32_LE_S:
+            case WASM_OP_I32_LE_U:
+            case WASM_OP_I32_GE_S:
+            case WASM_OP_I32_GE_U:
+                if (!aot_compile_op_i32_compare(
+                        comp_ctx, func_ctx, INT_EQZ + opcode - WASM_OP_I32_EQZ))
+                    return false;
+                break;
+
+            case WASM_OP_I64_EQZ:
+            case WASM_OP_I64_EQ:
+            case WASM_OP_I64_NE:
+            case WASM_OP_I64_LT_S:
+            case WASM_OP_I64_LT_U:
+            case WASM_OP_I64_GT_S:
+            case WASM_OP_I64_GT_U:
+            case WASM_OP_I64_LE_S:
+            case WASM_OP_I64_LE_U:
+            case WASM_OP_I64_GE_S:
+            case WASM_OP_I64_GE_U:
+                if (!aot_compile_op_i64_compare(
+                        comp_ctx, func_ctx, INT_EQZ + opcode - WASM_OP_I64_EQZ))
+                    return false;
+                break;
+
+            case WASM_OP_F32_EQ:
+            case WASM_OP_F32_NE:
+            case WASM_OP_F32_LT:
+            case WASM_OP_F32_GT:
+            case WASM_OP_F32_LE:
+            case WASM_OP_F32_GE:
+                if (!aot_compile_op_f32_compare(
+                        comp_ctx, func_ctx, FLOAT_EQ + opcode - WASM_OP_F32_EQ))
+                    return false;
+                break;
+
+            case WASM_OP_F64_EQ:
+            case WASM_OP_F64_NE:
+            case WASM_OP_F64_LT:
+            case WASM_OP_F64_GT:
+            case WASM_OP_F64_LE:
+            case WASM_OP_F64_GE:
+                if (!aot_compile_op_f64_compare(
+                        comp_ctx, func_ctx, FLOAT_EQ + opcode - WASM_OP_F64_EQ))
+                    return false;
+                break;
+
+            case WASM_OP_I32_CLZ:
+                if (!aot_compile_op_i32_clz(comp_ctx, func_ctx))
+                    return false;
+                break;
+
+            case WASM_OP_I32_CTZ:
+                if (!aot_compile_op_i32_ctz(comp_ctx, func_ctx))
+                    return false;
+                break;
+
+            case WASM_OP_I32_POPCNT:
+                if (!aot_compile_op_i32_popcnt(comp_ctx, func_ctx))
+                    return false;
+                break;
+
+            case WASM_OP_I32_ADD:
+            case WASM_OP_I32_SUB:
+            case WASM_OP_I32_MUL:
+            case WASM_OP_I32_DIV_S:
+            case WASM_OP_I32_DIV_U:
+            case WASM_OP_I32_REM_S:
+            case WASM_OP_I32_REM_U:
+                if (!aot_compile_op_i32_arithmetic(
+                        comp_ctx, func_ctx, INT_ADD + opcode - WASM_OP_I32_ADD,
+                        &frame_ip))
+                    return false;
+                break;
+
+            case WASM_OP_I32_AND:
+            case WASM_OP_I32_OR:
+            case WASM_OP_I32_XOR:
+                if (!aot_compile_op_i32_bitwise(
+                        comp_ctx, func_ctx, INT_SHL + opcode - WASM_OP_I32_AND))
+                    return false;
+                break;
+
+            case WASM_OP_I32_SHL:
+            case WASM_OP_I32_SHR_S:
+            case WASM_OP_I32_SHR_U:
+            case WASM_OP_I32_ROTL:
+            case WASM_OP_I32_ROTR:
+                if (!aot_compile_op_i32_shift(
+                        comp_ctx, func_ctx, INT_SHL + opcode - WASM_OP_I32_SHL))
+                    return false;
+                break;
+
+            case WASM_OP_I64_CLZ:
+                if (!aot_compile_op_i64_clz(comp_ctx, func_ctx))
+                    return false;
+                break;
+
+            case WASM_OP_I64_CTZ:
+                if (!aot_compile_op_i64_ctz(comp_ctx, func_ctx))
+                    return false;
+                break;
+
+            case WASM_OP_I64_POPCNT:
+                if (!aot_compile_op_i64_popcnt(comp_ctx, func_ctx))
+                    return false;
+                break;
+
+            case WASM_OP_I64_ADD:
+            case WASM_OP_I64_SUB:
+            case WASM_OP_I64_MUL:
+            case WASM_OP_I64_DIV_S:
+            case WASM_OP_I64_DIV_U:
+            case WASM_OP_I64_REM_S:
+            case WASM_OP_I64_REM_U:
+                if (!aot_compile_op_i64_arithmetic(
+                        comp_ctx, func_ctx, INT_ADD + opcode - WASM_OP_I64_ADD,
+                        &frame_ip))
+                    return false;
+                break;
+
+            case WASM_OP_I64_AND:
+            case WASM_OP_I64_OR:
+            case WASM_OP_I64_XOR:
+                if (!aot_compile_op_i64_bitwise(
+                        comp_ctx, func_ctx, INT_SHL + opcode - WASM_OP_I64_AND))
+                    return false;
+                break;
+
+            case WASM_OP_I64_SHL:
+            case WASM_OP_I64_SHR_S:
+            case WASM_OP_I64_SHR_U:
+            case WASM_OP_I64_ROTL:
+            case WASM_OP_I64_ROTR:
+                if (!aot_compile_op_i64_shift(
+                        comp_ctx, func_ctx, INT_SHL + opcode - WASM_OP_I64_SHL))
+                    return false;
+                break;
+
+            case WASM_OP_F32_ABS:
+            case WASM_OP_F32_NEG:
+            case WASM_OP_F32_CEIL:
+            case WASM_OP_F32_FLOOR:
+            case WASM_OP_F32_TRUNC:
+            case WASM_OP_F32_NEAREST:
+            case WASM_OP_F32_SQRT:
+                if (!aot_compile_op_f32_math(comp_ctx, func_ctx,
+                                             FLOAT_ABS + opcode
+                                                 - WASM_OP_F32_ABS))
+                    return false;
+                break;
+
+            case WASM_OP_F32_ADD:
+            case WASM_OP_F32_SUB:
+            case WASM_OP_F32_MUL:
+            case WASM_OP_F32_DIV:
+            case WASM_OP_F32_MIN:
+            case WASM_OP_F32_MAX:
+                if (!aot_compile_op_f32_arithmetic(comp_ctx, func_ctx,
+                                                   FLOAT_ADD + opcode
+                                                       - WASM_OP_F32_ADD))
+                    return false;
+                break;
+
+            case WASM_OP_F32_COPYSIGN:
+                if (!aot_compile_op_f32_copysign(comp_ctx, func_ctx))
+                    return false;
+                break;
+
+            case WASM_OP_F64_ABS:
+            case WASM_OP_F64_NEG:
+            case WASM_OP_F64_CEIL:
+            case WASM_OP_F64_FLOOR:
+            case WASM_OP_F64_TRUNC:
+            case WASM_OP_F64_NEAREST:
+            case WASM_OP_F64_SQRT:
+                if (!aot_compile_op_f64_math(comp_ctx, func_ctx,
+                                             FLOAT_ABS + opcode
+                                                 - WASM_OP_F64_ABS))
+                    return false;
+                break;
+
+            case WASM_OP_F64_ADD:
+            case WASM_OP_F64_SUB:
+            case WASM_OP_F64_MUL:
+            case WASM_OP_F64_DIV:
+            case WASM_OP_F64_MIN:
+            case WASM_OP_F64_MAX:
+                if (!aot_compile_op_f64_arithmetic(comp_ctx, func_ctx,
+                                                   FLOAT_ADD + opcode
+                                                       - WASM_OP_F64_ADD))
+                    return false;
+                break;
+
+            case WASM_OP_F64_COPYSIGN:
+                if (!aot_compile_op_f64_copysign(comp_ctx, func_ctx))
+                    return false;
+                break;
+
+            case WASM_OP_I32_WRAP_I64:
+                if (!aot_compile_op_i32_wrap_i64(comp_ctx, func_ctx))
+                    return false;
+                break;
+
+            case WASM_OP_I32_TRUNC_S_F32:
+            case WASM_OP_I32_TRUNC_U_F32:
+                sign = (opcode == WASM_OP_I32_TRUNC_S_F32) ? true : false;
+                if (!aot_compile_op_i32_trunc_f32(comp_ctx, func_ctx, sign,
+                                                  false))
+                    return false;
+                break;
+
+            case WASM_OP_I32_TRUNC_S_F64:
+            case WASM_OP_I32_TRUNC_U_F64:
+                sign = (opcode == WASM_OP_I32_TRUNC_S_F64) ? true : false;
+                if (!aot_compile_op_i32_trunc_f64(comp_ctx, func_ctx, sign,
+                                                  false))
+                    return false;
+                break;
+
+            case WASM_OP_I64_EXTEND_S_I32:
+            case WASM_OP_I64_EXTEND_U_I32:
+                sign = (opcode == WASM_OP_I64_EXTEND_S_I32) ? true : false;
+                if (!aot_compile_op_i64_extend_i32(comp_ctx, func_ctx, sign))
+                    return false;
+                break;
+
+            case WASM_OP_I64_TRUNC_S_F32:
+            case WASM_OP_I64_TRUNC_U_F32:
+                sign = (opcode == WASM_OP_I64_TRUNC_S_F32) ? true : false;
+                if (!aot_compile_op_i64_trunc_f32(comp_ctx, func_ctx, sign,
+                                                  false))
+                    return false;
+                break;
+
+            case WASM_OP_I64_TRUNC_S_F64:
+            case WASM_OP_I64_TRUNC_U_F64:
+                sign = (opcode == WASM_OP_I64_TRUNC_S_F64) ? true : false;
+                if (!aot_compile_op_i64_trunc_f64(comp_ctx, func_ctx, sign,
+                                                  false))
+                    return false;
+                break;
+
+            case WASM_OP_F32_CONVERT_S_I32:
+            case WASM_OP_F32_CONVERT_U_I32:
+                sign = (opcode == WASM_OP_F32_CONVERT_S_I32) ? true : false;
+                if (!aot_compile_op_f32_convert_i32(comp_ctx, func_ctx, sign))
+                    return false;
+                break;
+
+            case WASM_OP_F32_CONVERT_S_I64:
+            case WASM_OP_F32_CONVERT_U_I64:
+                sign = (opcode == WASM_OP_F32_CONVERT_S_I64) ? true : false;
+                if (!aot_compile_op_f32_convert_i64(comp_ctx, func_ctx, sign))
+                    return false;
+                break;
+
+            case WASM_OP_F32_DEMOTE_F64:
+                if (!aot_compile_op_f32_demote_f64(comp_ctx, func_ctx))
+                    return false;
+                break;
+
+            case WASM_OP_F64_CONVERT_S_I32:
+            case WASM_OP_F64_CONVERT_U_I32:
+                sign = (opcode == WASM_OP_F64_CONVERT_S_I32) ? true : false;
+                if (!aot_compile_op_f64_convert_i32(comp_ctx, func_ctx, sign))
+                    return false;
+                break;
+
+            case WASM_OP_F64_CONVERT_S_I64:
+            case WASM_OP_F64_CONVERT_U_I64:
+                sign = (opcode == WASM_OP_F64_CONVERT_S_I64) ? true : false;
+                if (!aot_compile_op_f64_convert_i64(comp_ctx, func_ctx, sign))
+                    return false;
+                break;
+
+            case WASM_OP_F64_PROMOTE_F32:
+                if (!aot_compile_op_f64_promote_f32(comp_ctx, func_ctx))
+                    return false;
+                break;
+
+            case WASM_OP_I32_REINTERPRET_F32:
+                if (!aot_compile_op_i32_reinterpret_f32(comp_ctx, func_ctx))
+                    return false;
+                break;
+
+            case WASM_OP_I64_REINTERPRET_F64:
+                if (!aot_compile_op_i64_reinterpret_f64(comp_ctx, func_ctx))
+                    return false;
+                break;
+
+            case WASM_OP_F32_REINTERPRET_I32:
+                if (!aot_compile_op_f32_reinterpret_i32(comp_ctx, func_ctx))
+                    return false;
+                break;
+
+            case WASM_OP_F64_REINTERPRET_I64:
+                if (!aot_compile_op_f64_reinterpret_i64(comp_ctx, func_ctx))
+                    return false;
+                break;
+
+            case WASM_OP_I32_EXTEND8_S:
+                if (!aot_compile_op_i32_extend_i32(comp_ctx, func_ctx, 8))
+                    return false;
+                break;
+
+            case WASM_OP_I32_EXTEND16_S:
+                if (!aot_compile_op_i32_extend_i32(comp_ctx, func_ctx, 16))
+                    return false;
+                break;
+
+            case WASM_OP_I64_EXTEND8_S:
+                if (!aot_compile_op_i64_extend_i64(comp_ctx, func_ctx, 8))
+                    return false;
+                break;
+
+            case WASM_OP_I64_EXTEND16_S:
+                if (!aot_compile_op_i64_extend_i64(comp_ctx, func_ctx, 16))
+                    return false;
+                break;
+
+            case WASM_OP_I64_EXTEND32_S:
+                if (!aot_compile_op_i64_extend_i64(comp_ctx, func_ctx, 32))
+                    return false;
+                break;
+
+            case WASM_OP_MISC_PREFIX:
+            {
+                uint32 opcode1;
+
+                read_leb_uint32(frame_ip, frame_ip_end, opcode1);
+                opcode = (uint32)opcode1;
+
+                /* TODO: --enable-bulk-memory ? */
 
 #if WASM_ENABLE_REF_TYPES != 0
-        if (WASM_OP_TABLE_INIT <= opcode && opcode <= WASM_OP_TABLE_FILL
-            && !comp_ctx->enable_ref_types) {
-          goto unsupport_ref_types;
-        }
+                if (WASM_OP_TABLE_INIT <= opcode && opcode <= WASM_OP_TABLE_FILL
+                    && !comp_ctx->enable_ref_types) {
+                    goto unsupport_ref_types;
+                }
 #endif
 
-        switch (opcode) {
-          case WASM_OP_I32_TRUNC_SAT_S_F32:
-          case WASM_OP_I32_TRUNC_SAT_U_F32:
-            sign = (opcode == WASM_OP_I32_TRUNC_SAT_S_F32) ? true : false;
-            if (!aot_compile_op_i32_trunc_f32(comp_ctx, func_ctx, sign, true))
-              return false;
-            break;
-          case WASM_OP_I32_TRUNC_SAT_S_F64:
-          case WASM_OP_I32_TRUNC_SAT_U_F64:
-            sign = (opcode == WASM_OP_I32_TRUNC_SAT_S_F64) ? true : false;
-            if (!aot_compile_op_i32_trunc_f64(comp_ctx, func_ctx, sign, true))
-              return false;
-            break;
-          case WASM_OP_I64_TRUNC_SAT_S_F32:
-          case WASM_OP_I64_TRUNC_SAT_U_F32:
-            sign = (opcode == WASM_OP_I64_TRUNC_SAT_S_F32) ? true : false;
-            if (!aot_compile_op_i64_trunc_f32(comp_ctx, func_ctx, sign, true))
-              return false;
-            break;
-          case WASM_OP_I64_TRUNC_SAT_S_F64:
-          case WASM_OP_I64_TRUNC_SAT_U_F64:
-            sign = (opcode == WASM_OP_I64_TRUNC_SAT_S_F64) ? true : false;
-            if (!aot_compile_op_i64_trunc_f64(comp_ctx, func_ctx, sign, true))
-              return false;
-            break;
+                switch (opcode) {
+                    case WASM_OP_I32_TRUNC_SAT_S_F32:
+                    case WASM_OP_I32_TRUNC_SAT_U_F32:
+                        sign = (opcode == WASM_OP_I32_TRUNC_SAT_S_F32) ? true
+                                                                       : false;
+                        if (!aot_compile_op_i32_trunc_f32(comp_ctx, func_ctx,
+                                                          sign, true))
+                            return false;
+                        break;
+                    case WASM_OP_I32_TRUNC_SAT_S_F64:
+                    case WASM_OP_I32_TRUNC_SAT_U_F64:
+                        sign = (opcode == WASM_OP_I32_TRUNC_SAT_S_F64) ? true
+                                                                       : false;
+                        if (!aot_compile_op_i32_trunc_f64(comp_ctx, func_ctx,
+                                                          sign, true))
+                            return false;
+                        break;
+                    case WASM_OP_I64_TRUNC_SAT_S_F32:
+                    case WASM_OP_I64_TRUNC_SAT_U_F32:
+                        sign = (opcode == WASM_OP_I64_TRUNC_SAT_S_F32) ? true
+                                                                       : false;
+                        if (!aot_compile_op_i64_trunc_f32(comp_ctx, func_ctx,
+                                                          sign, true))
+                            return false;
+                        break;
+                    case WASM_OP_I64_TRUNC_SAT_S_F64:
+                    case WASM_OP_I64_TRUNC_SAT_U_F64:
+                        sign = (opcode == WASM_OP_I64_TRUNC_SAT_S_F64) ? true
+                                                                       : false;
+                        if (!aot_compile_op_i64_trunc_f64(comp_ctx, func_ctx,
+                                                          sign, true))
+                            return false;
+                        break;
 #if WASM_ENABLE_BULK_MEMORY != 0
-          case WASM_OP_MEMORY_INIT:
-          {
-            uint32 seg_index;
-            read_leb_uint32(frame_ip, frame_ip_end, seg_index);
-            frame_ip++;
-            if (!aot_compile_op_memory_init(comp_ctx, func_ctx, seg_index))
-              return false;
-            break;
-          }
-          case WASM_OP_DATA_DROP:
-          {
-            uint32 seg_index;
-            read_leb_uint32(frame_ip, frame_ip_end, seg_index);
-            if (!aot_compile_op_data_drop(comp_ctx, func_ctx, seg_index))
-              return false;
-            break;
-          }
-          case WASM_OP_MEMORY_COPY:
-          {
-            frame_ip += 2;
-            if (!aot_compile_op_memory_copy(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-          case WASM_OP_MEMORY_FILL:
-          {
-            frame_ip++;
-            if (!aot_compile_op_memory_fill(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
+                    case WASM_OP_MEMORY_INIT:
+                    {
+                        uint32 seg_index;
+                        read_leb_uint32(frame_ip, frame_ip_end, seg_index);
+                        frame_ip++;
+                        if (!aot_compile_op_memory_init(comp_ctx, func_ctx,
+                                                        seg_index))
+                            return false;
+                        break;
+                    }
+                    case WASM_OP_DATA_DROP:
+                    {
+                        uint32 seg_index;
+                        read_leb_uint32(frame_ip, frame_ip_end, seg_index);
+                        if (!aot_compile_op_data_drop(comp_ctx, func_ctx,
+                                                      seg_index))
+                            return false;
+                        break;
+                    }
+                    case WASM_OP_MEMORY_COPY:
+                    {
+                        frame_ip += 2;
+                        if (!aot_compile_op_memory_copy(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+                    case WASM_OP_MEMORY_FILL:
+                    {
+                        frame_ip++;
+                        if (!aot_compile_op_memory_fill(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
 #endif /* WASM_ENABLE_BULK_MEMORY */
 #if WASM_ENABLE_REF_TYPES != 0
-          case WASM_OP_TABLE_INIT:
-          {
-            uint32 tbl_idx, tbl_seg_idx;
+                    case WASM_OP_TABLE_INIT:
+                    {
+                        uint32 tbl_idx, tbl_seg_idx;
 
-            read_leb_uint32(frame_ip, frame_ip_end, tbl_seg_idx);
-            read_leb_uint32(frame_ip, frame_ip_end, tbl_idx);
-            if (!aot_compile_op_table_init(comp_ctx, func_ctx, tbl_idx,
-                                           tbl_seg_idx))
-              return false;
-            break;
-          }
-          case WASM_OP_ELEM_DROP:
-          {
-            uint32 tbl_seg_idx;
+                        read_leb_uint32(frame_ip, frame_ip_end, tbl_seg_idx);
+                        read_leb_uint32(frame_ip, frame_ip_end, tbl_idx);
+                        if (!aot_compile_op_table_init(comp_ctx, func_ctx,
+                                                       tbl_idx, tbl_seg_idx))
+                            return false;
+                        break;
+                    }
+                    case WASM_OP_ELEM_DROP:
+                    {
+                        uint32 tbl_seg_idx;
 
-            read_leb_uint32(frame_ip, frame_ip_end, tbl_seg_idx);
-            if (!aot_compile_op_elem_drop(comp_ctx, func_ctx, tbl_seg_idx))
-              return false;
-            break;
-          }
-          case WASM_OP_TABLE_COPY:
-          {
-            uint32 src_tbl_idx, dst_tbl_idx;
+                        read_leb_uint32(frame_ip, frame_ip_end, tbl_seg_idx);
+                        if (!aot_compile_op_elem_drop(comp_ctx, func_ctx,
+                                                      tbl_seg_idx))
+                            return false;
+                        break;
+                    }
+                    case WASM_OP_TABLE_COPY:
+                    {
+                        uint32 src_tbl_idx, dst_tbl_idx;
 
-            read_leb_uint32(frame_ip, frame_ip_end, dst_tbl_idx);
-            read_leb_uint32(frame_ip, frame_ip_end, src_tbl_idx);
-            if (!aot_compile_op_table_copy(comp_ctx, func_ctx, src_tbl_idx,
-                                           dst_tbl_idx))
-              return false;
-            break;
-          }
-          case WASM_OP_TABLE_GROW:
-          {
-            uint32 tbl_idx;
+                        read_leb_uint32(frame_ip, frame_ip_end, dst_tbl_idx);
+                        read_leb_uint32(frame_ip, frame_ip_end, src_tbl_idx);
+                        if (!aot_compile_op_table_copy(
+                                comp_ctx, func_ctx, src_tbl_idx, dst_tbl_idx))
+                            return false;
+                        break;
+                    }
+                    case WASM_OP_TABLE_GROW:
+                    {
+                        uint32 tbl_idx;
 
-            read_leb_uint32(frame_ip, frame_ip_end, tbl_idx);
-            if (!aot_compile_op_table_grow(comp_ctx, func_ctx, tbl_idx))
-              return false;
-            break;
-          }
+                        read_leb_uint32(frame_ip, frame_ip_end, tbl_idx);
+                        if (!aot_compile_op_table_grow(comp_ctx, func_ctx,
+                                                       tbl_idx))
+                            return false;
+                        break;
+                    }
 
-          case WASM_OP_TABLE_SIZE:
-          {
-            uint32 tbl_idx;
+                    case WASM_OP_TABLE_SIZE:
+                    {
+                        uint32 tbl_idx;
 
-            read_leb_uint32(frame_ip, frame_ip_end, tbl_idx);
-            if (!aot_compile_op_table_size(comp_ctx, func_ctx, tbl_idx))
-              return false;
-            break;
-          }
-          case WASM_OP_TABLE_FILL:
-          {
-            uint32 tbl_idx;
+                        read_leb_uint32(frame_ip, frame_ip_end, tbl_idx);
+                        if (!aot_compile_op_table_size(comp_ctx, func_ctx,
+                                                       tbl_idx))
+                            return false;
+                        break;
+                    }
+                    case WASM_OP_TABLE_FILL:
+                    {
+                        uint32 tbl_idx;
 
-            read_leb_uint32(frame_ip, frame_ip_end, tbl_idx);
-            if (!aot_compile_op_table_fill(comp_ctx, func_ctx, tbl_idx))
-              return false;
-            break;
-          }
+                        read_leb_uint32(frame_ip, frame_ip_end, tbl_idx);
+                        if (!aot_compile_op_table_fill(comp_ctx, func_ctx,
+                                                       tbl_idx))
+                            return false;
+                        break;
+                    }
 #endif /* WASM_ENABLE_REF_TYPES */
-          default:
-            aot_set_last_error("unsupported opcode");
-            return false;
-        }
-        break;
-      }
+                    default:
+                        aot_set_last_error("unsupported opcode");
+                        return false;
+                }
+                break;
+            }
 
 #if WASM_ENABLE_SHARED_MEMORY != 0
-      case WASM_OP_ATOMIC_PREFIX:
-      {
-        uint8 bin_op, op_type;
+            case WASM_OP_ATOMIC_PREFIX:
+            {
+                uint8 bin_op, op_type;
 
-        if (frame_ip < frame_ip_end) {
-          opcode = *frame_ip++;
-        }
-        if (opcode != WASM_OP_ATOMIC_FENCE) {
-          read_leb_uint32(frame_ip, frame_ip_end, align);
-          read_leb_uint32(frame_ip, frame_ip_end, offset);
-        }
-        switch (opcode) {
-          case WASM_OP_ATOMIC_WAIT32:
-            if (!aot_compile_op_atomic_wait(comp_ctx, func_ctx, VALUE_TYPE_I32,
-                                            align, offset, 4))
-              return false;
-            break;
-          case WASM_OP_ATOMIC_WAIT64:
-            if (!aot_compile_op_atomic_wait(comp_ctx, func_ctx, VALUE_TYPE_I64,
-                                            align, offset, 8))
-              return false;
-            break;
-          case WASM_OP_ATOMIC_NOTIFY:
-            if (!aot_compiler_op_atomic_notify(comp_ctx, func_ctx, align,
-                                               offset, bytes))
-              return false;
-            break;
-          case WASM_OP_ATOMIC_I32_LOAD:
-            bytes = 4;
-            goto op_atomic_i32_load;
-          case WASM_OP_ATOMIC_I32_LOAD8_U:
-            bytes = 1;
-            goto op_atomic_i32_load;
-          case WASM_OP_ATOMIC_I32_LOAD16_U:
-            bytes = 2;
-op_atomic_i32_load:
-            if (!aot_compile_op_i32_load(comp_ctx, func_ctx, align, offset,
-                                         bytes, sign, true))
-              return false;
-            break;
+                if (frame_ip < frame_ip_end) {
+                    opcode = *frame_ip++;
+                }
+                if (opcode != WASM_OP_ATOMIC_FENCE) {
+                    read_leb_uint32(frame_ip, frame_ip_end, align);
+                    read_leb_uint32(frame_ip, frame_ip_end, offset);
+                }
+                switch (opcode) {
+                    case WASM_OP_ATOMIC_WAIT32:
+                        if (!aot_compile_op_atomic_wait(comp_ctx, func_ctx,
+                                                        VALUE_TYPE_I32, align,
+                                                        offset, 4))
+                            return false;
+                        break;
+                    case WASM_OP_ATOMIC_WAIT64:
+                        if (!aot_compile_op_atomic_wait(comp_ctx, func_ctx,
+                                                        VALUE_TYPE_I64, align,
+                                                        offset, 8))
+                            return false;
+                        break;
+                    case WASM_OP_ATOMIC_NOTIFY:
+                        if (!aot_compiler_op_atomic_notify(
+                                comp_ctx, func_ctx, align, offset, bytes))
+                            return false;
+                        break;
+                    case WASM_OP_ATOMIC_I32_LOAD:
+                        bytes = 4;
+                        goto op_atomic_i32_load;
+                    case WASM_OP_ATOMIC_I32_LOAD8_U:
+                        bytes = 1;
+                        goto op_atomic_i32_load;
+                    case WASM_OP_ATOMIC_I32_LOAD16_U:
+                        bytes = 2;
+                    op_atomic_i32_load:
+                        if (!aot_compile_op_i32_load(comp_ctx, func_ctx, align,
+                                                     offset, bytes, sign, true))
+                            return false;
+                        break;
 
-          case WASM_OP_ATOMIC_I64_LOAD:
-            bytes = 8;
-            goto op_atomic_i64_load;
-          case WASM_OP_ATOMIC_I64_LOAD8_U:
-            bytes = 1;
-            goto op_atomic_i64_load;
-          case WASM_OP_ATOMIC_I64_LOAD16_U:
-            bytes = 2;
-            goto op_atomic_i64_load;
-          case WASM_OP_ATOMIC_I64_LOAD32_U:
-            bytes = 4;
-op_atomic_i64_load:
-            if (!aot_compile_op_i64_load(comp_ctx, func_ctx, align, offset,
-                                         bytes, sign, true))
-              return false;
-            break;
+                    case WASM_OP_ATOMIC_I64_LOAD:
+                        bytes = 8;
+                        goto op_atomic_i64_load;
+                    case WASM_OP_ATOMIC_I64_LOAD8_U:
+                        bytes = 1;
+                        goto op_atomic_i64_load;
+                    case WASM_OP_ATOMIC_I64_LOAD16_U:
+                        bytes = 2;
+                        goto op_atomic_i64_load;
+                    case WASM_OP_ATOMIC_I64_LOAD32_U:
+                        bytes = 4;
+                    op_atomic_i64_load:
+                        if (!aot_compile_op_i64_load(comp_ctx, func_ctx, align,
+                                                     offset, bytes, sign, true))
+                            return false;
+                        break;
 
-          case WASM_OP_ATOMIC_I32_STORE:
-            bytes = 4;
-            goto op_atomic_i32_store;
-          case WASM_OP_ATOMIC_I32_STORE8:
-            bytes = 1;
-            goto op_atomic_i32_store;
-          case WASM_OP_ATOMIC_I32_STORE16:
-            bytes = 2;
-op_atomic_i32_store:
-            if (!aot_compile_op_i32_store(comp_ctx, func_ctx, align, offset,
-                                          bytes, true))
-              return false;
-            break;
+                    case WASM_OP_ATOMIC_I32_STORE:
+                        bytes = 4;
+                        goto op_atomic_i32_store;
+                    case WASM_OP_ATOMIC_I32_STORE8:
+                        bytes = 1;
+                        goto op_atomic_i32_store;
+                    case WASM_OP_ATOMIC_I32_STORE16:
+                        bytes = 2;
+                    op_atomic_i32_store:
+                        if (!aot_compile_op_i32_store(comp_ctx, func_ctx, align,
+                                                      offset, bytes, true))
+                            return false;
+                        break;
 
-          case WASM_OP_ATOMIC_I64_STORE:
-            bytes = 8;
-            goto op_atomic_i64_store;
-          case WASM_OP_ATOMIC_I64_STORE8:
-            bytes = 1;
-            goto op_atomic_i64_store;
-          case WASM_OP_ATOMIC_I64_STORE16:
-            bytes = 2;
-            goto op_atomic_i64_store;
-          case WASM_OP_ATOMIC_I64_STORE32:
-            bytes = 4;
-op_atomic_i64_store:
-            if (!aot_compile_op_i64_store(comp_ctx, func_ctx, align, offset,
-                                          bytes, true))
-              return false;
-            break;
+                    case WASM_OP_ATOMIC_I64_STORE:
+                        bytes = 8;
+                        goto op_atomic_i64_store;
+                    case WASM_OP_ATOMIC_I64_STORE8:
+                        bytes = 1;
+                        goto op_atomic_i64_store;
+                    case WASM_OP_ATOMIC_I64_STORE16:
+                        bytes = 2;
+                        goto op_atomic_i64_store;
+                    case WASM_OP_ATOMIC_I64_STORE32:
+                        bytes = 4;
+                    op_atomic_i64_store:
+                        if (!aot_compile_op_i64_store(comp_ctx, func_ctx, align,
+                                                      offset, bytes, true))
+                            return false;
+                        break;
 
-          case WASM_OP_ATOMIC_RMW_I32_CMPXCHG:
-            bytes = 4;
-            op_type = VALUE_TYPE_I32;
-            goto op_atomic_cmpxchg;
-          case WASM_OP_ATOMIC_RMW_I64_CMPXCHG:
-            bytes = 8;
-            op_type = VALUE_TYPE_I64;
-            goto op_atomic_cmpxchg;
-          case WASM_OP_ATOMIC_RMW_I32_CMPXCHG8_U:
-            bytes = 1;
-            op_type = VALUE_TYPE_I32;
-            goto op_atomic_cmpxchg;
-          case WASM_OP_ATOMIC_RMW_I32_CMPXCHG16_U:
-            bytes = 2;
-            op_type = VALUE_TYPE_I32;
-            goto op_atomic_cmpxchg;
-          case WASM_OP_ATOMIC_RMW_I64_CMPXCHG8_U:
-            bytes = 1;
-            op_type = VALUE_TYPE_I64;
-            goto op_atomic_cmpxchg;
-          case WASM_OP_ATOMIC_RMW_I64_CMPXCHG16_U:
-            bytes = 2;
-            op_type = VALUE_TYPE_I64;
-            goto op_atomic_cmpxchg;
-          case WASM_OP_ATOMIC_RMW_I64_CMPXCHG32_U:
-            bytes = 4;
-            op_type = VALUE_TYPE_I64;
-op_atomic_cmpxchg:
-            if (!aot_compile_op_atomic_cmpxchg(comp_ctx, func_ctx, op_type,
-                                               align, offset, bytes))
-              return false;
-            break;
+                    case WASM_OP_ATOMIC_RMW_I32_CMPXCHG:
+                        bytes = 4;
+                        op_type = VALUE_TYPE_I32;
+                        goto op_atomic_cmpxchg;
+                    case WASM_OP_ATOMIC_RMW_I64_CMPXCHG:
+                        bytes = 8;
+                        op_type = VALUE_TYPE_I64;
+                        goto op_atomic_cmpxchg;
+                    case WASM_OP_ATOMIC_RMW_I32_CMPXCHG8_U:
+                        bytes = 1;
+                        op_type = VALUE_TYPE_I32;
+                        goto op_atomic_cmpxchg;
+                    case WASM_OP_ATOMIC_RMW_I32_CMPXCHG16_U:
+                        bytes = 2;
+                        op_type = VALUE_TYPE_I32;
+                        goto op_atomic_cmpxchg;
+                    case WASM_OP_ATOMIC_RMW_I64_CMPXCHG8_U:
+                        bytes = 1;
+                        op_type = VALUE_TYPE_I64;
+                        goto op_atomic_cmpxchg;
+                    case WASM_OP_ATOMIC_RMW_I64_CMPXCHG16_U:
+                        bytes = 2;
+                        op_type = VALUE_TYPE_I64;
+                        goto op_atomic_cmpxchg;
+                    case WASM_OP_ATOMIC_RMW_I64_CMPXCHG32_U:
+                        bytes = 4;
+                        op_type = VALUE_TYPE_I64;
+                    op_atomic_cmpxchg:
+                        if (!aot_compile_op_atomic_cmpxchg(comp_ctx, func_ctx,
+                                                           op_type, align,
+                                                           offset, bytes))
+                            return false;
+                        break;
 
-          COMPILE_ATOMIC_RMW(Add, ADD);
-          COMPILE_ATOMIC_RMW(Sub, SUB);
-          COMPILE_ATOMIC_RMW(And, AND);
-          COMPILE_ATOMIC_RMW(Or, OR);
-          COMPILE_ATOMIC_RMW(Xor, XOR);
-          COMPILE_ATOMIC_RMW(Xchg, XCHG);
+                        COMPILE_ATOMIC_RMW(Add, ADD);
+                        COMPILE_ATOMIC_RMW(Sub, SUB);
+                        COMPILE_ATOMIC_RMW(And, AND);
+                        COMPILE_ATOMIC_RMW(Or, OR);
+                        COMPILE_ATOMIC_RMW(Xor, XOR);
+                        COMPILE_ATOMIC_RMW(Xchg, XCHG);
 
-build_atomic_rmw:
-            if (!aot_compile_op_atomic_rmw(comp_ctx, func_ctx, bin_op, op_type,
-                                           align, offset, bytes))
-              return false;
-            break;
+                    build_atomic_rmw:
+                        if (!aot_compile_op_atomic_rmw(comp_ctx, func_ctx,
+                                                       bin_op, op_type, align,
+                                                       offset, bytes))
+                            return false;
+                        break;
 
-          default:
-            aot_set_last_error("unsupported opcode");
-            return false;
-        }
-        break;
-      }
+                    default:
+                        aot_set_last_error("unsupported opcode");
+                        return false;
+                }
+                break;
+            }
 #endif /* end of WASM_ENABLE_SHARED_MEMORY */
 
 #if WASM_ENABLE_SIMD != 0
-      case WASM_OP_SIMD_PREFIX:
-      {
-        if (!comp_ctx->enable_simd) {
-          goto unsupport_simd;
-        }
-
-        opcode = *frame_ip++;
-        /* follow the order of enum WASMSimdEXTOpcode in wasm_opcode.h */
-        switch (opcode) {
-          /* Memory instruction */
-          case SIMD_v128_load:
-          {
-            read_leb_uint32(frame_ip, frame_ip_end, align);
-            read_leb_uint32(frame_ip, frame_ip_end, offset);
-            if (!aot_compile_simd_v128_load(comp_ctx, func_ctx, align, offset))
-              return false;
-            break;
-          }
-
-          case SIMD_v128_load8x8_s:
-          case SIMD_v128_load8x8_u:
-          case SIMD_v128_load16x4_s:
-          case SIMD_v128_load16x4_u:
-          case SIMD_v128_load32x2_s:
-          case SIMD_v128_load32x2_u:
-          {
-            read_leb_uint32(frame_ip, frame_ip_end, align);
-            read_leb_uint32(frame_ip, frame_ip_end, offset);
-            if (!aot_compile_simd_load_extend(comp_ctx, func_ctx, opcode,
-                                              align, offset))
-              return false;
-            break;
-          }
-
-          case SIMD_v128_load8_splat:
-          case SIMD_v128_load16_splat:
-          case SIMD_v128_load32_splat:
-          case SIMD_v128_load64_splat:
-          {
-            read_leb_uint32(frame_ip, frame_ip_end, align);
-            read_leb_uint32(frame_ip, frame_ip_end, offset);
-            if (!aot_compile_simd_load_splat(comp_ctx, func_ctx, opcode, align,
-                                             offset))
-              return false;
-            break;
-          }
-
-          case SIMD_v128_store:
-          {
-            read_leb_uint32(frame_ip, frame_ip_end, align);
-            read_leb_uint32(frame_ip, frame_ip_end, offset);
-            if (!aot_compile_simd_v128_store(comp_ctx, func_ctx, align,
-                                             offset))
-              return false;
-            break;
-          }
-
-          /* Basic operation */
-          case SIMD_v128_const:
-          {
-            if (!aot_compile_simd_v128_const(comp_ctx, func_ctx, frame_ip))
-              return false;
-            frame_ip += 16;
-            break;
-          }
-
-          case SIMD_v8x16_shuffle:
-          {
-            if (!aot_compile_simd_shuffle(comp_ctx, func_ctx, frame_ip))
-              return false;
-            frame_ip += 16;
-            break;
-          }
-
-          case SIMD_v8x16_swizzle:
-          {
-            if (!aot_compile_simd_swizzle(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          /* Splat operation */
-          case SIMD_i8x16_splat:
-          case SIMD_i16x8_splat:
-          case SIMD_i32x4_splat:
-          case SIMD_i64x2_splat:
-          case SIMD_f32x4_splat:
-          case SIMD_f64x2_splat:
-          {
-            if (!aot_compile_simd_splat(comp_ctx, func_ctx, opcode))
-              return false;
-            break;
-          }
-
-          /* Lane operation */
-          case SIMD_i8x16_extract_lane_s:
-          case SIMD_i8x16_extract_lane_u:
-          {
-            if (!aot_compile_simd_extract_i8x16(
-                  comp_ctx, func_ctx, *frame_ip++,
-                  SIMD_i8x16_extract_lane_s == opcode))
-              return false;
-            break;
-          }
-
-          case SIMD_i8x16_replace_lane:
-          {
-            if (!aot_compile_simd_replace_i8x16(comp_ctx, func_ctx,
-                                                *frame_ip++))
-              return false;
-            break;
-          }
-
-          case SIMD_i16x8_extract_lane_s:
-          case SIMD_i16x8_extract_lane_u:
-          {
-            if (!aot_compile_simd_extract_i16x8(
-                  comp_ctx, func_ctx, *frame_ip++,
-                  SIMD_i16x8_extract_lane_s == opcode))
-              return false;
-            break;
-          }
-
-          case SIMD_i16x8_replace_lane:
-          {
-            if (!aot_compile_simd_replace_i16x8(comp_ctx, func_ctx,
-                                                *frame_ip++))
-              return false;
-            break;
-          }
-
-          case SIMD_i32x4_extract_lane:
-          {
-            if (!aot_compile_simd_extract_i32x4(comp_ctx, func_ctx,
-                                                *frame_ip++))
-              return false;
-            break;
-          }
-
-          case SIMD_i32x4_replace_lane:
-          {
-            if (!aot_compile_simd_replace_i32x4(comp_ctx, func_ctx,
-                                                *frame_ip++))
-              return false;
-            break;
-          }
-
-          case SIMD_i64x2_extract_lane:
-          {
-            if (!aot_compile_simd_extract_i64x2(comp_ctx, func_ctx,
-                                                *frame_ip++))
-              return false;
-            break;
-          }
-
-          case SIMD_i64x2_replace_lane:
-          {
-            if (!aot_compile_simd_replace_i64x2(comp_ctx, func_ctx,
-                                                *frame_ip++))
-              return false;
-            break;
-          }
-
-          case SIMD_f32x4_extract_lane:
-          {
-            if (!aot_compile_simd_extract_f32x4(comp_ctx, func_ctx,
-                                                *frame_ip++))
-              return false;
-            break;
-          }
-
-          case SIMD_f32x4_replace_lane:
-          {
-            if (!aot_compile_simd_replace_f32x4(comp_ctx, func_ctx,
-                                                *frame_ip++))
-              return false;
-            break;
-          }
-
-          case SIMD_f64x2_extract_lane:
-          {
-            if (!aot_compile_simd_extract_f64x2(comp_ctx, func_ctx,
-                                                *frame_ip++))
-              return false;
-            break;
-          }
-
-          case SIMD_f64x2_replace_lane:
-          {
-            if (!aot_compile_simd_replace_f64x2(comp_ctx, func_ctx,
-                                                *frame_ip++))
-              return false;
-            break;
-          }
-
-          /* i8x16 Cmp */
-          case SIMD_i8x16_eq:
-          case SIMD_i8x16_ne:
-          case SIMD_i8x16_lt_s:
-          case SIMD_i8x16_lt_u:
-          case SIMD_i8x16_gt_s:
-          case SIMD_i8x16_gt_u:
-          case SIMD_i8x16_le_s:
-          case SIMD_i8x16_le_u:
-          case SIMD_i8x16_ge_s:
-          case SIMD_i8x16_ge_u:
-          {
-            if (!aot_compile_simd_i8x16_compare(
-                  comp_ctx, func_ctx, INT_EQ + opcode - SIMD_i8x16_eq))
-              return false;
-            break;
-          }
-
-          /* i16x8 Cmp */
-          case SIMD_i16x8_eq:
-          case SIMD_i16x8_ne:
-          case SIMD_i16x8_lt_s:
-          case SIMD_i16x8_lt_u:
-          case SIMD_i16x8_gt_s:
-          case SIMD_i16x8_gt_u:
-          case SIMD_i16x8_le_s:
-          case SIMD_i16x8_le_u:
-          case SIMD_i16x8_ge_s:
-          case SIMD_i16x8_ge_u:
-          {
-            if (!aot_compile_simd_i16x8_compare(
-                  comp_ctx, func_ctx, INT_EQ + opcode - SIMD_i16x8_eq))
-              return false;
-            break;
-          }
-
-          /* i32x4 Cmp */
-          case SIMD_i32x4_eq:
-          case SIMD_i32x4_ne:
-          case SIMD_i32x4_lt_s:
-          case SIMD_i32x4_lt_u:
-          case SIMD_i32x4_gt_s:
-          case SIMD_i32x4_gt_u:
-          case SIMD_i32x4_le_s:
-          case SIMD_i32x4_le_u:
-          case SIMD_i32x4_ge_s:
-          case SIMD_i32x4_ge_u:
-          {
-            if (!aot_compile_simd_i32x4_compare(
-                  comp_ctx, func_ctx, INT_EQ + opcode - SIMD_i32x4_eq))
-              return false;
-            break;
-          }
-
-          /* f32x4 Cmp */
-          case SIMD_f32x4_eq:
-          case SIMD_f32x4_ne:
-          case SIMD_f32x4_lt:
-          case SIMD_f32x4_gt:
-          case SIMD_f32x4_le:
-          case SIMD_f32x4_ge:
-          {
-            if (!aot_compile_simd_f32x4_compare(
-                  comp_ctx, func_ctx, FLOAT_EQ + opcode - SIMD_f32x4_eq))
-              return false;
-            break;
-          }
-
-          /* f64x2 Cmp */
-          case SIMD_f64x2_eq:
-          case SIMD_f64x2_ne:
-          case SIMD_f64x2_lt:
-          case SIMD_f64x2_gt:
-          case SIMD_f64x2_le:
-          case SIMD_f64x2_ge:
-          {
-            if (!aot_compile_simd_f64x2_compare(
-                  comp_ctx, func_ctx, FLOAT_EQ + opcode - SIMD_f64x2_eq))
-              return false;
-            break;
-          }
-
-          /* v128 Op */
-          case SIMD_v128_not:
-          case SIMD_v128_and:
-          case SIMD_v128_andnot:
-          case SIMD_v128_or:
-          case SIMD_v128_xor:
-          case SIMD_v128_bitselect:
-          {
-            if (!aot_compile_simd_v128_bitwise(
-                  comp_ctx, func_ctx, V128_NOT + opcode - SIMD_v128_not))
-              return false;
-            break;
-          }
-
-          case SIMD_v128_any_true:
-          {
-            if (!aot_compile_simd_v128_any_true(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          /* Load Lane Op */
-          case SIMD_v128_load8_lane:
-          case SIMD_v128_load16_lane:
-          case SIMD_v128_load32_lane:
-          case SIMD_v128_load64_lane:
-          {
-            read_leb_uint32(frame_ip, frame_ip_end, align);
-            read_leb_uint32(frame_ip, frame_ip_end, offset);
-            if (!aot_compile_simd_load_lane(comp_ctx, func_ctx, opcode, align,
-                                            offset, *frame_ip++))
-              return false;
-            break;
-          }
-
-          case SIMD_v128_store8_lane:
-          case SIMD_v128_store16_lane:
-          case SIMD_v128_store32_lane:
-          case SIMD_v128_store64_lane:
-          {
-            read_leb_uint32(frame_ip, frame_ip_end, align);
-            read_leb_uint32(frame_ip, frame_ip_end, offset);
-            if (!aot_compile_simd_store_lane(comp_ctx, func_ctx, opcode, align,
-                                             offset, *frame_ip++))
-              return false;
-            break;
-          }
-
-          case SIMD_v128_load32_zero:
-          case SIMD_v128_load64_zero:
-          {
-            read_leb_uint32(frame_ip, frame_ip_end, align);
-            read_leb_uint32(frame_ip, frame_ip_end, offset);
-            if (!aot_compile_simd_load_zero(comp_ctx, func_ctx, opcode, align,
-                                            offset))
-              return false;
-            break;
-          }
-
-          /* Float conversion */
-          case SIMD_f32x4_demote_f64x2_zero:
-          {
-            if (!aot_compile_simd_f64x2_demote(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_f64x2_promote_low_f32x4_zero:
-          {
-            if (!aot_compile_simd_f32x4_promote(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          /* i8x16 Op */
-          case SIMD_i8x16_abs:
-          {
-            if (!aot_compile_simd_i8x16_abs(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i8x16_neg:
-          {
-            if (!aot_compile_simd_i8x16_neg(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i8x16_popcnt:
-          {
-            if (!aot_compile_simd_i8x16_popcnt(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i8x16_all_true:
-          {
-            if (!aot_compile_simd_i8x16_all_true(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i8x16_bitmask:
-          {
-            if (!aot_compile_simd_i8x16_bitmask(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i8x16_narrow_i16x8_s:
-          case SIMD_i8x16_narrow_i16x8_u:
-          {
-            if (!aot_compile_simd_i8x16_narrow_i16x8(
-                  comp_ctx, func_ctx, (opcode == SIMD_i8x16_narrow_i16x8_s)))
-              return false;
-            break;
-          }
-
-          case SIMD_f32x4_ceil:
-          {
-            if (!aot_compile_simd_f32x4_ceil(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_f32x4_floor:
-          {
-            if (!aot_compile_simd_f32x4_floor(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_f32x4_trunc:
-          {
-            if (!aot_compile_simd_f32x4_trunc(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_f32x4_nearest:
-          {
-            if (!aot_compile_simd_f32x4_nearest(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i8x16_shl:
-          case SIMD_i8x16_shr_s:
-          case SIMD_i8x16_shr_u:
-          {
-            if (!aot_compile_simd_i8x16_shift(
-                  comp_ctx, func_ctx, INT_SHL + opcode - SIMD_i8x16_shl))
-              return false;
-            break;
-          }
-
-          case SIMD_i8x16_add:
-          {
-            if (!aot_compile_simd_i8x16_arith(comp_ctx, func_ctx, V128_ADD))
-              return false;
-            break;
-          }
-
-          case SIMD_i8x16_add_sat_s:
-          case SIMD_i8x16_add_sat_u:
-          {
-            if (!aot_compile_simd_i8x16_saturate(comp_ctx, func_ctx, V128_ADD,
-                                                 opcode
-                                                   == SIMD_i8x16_add_sat_s))
-              return false;
-            break;
-          }
-
-          case SIMD_i8x16_sub:
-          {
-            if (!aot_compile_simd_i8x16_arith(comp_ctx, func_ctx, V128_SUB))
-              return false;
-            break;
-          }
-
-          case SIMD_i8x16_sub_sat_s:
-          case SIMD_i8x16_sub_sat_u:
-          {
-            if (!aot_compile_simd_i8x16_saturate(comp_ctx, func_ctx, V128_SUB,
-                                                 opcode
-                                                   == SIMD_i8x16_sub_sat_s))
-              return false;
-            break;
-          }
-
-          case SIMD_f64x2_ceil:
-          {
-            if (!aot_compile_simd_f64x2_ceil(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_f64x2_floor:
-          {
-            if (!aot_compile_simd_f64x2_floor(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i8x16_min_s:
-          case SIMD_i8x16_min_u:
-          {
-            if (!aot_compile_simd_i8x16_cmp(comp_ctx, func_ctx, V128_MIN,
-                                            opcode == SIMD_i8x16_min_s))
-              return false;
-            break;
-          }
-
-          case SIMD_i8x16_max_s:
-          case SIMD_i8x16_max_u:
-          {
-            if (!aot_compile_simd_i8x16_cmp(comp_ctx, func_ctx, V128_MAX,
-                                            opcode == SIMD_i8x16_max_s))
-              return false;
-            break;
-          }
-
-          case SIMD_f64x2_trunc:
-          {
-            if (!aot_compile_simd_f64x2_trunc(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i8x16_avgr_u:
-          {
-            if (!aot_compile_simd_i8x16_avgr_u(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i16x8_extadd_pairwise_i8x16_s:
-          case SIMD_i16x8_extadd_pairwise_i8x16_u:
-          {
-            if (!aot_compile_simd_i16x8_extadd_pairwise_i8x16(
-                  comp_ctx, func_ctx,
-                  SIMD_i16x8_extadd_pairwise_i8x16_s == opcode))
-              return false;
-            break;
-          }
-
-          case SIMD_i32x4_extadd_pairwise_i16x8_s:
-          case SIMD_i32x4_extadd_pairwise_i16x8_u:
-          {
-            if (!aot_compile_simd_i32x4_extadd_pairwise_i16x8(
-                  comp_ctx, func_ctx,
-                  SIMD_i32x4_extadd_pairwise_i16x8_s == opcode))
-              return false;
-            break;
-          }
-
-          /* i16x8 Op */
-          case SIMD_i16x8_abs:
-          {
-            if (!aot_compile_simd_i16x8_abs(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i16x8_neg:
-          {
-            if (!aot_compile_simd_i16x8_neg(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i16x8_q15mulr_sat_s:
-          {
-            if (!aot_compile_simd_i16x8_q15mulr_sat(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i16x8_all_true:
-          {
-            if (!aot_compile_simd_i16x8_all_true(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i16x8_bitmask:
-          {
-            if (!aot_compile_simd_i16x8_bitmask(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i16x8_narrow_i32x4_s:
-          case SIMD_i16x8_narrow_i32x4_u:
-          {
-            if (!aot_compile_simd_i16x8_narrow_i32x4(
-                  comp_ctx, func_ctx, SIMD_i16x8_narrow_i32x4_s == opcode))
-              return false;
-            break;
-          }
-
-          case SIMD_i16x8_extend_low_i8x16_s:
-          case SIMD_i16x8_extend_high_i8x16_s:
-          {
-            if (!aot_compile_simd_i16x8_extend_i8x16(
-                  comp_ctx, func_ctx, SIMD_i16x8_extend_low_i8x16_s == opcode,
-                  true))
-              return false;
-            break;
-          }
-
-          case SIMD_i16x8_extend_low_i8x16_u:
-          case SIMD_i16x8_extend_high_i8x16_u:
-          {
-            if (!aot_compile_simd_i16x8_extend_i8x16(
-                  comp_ctx, func_ctx, SIMD_i16x8_extend_low_i8x16_u == opcode,
-                  false))
-              return false;
-            break;
-          }
-
-          case SIMD_i16x8_shl:
-          case SIMD_i16x8_shr_s:
-          case SIMD_i16x8_shr_u:
-          {
-            if (!aot_compile_simd_i16x8_shift(
-                  comp_ctx, func_ctx, INT_SHL + opcode - SIMD_i16x8_shl))
-              return false;
-            break;
-          }
-
-          case SIMD_i16x8_add:
-          {
-            if (!aot_compile_simd_i16x8_arith(comp_ctx, func_ctx, V128_ADD))
-              return false;
-            break;
-          }
-
-          case SIMD_i16x8_add_sat_s:
-          case SIMD_i16x8_add_sat_u:
-          {
-            if (!aot_compile_simd_i16x8_saturate(
-                  comp_ctx, func_ctx, V128_ADD,
-                  opcode == SIMD_i16x8_add_sat_s ? true : false))
-              return false;
-            break;
-          }
-
-          case SIMD_i16x8_sub:
-          {
-            if (!aot_compile_simd_i16x8_arith(comp_ctx, func_ctx, V128_SUB))
-              return false;
-            break;
-          }
-
-          case SIMD_i16x8_sub_sat_s:
-          case SIMD_i16x8_sub_sat_u:
-          {
-            if (!aot_compile_simd_i16x8_saturate(
-                  comp_ctx, func_ctx, V128_SUB,
-                  opcode == SIMD_i16x8_sub_sat_s ? true : false))
-              return false;
-            break;
-          }
-
-          case SIMD_f64x2_nearest:
-          {
-            if (!aot_compile_simd_f64x2_nearest(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i16x8_mul:
-          {
-            if (!aot_compile_simd_i16x8_arith(comp_ctx, func_ctx, V128_MUL))
-              return false;
-            break;
-          }
-
-          case SIMD_i16x8_min_s:
-          case SIMD_i16x8_min_u:
-          {
-            if (!aot_compile_simd_i16x8_cmp(comp_ctx, func_ctx, V128_MIN,
-                                            opcode == SIMD_i16x8_min_s))
-              return false;
-            break;
-          }
-
-          case SIMD_i16x8_max_s:
-          case SIMD_i16x8_max_u:
-          {
-            if (!aot_compile_simd_i16x8_cmp(comp_ctx, func_ctx, V128_MAX,
-                                            opcode == SIMD_i16x8_max_s))
-              return false;
-            break;
-          }
-
-          case SIMD_i16x8_avgr_u:
-          {
-            if (!aot_compile_simd_i16x8_avgr_u(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i16x8_extmul_low_i8x16_s:
-          case SIMD_i16x8_extmul_high_i8x16_s:
-          {
-            if (!(aot_compile_simd_i16x8_extmul_i8x16(
-                  comp_ctx, func_ctx, SIMD_i16x8_extmul_low_i8x16_s == opcode,
-                  true)))
-              return false;
-            break;
-          }
-
-          case SIMD_i16x8_extmul_low_i8x16_u:
-          case SIMD_i16x8_extmul_high_i8x16_u:
-          {
-            if (!(aot_compile_simd_i16x8_extmul_i8x16(
-                  comp_ctx, func_ctx, SIMD_i16x8_extmul_low_i8x16_u == opcode,
-                  false)))
-              return false;
-            break;
-          }
-
-          /* i32x4 Op */
-          case SIMD_i32x4_abs:
-          {
-            if (!aot_compile_simd_i32x4_abs(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i32x4_neg:
-          {
-            if (!aot_compile_simd_i32x4_neg(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i32x4_all_true:
-          {
-            if (!aot_compile_simd_i32x4_all_true(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i32x4_bitmask:
-          {
-            if (!aot_compile_simd_i32x4_bitmask(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i32x4_narrow_i64x2_s:
-          case SIMD_i32x4_narrow_i64x2_u:
-          {
-            if (!aot_compile_simd_i32x4_narrow_i64x2(
-                  comp_ctx, func_ctx, SIMD_i32x4_narrow_i64x2_s == opcode))
-              return false;
-            break;
-          }
-
-          case SIMD_i32x4_extend_low_i16x8_s:
-          case SIMD_i32x4_extend_high_i16x8_s:
-          {
-            if (!aot_compile_simd_i32x4_extend_i16x8(
-                  comp_ctx, func_ctx, SIMD_i32x4_extend_low_i16x8_s == opcode,
-                  true))
-              return false;
-            break;
-          }
-
-          case SIMD_i32x4_extend_low_i16x8_u:
-          case SIMD_i32x4_extend_high_i16x8_u:
-          {
-            if (!aot_compile_simd_i32x4_extend_i16x8(
-                  comp_ctx, func_ctx, SIMD_i32x4_extend_low_i16x8_u == opcode,
-                  false))
-              return false;
-            break;
-          }
-
-          case SIMD_i32x4_shl:
-          case SIMD_i32x4_shr_s:
-          case SIMD_i32x4_shr_u:
-          {
-            if (!aot_compile_simd_i32x4_shift(
-                  comp_ctx, func_ctx, INT_SHL + opcode - SIMD_i32x4_shl))
-              return false;
-            break;
-          }
-
-          case SIMD_i32x4_add:
-          {
-            if (!aot_compile_simd_i32x4_arith(comp_ctx, func_ctx, V128_ADD))
-              return false;
-            break;
-          }
-
-          case SIMD_i32x4_add_sat_s:
-          case SIMD_i32x4_add_sat_u:
-          {
-            if (!aot_compile_simd_i32x4_saturate(comp_ctx, func_ctx, V128_ADD,
-                                                 opcode
-                                                   == SIMD_i32x4_add_sat_s))
-              return false;
-            break;
-          }
-
-          case SIMD_i32x4_sub:
-          {
-            if (!aot_compile_simd_i32x4_arith(comp_ctx, func_ctx, V128_SUB))
-              return false;
-            break;
-          }
-
-          case SIMD_i32x4_sub_sat_s:
-          case SIMD_i32x4_sub_sat_u:
-          {
-            if (!aot_compile_simd_i32x4_saturate(comp_ctx, func_ctx, V128_SUB,
-                                                 opcode
-                                                   == SIMD_i32x4_add_sat_s))
-              return false;
-            break;
-          }
-
-          case SIMD_i32x4_mul:
-          {
-            if (!aot_compile_simd_i32x4_arith(comp_ctx, func_ctx, V128_MUL))
-              return false;
-            break;
-          }
-
-          case SIMD_i32x4_min_s:
-          case SIMD_i32x4_min_u:
-          {
-            if (!aot_compile_simd_i32x4_cmp(comp_ctx, func_ctx, V128_MIN,
-                                            SIMD_i32x4_min_s == opcode))
-              return false;
-            break;
-          }
-
-          case SIMD_i32x4_max_s:
-          case SIMD_i32x4_max_u:
-          {
-            if (!aot_compile_simd_i32x4_cmp(comp_ctx, func_ctx, V128_MAX,
-                                            SIMD_i32x4_max_s == opcode))
-              return false;
-            break;
-          }
-
-          case SIMD_i32x4_dot_i16x8_s:
-          {
-            if (!aot_compile_simd_i32x4_dot_i16x8(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i32x4_avgr_u:
-          {
-            if (!aot_compile_simd_i32x4_avgr_u(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i32x4_extmul_low_i16x8_s:
-          case SIMD_i32x4_extmul_high_i16x8_s:
-          {
-            if (!aot_compile_simd_i32x4_extmul_i16x8(
-                  comp_ctx, func_ctx, SIMD_i32x4_extmul_low_i16x8_s == opcode,
-                  true))
-              return false;
-            break;
-          }
-
-          case SIMD_i32x4_extmul_low_i16x8_u:
-          case SIMD_i32x4_extmul_high_i16x8_u:
-          {
-            if (!aot_compile_simd_i32x4_extmul_i16x8(
-                  comp_ctx, func_ctx, SIMD_i32x4_extmul_low_i16x8_u == opcode,
-                  false))
-              return false;
-            break;
-          }
-
-          /* i64x2 Op */
-          case SIMD_i64x2_abs:
-          {
-            if (!aot_compile_simd_i64x2_abs(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i64x2_neg:
-          {
-            if (!aot_compile_simd_i64x2_neg(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i64x2_all_true:
-          {
-            if (!aot_compile_simd_i64x2_all_true(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i64x2_bitmask:
-          {
-            if (!aot_compile_simd_i64x2_bitmask(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_i64x2_extend_low_i32x4_s:
-          case SIMD_i64x2_extend_high_i32x4_s:
-          {
-            if (!aot_compile_simd_i64x2_extend_i32x4(
-                  comp_ctx, func_ctx, SIMD_i64x2_extend_low_i32x4_s == opcode,
-                  true))
-              return false;
-            break;
-          }
-
-          case SIMD_i64x2_extend_low_i32x4_u:
-          case SIMD_i64x2_extend_high_i32x4_u:
-          {
-            if (!aot_compile_simd_i64x2_extend_i32x4(
-                  comp_ctx, func_ctx, SIMD_i64x2_extend_low_i32x4_u == opcode,
-                  false))
-              return false;
-            break;
-          }
-
-          case SIMD_i64x2_shl:
-          case SIMD_i64x2_shr_s:
-          case SIMD_i64x2_shr_u:
-          {
-            if (!aot_compile_simd_i64x2_shift(
-                  comp_ctx, func_ctx, INT_SHL + opcode - SIMD_i64x2_shl))
-              return false;
-            break;
-          }
-
-          case SIMD_i64x2_add:
-          {
-            if (!aot_compile_simd_i64x2_arith(comp_ctx, func_ctx, V128_ADD))
-              return false;
-            break;
-          }
-
-          case SIMD_i64x2_sub:
-          {
-            if (!aot_compile_simd_i64x2_arith(comp_ctx, func_ctx, V128_SUB))
-              return false;
-            break;
-          }
-
-          case SIMD_i64x2_mul:
-          {
-            if (!aot_compile_simd_i64x2_arith(comp_ctx, func_ctx, V128_MUL))
-              return false;
-            break;
-          }
-
-          case SIMD_i64x2_eq:
-          case SIMD_i64x2_ne:
-          case SIMD_i64x2_lt_s:
-          case SIMD_i64x2_gt_s:
-          case SIMD_i64x2_le_s:
-          case SIMD_i64x2_ge_s:
-          {
-            IntCond icond[] = { INT_EQ,   INT_NE,   INT_LT_S,
-                                INT_GT_S, INT_LE_S, INT_GE_S };
-            if (!aot_compile_simd_i64x2_compare(comp_ctx, func_ctx,
-                                                icond[opcode - SIMD_i64x2_eq]))
-              return false;
-            break;
-          }
-
-          case SIMD_i64x2_extmul_low_i32x4_s:
-          case SIMD_i64x2_extmul_high_i32x4_s:
-          {
-            if (!aot_compile_simd_i64x2_extmul_i32x4(
-                  comp_ctx, func_ctx, SIMD_i64x2_extmul_low_i32x4_s == opcode,
-                  true))
-              return false;
-            break;
-          }
-
-          case SIMD_i64x2_extmul_low_i32x4_u:
-          case SIMD_i64x2_extmul_high_i32x4_u:
-          {
-            if (!aot_compile_simd_i64x2_extmul_i32x4(
-                  comp_ctx, func_ctx, SIMD_i64x2_extmul_low_i32x4_u == opcode,
-                  false))
-              return false;
-            break;
-          }
-
-          /* f32x4 Op */
-          case SIMD_f32x4_abs:
-          {
-            if (!aot_compile_simd_f32x4_abs(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_f32x4_neg:
-          {
-            if (!aot_compile_simd_f32x4_neg(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_f32x4_round:
-          {
-            if (!aot_compile_simd_f32x4_round(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_f32x4_sqrt:
-          {
-            if (!aot_compile_simd_f32x4_sqrt(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_f32x4_add:
-          case SIMD_f32x4_sub:
-          case SIMD_f32x4_mul:
-          case SIMD_f32x4_div:
-          {
-            if (!aot_compile_simd_f32x4_arith(
-                  comp_ctx, func_ctx, FLOAT_ADD + opcode - SIMD_f32x4_add))
-              return false;
-            break;
-          }
-
-          case SIMD_f32x4_min:
-          case SIMD_f32x4_max:
-          {
-            if (!aot_compile_simd_f32x4_min_max(comp_ctx, func_ctx,
-                                                SIMD_f32x4_min == opcode))
-              return false;
-            break;
-          }
-
-          case SIMD_f32x4_pmin:
-          case SIMD_f32x4_pmax:
-          {
-            if (!aot_compile_simd_f32x4_pmin_pmax(comp_ctx, func_ctx,
-                                                  SIMD_f32x4_pmin == opcode))
-              return false;
-            break;
-          }
-
-          /* f64x2 Op */
-
-          case SIMD_f64x2_abs:
-          {
-            if (!aot_compile_simd_f64x2_abs(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_f64x2_neg:
-          {
-            if (!aot_compile_simd_f64x2_neg(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_f64x2_round:
-          {
-            if (!aot_compile_simd_f64x2_round(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_f64x2_sqrt:
-          {
-            if (!aot_compile_simd_f64x2_sqrt(comp_ctx, func_ctx))
-              return false;
-            break;
-          }
-
-          case SIMD_f64x2_add:
-          case SIMD_f64x2_sub:
-          case SIMD_f64x2_mul:
-          case SIMD_f64x2_div:
-          {
-            if (!aot_compile_simd_f64x2_arith(
-                  comp_ctx, func_ctx, FLOAT_ADD + opcode - SIMD_f64x2_add))
-              return false;
-            break;
-          }
-
-          case SIMD_f64x2_min:
-          case SIMD_f64x2_max:
-          {
-            if (!aot_compile_simd_f64x2_min_max(comp_ctx, func_ctx,
-                                                SIMD_f64x2_min == opcode))
-              return false;
-            break;
-          }
-
-          case SIMD_f64x2_pmin:
-          case SIMD_f64x2_pmax:
-          {
-            if (!aot_compile_simd_f64x2_pmin_pmax(comp_ctx, func_ctx,
-                                                  SIMD_f64x2_pmin == opcode))
-              return false;
-            break;
-          }
-
-          /* Conversion Op */
-          case SIMD_i32x4_trunc_sat_f32x4_s:
-          case SIMD_i32x4_trunc_sat_f32x4_u:
-          {
-            if (!aot_compile_simd_i32x4_trunc_sat_f32x4(
-                comp_ctx, func_ctx,
-                SIMD_i32x4_trunc_sat_f32x4_s == opcode))
-              return false;
-            break;
-          }
-
-          case SIMD_f32x4_convert_i32x4_s:
-          case SIMD_f32x4_convert_i32x4_u:
-          {
-            if (!aot_compile_simd_f32x4_convert_i32x4(
-                comp_ctx, func_ctx, SIMD_f32x4_convert_i32x4_s == opcode))
-              return false;
-            break;
-          }
-
-          case SIMD_i32x4_trunc_sat_f64x2_s_zero:
-          case SIMD_i32x4_trunc_sat_f64x2_u_zero:
-          {
-            if (!aot_compile_simd_i32x4_trunc_sat_f64x2(
-                comp_ctx, func_ctx,
-                SIMD_i32x4_trunc_sat_f64x2_s_zero == opcode))
-              return false;
-            break;
-          }
-
-          case SIMD_f64x2_convert_low_i32x4_s:
-          case SIMD_f64x2_convert_low_i32x4_u:
-          {
-            if (!aot_compile_simd_f64x2_convert_i32x4(
-                comp_ctx, func_ctx, SIMD_f64x2_convert_low_i32x4_s == opcode))
-              return false;
-            break;
-          }
-
-          default:
-            aot_set_last_error("unsupported opcode");
-            return false;
-        }
-        break;
-      }
+            case WASM_OP_SIMD_PREFIX:
+            {
+                if (!comp_ctx->enable_simd) {
+                    goto unsupport_simd;
+                }
+
+                opcode = *frame_ip++;
+                /* follow the order of enum WASMSimdEXTOpcode in
+                   wasm_opcode.h */
+                switch (opcode) {
+                    /* Memory instruction */
+                    case SIMD_v128_load:
+                    {
+                        read_leb_uint32(frame_ip, frame_ip_end, align);
+                        read_leb_uint32(frame_ip, frame_ip_end, offset);
+                        if (!aot_compile_simd_v128_load(comp_ctx, func_ctx,
+                                                        align, offset))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_v128_load8x8_s:
+                    case SIMD_v128_load8x8_u:
+                    case SIMD_v128_load16x4_s:
+                    case SIMD_v128_load16x4_u:
+                    case SIMD_v128_load32x2_s:
+                    case SIMD_v128_load32x2_u:
+                    {
+                        read_leb_uint32(frame_ip, frame_ip_end, align);
+                        read_leb_uint32(frame_ip, frame_ip_end, offset);
+                        if (!aot_compile_simd_load_extend(
+                                comp_ctx, func_ctx, opcode, align, offset))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_v128_load8_splat:
+                    case SIMD_v128_load16_splat:
+                    case SIMD_v128_load32_splat:
+                    case SIMD_v128_load64_splat:
+                    {
+                        read_leb_uint32(frame_ip, frame_ip_end, align);
+                        read_leb_uint32(frame_ip, frame_ip_end, offset);
+                        if (!aot_compile_simd_load_splat(comp_ctx, func_ctx,
+                                                         opcode, align, offset))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_v128_store:
+                    {
+                        read_leb_uint32(frame_ip, frame_ip_end, align);
+                        read_leb_uint32(frame_ip, frame_ip_end, offset);
+                        if (!aot_compile_simd_v128_store(comp_ctx, func_ctx,
+                                                         align, offset))
+                            return false;
+                        break;
+                    }
+
+                    /* Basic operation */
+                    case SIMD_v128_const:
+                    {
+                        if (!aot_compile_simd_v128_const(comp_ctx, func_ctx,
+                                                         frame_ip))
+                            return false;
+                        frame_ip += 16;
+                        break;
+                    }
+
+                    case SIMD_v8x16_shuffle:
+                    {
+                        if (!aot_compile_simd_shuffle(comp_ctx, func_ctx,
+                                                      frame_ip))
+                            return false;
+                        frame_ip += 16;
+                        break;
+                    }
+
+                    case SIMD_v8x16_swizzle:
+                    {
+                        if (!aot_compile_simd_swizzle(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    /* Splat operation */
+                    case SIMD_i8x16_splat:
+                    case SIMD_i16x8_splat:
+                    case SIMD_i32x4_splat:
+                    case SIMD_i64x2_splat:
+                    case SIMD_f32x4_splat:
+                    case SIMD_f64x2_splat:
+                    {
+                        if (!aot_compile_simd_splat(comp_ctx, func_ctx, opcode))
+                            return false;
+                        break;
+                    }
+
+                    /* Lane operation */
+                    case SIMD_i8x16_extract_lane_s:
+                    case SIMD_i8x16_extract_lane_u:
+                    {
+                        if (!aot_compile_simd_extract_i8x16(
+                                comp_ctx, func_ctx, *frame_ip++,
+                                SIMD_i8x16_extract_lane_s == opcode))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i8x16_replace_lane:
+                    {
+                        if (!aot_compile_simd_replace_i8x16(comp_ctx, func_ctx,
+                                                            *frame_ip++))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i16x8_extract_lane_s:
+                    case SIMD_i16x8_extract_lane_u:
+                    {
+                        if (!aot_compile_simd_extract_i16x8(
+                                comp_ctx, func_ctx, *frame_ip++,
+                                SIMD_i16x8_extract_lane_s == opcode))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i16x8_replace_lane:
+                    {
+                        if (!aot_compile_simd_replace_i16x8(comp_ctx, func_ctx,
+                                                            *frame_ip++))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i32x4_extract_lane:
+                    {
+                        if (!aot_compile_simd_extract_i32x4(comp_ctx, func_ctx,
+                                                            *frame_ip++))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i32x4_replace_lane:
+                    {
+                        if (!aot_compile_simd_replace_i32x4(comp_ctx, func_ctx,
+                                                            *frame_ip++))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i64x2_extract_lane:
+                    {
+                        if (!aot_compile_simd_extract_i64x2(comp_ctx, func_ctx,
+                                                            *frame_ip++))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i64x2_replace_lane:
+                    {
+                        if (!aot_compile_simd_replace_i64x2(comp_ctx, func_ctx,
+                                                            *frame_ip++))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f32x4_extract_lane:
+                    {
+                        if (!aot_compile_simd_extract_f32x4(comp_ctx, func_ctx,
+                                                            *frame_ip++))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f32x4_replace_lane:
+                    {
+                        if (!aot_compile_simd_replace_f32x4(comp_ctx, func_ctx,
+                                                            *frame_ip++))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f64x2_extract_lane:
+                    {
+                        if (!aot_compile_simd_extract_f64x2(comp_ctx, func_ctx,
+                                                            *frame_ip++))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f64x2_replace_lane:
+                    {
+                        if (!aot_compile_simd_replace_f64x2(comp_ctx, func_ctx,
+                                                            *frame_ip++))
+                            return false;
+                        break;
+                    }
+
+                    /* i8x16 Cmp */
+                    case SIMD_i8x16_eq:
+                    case SIMD_i8x16_ne:
+                    case SIMD_i8x16_lt_s:
+                    case SIMD_i8x16_lt_u:
+                    case SIMD_i8x16_gt_s:
+                    case SIMD_i8x16_gt_u:
+                    case SIMD_i8x16_le_s:
+                    case SIMD_i8x16_le_u:
+                    case SIMD_i8x16_ge_s:
+                    case SIMD_i8x16_ge_u:
+                    {
+                        if (!aot_compile_simd_i8x16_compare(
+                                comp_ctx, func_ctx,
+                                INT_EQ + opcode - SIMD_i8x16_eq))
+                            return false;
+                        break;
+                    }
+
+                    /* i16x8 Cmp */
+                    case SIMD_i16x8_eq:
+                    case SIMD_i16x8_ne:
+                    case SIMD_i16x8_lt_s:
+                    case SIMD_i16x8_lt_u:
+                    case SIMD_i16x8_gt_s:
+                    case SIMD_i16x8_gt_u:
+                    case SIMD_i16x8_le_s:
+                    case SIMD_i16x8_le_u:
+                    case SIMD_i16x8_ge_s:
+                    case SIMD_i16x8_ge_u:
+                    {
+                        if (!aot_compile_simd_i16x8_compare(
+                                comp_ctx, func_ctx,
+                                INT_EQ + opcode - SIMD_i16x8_eq))
+                            return false;
+                        break;
+                    }
+
+                    /* i32x4 Cmp */
+                    case SIMD_i32x4_eq:
+                    case SIMD_i32x4_ne:
+                    case SIMD_i32x4_lt_s:
+                    case SIMD_i32x4_lt_u:
+                    case SIMD_i32x4_gt_s:
+                    case SIMD_i32x4_gt_u:
+                    case SIMD_i32x4_le_s:
+                    case SIMD_i32x4_le_u:
+                    case SIMD_i32x4_ge_s:
+                    case SIMD_i32x4_ge_u:
+                    {
+                        if (!aot_compile_simd_i32x4_compare(
+                                comp_ctx, func_ctx,
+                                INT_EQ + opcode - SIMD_i32x4_eq))
+                            return false;
+                        break;
+                    }
+
+                    /* f32x4 Cmp */
+                    case SIMD_f32x4_eq:
+                    case SIMD_f32x4_ne:
+                    case SIMD_f32x4_lt:
+                    case SIMD_f32x4_gt:
+                    case SIMD_f32x4_le:
+                    case SIMD_f32x4_ge:
+                    {
+                        if (!aot_compile_simd_f32x4_compare(
+                                comp_ctx, func_ctx,
+                                FLOAT_EQ + opcode - SIMD_f32x4_eq))
+                            return false;
+                        break;
+                    }
+
+                    /* f64x2 Cmp */
+                    case SIMD_f64x2_eq:
+                    case SIMD_f64x2_ne:
+                    case SIMD_f64x2_lt:
+                    case SIMD_f64x2_gt:
+                    case SIMD_f64x2_le:
+                    case SIMD_f64x2_ge:
+                    {
+                        if (!aot_compile_simd_f64x2_compare(
+                                comp_ctx, func_ctx,
+                                FLOAT_EQ + opcode - SIMD_f64x2_eq))
+                            return false;
+                        break;
+                    }
+
+                    /* v128 Op */
+                    case SIMD_v128_not:
+                    case SIMD_v128_and:
+                    case SIMD_v128_andnot:
+                    case SIMD_v128_or:
+                    case SIMD_v128_xor:
+                    case SIMD_v128_bitselect:
+                    {
+                        if (!aot_compile_simd_v128_bitwise(comp_ctx, func_ctx,
+                                                           V128_NOT + opcode
+                                                               - SIMD_v128_not))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_v128_any_true:
+                    {
+                        if (!aot_compile_simd_v128_any_true(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    /* Load Lane Op */
+                    case SIMD_v128_load8_lane:
+                    case SIMD_v128_load16_lane:
+                    case SIMD_v128_load32_lane:
+                    case SIMD_v128_load64_lane:
+                    {
+                        read_leb_uint32(frame_ip, frame_ip_end, align);
+                        read_leb_uint32(frame_ip, frame_ip_end, offset);
+                        if (!aot_compile_simd_load_lane(comp_ctx, func_ctx,
+                                                        opcode, align, offset,
+                                                        *frame_ip++))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_v128_store8_lane:
+                    case SIMD_v128_store16_lane:
+                    case SIMD_v128_store32_lane:
+                    case SIMD_v128_store64_lane:
+                    {
+                        read_leb_uint32(frame_ip, frame_ip_end, align);
+                        read_leb_uint32(frame_ip, frame_ip_end, offset);
+                        if (!aot_compile_simd_store_lane(comp_ctx, func_ctx,
+                                                         opcode, align, offset,
+                                                         *frame_ip++))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_v128_load32_zero:
+                    case SIMD_v128_load64_zero:
+                    {
+                        read_leb_uint32(frame_ip, frame_ip_end, align);
+                        read_leb_uint32(frame_ip, frame_ip_end, offset);
+                        if (!aot_compile_simd_load_zero(comp_ctx, func_ctx,
+                                                        opcode, align, offset))
+                            return false;
+                        break;
+                    }
+
+                    /* Float conversion */
+                    case SIMD_f32x4_demote_f64x2_zero:
+                    {
+                        if (!aot_compile_simd_f64x2_demote(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f64x2_promote_low_f32x4_zero:
+                    {
+                        if (!aot_compile_simd_f32x4_promote(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    /* i8x16 Op */
+                    case SIMD_i8x16_abs:
+                    {
+                        if (!aot_compile_simd_i8x16_abs(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i8x16_neg:
+                    {
+                        if (!aot_compile_simd_i8x16_neg(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i8x16_popcnt:
+                    {
+                        if (!aot_compile_simd_i8x16_popcnt(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i8x16_all_true:
+                    {
+                        if (!aot_compile_simd_i8x16_all_true(comp_ctx,
+                                                             func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i8x16_bitmask:
+                    {
+                        if (!aot_compile_simd_i8x16_bitmask(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i8x16_narrow_i16x8_s:
+                    case SIMD_i8x16_narrow_i16x8_u:
+                    {
+                        if (!aot_compile_simd_i8x16_narrow_i16x8(
+                                comp_ctx, func_ctx,
+                                (opcode == SIMD_i8x16_narrow_i16x8_s)))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f32x4_ceil:
+                    {
+                        if (!aot_compile_simd_f32x4_ceil(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f32x4_floor:
+                    {
+                        if (!aot_compile_simd_f32x4_floor(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f32x4_trunc:
+                    {
+                        if (!aot_compile_simd_f32x4_trunc(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f32x4_nearest:
+                    {
+                        if (!aot_compile_simd_f32x4_nearest(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i8x16_shl:
+                    case SIMD_i8x16_shr_s:
+                    case SIMD_i8x16_shr_u:
+                    {
+                        if (!aot_compile_simd_i8x16_shift(comp_ctx, func_ctx,
+                                                          INT_SHL + opcode
+                                                              - SIMD_i8x16_shl))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i8x16_add:
+                    {
+                        if (!aot_compile_simd_i8x16_arith(comp_ctx, func_ctx,
+                                                          V128_ADD))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i8x16_add_sat_s:
+                    case SIMD_i8x16_add_sat_u:
+                    {
+                        if (!aot_compile_simd_i8x16_saturate(
+                                comp_ctx, func_ctx, V128_ADD,
+                                opcode == SIMD_i8x16_add_sat_s))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i8x16_sub:
+                    {
+                        if (!aot_compile_simd_i8x16_arith(comp_ctx, func_ctx,
+                                                          V128_SUB))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i8x16_sub_sat_s:
+                    case SIMD_i8x16_sub_sat_u:
+                    {
+                        if (!aot_compile_simd_i8x16_saturate(
+                                comp_ctx, func_ctx, V128_SUB,
+                                opcode == SIMD_i8x16_sub_sat_s))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f64x2_ceil:
+                    {
+                        if (!aot_compile_simd_f64x2_ceil(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f64x2_floor:
+                    {
+                        if (!aot_compile_simd_f64x2_floor(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i8x16_min_s:
+                    case SIMD_i8x16_min_u:
+                    {
+                        if (!aot_compile_simd_i8x16_cmp(
+                                comp_ctx, func_ctx, V128_MIN,
+                                opcode == SIMD_i8x16_min_s))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i8x16_max_s:
+                    case SIMD_i8x16_max_u:
+                    {
+                        if (!aot_compile_simd_i8x16_cmp(
+                                comp_ctx, func_ctx, V128_MAX,
+                                opcode == SIMD_i8x16_max_s))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f64x2_trunc:
+                    {
+                        if (!aot_compile_simd_f64x2_trunc(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i8x16_avgr_u:
+                    {
+                        if (!aot_compile_simd_i8x16_avgr_u(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i16x8_extadd_pairwise_i8x16_s:
+                    case SIMD_i16x8_extadd_pairwise_i8x16_u:
+                    {
+                        if (!aot_compile_simd_i16x8_extadd_pairwise_i8x16(
+                                comp_ctx, func_ctx,
+                                SIMD_i16x8_extadd_pairwise_i8x16_s == opcode))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i32x4_extadd_pairwise_i16x8_s:
+                    case SIMD_i32x4_extadd_pairwise_i16x8_u:
+                    {
+                        if (!aot_compile_simd_i32x4_extadd_pairwise_i16x8(
+                                comp_ctx, func_ctx,
+                                SIMD_i32x4_extadd_pairwise_i16x8_s == opcode))
+                            return false;
+                        break;
+                    }
+
+                    /* i16x8 Op */
+                    case SIMD_i16x8_abs:
+                    {
+                        if (!aot_compile_simd_i16x8_abs(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i16x8_neg:
+                    {
+                        if (!aot_compile_simd_i16x8_neg(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i16x8_q15mulr_sat_s:
+                    {
+                        if (!aot_compile_simd_i16x8_q15mulr_sat(comp_ctx,
+                                                                func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i16x8_all_true:
+                    {
+                        if (!aot_compile_simd_i16x8_all_true(comp_ctx,
+                                                             func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i16x8_bitmask:
+                    {
+                        if (!aot_compile_simd_i16x8_bitmask(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i16x8_narrow_i32x4_s:
+                    case SIMD_i16x8_narrow_i32x4_u:
+                    {
+                        if (!aot_compile_simd_i16x8_narrow_i32x4(
+                                comp_ctx, func_ctx,
+                                SIMD_i16x8_narrow_i32x4_s == opcode))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i16x8_extend_low_i8x16_s:
+                    case SIMD_i16x8_extend_high_i8x16_s:
+                    {
+                        if (!aot_compile_simd_i16x8_extend_i8x16(
+                                comp_ctx, func_ctx,
+                                SIMD_i16x8_extend_low_i8x16_s == opcode, true))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i16x8_extend_low_i8x16_u:
+                    case SIMD_i16x8_extend_high_i8x16_u:
+                    {
+                        if (!aot_compile_simd_i16x8_extend_i8x16(
+                                comp_ctx, func_ctx,
+                                SIMD_i16x8_extend_low_i8x16_u == opcode, false))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i16x8_shl:
+                    case SIMD_i16x8_shr_s:
+                    case SIMD_i16x8_shr_u:
+                    {
+                        if (!aot_compile_simd_i16x8_shift(comp_ctx, func_ctx,
+                                                          INT_SHL + opcode
+                                                              - SIMD_i16x8_shl))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i16x8_add:
+                    {
+                        if (!aot_compile_simd_i16x8_arith(comp_ctx, func_ctx,
+                                                          V128_ADD))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i16x8_add_sat_s:
+                    case SIMD_i16x8_add_sat_u:
+                    {
+                        if (!aot_compile_simd_i16x8_saturate(
+                                comp_ctx, func_ctx, V128_ADD,
+                                opcode == SIMD_i16x8_add_sat_s ? true : false))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i16x8_sub:
+                    {
+                        if (!aot_compile_simd_i16x8_arith(comp_ctx, func_ctx,
+                                                          V128_SUB))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i16x8_sub_sat_s:
+                    case SIMD_i16x8_sub_sat_u:
+                    {
+                        if (!aot_compile_simd_i16x8_saturate(
+                                comp_ctx, func_ctx, V128_SUB,
+                                opcode == SIMD_i16x8_sub_sat_s ? true : false))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f64x2_nearest:
+                    {
+                        if (!aot_compile_simd_f64x2_nearest(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i16x8_mul:
+                    {
+                        if (!aot_compile_simd_i16x8_arith(comp_ctx, func_ctx,
+                                                          V128_MUL))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i16x8_min_s:
+                    case SIMD_i16x8_min_u:
+                    {
+                        if (!aot_compile_simd_i16x8_cmp(
+                                comp_ctx, func_ctx, V128_MIN,
+                                opcode == SIMD_i16x8_min_s))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i16x8_max_s:
+                    case SIMD_i16x8_max_u:
+                    {
+                        if (!aot_compile_simd_i16x8_cmp(
+                                comp_ctx, func_ctx, V128_MAX,
+                                opcode == SIMD_i16x8_max_s))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i16x8_avgr_u:
+                    {
+                        if (!aot_compile_simd_i16x8_avgr_u(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i16x8_extmul_low_i8x16_s:
+                    case SIMD_i16x8_extmul_high_i8x16_s:
+                    {
+                        if (!(aot_compile_simd_i16x8_extmul_i8x16(
+                                comp_ctx, func_ctx,
+                                SIMD_i16x8_extmul_low_i8x16_s == opcode, true)))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i16x8_extmul_low_i8x16_u:
+                    case SIMD_i16x8_extmul_high_i8x16_u:
+                    {
+                        if (!(aot_compile_simd_i16x8_extmul_i8x16(
+                                comp_ctx, func_ctx,
+                                SIMD_i16x8_extmul_low_i8x16_u == opcode,
+                                false)))
+                            return false;
+                        break;
+                    }
+
+                    /* i32x4 Op */
+                    case SIMD_i32x4_abs:
+                    {
+                        if (!aot_compile_simd_i32x4_abs(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i32x4_neg:
+                    {
+                        if (!aot_compile_simd_i32x4_neg(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i32x4_all_true:
+                    {
+                        if (!aot_compile_simd_i32x4_all_true(comp_ctx,
+                                                             func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i32x4_bitmask:
+                    {
+                        if (!aot_compile_simd_i32x4_bitmask(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i32x4_narrow_i64x2_s:
+                    case SIMD_i32x4_narrow_i64x2_u:
+                    {
+                        if (!aot_compile_simd_i32x4_narrow_i64x2(
+                                comp_ctx, func_ctx,
+                                SIMD_i32x4_narrow_i64x2_s == opcode))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i32x4_extend_low_i16x8_s:
+                    case SIMD_i32x4_extend_high_i16x8_s:
+                    {
+                        if (!aot_compile_simd_i32x4_extend_i16x8(
+                                comp_ctx, func_ctx,
+                                SIMD_i32x4_extend_low_i16x8_s == opcode, true))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i32x4_extend_low_i16x8_u:
+                    case SIMD_i32x4_extend_high_i16x8_u:
+                    {
+                        if (!aot_compile_simd_i32x4_extend_i16x8(
+                                comp_ctx, func_ctx,
+                                SIMD_i32x4_extend_low_i16x8_u == opcode, false))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i32x4_shl:
+                    case SIMD_i32x4_shr_s:
+                    case SIMD_i32x4_shr_u:
+                    {
+                        if (!aot_compile_simd_i32x4_shift(comp_ctx, func_ctx,
+                                                          INT_SHL + opcode
+                                                              - SIMD_i32x4_shl))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i32x4_add:
+                    {
+                        if (!aot_compile_simd_i32x4_arith(comp_ctx, func_ctx,
+                                                          V128_ADD))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i32x4_add_sat_s:
+                    case SIMD_i32x4_add_sat_u:
+                    {
+                        if (!aot_compile_simd_i32x4_saturate(
+                                comp_ctx, func_ctx, V128_ADD,
+                                opcode == SIMD_i32x4_add_sat_s))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i32x4_sub:
+                    {
+                        if (!aot_compile_simd_i32x4_arith(comp_ctx, func_ctx,
+                                                          V128_SUB))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i32x4_sub_sat_s:
+                    case SIMD_i32x4_sub_sat_u:
+                    {
+                        if (!aot_compile_simd_i32x4_saturate(
+                                comp_ctx, func_ctx, V128_SUB,
+                                opcode == SIMD_i32x4_add_sat_s))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i32x4_mul:
+                    {
+                        if (!aot_compile_simd_i32x4_arith(comp_ctx, func_ctx,
+                                                          V128_MUL))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i32x4_min_s:
+                    case SIMD_i32x4_min_u:
+                    {
+                        if (!aot_compile_simd_i32x4_cmp(
+                                comp_ctx, func_ctx, V128_MIN,
+                                SIMD_i32x4_min_s == opcode))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i32x4_max_s:
+                    case SIMD_i32x4_max_u:
+                    {
+                        if (!aot_compile_simd_i32x4_cmp(
+                                comp_ctx, func_ctx, V128_MAX,
+                                SIMD_i32x4_max_s == opcode))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i32x4_dot_i16x8_s:
+                    {
+                        if (!aot_compile_simd_i32x4_dot_i16x8(comp_ctx,
+                                                              func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i32x4_avgr_u:
+                    {
+                        if (!aot_compile_simd_i32x4_avgr_u(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i32x4_extmul_low_i16x8_s:
+                    case SIMD_i32x4_extmul_high_i16x8_s:
+                    {
+                        if (!aot_compile_simd_i32x4_extmul_i16x8(
+                                comp_ctx, func_ctx,
+                                SIMD_i32x4_extmul_low_i16x8_s == opcode, true))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i32x4_extmul_low_i16x8_u:
+                    case SIMD_i32x4_extmul_high_i16x8_u:
+                    {
+                        if (!aot_compile_simd_i32x4_extmul_i16x8(
+                                comp_ctx, func_ctx,
+                                SIMD_i32x4_extmul_low_i16x8_u == opcode, false))
+                            return false;
+                        break;
+                    }
+
+                    /* i64x2 Op */
+                    case SIMD_i64x2_abs:
+                    {
+                        if (!aot_compile_simd_i64x2_abs(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i64x2_neg:
+                    {
+                        if (!aot_compile_simd_i64x2_neg(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i64x2_all_true:
+                    {
+                        if (!aot_compile_simd_i64x2_all_true(comp_ctx,
+                                                             func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i64x2_bitmask:
+                    {
+                        if (!aot_compile_simd_i64x2_bitmask(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i64x2_extend_low_i32x4_s:
+                    case SIMD_i64x2_extend_high_i32x4_s:
+                    {
+                        if (!aot_compile_simd_i64x2_extend_i32x4(
+                                comp_ctx, func_ctx,
+                                SIMD_i64x2_extend_low_i32x4_s == opcode, true))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i64x2_extend_low_i32x4_u:
+                    case SIMD_i64x2_extend_high_i32x4_u:
+                    {
+                        if (!aot_compile_simd_i64x2_extend_i32x4(
+                                comp_ctx, func_ctx,
+                                SIMD_i64x2_extend_low_i32x4_u == opcode, false))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i64x2_shl:
+                    case SIMD_i64x2_shr_s:
+                    case SIMD_i64x2_shr_u:
+                    {
+                        if (!aot_compile_simd_i64x2_shift(comp_ctx, func_ctx,
+                                                          INT_SHL + opcode
+                                                              - SIMD_i64x2_shl))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i64x2_add:
+                    {
+                        if (!aot_compile_simd_i64x2_arith(comp_ctx, func_ctx,
+                                                          V128_ADD))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i64x2_sub:
+                    {
+                        if (!aot_compile_simd_i64x2_arith(comp_ctx, func_ctx,
+                                                          V128_SUB))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i64x2_mul:
+                    {
+                        if (!aot_compile_simd_i64x2_arith(comp_ctx, func_ctx,
+                                                          V128_MUL))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i64x2_eq:
+                    case SIMD_i64x2_ne:
+                    case SIMD_i64x2_lt_s:
+                    case SIMD_i64x2_gt_s:
+                    case SIMD_i64x2_le_s:
+                    case SIMD_i64x2_ge_s:
+                    {
+                        IntCond icond[] = { INT_EQ,   INT_NE,   INT_LT_S,
+                                            INT_GT_S, INT_LE_S, INT_GE_S };
+                        if (!aot_compile_simd_i64x2_compare(
+                                comp_ctx, func_ctx,
+                                icond[opcode - SIMD_i64x2_eq]))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i64x2_extmul_low_i32x4_s:
+                    case SIMD_i64x2_extmul_high_i32x4_s:
+                    {
+                        if (!aot_compile_simd_i64x2_extmul_i32x4(
+                                comp_ctx, func_ctx,
+                                SIMD_i64x2_extmul_low_i32x4_s == opcode, true))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i64x2_extmul_low_i32x4_u:
+                    case SIMD_i64x2_extmul_high_i32x4_u:
+                    {
+                        if (!aot_compile_simd_i64x2_extmul_i32x4(
+                                comp_ctx, func_ctx,
+                                SIMD_i64x2_extmul_low_i32x4_u == opcode, false))
+                            return false;
+                        break;
+                    }
+
+                    /* f32x4 Op */
+                    case SIMD_f32x4_abs:
+                    {
+                        if (!aot_compile_simd_f32x4_abs(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f32x4_neg:
+                    {
+                        if (!aot_compile_simd_f32x4_neg(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f32x4_round:
+                    {
+                        if (!aot_compile_simd_f32x4_round(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f32x4_sqrt:
+                    {
+                        if (!aot_compile_simd_f32x4_sqrt(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f32x4_add:
+                    case SIMD_f32x4_sub:
+                    case SIMD_f32x4_mul:
+                    case SIMD_f32x4_div:
+                    {
+                        if (!aot_compile_simd_f32x4_arith(comp_ctx, func_ctx,
+                                                          FLOAT_ADD + opcode
+                                                              - SIMD_f32x4_add))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f32x4_min:
+                    case SIMD_f32x4_max:
+                    {
+                        if (!aot_compile_simd_f32x4_min_max(
+                                comp_ctx, func_ctx, SIMD_f32x4_min == opcode))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f32x4_pmin:
+                    case SIMD_f32x4_pmax:
+                    {
+                        if (!aot_compile_simd_f32x4_pmin_pmax(
+                                comp_ctx, func_ctx, SIMD_f32x4_pmin == opcode))
+                            return false;
+                        break;
+                    }
+
+                        /* f64x2 Op */
+
+                    case SIMD_f64x2_abs:
+                    {
+                        if (!aot_compile_simd_f64x2_abs(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f64x2_neg:
+                    {
+                        if (!aot_compile_simd_f64x2_neg(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f64x2_round:
+                    {
+                        if (!aot_compile_simd_f64x2_round(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f64x2_sqrt:
+                    {
+                        if (!aot_compile_simd_f64x2_sqrt(comp_ctx, func_ctx))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f64x2_add:
+                    case SIMD_f64x2_sub:
+                    case SIMD_f64x2_mul:
+                    case SIMD_f64x2_div:
+                    {
+                        if (!aot_compile_simd_f64x2_arith(comp_ctx, func_ctx,
+                                                          FLOAT_ADD + opcode
+                                                              - SIMD_f64x2_add))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f64x2_min:
+                    case SIMD_f64x2_max:
+                    {
+                        if (!aot_compile_simd_f64x2_min_max(
+                                comp_ctx, func_ctx, SIMD_f64x2_min == opcode))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f64x2_pmin:
+                    case SIMD_f64x2_pmax:
+                    {
+                        if (!aot_compile_simd_f64x2_pmin_pmax(
+                                comp_ctx, func_ctx, SIMD_f64x2_pmin == opcode))
+                            return false;
+                        break;
+                    }
+
+                    /* Conversion Op */
+                    case SIMD_i32x4_trunc_sat_f32x4_s:
+                    case SIMD_i32x4_trunc_sat_f32x4_u:
+                    {
+                        if (!aot_compile_simd_i32x4_trunc_sat_f32x4(
+                                comp_ctx, func_ctx,
+                                SIMD_i32x4_trunc_sat_f32x4_s == opcode))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f32x4_convert_i32x4_s:
+                    case SIMD_f32x4_convert_i32x4_u:
+                    {
+                        if (!aot_compile_simd_f32x4_convert_i32x4(
+                                comp_ctx, func_ctx,
+                                SIMD_f32x4_convert_i32x4_s == opcode))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_i32x4_trunc_sat_f64x2_s_zero:
+                    case SIMD_i32x4_trunc_sat_f64x2_u_zero:
+                    {
+                        if (!aot_compile_simd_i32x4_trunc_sat_f64x2(
+                                comp_ctx, func_ctx,
+                                SIMD_i32x4_trunc_sat_f64x2_s_zero == opcode))
+                            return false;
+                        break;
+                    }
+
+                    case SIMD_f64x2_convert_low_i32x4_s:
+                    case SIMD_f64x2_convert_low_i32x4_u:
+                    {
+                        if (!aot_compile_simd_f64x2_convert_i32x4(
+                                comp_ctx, func_ctx,
+                                SIMD_f64x2_convert_low_i32x4_s == opcode))
+                            return false;
+                        break;
+                    }
+
+                    default:
+                        aot_set_last_error("unsupported opcode");
+                        return false;
+                }
+                break;
+            }
 #endif /* end of WASM_ENABLE_SIMD */
 
-      default:
-        aot_set_last_error("unsupported opcode");
-        return false;
+            default:
+                aot_set_last_error("unsupported opcode");
+                return false;
+        }
     }
-  }
 
-  /* Move func_return block to the bottom */
-  if (func_ctx->func_return_block) {
-    LLVMBasicBlockRef last_block =
-        LLVMGetLastBasicBlock(func_ctx->func);
-    if (last_block != func_ctx->func_return_block)
-      LLVMMoveBasicBlockAfter(func_ctx->func_return_block,
-                              last_block);
-  }
+    /* Move func_return block to the bottom */
+    if (func_ctx->func_return_block) {
+        LLVMBasicBlockRef last_block = LLVMGetLastBasicBlock(func_ctx->func);
+        if (last_block != func_ctx->func_return_block)
+            LLVMMoveBasicBlockAfter(func_ctx->func_return_block, last_block);
+    }
 
-  /* Move got_exception block to the bottom */
-  if (func_ctx->got_exception_block) {
-    LLVMBasicBlockRef last_block = LLVMGetLastBasicBlock(func_ctx->func);
-    if (last_block != func_ctx->got_exception_block)
-      LLVMMoveBasicBlockAfter(func_ctx->got_exception_block, last_block);
-  }
-  return true;
+    /* Move got_exception block to the bottom */
+    if (func_ctx->got_exception_block) {
+        LLVMBasicBlockRef last_block = LLVMGetLastBasicBlock(func_ctx->func);
+        if (last_block != func_ctx->got_exception_block)
+            LLVMMoveBasicBlockAfter(func_ctx->got_exception_block, last_block);
+    }
+    return true;
 
 #if WASM_ENABLE_SIMD != 0
 unsupport_simd:
-  aot_set_last_error("SIMD instruction was found, "
-                     "try adding --enable-simd option?");
-  return false;
+    aot_set_last_error("SIMD instruction was found, "
+                       "try adding --enable-simd option?");
+    return false;
 #endif
 
 #if WASM_ENABLE_REF_TYPES != 0
 unsupport_ref_types:
-  aot_set_last_error("reference type instruction was found, "
-                     "try adding --enable-ref-types option?");
-  return false;
+    aot_set_last_error("reference type instruction was found, "
+                       "try adding --enable-ref-types option?");
+    return false;
 #endif
 
 fail:
-  return false;
+    return false;
 }
 
 bool
 aot_compile_wasm(AOTCompContext *comp_ctx)
 {
-  char *msg = NULL;
-  bool ret;
-  uint32 i;
+    char *msg = NULL;
+    bool ret;
+    uint32 i;
 
-  bh_print_time("Begin to compile WASM bytecode to LLVM IR");
+    bh_print_time("Begin to compile WASM bytecode to LLVM IR");
 
-  for (i = 0; i < comp_ctx->func_ctx_count; i++)
-    if (!aot_compile_func(comp_ctx, i)) {
+    for (i = 0; i < comp_ctx->func_ctx_count; i++)
+        if (!aot_compile_func(comp_ctx, i)) {
 #if 0
-      LLVMDumpModule(comp_ctx->module);
-      char *err;
-      LLVMTargetMachineEmitToFile(comp_ctx->target_machine, comp_ctx->module,
-                                  "./test.o", LLVMObjectFile, &err);
+            LLVMDumpModule(comp_ctx->module);
+            char *err;
+            LLVMTargetMachineEmitToFile(comp_ctx->target_machine,
+                                        comp_ctx->module, "./test.o",
+                                        LLVMObjectFile, &err);
 #endif
-      return false;
-    }
+            return false;
+        }
 
 #if 0
-  LLVMDumpModule(comp_ctx->module);
-  /* Clear error no, LLVMDumpModule may set errno */
-  errno = 0;
+    LLVMDumpModule(comp_ctx->module);
+    /* Clear error no, LLVMDumpModule may set errno */
+    errno = 0;
 #endif
 
 #if WASM_ENABLE_DEBUG_AOT != 0
-  LLVMDIBuilderFinalize(comp_ctx->debug_builder);
+    LLVMDIBuilderFinalize(comp_ctx->debug_builder);
 #endif
 
-  bh_print_time("Begin to verify LLVM module");
+    bh_print_time("Begin to verify LLVM module");
 
-  ret = LLVMVerifyModule(comp_ctx->module, LLVMPrintMessageAction, &msg);
-  if (!ret && msg) {
-    if (msg[0] != '\0') {
-      aot_set_last_error(msg);
-      LLVMDisposeMessage(msg);
-      return false;
+    ret = LLVMVerifyModule(comp_ctx->module, LLVMPrintMessageAction, &msg);
+    if (!ret && msg) {
+        if (msg[0] != '\0') {
+            aot_set_last_error(msg);
+            LLVMDisposeMessage(msg);
+            return false;
+        }
+        LLVMDisposeMessage(msg);
     }
-    LLVMDisposeMessage(msg);
-  }
 
-  bh_print_time("Begin to run function optimization passes");
+    bh_print_time("Begin to run function optimization passes");
 
-  if (comp_ctx->optimize) {
-    LLVMInitializeFunctionPassManager(comp_ctx->pass_mgr);
-    for (i = 0; i < comp_ctx->func_ctx_count; i++)
-      LLVMRunFunctionPassManager(comp_ctx->pass_mgr,
-                                 comp_ctx->func_ctxes[i]->func);
-  }
+    if (comp_ctx->optimize) {
+        LLVMInitializeFunctionPassManager(comp_ctx->pass_mgr);
+        for (i = 0; i < comp_ctx->func_ctx_count; i++)
+            LLVMRunFunctionPassManager(comp_ctx->pass_mgr,
+                                       comp_ctx->func_ctxes[i]->func);
+    }
 
-  return true;
+    return true;
 }
 
 bool
 aot_emit_llvm_file(AOTCompContext *comp_ctx, const char *file_name)
 {
-  char *err = NULL;
+    char *err = NULL;
 
-  bh_print_time("Begin to emit LLVM IR file");
+    bh_print_time("Begin to emit LLVM IR file");
 
-  if (LLVMPrintModuleToFile(comp_ctx->module, file_name, &err) != 0) {
-    if (err) {
-      LLVMDisposeMessage(err);
-      err = NULL;
+    if (LLVMPrintModuleToFile(comp_ctx->module, file_name, &err) != 0) {
+        if (err) {
+            LLVMDisposeMessage(err);
+            err = NULL;
+        }
+        aot_set_last_error("emit llvm ir to file failed.");
+        return false;
     }
-    aot_set_last_error("emit llvm ir to file failed.");
-    return false;
-  }
 
-  return true;
+    return true;
 }
 
 bool
 aot_emit_object_file(AOTCompContext *comp_ctx, char *file_name)
 {
-  char *err = NULL;
-  LLVMCodeGenFileType file_type = LLVMObjectFile;
-  LLVMTargetRef target =
-      LLVMGetTargetMachineTarget(comp_ctx->target_machine);
+    char *err = NULL;
+    LLVMCodeGenFileType file_type = LLVMObjectFile;
+    LLVMTargetRef target = LLVMGetTargetMachineTarget(comp_ctx->target_machine);
 
-  bh_print_time("Begin to emit object file");
+    bh_print_time("Begin to emit object file");
 
-  if (!strncmp(LLVMGetTargetName(target), "arc", 3))
-    /* Emit to assmelby file instead for arc target
-       as it cannot emit to object file */
-    file_type = LLVMAssemblyFile;
+    if (!strncmp(LLVMGetTargetName(target), "arc", 3))
+        /* Emit to assmelby file instead for arc target
+           as it cannot emit to object file */
+        file_type = LLVMAssemblyFile;
 
-  if (LLVMTargetMachineEmitToFile(comp_ctx->target_machine,
-                                  comp_ctx->module,
-                                  file_name, file_type,
-                                  &err) != 0) {
-    if (err) {
-      LLVMDisposeMessage(err);
-      err = NULL;
+    if (LLVMTargetMachineEmitToFile(comp_ctx->target_machine, comp_ctx->module,
+                                    file_name, file_type, &err)
+        != 0) {
+        if (err) {
+            LLVMDisposeMessage(err);
+            err = NULL;
+        }
+        aot_set_last_error("emit elf to object file failed.");
+        return false;
     }
-    aot_set_last_error("emit elf to object file failed.");
-    return false;
-  }
 
-  return true;
+    return true;
 }
 
 #if WASM_ENABLE_REF_TYPES != 0
@@ -2538,11 +2611,11 @@ wasm_set_ref_types_flag(bool enable);
 #endif
 
 typedef struct AOTFileMap {
-  uint8 *wasm_file_buf;
-  uint32 wasm_file_size;
-  uint8 *aot_file_buf;
-  uint32 aot_file_size;
-  struct AOTFileMap *next;
+    uint8 *wasm_file_buf;
+    uint32 wasm_file_size;
+    uint8 *aot_file_buf;
+    uint32 aot_file_size;
+    struct AOTFileMap *next;
 } AOTFileMap;
 
 static bool aot_compile_wasm_file_inited = false;
@@ -2552,195 +2625,192 @@ static korp_mutex aot_file_map_lock;
 bool
 aot_compile_wasm_file_init()
 {
-  if (aot_compile_wasm_file_inited) {
+    if (aot_compile_wasm_file_inited) {
+        return true;
+    }
+
+    if (BHT_OK != os_mutex_init(&aot_file_map_lock)) {
+        return false;
+    }
+
+    aot_file_maps = NULL;
+    aot_compile_wasm_file_inited = true;
     return true;
-  }
-
-  if (BHT_OK != os_mutex_init(&aot_file_map_lock)) {
-    return false;
-  }
-
-  aot_file_maps = NULL;
-  aot_compile_wasm_file_inited = true;
-  return true;
 }
 
 void
 aot_compile_wasm_file_destroy()
 {
-  AOTFileMap *file_map = aot_file_maps, *file_map_next;
+    AOTFileMap *file_map = aot_file_maps, *file_map_next;
 
-  if (!aot_compile_wasm_file_inited) {
-    return;
-  }
+    if (!aot_compile_wasm_file_inited) {
+        return;
+    }
 
-  while (file_map) {
-    file_map_next = file_map->next;
+    while (file_map) {
+        file_map_next = file_map->next;
 
-    wasm_runtime_free(file_map->wasm_file_buf);
-    wasm_runtime_free(file_map->aot_file_buf);
-    wasm_runtime_free(file_map);
+        wasm_runtime_free(file_map->wasm_file_buf);
+        wasm_runtime_free(file_map->aot_file_buf);
+        wasm_runtime_free(file_map);
 
-    file_map = file_map_next;
-  }
+        file_map = file_map_next;
+    }
 
-  aot_file_maps = NULL;
-  os_mutex_destroy(&aot_file_map_lock);
-  aot_compile_wasm_file_inited = false;
+    aot_file_maps = NULL;
+    os_mutex_destroy(&aot_file_map_lock);
+    aot_compile_wasm_file_inited = false;
 }
 
 static void
 set_error_buf(char *error_buf, uint32 error_buf_size, const char *string)
 {
-  if (error_buf != NULL) {
-    snprintf(error_buf, error_buf_size, "WASM module load failed: %s", string);
-  }
+    if (error_buf != NULL) {
+        snprintf(error_buf, error_buf_size, "WASM module load failed: %s",
+                 string);
+    }
 }
 
 uint8 *
-aot_compile_wasm_file(const uint8 *wasm_file_buf,
-                      uint32 wasm_file_size,
-                      uint32 opt_level,
-                      uint32 size_level,
-                      char *error_buf,
-                      uint32 error_buf_size,
-                      uint32 *p_aot_file_size)
+aot_compile_wasm_file(const uint8 *wasm_file_buf, uint32 wasm_file_size,
+                      uint32 opt_level, uint32 size_level, char *error_buf,
+                      uint32 error_buf_size, uint32 *p_aot_file_size)
 {
-  WASMModule *wasm_module = NULL;
-  AOTCompData *comp_data = NULL;
-  AOTCompContext *comp_ctx = NULL;
-  RuntimeInitArgs init_args;
-  AOTCompOption option = { 0 };
-  AOTFileMap *file_map = NULL, *file_map_next;
-  uint8 *wasm_file_buf_cloned = NULL;
-  uint8 *aot_file_buf = NULL;
-  uint32 aot_file_size;
+    WASMModule *wasm_module = NULL;
+    AOTCompData *comp_data = NULL;
+    AOTCompContext *comp_ctx = NULL;
+    RuntimeInitArgs init_args;
+    AOTCompOption option = { 0 };
+    AOTFileMap *file_map = NULL, *file_map_next;
+    uint8 *wasm_file_buf_cloned = NULL;
+    uint8 *aot_file_buf = NULL;
+    uint32 aot_file_size;
 
-  option.is_jit_mode = false;
-  option.opt_level = opt_level;
-  option.size_level = size_level;
-  option.output_format = AOT_FORMAT_FILE;
-  /* default value, enable or disable depends on the platform */
-  option.bounds_checks = 2;
-  option.enable_aux_stack_check = true;
+    option.is_jit_mode = false;
+    option.opt_level = opt_level;
+    option.size_level = size_level;
+    option.output_format = AOT_FORMAT_FILE;
+    /* default value, enable or disable depends on the platform */
+    option.bounds_checks = 2;
+    option.enable_aux_stack_check = true;
 #if WASM_ENABLE_BULK_MEMORY != 0
-  option.enable_bulk_memory = true;
+    option.enable_bulk_memory = true;
 #endif
 #if WASM_ENABLE_THREAD_MGR != 0
-  option.enable_thread_mgr = true;
+    option.enable_thread_mgr = true;
 #endif
 #if WASM_ENABLE_TAIL_CALL != 0
-  option.enable_tail_call = true;
+    option.enable_tail_call = true;
 #endif
 #if WASM_ENABLE_SIMD != 0
-  option.enable_simd = true;
+    option.enable_simd = true;
 #endif
 #if WASM_ENABLE_REF_TYPES != 0
-  option.enable_ref_types = true;
+    option.enable_ref_types = true;
 #endif
 #if (WASM_ENABLE_PERF_PROFILING != 0) || (WASM_ENABLE_DUMP_CALL_STACK != 0)
-  option.enable_aux_stack_frame = true;
+    option.enable_aux_stack_frame = true;
 #endif
 
 #if WASM_ENABLE_REF_TYPES != 0
-  wasm_set_ref_types_flag(option.enable_ref_types);
+    wasm_set_ref_types_flag(option.enable_ref_types);
 #endif
 
-  memset(&init_args, 0, sizeof(RuntimeInitArgs));
+    memset(&init_args, 0, sizeof(RuntimeInitArgs));
 
-  init_args.mem_alloc_type = Alloc_With_Allocator;
-  init_args.mem_alloc_option.allocator.malloc_func = malloc;
-  init_args.mem_alloc_option.allocator.realloc_func = realloc;
-  init_args.mem_alloc_option.allocator.free_func = free;
+    init_args.mem_alloc_type = Alloc_With_Allocator;
+    init_args.mem_alloc_option.allocator.malloc_func = malloc;
+    init_args.mem_alloc_option.allocator.realloc_func = realloc;
+    init_args.mem_alloc_option.allocator.free_func = free;
 
-  os_mutex_lock(&aot_file_map_lock);
+    os_mutex_lock(&aot_file_map_lock);
 
-  /* lookup the file maps */
-  file_map = aot_file_maps;
-  while (file_map) {
-    file_map_next = file_map->next;
+    /* lookup the file maps */
+    file_map = aot_file_maps;
+    while (file_map) {
+        file_map_next = file_map->next;
 
-    if (wasm_file_size == file_map->wasm_file_size
-        && memcmp(wasm_file_buf, file_map->wasm_file_buf, wasm_file_size)
-             == 0) {
-      os_mutex_unlock(&aot_file_map_lock);
-      /* found */
-      *p_aot_file_size = file_map->aot_file_size;
-      return file_map->aot_file_buf;
+        if (wasm_file_size == file_map->wasm_file_size
+            && memcmp(wasm_file_buf, file_map->wasm_file_buf, wasm_file_size)
+                   == 0) {
+            os_mutex_unlock(&aot_file_map_lock);
+            /* found */
+            *p_aot_file_size = file_map->aot_file_size;
+            return file_map->aot_file_buf;
+        }
+
+        file_map = file_map_next;
     }
 
-    file_map = file_map_next;
-  }
+    /* not found, initialize file map and clone wasm file */
+    if (!(file_map = wasm_runtime_malloc(sizeof(AOTFileMap)))
+        || !(wasm_file_buf_cloned = wasm_runtime_malloc(wasm_file_size))) {
+        set_error_buf(error_buf, error_buf_size, "allocate memory failed");
+        goto fail1;
+    }
 
-  /* not found, initialize file map and clone wasm file */
-  if (!(file_map = wasm_runtime_malloc(sizeof(AOTFileMap)))
-      || !(wasm_file_buf_cloned = wasm_runtime_malloc(wasm_file_size))) {
-    set_error_buf(error_buf, error_buf_size, "allocate memory failed");
-    goto fail1;
-  }
+    bh_memcpy_s(wasm_file_buf_cloned, wasm_file_size, wasm_file_buf,
+                wasm_file_size);
+    memset(file_map, 0, sizeof(AOTFileMap));
+    file_map->wasm_file_buf = wasm_file_buf_cloned;
+    file_map->wasm_file_size = wasm_file_size;
 
-  bh_memcpy_s(wasm_file_buf_cloned, wasm_file_size, wasm_file_buf,
-              wasm_file_size);
-  memset(file_map, 0, sizeof(AOTFileMap));
-  file_map->wasm_file_buf = wasm_file_buf_cloned;
-  file_map->wasm_file_size = wasm_file_size;
+    /* load WASM module */
+    if (!(wasm_module = wasm_load(wasm_file_buf, wasm_file_size, error_buf,
+                                  sizeof(error_buf)))) {
+        goto fail1;
+    }
 
-  /* load WASM module */
-  if (!(wasm_module = wasm_load(wasm_file_buf, wasm_file_size, error_buf,
-                                sizeof(error_buf)))) {
-    goto fail1;
-  }
+    if (!(comp_data = aot_create_comp_data(wasm_module))) {
+        set_error_buf(error_buf, error_buf_size, aot_get_last_error());
+        goto fail2;
+    }
 
-  if (!(comp_data = aot_create_comp_data(wasm_module))) {
-    set_error_buf(error_buf, error_buf_size, aot_get_last_error());
-    goto fail2;
-  }
+    if (!(comp_ctx = aot_create_comp_context(comp_data, &option))) {
+        set_error_buf(error_buf, error_buf_size, aot_get_last_error());
+        goto fail3;
+    }
 
-  if (!(comp_ctx = aot_create_comp_context(comp_data, &option))) {
-    set_error_buf(error_buf, error_buf_size, aot_get_last_error());
-    goto fail3;
-  }
+    if (!aot_compile_wasm(comp_ctx)) {
+        set_error_buf(error_buf, error_buf_size, aot_get_last_error());
+        goto fail4;
+    }
 
-  if (!aot_compile_wasm(comp_ctx)) {
-    set_error_buf(error_buf, error_buf_size, aot_get_last_error());
-    goto fail4;
-  }
+    if (!(aot_file_buf =
+              aot_emit_aot_file_buf(comp_ctx, comp_data, &aot_file_size))) {
+        set_error_buf(error_buf, error_buf_size, aot_get_last_error());
+        goto fail4;
+    }
 
-  if (!(aot_file_buf =
-          aot_emit_aot_file_buf(comp_ctx, comp_data, &aot_file_size))) {
-    set_error_buf(error_buf, error_buf_size, aot_get_last_error());
-    goto fail4;
-  }
+    file_map->aot_file_buf = aot_file_buf;
+    file_map->aot_file_size = aot_file_size;
 
-  file_map->aot_file_buf = aot_file_buf;
-  file_map->aot_file_size = aot_file_size;
+    if (!aot_file_maps)
+        aot_file_maps = file_map;
+    else {
+        file_map->next = aot_file_maps;
+        aot_file_maps = file_map;
+    }
 
-  if (!aot_file_maps)
-    aot_file_maps = file_map;
-  else {
-    file_map->next = aot_file_maps;
-    aot_file_maps = file_map;
-  }
-
-  *p_aot_file_size = aot_file_size;
+    *p_aot_file_size = aot_file_size;
 
 fail4:
-  /* Destroy compiler context */
-  aot_destroy_comp_context(comp_ctx);
+    /* Destroy compiler context */
+    aot_destroy_comp_context(comp_ctx);
 fail3:
-  /* Destroy compile data */
-  aot_destroy_comp_data(comp_data);
+    /* Destroy compile data */
+    aot_destroy_comp_data(comp_data);
 fail2:
-  wasm_unload(wasm_module);
+    wasm_unload(wasm_module);
 fail1:
-  if (!aot_file_buf) {
-    if (wasm_file_buf_cloned)
-      wasm_runtime_free(wasm_file_buf_cloned);
-    if (file_map)
-      wasm_runtime_free(file_map);
-  }
+    if (!aot_file_buf) {
+        if (wasm_file_buf_cloned)
+            wasm_runtime_free(wasm_file_buf_cloned);
+        if (file_map)
+            wasm_runtime_free(file_map);
+    }
 
-  os_mutex_unlock(&aot_file_map_lock);
+    os_mutex_unlock(&aot_file_map_lock);
 
-  return aot_file_buf;
+    return aot_file_buf;
 }

--- a/core/iwasm/compilation/aot_emit_compare.c
+++ b/core/iwasm/compilation/aot_emit_compare.c
@@ -23,25 +23,25 @@ int_cond_to_llvm_op(IntCond cond, LLVMIntPredicate *op)
         case INT_LT_S:
             *op = LLVMIntSLT;
             break;
-        case  INT_LT_U:
+        case INT_LT_U:
             *op = LLVMIntULT;
             break;
         case INT_GT_S:
             *op = LLVMIntSGT;
             break;
-        case  INT_GT_U:
+        case INT_GT_U:
             *op = LLVMIntUGT;
             break;
         case INT_LE_S:
             *op = LLVMIntSLE;
             break;
-        case  INT_LE_U:
+        case INT_LE_U:
             *op = LLVMIntULE;
             break;
         case INT_GE_S:
             *op = LLVMIntSGE;
             break;
-        case  INT_GE_U:
+        case INT_GE_U:
             *op = LLVMIntUGE;
             break;
         default:
@@ -230,4 +230,3 @@ aot_compile_op_f64_compare(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 fail:
     return false;
 }
-

--- a/core/iwasm/compilation/aot_emit_compare.h
+++ b/core/iwasm/compilation/aot_emit_compare.h
@@ -28,10 +28,8 @@ bool
 aot_compile_op_f64_compare(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                            FloatCond cond);
 
-
 #ifdef __cplusplus
 } /* end of extern "C" */
 #endif
 
 #endif /* end of _AOT_EMIT_COMPARE_H_ */
-

--- a/core/iwasm/compilation/aot_emit_const.c
+++ b/core/iwasm/compilation/aot_emit_const.c
@@ -5,111 +5,109 @@
 
 #include "aot_emit_const.h"
 
-
 bool
 aot_compile_op_i32_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                          int32 i32_const)
 {
-  LLVMValueRef value = I32_CONST((uint32)i32_const);
-  CHECK_LLVM_CONST(value);
-  PUSH_I32(value);
-  return true;
+    LLVMValueRef value = I32_CONST((uint32)i32_const);
+    CHECK_LLVM_CONST(value);
+    PUSH_I32(value);
+    return true;
 fail:
-  return false;
+    return false;
 }
 
 bool
 aot_compile_op_i64_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                          int64 i64_const)
 {
-  LLVMValueRef value = I64_CONST((uint64)i64_const);
-  CHECK_LLVM_CONST(value);
-  PUSH_I64(value);
-  return true;
+    LLVMValueRef value = I64_CONST((uint64)i64_const);
+    CHECK_LLVM_CONST(value);
+    PUSH_I64(value);
+    return true;
 fail:
-  return false;
+    return false;
 }
 
 bool
 aot_compile_op_f32_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                          float32 f32_const)
 {
-  LLVMValueRef alloca, value;
+    LLVMValueRef alloca, value;
 
-  if (!isnan(f32_const)) {
-    value = F32_CONST(f32_const);
-    CHECK_LLVM_CONST(value);
-    PUSH_F32(value);
-  }
-  else {
-      int32 i32_const;
-      memcpy(&i32_const, &f32_const, sizeof(int32));
-      if (!(alloca = LLVMBuildAlloca(comp_ctx->builder,
-                                     I32_TYPE, "i32_ptr"))) {
-          aot_set_last_error("llvm build alloca failed.");
-          return false;
-      }
-      if (!LLVMBuildStore(comp_ctx->builder,
-                          I32_CONST((uint32)i32_const), alloca)) {
-          aot_set_last_error("llvm build store failed.");
-          return false;
-      }
-      if (!(alloca = LLVMBuildBitCast(comp_ctx->builder,
-                                      alloca, F32_PTR_TYPE, "f32_ptr"))) {
-          aot_set_last_error("llvm build bitcast failed.");
-          return false;
-      }
-      if (!(value = LLVMBuildLoad(comp_ctx->builder, alloca, ""))) {
-          aot_set_last_error("llvm build load failed.");
-          return false;
-      }
-      PUSH_F32(value);
-  }
+    if (!isnan(f32_const)) {
+        value = F32_CONST(f32_const);
+        CHECK_LLVM_CONST(value);
+        PUSH_F32(value);
+    }
+    else {
+        int32 i32_const;
+        memcpy(&i32_const, &f32_const, sizeof(int32));
+        if (!(alloca =
+                  LLVMBuildAlloca(comp_ctx->builder, I32_TYPE, "i32_ptr"))) {
+            aot_set_last_error("llvm build alloca failed.");
+            return false;
+        }
+        if (!LLVMBuildStore(comp_ctx->builder, I32_CONST((uint32)i32_const),
+                            alloca)) {
+            aot_set_last_error("llvm build store failed.");
+            return false;
+        }
+        if (!(alloca = LLVMBuildBitCast(comp_ctx->builder, alloca, F32_PTR_TYPE,
+                                        "f32_ptr"))) {
+            aot_set_last_error("llvm build bitcast failed.");
+            return false;
+        }
+        if (!(value = LLVMBuildLoad(comp_ctx->builder, alloca, ""))) {
+            aot_set_last_error("llvm build load failed.");
+            return false;
+        }
+        PUSH_F32(value);
+    }
 
-  return true;
+    return true;
 fail:
-  return false;
+    return false;
 }
 
 bool
 aot_compile_op_f64_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                          float64 f64_const)
 {
-  LLVMValueRef alloca, value;
+    LLVMValueRef alloca, value;
 
-  if (!isnan(f64_const)) {
-    value = F64_CONST(f64_const);
-    CHECK_LLVM_CONST(value);
-    PUSH_F64(value);
-  }
-  else {
-      int64 i64_const;
-      memcpy(&i64_const, &f64_const, sizeof(int64));
-      if (!(alloca = LLVMBuildAlloca(comp_ctx->builder,
-                                     I64_TYPE, "i64_ptr"))) {
-          aot_set_last_error("llvm build alloca failed.");
-          return false;
-      }
-      value = I64_CONST((uint64)i64_const);
-      CHECK_LLVM_CONST(value);
-      if (!LLVMBuildStore(comp_ctx->builder, value, alloca)) {
-          aot_set_last_error("llvm build store failed.");
-          return false;
-      }
-      if (!(alloca = LLVMBuildBitCast(comp_ctx->builder,
-                                      alloca, F64_PTR_TYPE, "f64_ptr"))) {
-          aot_set_last_error("llvm build bitcast failed.");
-          return false;
-      }
-      if (!(value = LLVMBuildLoad(comp_ctx->builder, alloca, ""))) {
-          aot_set_last_error("llvm build load failed.");
-          return false;
-      }
-      PUSH_F64(value);
-  }
+    if (!isnan(f64_const)) {
+        value = F64_CONST(f64_const);
+        CHECK_LLVM_CONST(value);
+        PUSH_F64(value);
+    }
+    else {
+        int64 i64_const;
+        memcpy(&i64_const, &f64_const, sizeof(int64));
+        if (!(alloca =
+                  LLVMBuildAlloca(comp_ctx->builder, I64_TYPE, "i64_ptr"))) {
+            aot_set_last_error("llvm build alloca failed.");
+            return false;
+        }
+        value = I64_CONST((uint64)i64_const);
+        CHECK_LLVM_CONST(value);
+        if (!LLVMBuildStore(comp_ctx->builder, value, alloca)) {
+            aot_set_last_error("llvm build store failed.");
+            return false;
+        }
+        if (!(alloca = LLVMBuildBitCast(comp_ctx->builder, alloca, F64_PTR_TYPE,
+                                        "f64_ptr"))) {
+            aot_set_last_error("llvm build bitcast failed.");
+            return false;
+        }
+        if (!(value = LLVMBuildLoad(comp_ctx->builder, alloca, ""))) {
+            aot_set_last_error("llvm build load failed.");
+            return false;
+        }
+        PUSH_F64(value);
+    }
 
-  return true;
+    return true;
 fail:
-  return false;
+    return false;
 }
-

--- a/core/iwasm/compilation/aot_emit_const.h
+++ b/core/iwasm/compilation/aot_emit_const.h
@@ -33,4 +33,3 @@ aot_compile_op_f64_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 #endif
 
 #endif /* end of _AOT_EMIT_CONST_H_ */
-

--- a/core/iwasm/compilation/aot_emit_control.h
+++ b/core/iwasm/compilation/aot_emit_control.h
@@ -14,8 +14,8 @@ extern "C" {
 
 bool
 aot_compile_op_block(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                     uint8 **p_frame_ip, uint8 *frame_ip_end,
-                     uint32 label_type, uint32 param_count, uint8 *param_types,
+                     uint8 **p_frame_ip, uint8 *frame_ip_end, uint32 label_type,
+                     uint32 param_count, uint8 *param_types,
                      uint32 result_count, uint8 *result_types);
 
 bool
@@ -36,22 +36,19 @@ aot_compile_op_br_if(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
 bool
 aot_compile_op_br_table(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                        uint32 *br_depths, uint32 br_count,
-                        uint8 **p_frame_ip);
+                        uint32 *br_depths, uint32 br_count, uint8 **p_frame_ip);
 
 bool
 aot_compile_op_return(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                       uint8 **p_frame_ip);
 
 bool
-aot_compile_op_unreachable(AOTCompContext *comp_ctx,
-                           AOTFuncContext *func_ctx,
+aot_compile_op_unreachable(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                            uint8 **p_frame_ip);
 
 bool
 aot_handle_next_reachable_block(AOTCompContext *comp_ctx,
-                                AOTFuncContext *func_ctx,
-                                uint8 **p_frame_ip);
+                                AOTFuncContext *func_ctx, uint8 **p_frame_ip);
 
 #if WASM_ENABLE_THREAD_MGR != 0
 bool
@@ -63,4 +60,3 @@ check_suspend_flags(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx);
 #endif
 
 #endif /* end of _AOT_EMIT_CONTROL_H_ */
-

--- a/core/iwasm/compilation/aot_emit_conversion.h
+++ b/core/iwasm/compilation/aot_emit_conversion.h
@@ -24,16 +24,16 @@ aot_compile_op_i32_trunc_f64(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              bool sign, bool saturating);
 
 bool
-aot_compile_op_i64_extend_i32(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                              bool sign);
+aot_compile_op_i64_extend_i32(AOTCompContext *comp_ctx,
+                              AOTFuncContext *func_ctx, bool sign);
 
 bool
-aot_compile_op_i64_extend_i64(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                              int8 bitwidth);
+aot_compile_op_i64_extend_i64(AOTCompContext *comp_ctx,
+                              AOTFuncContext *func_ctx, int8 bitwidth);
 
 bool
-aot_compile_op_i32_extend_i32(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                              int8 bitwidth);
+aot_compile_op_i32_extend_i32(AOTCompContext *comp_ctx,
+                              AOTFuncContext *func_ctx, int8 bitwidth);
 
 bool
 aot_compile_op_i64_trunc_f32(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
@@ -44,26 +44,28 @@ aot_compile_op_i64_trunc_f64(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              bool sign, bool saturating);
 
 bool
-aot_compile_op_f32_convert_i32(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                               bool sign);
+aot_compile_op_f32_convert_i32(AOTCompContext *comp_ctx,
+                               AOTFuncContext *func_ctx, bool sign);
 
 bool
-aot_compile_op_f32_convert_i64(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                               bool sign);
+aot_compile_op_f32_convert_i64(AOTCompContext *comp_ctx,
+                               AOTFuncContext *func_ctx, bool sign);
 
 bool
-aot_compile_op_f32_demote_f64(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx);
+aot_compile_op_f32_demote_f64(AOTCompContext *comp_ctx,
+                              AOTFuncContext *func_ctx);
 
 bool
-aot_compile_op_f64_convert_i32(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                               bool sign);
+aot_compile_op_f64_convert_i32(AOTCompContext *comp_ctx,
+                               AOTFuncContext *func_ctx, bool sign);
 
 bool
-aot_compile_op_f64_convert_i64(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                               bool sign);
+aot_compile_op_f64_convert_i64(AOTCompContext *comp_ctx,
+                               AOTFuncContext *func_ctx, bool sign);
 
 bool
-aot_compile_op_f64_promote_f32(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx);
+aot_compile_op_f64_promote_f32(AOTCompContext *comp_ctx,
+                               AOTFuncContext *func_ctx);
 
 bool
 aot_compile_op_i64_reinterpret_f64(AOTCompContext *comp_ctx,
@@ -86,4 +88,3 @@ aot_compile_op_f32_reinterpret_i32(AOTCompContext *comp_ctx,
 #endif
 
 #endif /* end of _AOT_EMIT_CONVERSION_H_ */
-

--- a/core/iwasm/compilation/aot_emit_exception.c
+++ b/core/iwasm/compilation/aot_emit_exception.c
@@ -8,9 +8,7 @@
 
 bool
 aot_emit_exception(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                   int32 exception_id,
-                   bool is_cond_br,
-                   LLVMValueRef cond_br_if,
+                   int32 exception_id, bool is_cond_br, LLVMValueRef cond_br_if,
                    LLVMBasicBlockRef cond_br_else_block)
 {
     LLVMBasicBlockRef block_curr = LLVMGetInsertBlock(comp_ctx->builder);
@@ -24,10 +22,8 @@ aot_emit_exception(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
     /* Create got_exception block if needed */
     if (!func_ctx->got_exception_block) {
-        if (!(func_ctx->got_exception_block =
-                LLVMAppendBasicBlockInContext(comp_ctx->context,
-                                              func_ctx->func,
-                                              "got_exception"))) {
+        if (!(func_ctx->got_exception_block = LLVMAppendBasicBlockInContext(
+                  comp_ctx->context, func_ctx->func, "got_exception"))) {
             aot_set_last_error("add LLVM basic block failed.");
             return false;
         }
@@ -37,7 +33,7 @@ aot_emit_exception(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
         /* Create exection id phi */
         if (!(func_ctx->exception_id_phi = LLVMBuildPhi(
-                comp_ctx->builder, I32_TYPE, "exception_id_phi"))) {
+                  comp_ctx->builder, I32_TYPE, "exception_id_phi"))) {
             aot_set_last_error("llvm build phi failed.");
             return false;
         }
@@ -48,8 +44,7 @@ aot_emit_exception(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         ret_type = VOID_TYPE;
 
         /* Create function type */
-        if (!(func_type = LLVMFunctionType(ret_type, param_types,
-                                           2, false))) {
+        if (!(func_type = LLVMFunctionType(ret_type, param_types, 2, false))) {
             aot_set_last_error("create LLVM function type failed.");
             return false;
         }
@@ -62,7 +57,7 @@ aot_emit_exception(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             }
             /* Create LLVM function with const function pointer */
             if (!(func_const =
-                    I64_CONST((uint64)(uintptr_t)aot_set_exception_with_id))
+                      I64_CONST((uint64)(uintptr_t)aot_set_exception_with_id))
                 || !(func = LLVMConstIntToPtr(func_const, func_ptr_type))) {
                 aot_set_last_error("create LLVM value failed.");
                 return false;
@@ -76,13 +71,13 @@ aot_emit_exception(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             }
 
             func_index = aot_get_native_symbol_index(
-                      comp_ctx, "aot_set_exception_with_id");
+                comp_ctx, "aot_set_exception_with_id");
             if (func_index < 0) {
                 return false;
             }
             if (!(func =
-                    aot_get_func_from_table(comp_ctx, func_ctx->native_symbol,
-                                            func_ptr_type, func_index))) {
+                      aot_get_func_from_table(comp_ctx, func_ctx->native_symbol,
+                                              func_ptr_type, func_index))) {
                 return false;
             }
         }
@@ -101,8 +96,7 @@ aot_emit_exception(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         /* Call the aot_set_exception_with_id() function */
         param_values[0] = func_ctx->aot_inst;
         param_values[1] = func_ctx->exception_id_phi;
-        if (!LLVMBuildCall(comp_ctx->builder, func, param_values,
-                           2, "")) {
+        if (!LLVMBuildCall(comp_ctx->builder, func, param_values, 2, "")) {
             aot_set_last_error("llvm build call failed.");
             return false;
         }
@@ -130,7 +124,8 @@ aot_emit_exception(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     else {
         /* Create condition br */
         if (!LLVMBuildCondBr(comp_ctx->builder, cond_br_if,
-                             func_ctx->got_exception_block, cond_br_else_block)) {
+                             func_ctx->got_exception_block,
+                             cond_br_else_block)) {
             aot_set_last_error("llvm build cond br failed.");
             return false;
         }
@@ -142,4 +137,3 @@ aot_emit_exception(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 fail:
     return false;
 }
-

--- a/core/iwasm/compilation/aot_emit_exception.h
+++ b/core/iwasm/compilation/aot_emit_exception.h
@@ -14,9 +14,7 @@ extern "C" {
 
 bool
 aot_emit_exception(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                   int32 exception_id,
-                   bool is_cond_br,
-                   LLVMValueRef cond_br_if,
+                   int32 exception_id, bool is_cond_br, LLVMValueRef cond_br_if,
                    LLVMBasicBlockRef cond_br_else_block);
 
 #ifdef __cplusplus
@@ -24,4 +22,3 @@ aot_emit_exception(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 #endif
 
 #endif /* end of _AOT_EMIT_EXCEPTION_H_ */
-

--- a/core/iwasm/compilation/aot_emit_function.c
+++ b/core/iwasm/compilation/aot_emit_function.c
@@ -9,14 +9,14 @@
 #include "aot_emit_table.h"
 #include "../aot/aot_runtime.h"
 
-#define ADD_BASIC_BLOCK(block, name) do {                           \
-    if (!(block = LLVMAppendBasicBlockInContext(comp_ctx->context,  \
-                                                func_ctx->func,     \
-                                                name))) {           \
-        aot_set_last_error("llvm add basic block failed.");         \
-        goto fail;                                                  \
-    }                                                               \
-  } while (0)
+#define ADD_BASIC_BLOCK(block, name)                                          \
+    do {                                                                      \
+        if (!(block = LLVMAppendBasicBlockInContext(comp_ctx->context,        \
+                                                    func_ctx->func, name))) { \
+            aot_set_last_error("llvm add basic block failed.");               \
+            goto fail;                                                        \
+        }                                                                     \
+    } while (0)
 
 static bool
 create_func_return_block(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
@@ -26,15 +26,15 @@ create_func_return_block(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 
     /* Create function return block if it isn't created */
     if (!func_ctx->func_return_block) {
-        if (!(func_ctx->func_return_block =
-                    LLVMAppendBasicBlockInContext(comp_ctx->context,
-                                                  func_ctx->func, "func_ret"))) {
+        if (!(func_ctx->func_return_block = LLVMAppendBasicBlockInContext(
+                  comp_ctx->context, func_ctx->func, "func_ret"))) {
             aot_set_last_error("llvm add basic block failed.");
             return false;
         }
 
         /* Create return IR */
-        LLVMPositionBuilderAtEnd(comp_ctx->builder, func_ctx->func_return_block);
+        LLVMPositionBuilderAtEnd(comp_ctx->builder,
+                                 func_ctx->func_return_block);
         if (!aot_build_zero_function_ret(comp_ctx, func_ctx, aot_func_type)) {
             return false;
         }
@@ -59,16 +59,15 @@ check_exception_thrown(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
        whether it is '\0'. If yes, no exception was thrown. */
     if (!(value = LLVMBuildLoad(comp_ctx->builder, func_ctx->cur_exception,
                                 "exce_value"))
-        || !(cmp = LLVMBuildICmp(comp_ctx->builder, LLVMIntEQ,
-                                 value, I8_ZERO, "cmp"))) {
+        || !(cmp = LLVMBuildICmp(comp_ctx->builder, LLVMIntEQ, value, I8_ZERO,
+                                 "cmp"))) {
         aot_set_last_error("llvm build icmp failed.");
         return false;
     }
 
     /* Add check exection success block */
-    if (!(check_exce_succ = LLVMAppendBasicBlockInContext(comp_ctx->context,
-                                                          func_ctx->func,
-                                                          "check_exce_succ"))) {
+    if (!(check_exce_succ = LLVMAppendBasicBlockInContext(
+              comp_ctx->context, func_ctx->func, "check_exce_succ"))) {
         aot_set_last_error("llvm add basic block failed.");
         return false;
     }
@@ -78,8 +77,8 @@ check_exception_thrown(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 
     LLVMPositionBuilderAtEnd(comp_ctx->builder, block_curr);
     /* Create condition br */
-    if (!LLVMBuildCondBr(comp_ctx->builder, cmp,
-                         check_exce_succ, func_ctx->func_return_block)) {
+    if (!LLVMBuildCondBr(comp_ctx->builder, cmp, check_exce_succ,
+                         func_ctx->func_return_block)) {
         aot_set_last_error("llvm build cond br failed.");
         return false;
     }
@@ -100,16 +99,15 @@ check_call_return(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     if (!create_func_return_block(comp_ctx, func_ctx))
         return false;
 
-    if (!(cmp = LLVMBuildICmp(comp_ctx->builder, LLVMIntNE,
-                              res, I8_ZERO, "cmp"))) {
+    if (!(cmp = LLVMBuildICmp(comp_ctx->builder, LLVMIntNE, res, I8_ZERO,
+                              "cmp"))) {
         aot_set_last_error("llvm build icmp failed.");
         return false;
     }
 
     /* Add check exection success block */
-    if (!(check_call_succ = LLVMAppendBasicBlockInContext(comp_ctx->context,
-                                                          func_ctx->func,
-                                                          "check_call_succ"))) {
+    if (!(check_call_succ = LLVMAppendBasicBlockInContext(
+              comp_ctx->context, func_ctx->func, "check_call_succ"))) {
         aot_set_last_error("llvm add basic block failed.");
         return false;
     }
@@ -119,8 +117,8 @@ check_call_return(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
     LLVMPositionBuilderAtEnd(comp_ctx->builder, block_curr);
     /* Create condition br */
-    if (!LLVMBuildCondBr(comp_ctx->builder, cmp,
-                         check_call_succ, func_ctx->func_return_block)) {
+    if (!LLVMBuildCondBr(comp_ctx->builder, cmp, check_call_succ,
+                         func_ctx->func_return_block)) {
         aot_set_last_error("llvm build cond br failed.");
         return false;
     }
@@ -132,10 +130,11 @@ check_call_return(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 static bool
 call_aot_invoke_native_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                             LLVMValueRef func_idx, AOTFuncType *aot_func_type,
-                            LLVMTypeRef *param_types, LLVMValueRef *param_values,
-                            uint32 param_count, uint32 param_cell_num,
-                            LLVMTypeRef ret_type, uint8 wasm_ret_type,
-                            LLVMValueRef *p_value_ret, LLVMValueRef *p_res)
+                            LLVMTypeRef *param_types,
+                            LLVMValueRef *param_values, uint32 param_count,
+                            uint32 param_cell_num, LLVMTypeRef ret_type,
+                            uint8 wasm_ret_type, LLVMValueRef *p_value_ret,
+                            LLVMValueRef *p_res)
 {
     LLVMTypeRef func_type, func_ptr_type, func_param_types[4];
     LLVMTypeRef ret_ptr_type, elem_ptr_type;
@@ -145,11 +144,12 @@ call_aot_invoke_native_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     uint32 i, cell_num = 0;
 
     /* prepare function type of aot_invoke_native */
-    func_param_types[0] = comp_ctx->exec_env_type;  /* exec_env */
-    func_param_types[1] = I32_TYPE;                 /* func_idx */
-    func_param_types[2] = I32_TYPE;                 /* argc */
-    func_param_types[3] = INT32_PTR_TYPE;           /* argv */
-    if (!(func_type = LLVMFunctionType(INT8_TYPE, func_param_types, 4, false))) {
+    func_param_types[0] = comp_ctx->exec_env_type; /* exec_env */
+    func_param_types[1] = I32_TYPE;                /* func_idx */
+    func_param_types[2] = I32_TYPE;                /* argc */
+    func_param_types[3] = INT32_PTR_TYPE;          /* argv */
+    if (!(func_type =
+              LLVMFunctionType(INT8_TYPE, func_param_types, 4, false))) {
         aot_set_last_error("llvm add function type failed.");
         return false;
     }
@@ -174,8 +174,7 @@ call_aot_invoke_native_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             aot_set_last_error("create LLVM function type failed.");
             return false;
         }
-        func_index =
-          aot_get_native_symbol_index(comp_ctx, func_name);
+        func_index = aot_get_native_symbol_index(comp_ctx, func_name);
         if (func_index < 0) {
             return false;
         }
@@ -187,7 +186,7 @@ call_aot_invoke_native_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     else {
         if (!(func = LLVMGetNamedFunction(comp_ctx->module, func_name))
             && !(func =
-                   LLVMAddFunction(comp_ctx->module, func_name, func_type))) {
+                     LLVMAddFunction(comp_ctx->module, func_name, func_type))) {
             aot_set_last_error("add LLVM function failed.");
             return false;
         }
@@ -208,15 +207,16 @@ call_aot_invoke_native_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         }
 
         snprintf(buf, sizeof(buf), "%s%d", "elem", i);
-        if (!(elem_ptr = LLVMBuildInBoundsGEP(comp_ctx->builder,
-                                              func_ctx->argv_buf, &elem_idx, 1, buf))
+        if (!(elem_ptr = LLVMBuildInBoundsGEP(
+                  comp_ctx->builder, func_ctx->argv_buf, &elem_idx, 1, buf))
             || !(elem_ptr = LLVMBuildBitCast(comp_ctx->builder, elem_ptr,
                                              elem_ptr_type, buf))) {
             aot_set_last_error("llvm build bit cast failed.");
             return false;
         }
 
-        if (!(res = LLVMBuildStore(comp_ctx->builder, param_values[i], elem_ptr))) {
+        if (!(res = LLVMBuildStore(comp_ctx->builder, param_values[i],
+                                   elem_ptr))) {
             aot_set_last_error("llvm build store failed.");
             return false;
         }
@@ -236,8 +236,8 @@ call_aot_invoke_native_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     }
 
     /* call aot_invoke_native() function */
-    if (!(res = LLVMBuildCall(comp_ctx->builder, func,
-                              func_param_values, 4, "res"))) {
+    if (!(res = LLVMBuildCall(comp_ctx->builder, func, func_param_values, 4,
+                              "res"))) {
         aot_set_last_error("llvm build call failed.");
         return false;
     }
@@ -249,13 +249,14 @@ call_aot_invoke_native_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             return false;
         }
 
-        if (!(value_ret = LLVMBuildBitCast(comp_ctx->builder, func_ctx->argv_buf,
-                                           ret_ptr_type, "argv_ret"))) {
+        if (!(value_ret =
+                  LLVMBuildBitCast(comp_ctx->builder, func_ctx->argv_buf,
+                                   ret_ptr_type, "argv_ret"))) {
             aot_set_last_error("llvm build bit cast failed.");
             return false;
         }
-        if (!(*p_value_ret = LLVMBuildLoad(comp_ctx->builder, value_ret,
-                                           "value_ret"))) {
+        if (!(*p_value_ret =
+                  LLVMBuildLoad(comp_ctx->builder, value_ret, "value_ret"))) {
             aot_set_last_error("llvm build load failed.");
             return false;
         }
@@ -285,15 +286,14 @@ call_aot_alloc_frame_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     param_values[0] = func_ctx->exec_env;
     param_values[1] = func_idx;
 
-    if (!(ret_value = LLVMBuildCall(comp_ctx->builder, func,
-                                    param_values, 2,
+    if (!(ret_value = LLVMBuildCall(comp_ctx->builder, func, param_values, 2,
                                     "call_aot_alloc_frame"))) {
         aot_set_last_error("llvm build call failed.");
         return false;
     }
 
-    if (!(ret_value = LLVMBuildICmp(comp_ctx->builder, LLVMIntUGT,
-                                    ret_value, I8_ZERO, "frame_alloc_ret"))) {
+    if (!(ret_value = LLVMBuildICmp(comp_ctx->builder, LLVMIntUGT, ret_value,
+                                    I8_ZERO, "frame_alloc_ret"))) {
         aot_set_last_error("llvm build icmp failed.");
         return false;
     }
@@ -304,8 +304,8 @@ call_aot_alloc_frame_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     LLVMMoveBasicBlockAfter(frame_alloc_fail, block_curr);
     LLVMMoveBasicBlockAfter(frame_alloc_success, block_curr);
 
-    if (!LLVMBuildCondBr(comp_ctx->builder, ret_value,
-                         frame_alloc_success, frame_alloc_fail)) {
+    if (!LLVMBuildCondBr(comp_ctx->builder, ret_value, frame_alloc_success,
+                         frame_alloc_fail)) {
         aot_set_last_error("llvm build cond br failed.");
         return false;
     }
@@ -338,8 +338,7 @@ call_aot_free_frame_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 
     param_values[0] = func_ctx->exec_env;
 
-    if (!(ret_value = LLVMBuildCall(comp_ctx->builder, func,
-                                    param_values, 1,
+    if (!(ret_value = LLVMBuildCall(comp_ctx->builder, func, param_values, 1,
                                     "call_aot_free_frame"))) {
         aot_set_last_error("llvm build call failed.");
         return false;
@@ -347,7 +346,7 @@ call_aot_free_frame_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 
     return true;
 }
-#endif /* end of (WASM_ENABLE_DUMP_CALL_STACK != 0)
+#endif /* end of (WASM_ENABLE_DUMP_CALL_STACK != 0) \
                  || (WASM_ENABLE_PERF_PROFILING != 0) */
 
 static bool
@@ -363,17 +362,15 @@ check_stack_boundary(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         return false;
     }
 
-    if (!(stack_bound = LLVMBuildInBoundsGEP(comp_ctx->builder,
-                                             func_ctx->native_stack_bound,
-                                             &callee_local_size, 1,
-                                             "stack_bound"))) {
+    if (!(stack_bound = LLVMBuildInBoundsGEP(
+              comp_ctx->builder, func_ctx->native_stack_bound,
+              &callee_local_size, 1, "stack_bound"))) {
         aot_set_last_error("llvm build inbound gep failed.");
         return false;
     }
 
-    if (!(check_stack = LLVMAppendBasicBlockInContext(comp_ctx->context,
-                                                      func_ctx->func,
-                                                      "check_stack"))) {
+    if (!(check_stack = LLVMAppendBasicBlockInContext(
+              comp_ctx->context, func_ctx->func, "check_stack"))) {
         aot_set_last_error("llvm add basic block failed.");
         return false;
     }
@@ -381,14 +378,12 @@ check_stack_boundary(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     LLVMMoveBasicBlockAfter(check_stack, block_curr);
 
     if (!(cmp = LLVMBuildICmp(comp_ctx->builder, LLVMIntULT,
-                              func_ctx->last_alloca, stack_bound,
-                              "cmp"))) {
+                              func_ctx->last_alloca, stack_bound, "cmp"))) {
         aot_set_last_error("llvm build icmp failed.");
         return false;
     }
 
-    if (!aot_emit_exception(comp_ctx, func_ctx,
-                            EXCE_NATIVE_STACK_OVERFLOW,
+    if (!aot_emit_exception(comp_ctx, func_ctx, EXCE_NATIVE_STACK_OVERFLOW,
                             true, cmp, check_stack)) {
         return false;
     }
@@ -439,8 +434,8 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     if (func_idx < import_func_count)
         func_type = import_funcs[func_idx].func_type;
     else
-        func_type = func_ctxes[func_idx - import_func_count]->
-                                                aot_func->func_type;
+        func_type =
+            func_ctxes[func_idx - import_func_count]->aot_func->func_type;
 
     /* Get param cell number */
     param_cell_num = func_type->param_cell_num;
@@ -467,8 +462,8 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     param_count = (int32)func_type->param_count;
     result_count = (int32)func_type->result_count;
     ext_ret_count = result_count > 1 ? result_count - 1 : 0;
-    total_size = sizeof(LLVMValueRef) * (uint64)(param_count + 1
-                                                 + ext_ret_count);
+    total_size =
+        sizeof(LLVMValueRef) * (uint64)(param_count + 1 + ext_ret_count);
     if (total_size >= UINT32_MAX
         || !(param_values = wasm_runtime_malloc((uint32)total_size))) {
         aot_set_last_error("allocate memory failed.");
@@ -498,7 +493,7 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         for (i = 0; i < ext_ret_count; i++) {
             if (!(ext_ret_idx = I32_CONST(cell_num))
                 || !(ext_ret_ptr_type =
-                        LLVMPointerType(TO_LLVM_TYPE(ext_ret_types[i]), 0))) {
+                         LLVMPointerType(TO_LLVM_TYPE(ext_ret_types[i]), 0))) {
                 aot_set_last_error("llvm add const or pointer type failed.");
                 goto fail;
             }
@@ -511,9 +506,8 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                 goto fail;
             }
             snprintf(buf, sizeof(buf), "ext_ret%d_ptr_cast", i);
-            if (!(ext_ret_ptr = LLVMBuildBitCast(comp_ctx->builder,
-                                                 ext_ret_ptr, ext_ret_ptr_type,
-                                                 buf))) {
+            if (!(ext_ret_ptr = LLVMBuildBitCast(comp_ctx->builder, ext_ret_ptr,
+                                                 ext_ret_ptr_type, buf))) {
                 aot_set_last_error("llvm build bit cast failed.");
                 goto fail;
             }
@@ -552,13 +546,14 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         }
 
         /* call aot_invoke_native() */
-        if (!call_aot_invoke_native_func(comp_ctx, func_ctx, import_func_idx, func_type,
-                                         param_types + 1, param_values + 1,
-                                         param_count, param_cell_num,
-                                         ret_type, wasm_ret_type, &value_ret, &res))
+        if (!call_aot_invoke_native_func(
+                comp_ctx, func_ctx, import_func_idx, func_type, param_types + 1,
+                param_values + 1, param_count, param_cell_num, ret_type,
+                wasm_ret_type, &value_ret, &res))
             goto fail;
 
-        /* Check whether there was exception thrown when executing the function */
+        /* Check whether there was exception thrown when executing
+           the function */
         if (!check_call_return(comp_ctx, func_ctx, res))
             goto fail;
     }
@@ -567,7 +562,8 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             LLVMTypeRef func_ptr_type;
 
             if (!(func_ptr_type = LLVMPointerType(
-                    func_ctxes[func_idx - import_func_count]->func_type, 0))) {
+                      func_ctxes[func_idx - import_func_count]->func_type,
+                      0))) {
                 aot_set_last_error("construct func ptr type failed.");
                 goto fail;
             }
@@ -580,31 +576,32 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             func = func_ctxes[func_idx - import_func_count]->func;
         }
         aot_func = func_ctxes[func_idx - import_func_count]->aot_func;
-        callee_cell_num = aot_func->param_cell_num + aot_func->local_cell_num + 1;
+        callee_cell_num =
+            aot_func->param_cell_num + aot_func->local_cell_num + 1;
 
         if (comp_ctx->enable_bound_check
             && !check_stack_boundary(comp_ctx, func_ctx, callee_cell_num))
             goto fail;
 
         /* Call the function */
-        if (!(value_ret = LLVMBuildCall(comp_ctx->builder, func,
-                                        param_values,
-                                        (uint32)param_count + 1 + ext_ret_count,
-                                        (func_type->result_count > 0
-                                         ? "call" : "")))) {
+        if (!(value_ret =
+                  LLVMBuildCall(comp_ctx->builder, func, param_values,
+                                (uint32)param_count + 1 + ext_ret_count,
+                                (func_type->result_count > 0 ? "call" : "")))) {
             aot_set_last_error("LLVM build call failed.");
             goto fail;
         }
 
-        /* Set calling convention for the call with the func's calling convention */
+        /* Set calling convention for the call with the func's calling
+           convention */
         LLVMSetInstructionCallConv(value_ret, LLVMGetFunctionCallConv(func));
 
         if (tail_call)
             LLVMSetTailCall(value_ret, true);
 
-        /* Check whether there was exception thrown when executing the function */
-        if (!tail_call
-            && !check_exception_thrown(comp_ctx, func_ctx))
+        /* Check whether there was exception thrown when executing
+           the function */
+        if (!tail_call && !check_exception_thrown(comp_ctx, func_ctx))
             goto fail;
     }
 
@@ -614,9 +611,9 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         /* Load extra result from its address and push to stack */
         for (i = 0; i < ext_ret_count; i++) {
             snprintf(buf, sizeof(buf), "func%d_ext_ret%d", func_idx, i);
-            if (!(ext_ret = LLVMBuildLoad(comp_ctx->builder,
-                                          param_values[1 + param_count + i],
-                                          buf))) {
+            if (!(ext_ret =
+                      LLVMBuildLoad(comp_ctx->builder,
+                                    param_values[1 + param_count + i], buf))) {
                 aot_set_last_error("llvm build load failed.");
                 goto fail;
             }
@@ -642,12 +639,14 @@ fail:
 
 static bool
 call_aot_call_indirect_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                            AOTFuncType *aot_func_type, LLVMValueRef func_type_idx,
-                            LLVMValueRef table_idx, LLVMValueRef table_elem_idx,
-                            LLVMTypeRef *param_types, LLVMValueRef *param_values,
-                            uint32 param_count, uint32 param_cell_num,
-                            uint32 result_count, uint8 *wasm_ret_types,
-                            LLVMValueRef *value_rets, LLVMValueRef *p_res)
+                            AOTFuncType *aot_func_type,
+                            LLVMValueRef func_type_idx, LLVMValueRef table_idx,
+                            LLVMValueRef table_elem_idx,
+                            LLVMTypeRef *param_types,
+                            LLVMValueRef *param_values, uint32 param_count,
+                            uint32 param_cell_num, uint32 result_count,
+                            uint8 *wasm_ret_types, LLVMValueRef *value_rets,
+                            LLVMValueRef *p_res)
 {
     LLVMTypeRef func_type, func_ptr_type, func_param_types[6];
     LLVMTypeRef ret_type, ret_ptr_type, elem_ptr_type;
@@ -657,12 +656,13 @@ call_aot_call_indirect_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     uint32 i, cell_num = 0, ret_cell_num, argv_cell_num;
 
     /* prepare function type of aot_call_indirect */
-    func_param_types[0] = comp_ctx->exec_env_type;  /* exec_env */
-    func_param_types[1] = I32_TYPE;                 /* table_idx */
-    func_param_types[2] = I32_TYPE;                 /* table_elem_idx */
-    func_param_types[3] = I32_TYPE;                 /* argc */
-    func_param_types[4] = INT32_PTR_TYPE;           /* argv */
-    if (!(func_type = LLVMFunctionType(INT8_TYPE, func_param_types, 5, false))) {
+    func_param_types[0] = comp_ctx->exec_env_type; /* exec_env */
+    func_param_types[1] = I32_TYPE;                /* table_idx */
+    func_param_types[2] = I32_TYPE;                /* table_elem_idx */
+    func_param_types[3] = I32_TYPE;                /* argc */
+    func_param_types[4] = INT32_PTR_TYPE;          /* argv */
+    if (!(func_type =
+              LLVMFunctionType(INT8_TYPE, func_param_types, 5, false))) {
         aot_set_last_error("llvm add function type failed.");
         return false;
     }
@@ -687,8 +687,7 @@ call_aot_call_indirect_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             aot_set_last_error("create LLVM function type failed.");
             return false;
         }
-        func_index =
-          aot_get_native_symbol_index(comp_ctx, func_name);
+        func_index = aot_get_native_symbol_index(comp_ctx, func_name);
         if (func_index < 0) {
             return false;
         }
@@ -699,15 +698,16 @@ call_aot_call_indirect_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     }
     else {
         if (!(func = LLVMGetNamedFunction(comp_ctx->module, func_name))
-            && !(func = LLVMAddFunction(comp_ctx->module,
-                                        func_name, func_type))) {
+            && !(func =
+                     LLVMAddFunction(comp_ctx->module, func_name, func_type))) {
             aot_set_last_error("add LLVM function failed.");
             return false;
         }
     }
 
     ret_cell_num = wasm_get_cell_num(wasm_ret_types, result_count);
-    argv_cell_num = param_cell_num > ret_cell_num ? param_cell_num : ret_cell_num;
+    argv_cell_num =
+        param_cell_num > ret_cell_num ? param_cell_num : ret_cell_num;
     if (argv_cell_num > 64) {
         aot_set_last_error("prepare native arguments failed: "
                            "maximum 64 parameter cell number supported.");
@@ -723,15 +723,16 @@ call_aot_call_indirect_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         }
 
         snprintf(buf, sizeof(buf), "%s%d", "elem", i);
-        if (!(elem_ptr = LLVMBuildInBoundsGEP(comp_ctx->builder,
-                                              func_ctx->argv_buf, &elem_idx, 1, buf))
+        if (!(elem_ptr = LLVMBuildInBoundsGEP(
+                  comp_ctx->builder, func_ctx->argv_buf, &elem_idx, 1, buf))
             || !(elem_ptr = LLVMBuildBitCast(comp_ctx->builder, elem_ptr,
                                              elem_ptr_type, buf))) {
             aot_set_last_error("llvm build bit cast failed.");
             return false;
         }
 
-        if (!(res = LLVMBuildStore(comp_ctx->builder, param_values[i], elem_ptr))) {
+        if (!(res = LLVMBuildStore(comp_ctx->builder, param_values[i],
+                                   elem_ptr))) {
             aot_set_last_error("llvm build store failed.");
             return false;
         }
@@ -752,8 +753,8 @@ call_aot_call_indirect_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     }
 
     /* call aot_call_indirect() function */
-    if (!(res = LLVMBuildCall(comp_ctx->builder, func,
-                              func_param_values, 5, "res"))) {
+    if (!(res = LLVMBuildCall(comp_ctx->builder, func, func_param_values, 5,
+                              "res"))) {
         aot_set_last_error("llvm build call failed.");
         return false;
     }
@@ -769,8 +770,8 @@ call_aot_call_indirect_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         }
 
         snprintf(buf, sizeof(buf), "argv_ret%d", i);
-        if (!(ret_ptr = LLVMBuildInBoundsGEP(comp_ctx->builder,
-                                             func_ctx->argv_buf, &ret_idx, 1, buf))
+        if (!(ret_ptr = LLVMBuildInBoundsGEP(
+                  comp_ctx->builder, func_ctx->argv_buf, &ret_idx, 1, buf))
             || !(ret_ptr = LLVMBuildBitCast(comp_ctx->builder, ret_ptr,
                                             ret_ptr_type, buf))) {
             aot_set_last_error("llvm build GEP or bit cast failed.");
@@ -846,38 +847,35 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         goto fail;
     }
 
-    if (!(table_size_const =
-            LLVMBuildGEP(comp_ctx->builder, func_ctx->aot_inst, &offset, 1,
-                         "cur_size_i8p"))) {
+    if (!(table_size_const = LLVMBuildGEP(comp_ctx->builder, func_ctx->aot_inst,
+                                          &offset, 1, "cur_size_i8p"))) {
         HANDLE_FAILURE("LLVMBuildGEP");
         goto fail;
     }
 
     if (!(table_size_const =
-            LLVMBuildBitCast(comp_ctx->builder, table_size_const,
-                             INT32_PTR_TYPE, "cur_siuze_i32p"))) {
+              LLVMBuildBitCast(comp_ctx->builder, table_size_const,
+                               INT32_PTR_TYPE, "cur_siuze_i32p"))) {
         HANDLE_FAILURE("LLVMBuildBitCast");
         goto fail;
     }
 
-    if (!(table_size_const = LLVMBuildLoad(comp_ctx->builder, table_size_const, "cur_size"))) {
+    if (!(table_size_const =
+              LLVMBuildLoad(comp_ctx->builder, table_size_const, "cur_size"))) {
         HANDLE_FAILURE("LLVMBuildLoad");
         goto fail;
     }
 
     /* Check if (uint32)elem index >= table size */
-    if (!(cmp_elem_idx = LLVMBuildICmp(comp_ctx->builder, LLVMIntUGE,
-                                       elem_idx, table_size_const,
-                                       "cmp_elem_idx"))) {
+    if (!(cmp_elem_idx = LLVMBuildICmp(comp_ctx->builder, LLVMIntUGE, elem_idx,
+                                       table_size_const, "cmp_elem_idx"))) {
         aot_set_last_error("llvm build icmp failed.");
         goto fail;
     }
 
     /* Throw exception if elem index >= table size */
-    if (!(check_elem_idx_succ =
-                LLVMAppendBasicBlockInContext(comp_ctx->context,
-                                              func_ctx->func,
-                                              "check_elem_idx_succ"))) {
+    if (!(check_elem_idx_succ = LLVMAppendBasicBlockInContext(
+              comp_ctx->context, func_ctx->func, "check_elem_idx_succ"))) {
         aot_set_last_error("llvm add basic block failed.");
         goto fail;
     }
@@ -885,8 +883,8 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     LLVMMoveBasicBlockAfter(check_elem_idx_succ,
                             LLVMGetInsertBlock(comp_ctx->builder));
 
-    if (!(aot_emit_exception(comp_ctx, func_ctx, EXCE_UNDEFINED_ELEMENT,
-                             true, cmp_elem_idx, check_elem_idx_succ)))
+    if (!(aot_emit_exception(comp_ctx, func_ctx, EXCE_UNDEFINED_ELEMENT, true,
+                             cmp_elem_idx, check_elem_idx_succ)))
         goto fail;
 
     /* load data as i32* */
@@ -909,31 +907,28 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     }
 
     /* Load function index */
-    if (!(table_elem = LLVMBuildGEP(comp_ctx->builder, table_elem, &elem_idx,
-                                    1, "table_elem"))) {
+    if (!(table_elem = LLVMBuildGEP(comp_ctx->builder, table_elem, &elem_idx, 1,
+                                    "table_elem"))) {
         HANDLE_FAILURE("LLVMBuildNUWAdd");
         goto fail;
     }
 
-    if (!(func_idx = LLVMBuildLoad(comp_ctx->builder,
-                                   table_elem, "func_idx"))) {
+    if (!(func_idx =
+              LLVMBuildLoad(comp_ctx->builder, table_elem, "func_idx"))) {
         aot_set_last_error("llvm build load failed.");
         goto fail;
     }
 
     /* Check if func_idx == -1 */
-    if (!(cmp_func_idx = LLVMBuildICmp(comp_ctx->builder, LLVMIntEQ,
-                                       func_idx, I32_NEG_ONE,
-                                       "cmp_func_idx"))) {
+    if (!(cmp_func_idx = LLVMBuildICmp(comp_ctx->builder, LLVMIntEQ, func_idx,
+                                       I32_NEG_ONE, "cmp_func_idx"))) {
         aot_set_last_error("llvm build icmp failed.");
         goto fail;
     }
 
     /* Throw exception if func_idx == -1 */
-    if (!(check_func_idx_succ =
-                LLVMAppendBasicBlockInContext(comp_ctx->context,
-                                              func_ctx->func,
-                                              "check_func_idx_succ"))) {
+    if (!(check_func_idx_succ = LLVMAppendBasicBlockInContext(
+              comp_ctx->context, func_ctx->func, "check_func_idx_succ"))) {
         aot_set_last_error("llvm add basic block failed.");
         goto fail;
     }
@@ -946,33 +941,29 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         goto fail;
 
     /* Load function type index */
-    if (!(ftype_idx_ptr = LLVMBuildInBoundsGEP(comp_ctx->builder,
-                                               func_ctx->func_type_indexes,
-                                               &func_idx, 1,
-                                               "ftype_idx_ptr"))) {
+    if (!(ftype_idx_ptr = LLVMBuildInBoundsGEP(
+              comp_ctx->builder, func_ctx->func_type_indexes, &func_idx, 1,
+              "ftype_idx_ptr"))) {
         aot_set_last_error("llvm build inbounds gep failed.");
         goto fail;
     }
 
-    if (!(ftype_idx = LLVMBuildLoad(comp_ctx->builder, ftype_idx_ptr,
-                                    "ftype_idx"))) {
+    if (!(ftype_idx =
+              LLVMBuildLoad(comp_ctx->builder, ftype_idx_ptr, "ftype_idx"))) {
         aot_set_last_error("llvm build load failed.");
         goto fail;
     }
 
     /* Check if function type index not equal */
-    if (!(cmp_ftype_idx = LLVMBuildICmp(comp_ctx->builder, LLVMIntNE,
-                                        ftype_idx, ftype_idx_const,
-                                        "cmp_ftype_idx"))) {
+    if (!(cmp_ftype_idx = LLVMBuildICmp(comp_ctx->builder, LLVMIntNE, ftype_idx,
+                                        ftype_idx_const, "cmp_ftype_idx"))) {
         aot_set_last_error("llvm build icmp failed.");
         goto fail;
     }
 
     /* Throw exception if ftype_idx != ftype_idx_const */
-    if (!(check_ftype_idx_succ =
-                LLVMAppendBasicBlockInContext(comp_ctx->context,
-                                              func_ctx->func,
-                                              "check_ftype_idx_succ"))) {
+    if (!(check_ftype_idx_succ = LLVMAppendBasicBlockInContext(
+              comp_ctx->context, func_ctx->func, "check_ftype_idx_succ"))) {
         aot_set_last_error("llvm add basic block failed.");
         goto fail;
     }
@@ -981,17 +972,17 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                             LLVMGetInsertBlock(comp_ctx->builder));
 
     if (!(aot_emit_exception(comp_ctx, func_ctx,
-                             EXCE_INVALID_FUNCTION_TYPE_INDEX,
-                             true, cmp_ftype_idx, check_ftype_idx_succ)))
+                             EXCE_INVALID_FUNCTION_TYPE_INDEX, true,
+                             cmp_ftype_idx, check_ftype_idx_succ)))
         goto fail;
 
     /* Initialize parameter types of the LLVM function */
     total_param_count = 1 + func_param_count;
 
     /* Extra function results' addresses (except the first one) are
-     * appended to aot function parameters. */
+       appended to aot function parameters. */
     if (func_result_count > 1)
-      total_param_count += func_result_count - 1;
+        total_param_count += func_result_count - 1;
 
     total_size = sizeof(LLVMTypeRef) * (uint64)total_param_count;
     if (total_size >= UINT32_MAX
@@ -1007,8 +998,7 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         param_types[j++] = TO_LLVM_TYPE(func_type->types[i]);
 
     for (i = 1; i < func_result_count; i++, j++) {
-        param_types[j] =
-            TO_LLVM_TYPE(func_type->types[func_param_count + i]);
+        param_types[j] = TO_LLVM_TYPE(func_type->types[func_param_count + i]);
         if (!(param_types[j] = LLVMPointerType(param_types[j], 0))) {
             aot_set_last_error("llvm get pointer type failed.");
             goto fail;
@@ -1048,25 +1038,24 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         CHECK_LLVM_CONST(ext_ret_offset);
 
         snprintf(buf, sizeof(buf), "ext_ret%d_ptr", i - 1);
-        if (!(ext_ret_ptr = LLVMBuildInBoundsGEP(comp_ctx->builder,
-                                                 func_ctx->argv_buf,
-                                                 &ext_ret_offset, 1, buf))) {
+        if (!(ext_ret_ptr =
+                  LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->argv_buf,
+                                       &ext_ret_offset, 1, buf))) {
             aot_set_last_error("llvm build GEP failed.");
             goto fail;
         }
 
         ext_ret_ptr_type = param_types[func_param_count + i];
         snprintf(buf, sizeof(buf), "ext_ret%d_ptr_cast", i - 1);
-        if (!(ext_ret_ptr = LLVMBuildBitCast(comp_ctx->builder,
-                                             ext_ret_ptr, ext_ret_ptr_type,
-                                             buf))) {
+        if (!(ext_ret_ptr = LLVMBuildBitCast(comp_ctx->builder, ext_ret_ptr,
+                                             ext_ret_ptr_type, buf))) {
             aot_set_last_error("llvm build bit cast failed.");
             goto fail;
         }
 
         param_values[func_param_count + i] = ext_ret_ptr;
-        ext_cell_num += wasm_value_type_cell_num(
-                func_type->types[func_param_count + i]);
+        ext_cell_num +=
+            wasm_value_type_cell_num(func_type->types[func_param_count + i]);
     }
 
     if (ext_cell_num > 64) {
@@ -1091,15 +1080,12 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 #endif
 
     /* Add basic blocks */
-    block_call_import =
-        LLVMAppendBasicBlockInContext(comp_ctx->context, func_ctx->func,
-                                      "call_import");
-    block_call_non_import =
-        LLVMAppendBasicBlockInContext(comp_ctx->context, func_ctx->func,
-                                      "call_non_import");
-    block_return =
-        LLVMAppendBasicBlockInContext(comp_ctx->context, func_ctx->func,
-                                      "func_return");
+    block_call_import = LLVMAppendBasicBlockInContext(
+        comp_ctx->context, func_ctx->func, "call_import");
+    block_call_non_import = LLVMAppendBasicBlockInContext(
+        comp_ctx->context, func_ctx->func, "call_non_import");
+    block_return = LLVMAppendBasicBlockInContext(comp_ctx->context,
+                                                 func_ctx->func, "func_return");
     if (!block_call_import || !block_call_non_import || !block_return) {
         aot_set_last_error("llvm add basic block failed.");
         goto fail;
@@ -1114,17 +1100,16 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     CHECK_LLVM_CONST(import_func_count);
 
     /* Check if func_idx < import_func_count */
-    if (!(cmp_func_idx = LLVMBuildICmp(comp_ctx->builder, LLVMIntULT,
-                                       func_idx, import_func_count,
-                                       "cmp_func_idx"))) {
+    if (!(cmp_func_idx = LLVMBuildICmp(comp_ctx->builder, LLVMIntULT, func_idx,
+                                       import_func_count, "cmp_func_idx"))) {
         aot_set_last_error("llvm build icmp failed.");
         goto fail;
     }
 
     /* If func_idx < import_func_count, jump to call import block,
        else jump to call non-import block */
-    if (!LLVMBuildCondBr(comp_ctx->builder, cmp_func_idx,
-                         block_call_import, block_call_non_import)) {
+    if (!LLVMBuildCondBr(comp_ctx->builder, cmp_func_idx, block_call_import,
+                         block_call_non_import)) {
         aot_set_last_error("llvm build cond br failed.");
         goto fail;
     }
@@ -1143,8 +1128,8 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         for (i = 0; i < func_result_count; i++) {
             LLVMTypeRef tmp_type =
                 TO_LLVM_TYPE(func_type->types[func_param_count + i]);
-            if (!(result_phis[i] = LLVMBuildPhi(comp_ctx->builder,
-                                                tmp_type, "phi"))) {
+            if (!(result_phis[i] =
+                      LLVMBuildPhi(comp_ctx->builder, tmp_type, "phi"))) {
                 aot_set_last_error("llvm build phi failed.");
                 goto fail;
             }
@@ -1174,13 +1159,10 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         goto fail;
     }
 
-    if (!call_aot_call_indirect_func(comp_ctx, func_ctx,
-                                     func_type, ftype_idx,
-                                     tbl_idx_value, elem_idx,
-                                     param_types + 1, param_values + 1,
-                                     func_param_count, param_cell_num,
-                                     func_result_count, wasm_ret_types,
-                                     value_rets, &res))
+    if (!call_aot_call_indirect_func(
+            comp_ctx, func_ctx, func_type, ftype_idx, tbl_idx_value, elem_idx,
+            param_types + 1, param_values + 1, func_param_count, param_cell_num,
+            func_result_count, wasm_ret_types, value_rets, &res))
         goto fail;
 
     /* Check whether exception was thrown when executing the function */
@@ -1202,14 +1184,16 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
     if (comp_ctx->enable_bound_check
         && !check_stack_boundary(comp_ctx, func_ctx,
-                                 param_cell_num + ext_cell_num + 1
-                                 /* Reserve some local variables */
-                                 + 16))
+                                 param_cell_num + ext_cell_num
+                                     + 1
+                                     /* Reserve some local variables */
+                                     + 16))
         goto fail;
 
     /* Load function pointer */
-    if (!(func_ptr = LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->func_ptrs,
-                                          &func_idx, 1, "func_ptr_tmp"))) {
+    if (!(func_ptr =
+              LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->func_ptrs,
+                                   &func_idx, 1, "func_ptr_tmp"))) {
         aot_set_last_error("llvm build inbounds gep failed.");
         goto fail;
     }
@@ -1219,24 +1203,22 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         goto fail;
     }
 
-    if (!(llvm_func_type = LLVMFunctionType(ret_type, param_types,
-                                            total_param_count, false))
+    if (!(llvm_func_type =
+              LLVMFunctionType(ret_type, param_types, total_param_count, false))
         || !(llvm_func_ptr_type = LLVMPointerType(llvm_func_type, 0))) {
         aot_set_last_error("llvm add function type failed.");
         goto fail;
     }
 
-    if (!(func = LLVMBuildBitCast(comp_ctx->builder,
-                                  func_ptr, llvm_func_ptr_type,
-                                  "indirect_func"))) {
+    if (!(func = LLVMBuildBitCast(comp_ctx->builder, func_ptr,
+                                  llvm_func_ptr_type, "indirect_func"))) {
         aot_set_last_error("llvm build bit cast failed.");
         goto fail;
     }
 
-    if (!(value_ret = LLVMBuildCall(comp_ctx->builder, func,
-                                    param_values, total_param_count,
-                                    func_result_count > 0
-                                    ? "ret" : ""))) {
+    if (!(value_ret = LLVMBuildCall(comp_ctx->builder, func, param_values,
+                                    total_param_count,
+                                    func_result_count > 0 ? "ret" : ""))) {
         aot_set_last_error("llvm build call failed.");
         goto fail;
     }
@@ -1254,9 +1236,9 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         /* Load extra result from its address and push to stack */
         for (i = 1; i < func_result_count; i++) {
             snprintf(buf, sizeof(buf), "ext_ret%d", i - 1);
-            if (!(ext_ret = LLVMBuildLoad(comp_ctx->builder,
-                                          param_values[func_param_count + i],
-                                          buf))) {
+            if (!(ext_ret =
+                      LLVMBuildLoad(comp_ctx->builder,
+                                    param_values[func_param_count + i], buf))) {
                 aot_set_last_error("llvm build load failed.");
                 goto fail;
             }
@@ -1333,8 +1315,7 @@ fail:
 }
 
 bool
-aot_compile_op_ref_func(AOTCompContext *comp_ctx,
-                        AOTFuncContext *func_ctx,
+aot_compile_op_ref_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                         uint32 func_idx)
 {
     LLVMValueRef ref_idx;

--- a/core/iwasm/compilation/aot_emit_function.h
+++ b/core/iwasm/compilation/aot_emit_function.h
@@ -17,10 +17,8 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                     uint32 func_idx, bool tail_call);
 
 bool
-aot_compile_op_call_indirect(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
-                             uint32 type_idx,
-                             uint32 tbl_idx);
+aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                             uint32 type_idx, uint32 tbl_idx);
 
 bool
 aot_compile_op_ref_null(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx);
@@ -29,12 +27,10 @@ bool
 aot_compile_op_ref_is_null(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx);
 
 bool
-aot_compile_op_ref_func(AOTCompContext *comp_ctx,
-                        AOTFuncContext *func_ctx,
+aot_compile_op_ref_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                         uint32 func_idx);
 #ifdef __cplusplus
 } /* end of extern "C" */
 #endif
 
 #endif /* end of _AOT_EMIT_FUNCTION_H_ */
-

--- a/core/iwasm/compilation/aot_emit_memory.c
+++ b/core/iwasm/compilation/aot_emit_memory.c
@@ -7,33 +7,33 @@
 #include "aot_emit_exception.h"
 #include "../aot/aot_runtime.h"
 
-#define BUILD_ICMP(op, left, right, res, name) do {     \
-    if (!(res = LLVMBuildICmp(comp_ctx->builder, op,    \
-                              left, right, name))) {    \
-        aot_set_last_error("llvm build icmp failed.");  \
-        goto fail;                                      \
-    }                                                   \
-  } while (0)
+#define BUILD_ICMP(op, left, right, res, name)                                \
+    do {                                                                      \
+        if (!(res =                                                           \
+                  LLVMBuildICmp(comp_ctx->builder, op, left, right, name))) { \
+            aot_set_last_error("llvm build icmp failed.");                    \
+            goto fail;                                                        \
+        }                                                                     \
+    } while (0)
 
-#define BUILD_OP(Op, left, right, res, name) do {       \
-    if (!(res = LLVMBuild##Op(comp_ctx->builder,        \
-                              left, right, name))) {    \
-        aot_set_last_error("llvm build " #Op " fail."); \
-        goto fail;                                      \
-    }                                                   \
-  } while (0)
+#define BUILD_OP(Op, left, right, res, name)                                \
+    do {                                                                    \
+        if (!(res = LLVMBuild##Op(comp_ctx->builder, left, right, name))) { \
+            aot_set_last_error("llvm build " #Op " fail.");                 \
+            goto fail;                                                      \
+        }                                                                   \
+    } while (0)
 
-#define ADD_BASIC_BLOCK(block, name) do {                           \
-    if (!(block = LLVMAppendBasicBlockInContext(comp_ctx->context,  \
-                                                func_ctx->func,     \
-                                                name))) {           \
-        aot_set_last_error("llvm add basic block failed.");         \
-        goto fail;                                                  \
-    }                                                               \
-  } while (0)
+#define ADD_BASIC_BLOCK(block, name)                                          \
+    do {                                                                      \
+        if (!(block = LLVMAppendBasicBlockInContext(comp_ctx->context,        \
+                                                    func_ctx->func, name))) { \
+            aot_set_last_error("llvm add basic block failed.");               \
+            goto fail;                                                        \
+        }                                                                     \
+    } while (0)
 
-#define SET_BUILD_POS(block)    \
-    LLVMPositionBuilderAtEnd(comp_ctx->builder, block)
+#define SET_BUILD_POS(block) LLVMPositionBuilderAtEnd(comp_ctx->builder, block)
 
 static LLVMValueRef
 get_memory_check_bound(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
@@ -64,8 +64,7 @@ get_memory_check_bound(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     if (func_ctx->mem_space_unchanged)
         return mem_check_bound;
 
-    if (!(mem_check_bound = LLVMBuildLoad(comp_ctx->builder,
-                                          mem_check_bound,
+    if (!(mem_check_bound = LLVMBuildLoad(comp_ctx->builder, mem_check_bound,
                                           "mem_check_bound"))) {
         aot_set_last_error("llvm build load failed.");
         return NULL;
@@ -93,8 +92,7 @@ aot_check_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         comp_ctx->comp_data->memories[0].memory_flags & 0x02;
 #endif
 
-    is_target_64bit = (comp_ctx->pointer_size == sizeof(uint64))
-                      ? true : false;
+    is_target_64bit = (comp_ctx->pointer_size == sizeof(uint64)) ? true : false;
 
     CHECK_LLVM_CONST(offset_const);
 
@@ -103,20 +101,20 @@ aot_check_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 #if WASM_ENABLE_SHARED_MEMORY != 0
         || is_shared_memory
 #endif
-       ) {
+    ) {
         mem_base_addr = func_ctx->mem_info[0].mem_base_addr;
     }
     else {
-        if (!(mem_base_addr =
-                LLVMBuildLoad(comp_ctx->builder,
-                              func_ctx->mem_info[0].mem_base_addr,
-                              "mem_base"))) {
+        if (!(mem_base_addr = LLVMBuildLoad(comp_ctx->builder,
+                                            func_ctx->mem_info[0].mem_base_addr,
+                                            "mem_base"))) {
             aot_set_last_error("llvm build load failed.");
             goto fail;
         }
     }
 
-    aot_value = func_ctx->block_stack.block_list_end->value_stack.value_list_end;
+    aot_value =
+        func_ctx->block_stack.block_list_end->value_stack.value_list_end;
     if (aot_value) {
         /* aot_value is freed in the following POP_I32(addr),
            so save its fields here for further use */
@@ -136,12 +134,12 @@ aot_check_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         && !LLVMIsPoison(addr)
 #endif
     ) {
-        uint64 mem_offset = (uint64)LLVMConstIntGetZExtValue(addr)
-                             + (uint64)offset;
+        uint64 mem_offset =
+            (uint64)LLVMConstIntGetZExtValue(addr) + (uint64)offset;
         uint32 num_bytes_per_page =
-                comp_ctx->comp_data->memories[0].num_bytes_per_page;
+            comp_ctx->comp_data->memories[0].num_bytes_per_page;
         uint32 init_page_count =
-                comp_ctx->comp_data->memories[0].mem_init_page_count;
+            comp_ctx->comp_data->memories[0].mem_init_page_count;
         uint64 mem_data_size = num_bytes_per_page * init_page_count;
 
         if (mem_offset + bytes <= mem_data_size) {
@@ -160,8 +158,8 @@ aot_check_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     if (is_target_64bit) {
         if (!(offset_const = LLVMBuildZExt(comp_ctx->builder, offset_const,
                                            I64_TYPE, "offset_i64"))
-            || !(addr = LLVMBuildZExt(comp_ctx->builder, addr,
-                                      I64_TYPE, "addr_i64"))) {
+            || !(addr = LLVMBuildZExt(comp_ctx->builder, addr, I64_TYPE,
+                                      "addr_i64"))) {
             aot_set_last_error("llvm build zero extend failed.");
             goto fail;
         }
@@ -175,7 +173,7 @@ aot_check_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
              && aot_checked_addr_list_find(func_ctx, local_idx_of_aot_value,
                                            offset, bytes))) {
         uint32 init_page_count =
-                comp_ctx->comp_data->memories[0].mem_init_page_count;
+            comp_ctx->comp_data->memories[0].mem_init_page_count;
         if (init_page_count == 0) {
             LLVMValueRef mem_size;
 
@@ -186,8 +184,8 @@ aot_check_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             ADD_BASIC_BLOCK(check_succ, "check_mem_size_succ");
             LLVMMoveBasicBlockAfter(check_succ, block_curr);
             if (!aot_emit_exception(comp_ctx, func_ctx,
-                                    EXCE_OUT_OF_BOUNDS_MEMORY_ACCESS,
-                                    true, cmp, check_succ)) {
+                                    EXCE_OUT_OF_BOUNDS_MEMORY_ACCESS, true, cmp,
+                                    check_succ)) {
                 goto fail;
             }
 
@@ -196,7 +194,7 @@ aot_check_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         }
 
         if (!(mem_check_bound =
-                    get_memory_check_bound(comp_ctx, func_ctx, bytes))) {
+                  get_memory_check_bound(comp_ctx, func_ctx, bytes))) {
             goto fail;
         }
 
@@ -215,8 +213,8 @@ aot_check_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         LLVMMoveBasicBlockAfter(check_succ, block_curr);
 
         if (!aot_emit_exception(comp_ctx, func_ctx,
-                                EXCE_OUT_OF_BOUNDS_MEMORY_ACCESS,
-                                true, cmp, check_succ)) {
+                                EXCE_OUT_OF_BOUNDS_MEMORY_ACCESS, true, cmp,
+                                check_succ)) {
             goto fail;
         }
 
@@ -240,55 +238,60 @@ fail:
     return NULL;
 }
 
-#define BUILD_PTR_CAST(ptr_type) do {                       \
-    if (!(maddr = LLVMBuildBitCast(comp_ctx->builder, maddr,\
-                                   ptr_type, "data_ptr"))) {\
-        aot_set_last_error("llvm build bit cast failed.");  \
-        goto fail;                                          \
-    }                                                       \
-  } while (0)
+#define BUILD_PTR_CAST(ptr_type)                                           \
+    do {                                                                   \
+        if (!(maddr = LLVMBuildBitCast(comp_ctx->builder, maddr, ptr_type, \
+                                       "data_ptr"))) {                     \
+            aot_set_last_error("llvm build bit cast failed.");             \
+            goto fail;                                                     \
+        }                                                                  \
+    } while (0)
 
-#define BUILD_LOAD() do {                                   \
-    if (!(value = LLVMBuildLoad(comp_ctx->builder, maddr,   \
-                                "data"))) {                 \
-        aot_set_last_error("llvm build load failed.");      \
-        goto fail;                                          \
-    }                                                       \
-    LLVMSetAlignment(value, 1);                             \
-  } while (0)
+#define BUILD_LOAD()                                                      \
+    do {                                                                  \
+        if (!(value = LLVMBuildLoad(comp_ctx->builder, maddr, "data"))) { \
+            aot_set_last_error("llvm build load failed.");                \
+            goto fail;                                                    \
+        }                                                                 \
+        LLVMSetAlignment(value, 1);                                       \
+    } while (0)
 
-#define BUILD_TRUNC(value, data_type) do {                  \
-    if (!(value = LLVMBuildTrunc(comp_ctx->builder, value,  \
-                                 data_type, "val_trunc"))){ \
-        aot_set_last_error("llvm build trunc failed.");     \
-        goto fail;                                          \
-    }                                                       \
-  } while (0)
+#define BUILD_TRUNC(value, data_type)                                     \
+    do {                                                                  \
+        if (!(value = LLVMBuildTrunc(comp_ctx->builder, value, data_type, \
+                                     "val_trunc"))) {                     \
+            aot_set_last_error("llvm build trunc failed.");               \
+            goto fail;                                                    \
+        }                                                                 \
+    } while (0)
 
-#define BUILD_STORE() do {                                  \
-    LLVMValueRef res;                                       \
-    if (!(res = LLVMBuildStore(comp_ctx->builder, value, maddr))) { \
-        aot_set_last_error("llvm build store failed.");     \
-        goto fail;                                          \
-    }                                                       \
-    LLVMSetAlignment(res, 1);                               \
-  } while (0)
+#define BUILD_STORE()                                                   \
+    do {                                                                \
+        LLVMValueRef res;                                               \
+        if (!(res = LLVMBuildStore(comp_ctx->builder, value, maddr))) { \
+            aot_set_last_error("llvm build store failed.");             \
+            goto fail;                                                  \
+        }                                                               \
+        LLVMSetAlignment(res, 1);                                       \
+    } while (0)
 
-#define BUILD_SIGN_EXT(dst_type) do {                       \
-    if (!(value = LLVMBuildSExt(comp_ctx->builder, value,   \
-                                dst_type, "data_s_ext"))) { \
-        aot_set_last_error("llvm build sign ext failed.");  \
-        goto fail;                                          \
-    }                                                       \
-  } while (0)
+#define BUILD_SIGN_EXT(dst_type)                                        \
+    do {                                                                \
+        if (!(value = LLVMBuildSExt(comp_ctx->builder, value, dst_type, \
+                                    "data_s_ext"))) {                   \
+            aot_set_last_error("llvm build sign ext failed.");          \
+            goto fail;                                                  \
+        }                                                               \
+    } while (0)
 
-#define BUILD_ZERO_EXT(dst_type) do {                       \
-    if (!(value = LLVMBuildZExt(comp_ctx->builder, value,   \
-                                dst_type, "data_z_ext"))) { \
-        aot_set_last_error("llvm build zero ext failed.");  \
-        goto fail;                                          \
-    }                                                       \
-  } while (0)
+#define BUILD_ZERO_EXT(dst_type)                                        \
+    do {                                                                \
+        if (!(value = LLVMBuildZExt(comp_ctx->builder, value, dst_type, \
+                                    "data_z_ext"))) {                   \
+            aot_set_last_error("llvm build zero ext failed.");          \
+            goto fail;                                                  \
+        }                                                               \
+    } while (0)
 
 #if WASM_ENABLE_SHARED_MEMORY != 0
 bool
@@ -303,8 +306,8 @@ check_memory_alignment(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     CHECK_LLVM_CONST(align_mask);
 
     /* Convert pointer to int */
-    if (!(addr = LLVMBuildPtrToInt(comp_ctx->builder, addr,
-                                   I32_TYPE, "address"))) {
+    if (!(addr = LLVMBuildPtrToInt(comp_ctx->builder, addr, I32_TYPE,
+                                   "address"))) {
         aot_set_last_error("llvm build ptr to int failed.");
         goto fail;
     }
@@ -317,9 +320,8 @@ check_memory_alignment(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     ADD_BASIC_BLOCK(check_align_succ, "check_align_succ");
     LLVMMoveBasicBlockAfter(check_align_succ, block_curr);
 
-    if (!aot_emit_exception(comp_ctx, func_ctx,
-                            EXCE_UNALIGNED_ATOMIC,
-                            true, res, check_align_succ)) {
+    if (!aot_emit_exception(comp_ctx, func_ctx, EXCE_UNALIGNED_ATOMIC, true,
+                            res, check_align_succ)) {
         goto fail;
     }
 
@@ -330,39 +332,40 @@ fail:
     return false;
 }
 
-#define BUILD_ATOMIC_LOAD(align) do {                                   \
-    if (!(check_memory_alignment(comp_ctx, func_ctx, maddr, align))) {  \
-        goto fail;                                                      \
-    }                                                                   \
-    if (!(value = LLVMBuildLoad(comp_ctx->builder, maddr,               \
-                                "data"))) {                             \
-        aot_set_last_error("llvm build load failed.");                  \
-        goto fail;                                                      \
-    }                                                                   \
-    LLVMSetAlignment(value, 1 << align);                                \
-    LLVMSetVolatile(value, true);                                       \
-    LLVMSetOrdering(value, LLVMAtomicOrderingSequentiallyConsistent);   \
-  } while (0)
+#define BUILD_ATOMIC_LOAD(align)                                           \
+    do {                                                                   \
+        if (!(check_memory_alignment(comp_ctx, func_ctx, maddr, align))) { \
+            goto fail;                                                     \
+        }                                                                  \
+        if (!(value = LLVMBuildLoad(comp_ctx->builder, maddr, "data"))) {  \
+            aot_set_last_error("llvm build load failed.");                 \
+            goto fail;                                                     \
+        }                                                                  \
+        LLVMSetAlignment(value, 1 << align);                               \
+        LLVMSetVolatile(value, true);                                      \
+        LLVMSetOrdering(value, LLVMAtomicOrderingSequentiallyConsistent);  \
+    } while (0)
 
-#define BUILD_ATOMIC_STORE(align) do {                                  \
-    LLVMValueRef res;                                                   \
-    if (!(check_memory_alignment(comp_ctx, func_ctx, maddr, align))) {  \
-        goto fail;                                                      \
-    }                                                                   \
-    if (!(res = LLVMBuildStore(comp_ctx->builder, value, maddr))) {     \
-        aot_set_last_error("llvm build store failed.");                 \
-        goto fail;                                                      \
-    }                                                                   \
-    LLVMSetAlignment(res, 1 << align);                                  \
-    LLVMSetVolatile(res, true);                                         \
-    LLVMSetOrdering(res, LLVMAtomicOrderingSequentiallyConsistent);     \
-  } while (0)
+#define BUILD_ATOMIC_STORE(align)                                          \
+    do {                                                                   \
+        LLVMValueRef res;                                                  \
+        if (!(check_memory_alignment(comp_ctx, func_ctx, maddr, align))) { \
+            goto fail;                                                     \
+        }                                                                  \
+        if (!(res = LLVMBuildStore(comp_ctx->builder, value, maddr))) {    \
+            aot_set_last_error("llvm build store failed.");                \
+            goto fail;                                                     \
+        }                                                                  \
+        LLVMSetAlignment(res, 1 << align);                                 \
+        LLVMSetVolatile(res, true);                                        \
+        LLVMSetOrdering(res, LLVMAtomicOrderingSequentiallyConsistent);    \
+    } while (0)
 #endif
 
 bool
 aot_compile_op_i32_load(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                        uint32 align, uint32 offset, uint32 bytes,
-                        bool sign, bool atomic)
+                        uint32 align, uint32 offset, uint32 bytes, bool sign,
+                        bool atomic)
 {
     LLVMValueRef maddr, value = NULL;
 
@@ -413,8 +416,8 @@ fail:
 
 bool
 aot_compile_op_i64_load(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                        uint32 align, uint32 offset, uint32 bytes,
-                        bool sign, bool atomic)
+                        uint32 align, uint32 offset, uint32 bytes, bool sign,
+                        bool atomic)
 {
     LLVMValueRef maddr, value = NULL;
 
@@ -627,10 +630,9 @@ get_memory_curr_page_count(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
         mem_size = func_ctx->mem_info[0].mem_cur_page_count_addr;
     }
     else {
-        if (!(mem_size =
-                LLVMBuildLoad(comp_ctx->builder,
-                              func_ctx->mem_info[0].mem_cur_page_count_addr,
-                              "mem_size"))) {
+        if (!(mem_size = LLVMBuildLoad(
+                  comp_ctx->builder,
+                  func_ctx->mem_info[0].mem_cur_page_count_addr, "mem_size"))) {
             aot_set_last_error("llvm build load failed.");
             goto fail;
         }
@@ -694,7 +696,7 @@ aot_compile_op_memory_grow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
             return false;
         }
         func_index =
-          aot_get_native_symbol_index(comp_ctx, "aot_enlarge_memory");
+            aot_get_native_symbol_index(comp_ctx, "aot_enlarge_memory");
         if (func_index < 0) {
             return false;
         }
@@ -707,8 +709,8 @@ aot_compile_op_memory_grow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
         char *func_name = "aot_enlarge_memory";
         /* AOT mode, delcare the function */
         if (!(func = LLVMGetNamedFunction(comp_ctx->module, func_name))
-            && !(func = LLVMAddFunction(comp_ctx->module,
-                                        func_name, func_type))) {
+            && !(func =
+                     LLVMAddFunction(comp_ctx->module, func_name, func_type))) {
             aot_set_last_error("llvm add function failed.");
             return false;
         }
@@ -717,8 +719,8 @@ aot_compile_op_memory_grow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
     /* Call function aot_enlarge_memory() */
     param_values[0] = func_ctx->aot_inst;
     param_values[1] = delta;
-    if (!(ret_value = LLVMBuildCall(comp_ctx->builder, func,
-                                    param_values, 2, "call"))) {
+    if (!(ret_value = LLVMBuildCall(comp_ctx->builder, func, param_values, 2,
+                                    "call"))) {
         aot_set_last_error("llvm build call failed.");
         return false;
     }
@@ -726,9 +728,8 @@ aot_compile_op_memory_grow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
     BUILD_ICMP(LLVMIntUGT, ret_value, I8_ZERO, ret_value, "mem_grow_ret");
 
     /* ret_value = ret_value == true ? delta : pre_page_count */
-    if (!(ret_value = LLVMBuildSelect(comp_ctx->builder, ret_value,
-                                      mem_size, I32_NEG_ONE,
-                                      "mem_grow_ret"))) {
+    if (!(ret_value = LLVMBuildSelect(comp_ctx->builder, ret_value, mem_size,
+                                      I32_NEG_ONE, "mem_grow_ret"))) {
         aot_set_last_error("llvm build select failed.");
         return false;
     }
@@ -763,10 +764,9 @@ check_bulk_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         mem_base_addr = func_ctx->mem_info[0].mem_base_addr;
     }
     else {
-        if (!(mem_base_addr =
-                LLVMBuildLoad(comp_ctx->builder,
-                              func_ctx->mem_info[0].mem_base_addr,
-                              "mem_base"))) {
+        if (!(mem_base_addr = LLVMBuildLoad(comp_ctx->builder,
+                                            func_ctx->mem_info[0].mem_base_addr,
+                                            "mem_base"))) {
             aot_set_last_error("llvm build load failed.");
             goto fail;
         }
@@ -785,16 +785,14 @@ check_bulk_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         uint64 mem_offset = (uint64)LLVMConstIntGetZExtValue(offset);
         uint64 mem_len = (uint64)LLVMConstIntGetZExtValue(bytes);
         uint32 num_bytes_per_page =
-                comp_ctx->comp_data->memories[0].num_bytes_per_page;
+            comp_ctx->comp_data->memories[0].num_bytes_per_page;
         uint32 init_page_count =
-                comp_ctx->comp_data->memories[0].mem_init_page_count;
+            comp_ctx->comp_data->memories[0].mem_init_page_count;
         uint32 mem_data_size = num_bytes_per_page * init_page_count;
-        if (mem_data_size > 0
-            && mem_offset + mem_len <= mem_data_size) {
+        if (mem_data_size > 0 && mem_offset + mem_len <= mem_data_size) {
             /* inside memory space */
             /* maddr = mem_base_addr + moffset */
-            if (!(maddr = LLVMBuildInBoundsGEP(comp_ctx->builder,
-                                               mem_base_addr,
+            if (!(maddr = LLVMBuildInBoundsGEP(comp_ctx->builder, mem_base_addr,
                                                &offset, 1, "maddr"))) {
                 aot_set_last_error("llvm build add failed.");
                 goto fail;
@@ -807,10 +805,9 @@ check_bulk_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         mem_size = func_ctx->mem_info[0].mem_data_size_addr;
     }
     else {
-        if (!(mem_size =
-                LLVMBuildLoad(comp_ctx->builder,
-                              func_ctx->mem_info[0].mem_data_size_addr,
-                              "mem_size"))) {
+        if (!(mem_size = LLVMBuildLoad(comp_ctx->builder,
+                                       func_ctx->mem_info[0].mem_data_size_addr,
+                                       "mem_size"))) {
             aot_set_last_error("llvm build load failed.");
             goto fail;
         }
@@ -819,16 +816,17 @@ check_bulk_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     ADD_BASIC_BLOCK(check_succ, "check_succ");
     LLVMMoveBasicBlockAfter(check_succ, block_curr);
 
-    offset = LLVMBuildZExt(comp_ctx->builder, offset, I64_TYPE, "extend_offset");
+    offset =
+        LLVMBuildZExt(comp_ctx->builder, offset, I64_TYPE, "extend_offset");
     bytes = LLVMBuildZExt(comp_ctx->builder, bytes, I64_TYPE, "extend_len");
-    mem_size = LLVMBuildZExt(comp_ctx->builder, mem_size, I64_TYPE, "extend_size");
+    mem_size =
+        LLVMBuildZExt(comp_ctx->builder, mem_size, I64_TYPE, "extend_size");
 
     BUILD_OP(Add, offset, bytes, max_addr, "max_addr");
-    BUILD_ICMP(LLVMIntUGT, max_addr, mem_size, cmp,
-               "cmp_max_mem_addr");
+    BUILD_ICMP(LLVMIntUGT, max_addr, mem_size, cmp, "cmp_max_mem_addr");
     if (!aot_emit_exception(comp_ctx, func_ctx,
-                            EXCE_OUT_OF_BOUNDS_MEMORY_ACCESS,
-                            true, cmp, check_succ)) {
+                            EXCE_OUT_OF_BOUNDS_MEMORY_ACCESS, true, cmp,
+                            check_succ)) {
         goto fail;
     }
 
@@ -874,8 +872,8 @@ aot_compile_op_memory_init(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     param_values[2] = offset;
     param_values[3] = len;
     param_values[4] = dst;
-    if (!(ret_value = LLVMBuildCall(comp_ctx->builder, func,
-                                    param_values, 5, "call"))) {
+    if (!(ret_value = LLVMBuildCall(comp_ctx->builder, func, param_values, 5,
+                                    "call"))) {
         aot_set_last_error("llvm build call failed.");
         return false;
     }
@@ -888,14 +886,14 @@ aot_compile_op_memory_init(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     LLVMMoveBasicBlockAfter(mem_init_fail, block_curr);
     LLVMMoveBasicBlockAfter(init_success, block_curr);
 
-    if (!LLVMBuildCondBr(comp_ctx->builder, ret_value,
-                         init_success, mem_init_fail)) {
+    if (!LLVMBuildCondBr(comp_ctx->builder, ret_value, init_success,
+                         mem_init_fail)) {
         aot_set_last_error("llvm build cond br failed.");
         goto fail;
     }
 
     /* If memory.init failed, return this function
-        so the runtime can catch the exception */
+       so the runtime can catch the exception */
     LLVMPositionBuilderAtEnd(comp_ctx->builder, mem_init_fail);
     if (!aot_build_zero_function_ret(comp_ctx, func_ctx, aot_func_type)) {
         goto fail;
@@ -927,8 +925,8 @@ aot_compile_op_data_drop(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     /* Call function aot_data_drop() */
     param_values[0] = func_ctx->aot_inst;
     param_values[1] = seg;
-    if (!(ret_value = LLVMBuildCall(comp_ctx->builder, func,
-                                    param_values, 2, "call"))) {
+    if (!(ret_value = LLVMBuildCall(comp_ctx->builder, func, param_values, 2,
+                                    "call"))) {
         aot_set_last_error("llvm build call failed.");
         return false;
     }
@@ -947,18 +945,16 @@ aot_compile_op_memory_copy(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
     POP_I32(src);
     POP_I32(dst);
 
-    if (!(src_addr =
-            check_bulk_memory_overflow(comp_ctx, func_ctx, src, len)))
+    if (!(src_addr = check_bulk_memory_overflow(comp_ctx, func_ctx, src, len)))
         return false;
 
-    if (!(dst_addr =
-            check_bulk_memory_overflow(comp_ctx, func_ctx, dst, len)))
+    if (!(dst_addr = check_bulk_memory_overflow(comp_ctx, func_ctx, dst, len)))
         return false;
 
     /* TODO: lookup func ptr of "memmove" to call for XIP mode */
 
-    if (!(res = LLVMBuildMemMove(comp_ctx->builder, dst_addr, 1,
-                                 src_addr, 1, len))) {
+    if (!(res = LLVMBuildMemMove(comp_ctx->builder, dst_addr, 1, src_addr, 1,
+                                 len))) {
         aot_set_last_error("llvm build memmove failed.");
         return false;
     }
@@ -976,20 +972,18 @@ aot_compile_op_memory_fill(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
     POP_I32(val);
     POP_I32(dst);
 
-    if (!(dst_addr =
-            check_bulk_memory_overflow(comp_ctx, func_ctx, dst, len)))
+    if (!(dst_addr = check_bulk_memory_overflow(comp_ctx, func_ctx, dst, len)))
         return false;
 
-    if (!(val = LLVMBuildIntCast2(comp_ctx->builder, val, INT8_TYPE,
-                                  true, "mem_set_value"))) {
+    if (!(val = LLVMBuildIntCast2(comp_ctx->builder, val, INT8_TYPE, true,
+                                  "mem_set_value"))) {
         aot_set_last_error("llvm build int cast2 failed.");
         return false;
     }
 
     /* TODO: lookup func ptr of "memset" to call for XIP mode */
 
-    if (!(res = LLVMBuildMemSet(comp_ctx->builder, dst_addr,
-                                val, len, 1))) {
+    if (!(res = LLVMBuildMemSet(comp_ctx->builder, dst_addr, val, len, 1))) {
         aot_set_last_error("llvm build memset failed.");
         return false;
     }
@@ -1001,11 +995,9 @@ fail:
 
 #if WASM_ENABLE_SHARED_MEMORY != 0
 bool
-aot_compile_op_atomic_rmw(AOTCompContext *comp_ctx,
-                          AOTFuncContext *func_ctx,
-                          uint8 atomic_op, uint8 op_type,
-                          uint32 align, uint32 offset,
-                          uint32 bytes)
+aot_compile_op_atomic_rmw(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                          uint8 atomic_op, uint8 op_type, uint32 align,
+                          uint32 offset, uint32 bytes)
 {
     LLVMValueRef maddr, value, result;
 
@@ -1042,25 +1034,24 @@ aot_compile_op_atomic_rmw(AOTCompContext *comp_ctx,
             break;
     }
 
-    if (!(result =
-        LLVMBuildAtomicRMW(comp_ctx->builder,
-                           atomic_op, maddr, value,
-                           LLVMAtomicOrderingSequentiallyConsistent, false))) {
+    if (!(result = LLVMBuildAtomicRMW(
+              comp_ctx->builder, atomic_op, maddr, value,
+              LLVMAtomicOrderingSequentiallyConsistent, false))) {
         goto fail;
     }
 
     LLVMSetVolatile(result, true);
 
     if (op_type == VALUE_TYPE_I32) {
-        if (!(result = LLVMBuildZExt(comp_ctx->builder, result,
-                                     I32_TYPE, "result_i32"))) {
+        if (!(result = LLVMBuildZExt(comp_ctx->builder, result, I32_TYPE,
+                                     "result_i32"))) {
             goto fail;
         }
         PUSH_I32(result);
     }
     else {
-        if (!(result = LLVMBuildZExt(comp_ctx->builder, result,
-                                     I64_TYPE, "result_i64"))) {
+        if (!(result = LLVMBuildZExt(comp_ctx->builder, result, I64_TYPE,
+                                     "result_i64"))) {
             goto fail;
         }
         PUSH_I64(result);
@@ -1073,9 +1064,8 @@ fail:
 
 bool
 aot_compile_op_atomic_cmpxchg(AOTCompContext *comp_ctx,
-                              AOTFuncContext *func_ctx,
-                              uint8 op_type, uint32 align,
-                              uint32 offset, uint32 bytes)
+                              AOTFuncContext *func_ctx, uint8 op_type,
+                              uint32 align, uint32 offset, uint32 bytes)
 {
     LLVMValueRef maddr, value, expect, result;
 
@@ -1120,34 +1110,32 @@ aot_compile_op_atomic_cmpxchg(AOTCompContext *comp_ctx,
             break;
     }
 
-    if (!(result =
-        LLVMBuildAtomicCmpXchg(comp_ctx->builder, maddr, expect, value,
-                               LLVMAtomicOrderingSequentiallyConsistent,
-                               LLVMAtomicOrderingSequentiallyConsistent,
-                               false))) {
+    if (!(result = LLVMBuildAtomicCmpXchg(
+              comp_ctx->builder, maddr, expect, value,
+              LLVMAtomicOrderingSequentiallyConsistent,
+              LLVMAtomicOrderingSequentiallyConsistent, false))) {
         goto fail;
     }
 
     LLVMSetVolatile(result, true);
 
     /* CmpXchg return {i32, i1} structure,
-        we need to extrack the previous_value from the structure */
-    if (!(result =
-        LLVMBuildExtractValue(comp_ctx->builder,
-                              result, 0, "previous_value"))) {
+       we need to extrack the previous_value from the structure */
+    if (!(result = LLVMBuildExtractValue(comp_ctx->builder, result, 0,
+                                         "previous_value"))) {
         goto fail;
     }
 
     if (op_type == VALUE_TYPE_I32) {
-        if (!(result = LLVMBuildZExt(comp_ctx->builder, result,
-                                     I32_TYPE, "result_i32"))) {
+        if (!(result = LLVMBuildZExt(comp_ctx->builder, result, I32_TYPE,
+                                     "result_i32"))) {
             goto fail;
         }
         PUSH_I32(result);
     }
     else {
-        if (!(result = LLVMBuildZExt(comp_ctx->builder, result,
-                                     I64_TYPE, "result_i64"))) {
+        if (!(result = LLVMBuildZExt(comp_ctx->builder, result, I64_TYPE,
+                                     "result_i64"))) {
             goto fail;
         }
         PUSH_I64(result);
@@ -1160,8 +1148,8 @@ fail:
 
 bool
 aot_compile_op_atomic_wait(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                           uint8 op_type, uint32 align,
-                           uint32 offset, uint32 bytes)
+                           uint8 op_type, uint32 align, uint32 offset,
+                           uint32 bytes)
 {
     LLVMValueRef maddr, value, timeout, expect, cmp;
     LLVMValueRef param_values[5], ret_value, func, is_wait64;
@@ -1174,9 +1162,8 @@ aot_compile_op_atomic_wait(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     if (op_type == VALUE_TYPE_I32) {
         POP_I32(expect);
         is_wait64 = I8_CONST(false);
-        if (!(expect =
-            LLVMBuildZExt(comp_ctx->builder, expect,
-                          I64_TYPE, "expect_i64"))) {
+        if (!(expect = LLVMBuildZExt(comp_ctx->builder, expect, I64_TYPE,
+                                     "expect_i64"))) {
             goto fail;
         }
     }
@@ -1208,8 +1195,8 @@ aot_compile_op_atomic_wait(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     param_values[2] = expect;
     param_values[3] = timeout;
     param_values[4] = is_wait64;
-    if (!(ret_value = LLVMBuildCall(comp_ctx->builder, func,
-                                    param_values, 5, "call"))) {
+    if (!(ret_value = LLVMBuildCall(comp_ctx->builder, func, param_values, 5,
+                                    "call"))) {
         aot_set_last_error("llvm build call failed.");
         return false;
     }
@@ -1222,14 +1209,13 @@ aot_compile_op_atomic_wait(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     LLVMMoveBasicBlockAfter(wait_fail, block_curr);
     LLVMMoveBasicBlockAfter(wait_success, block_curr);
 
-    if (!LLVMBuildCondBr(comp_ctx->builder, cmp,
-                         wait_success, wait_fail)) {
+    if (!LLVMBuildCondBr(comp_ctx->builder, cmp, wait_success, wait_fail)) {
         aot_set_last_error("llvm build cond br failed.");
         goto fail;
     }
 
     /* If atomic wait failed, return this function
-        so the runtime can catch the exception */
+       so the runtime can catch the exception */
     LLVMPositionBuilderAtEnd(comp_ctx->builder, wait_fail);
     if (!aot_build_zero_function_ret(comp_ctx, func_ctx, aot_func_type)) {
         goto fail;
@@ -1246,8 +1232,8 @@ fail:
 
 bool
 aot_compiler_op_atomic_notify(AOTCompContext *comp_ctx,
-                              AOTFuncContext *func_ctx,
-                              uint32 align, uint32 offset, uint32 bytes)
+                              AOTFuncContext *func_ctx, uint32 align,
+                              uint32 offset, uint32 bytes)
 {
     LLVMValueRef maddr, value, count;
     LLVMValueRef param_values[3], ret_value, func;
@@ -1272,8 +1258,8 @@ aot_compiler_op_atomic_notify(AOTCompContext *comp_ctx,
     param_values[0] = func_ctx->aot_inst;
     param_values[1] = maddr;
     param_values[2] = count;
-    if (!(ret_value = LLVMBuildCall(comp_ctx->builder, func,
-                                    param_values, 3, "call"))) {
+    if (!(ret_value = LLVMBuildCall(comp_ctx->builder, func, param_values, 3,
+                                    "call"))) {
         aot_set_last_error("llvm build call failed.");
         return false;
     }

--- a/core/iwasm/compilation/aot_emit_memory.h
+++ b/core/iwasm/compilation/aot_emit_memory.h
@@ -17,13 +17,13 @@ extern "C" {
 
 bool
 aot_compile_op_i32_load(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                        uint32 align, uint32 offset, uint32 bytes,
-                        bool sign, bool atomic);
+                        uint32 align, uint32 offset, uint32 bytes, bool sign,
+                        bool atomic);
 
 bool
 aot_compile_op_i64_load(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                        uint32 align, uint32 offset, uint32 bytes,
-                        bool sign, bool atomic);
+                        uint32 align, uint32 offset, uint32 bytes, bool sign,
+                        bool atomic);
 
 bool
 aot_compile_op_f32_load(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
@@ -35,11 +35,13 @@ aot_compile_op_f64_load(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
 bool
 aot_compile_op_i32_store(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                         uint32 align, uint32 offset, uint32 bytes, bool atomic);
+                         uint32 align, uint32 offset, uint32 bytes,
+                         bool atomic);
 
 bool
 aot_compile_op_i64_store(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                         uint32 align, uint32 offset, uint32 bytes, bool atomic);
+                         uint32 align, uint32 offset, uint32 bytes,
+                         bool atomic);
 
 bool
 aot_compile_op_f32_store(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
@@ -77,27 +79,24 @@ aot_compile_op_memory_fill(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx);
 
 #if WASM_ENABLE_SHARED_MEMORY != 0
 bool
-aot_compile_op_atomic_rmw(AOTCompContext *comp_ctx,
-                          AOTFuncContext *func_ctx,
-                          uint8 atomic_op, uint8 op_type,
-                          uint32 align, uint32 offset,
-                          uint32 bytes);
+aot_compile_op_atomic_rmw(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                          uint8 atomic_op, uint8 op_type, uint32 align,
+                          uint32 offset, uint32 bytes);
 
 bool
 aot_compile_op_atomic_cmpxchg(AOTCompContext *comp_ctx,
-                              AOTFuncContext *func_ctx,
-                              uint8 op_type, uint32 align,
-                              uint32 offset, uint32 bytes);
+                              AOTFuncContext *func_ctx, uint8 op_type,
+                              uint32 align, uint32 offset, uint32 bytes);
 
 bool
 aot_compile_op_atomic_wait(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                           uint8 op_type, uint32 align,
-                           uint32 offset, uint32 bytes);
+                           uint8 op_type, uint32 align, uint32 offset,
+                           uint32 bytes);
 
 bool
 aot_compiler_op_atomic_notify(AOTCompContext *comp_ctx,
-                              AOTFuncContext *func_ctx,
-                              uint32 align, uint32 offset, uint32 bytes);
+                              AOTFuncContext *func_ctx, uint32 align,
+                              uint32 offset, uint32 bytes);
 #endif
 
 #ifdef __cplusplus
@@ -105,4 +104,3 @@ aot_compiler_op_atomic_notify(AOTCompContext *comp_ctx,
 #endif
 
 #endif /* end of _AOT_EMIT_MEMORY_H_ */
-

--- a/core/iwasm/compilation/aot_emit_numberic.h
+++ b/core/iwasm/compilation/aot_emit_numberic.h
@@ -31,12 +31,14 @@ bool
 aot_compile_op_i64_popcnt(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx);
 
 bool
-aot_compile_op_i32_arithmetic(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                              IntArithmetic arith_op, uint8 **p_frame_ip);
+aot_compile_op_i32_arithmetic(AOTCompContext *comp_ctx,
+                              AOTFuncContext *func_ctx, IntArithmetic arith_op,
+                              uint8 **p_frame_ip);
 
 bool
-aot_compile_op_i64_arithmetic(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                              IntArithmetic arith_op, uint8 **p_frame_ip);
+aot_compile_op_i64_arithmetic(AOTCompContext *comp_ctx,
+                              AOTFuncContext *func_ctx, IntArithmetic arith_op,
+                              uint8 **p_frame_ip);
 
 bool
 aot_compile_op_i32_bitwise(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
@@ -63,11 +65,13 @@ aot_compile_op_f64_math(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                         FloatMath math_op);
 
 bool
-aot_compile_op_f32_arithmetic(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+aot_compile_op_f32_arithmetic(AOTCompContext *comp_ctx,
+                              AOTFuncContext *func_ctx,
                               FloatArithmetic arith_op);
 
 bool
-aot_compile_op_f64_arithmetic(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+aot_compile_op_f64_arithmetic(AOTCompContext *comp_ctx,
+                              AOTFuncContext *func_ctx,
                               FloatArithmetic arith_op);
 
 bool
@@ -81,4 +85,3 @@ aot_compile_op_f64_copysign(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx);
 #endif
 
 #endif /* end of _AOT_EMIT_NUMBERIC_H_ */
-

--- a/core/iwasm/compilation/aot_emit_parametric.c
+++ b/core/iwasm/compilation/aot_emit_parametric.c
@@ -7,8 +7,7 @@
 
 static bool
 pop_value_from_wasm_stack(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                          LLVMValueRef *p_value,
-                          bool is_32, uint8 *p_type)
+                          LLVMValueRef *p_value, bool is_32, uint8 *p_type)
 {
     AOTValue *aot_value;
     uint8 type;
@@ -22,14 +21,14 @@ pop_value_from_wasm_stack(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         return false;
     }
 
-    aot_value = aot_value_stack_pop
-        (&func_ctx->block_stack.block_list_end->value_stack);
+    aot_value =
+        aot_value_stack_pop(&func_ctx->block_stack.block_list_end->value_stack);
     type = aot_value->type;
 
     if (aot_value->type == VALUE_TYPE_I1) {
         if (!(aot_value->value =
-                    LLVMBuildZExt(comp_ctx->builder, aot_value->value,
-                                  I32_TYPE, "val_s_ext"))) {
+                  LLVMBuildZExt(comp_ctx->builder, aot_value->value, I32_TYPE,
+                                "val_s_ext"))) {
             aot_set_last_error("llvm build sign ext failed.");
             return false;
         }
@@ -55,15 +54,13 @@ pop_value_from_wasm_stack(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     }
 
     /* !is_32: i64, f64 */
-    if (!is_32
-        && !(type == VALUE_TYPE_I64 || type == VALUE_TYPE_F64)) {
+    if (!is_32 && !(type == VALUE_TYPE_I64 || type == VALUE_TYPE_F64)) {
         aot_set_last_error("invalid WASM stack data type.");
         return false;
     }
 
     return true;
 }
-
 
 bool
 aot_compile_op_drop(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
@@ -84,8 +81,10 @@ aot_compile_op_select(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
     POP_COND(cond);
 
-    if (!pop_value_from_wasm_stack(comp_ctx, func_ctx, &val2, is_select_32, &val2_type)
-        || !pop_value_from_wasm_stack(comp_ctx, func_ctx, &val1, is_select_32, &val1_type))
+    if (!pop_value_from_wasm_stack(comp_ctx, func_ctx, &val2, is_select_32,
+                                   &val2_type)
+        || !pop_value_from_wasm_stack(comp_ctx, func_ctx, &val1, is_select_32,
+                                      &val1_type))
         return false;
 
     if (val1_type != val2_type) {
@@ -93,9 +92,8 @@ aot_compile_op_select(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         return false;
     }
 
-    if (!(selected = LLVMBuildSelect(comp_ctx->builder,
-                                     cond, val1, val2,
-                                     "select"))) {
+    if (!(selected =
+              LLVMBuildSelect(comp_ctx->builder, cond, val1, val2, "select"))) {
         aot_set_last_error("llvm build select failed.");
         return false;
     }
@@ -107,4 +105,3 @@ aot_compile_op_select(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 fail:
     return false;
 }
-

--- a/core/iwasm/compilation/aot_emit_parametric.h
+++ b/core/iwasm/compilation/aot_emit_parametric.h
@@ -18,12 +18,10 @@ aot_compile_op_drop(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
 bool
 aot_compile_op_select(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                    bool is_select_32);
-
+                      bool is_select_32);
 
 #ifdef __cplusplus
 } /* end of extern "C" */
 #endif
 
 #endif /* end of _AOT_EMIT_PARAMETRIC_H_ */
-

--- a/core/iwasm/compilation/aot_emit_table.c
+++ b/core/iwasm/compilation/aot_emit_table.c
@@ -7,11 +7,9 @@
 #include "aot_emit_exception.h"
 #include "../aot/aot_runtime.h"
 
-
 uint64
 get_tbl_inst_offset(const AOTCompContext *comp_ctx,
-                    const AOTFuncContext *func_ctx,
-                    uint32 tbl_idx)
+                    const AOTFuncContext *func_ctx, uint32 tbl_idx)
 {
     uint64 offset = 0, i = 0;
     AOTImportTable *imp_tbls = comp_ctx->comp_data->import_tables;
@@ -19,9 +17,9 @@ get_tbl_inst_offset(const AOTCompContext *comp_ctx,
 
     /* from the head of AOTModuleInstance */
     offset =
-      offsetof(AOTModuleInstance, global_table_data.bytes)
-      + (uint64)comp_ctx->comp_data->memory_count * sizeof(AOTMemoryInstance)
-      + comp_ctx->comp_data->global_data_size;
+        offsetof(AOTModuleInstance, global_table_data.bytes)
+        + (uint64)comp_ctx->comp_data->memory_count * sizeof(AOTMemoryInstance)
+        + comp_ctx->comp_data->global_data_size;
 
     while (i < tbl_idx && i < comp_ctx->comp_data->import_table_count) {
         offset += offsetof(AOTTableInstance, data);
@@ -49,14 +47,13 @@ get_tbl_inst_offset(const AOTCompContext *comp_ctx,
 #if WASM_ENABLE_REF_TYPES != 0
 
 LLVMValueRef
-aot_compile_get_tbl_inst(AOTCompContext *comp_ctx,
-                         AOTFuncContext *func_ctx,
+aot_compile_get_tbl_inst(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                          uint32 tbl_idx)
 {
     LLVMValueRef offset, tbl_inst;
 
     if (!(offset =
-            I64_CONST(get_tbl_inst_offset(comp_ctx, func_ctx, tbl_idx)))) {
+              I64_CONST(get_tbl_inst_offset(comp_ctx, func_ctx, tbl_idx)))) {
         HANDLE_FAILURE("LLVMConstInt");
         goto fail;
     }
@@ -73,8 +70,7 @@ fail:
 }
 
 bool
-aot_compile_op_elem_drop(AOTCompContext *comp_ctx,
-                         AOTFuncContext *func_ctx,
+aot_compile_op_elem_drop(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                          uint32 tbl_seg_idx)
 {
     LLVMTypeRef param_types[2], ret_type, func_type, func_ptr_type;
@@ -95,7 +91,7 @@ aot_compile_op_elem_drop(AOTCompContext *comp_ctx,
 
     /* "" means return void */
     if (!(ret_value =
-            LLVMBuildCall(comp_ctx->builder, func, param_values, 2, ""))) {
+              LLVMBuildCall(comp_ctx->builder, func, param_values, 2, ""))) {
         HANDLE_FAILURE("LLVMBuildCall");
         goto fail;
     }
@@ -106,10 +102,8 @@ fail:
 }
 
 static bool
-aot_check_table_access(AOTCompContext *comp_ctx,
-                       AOTFuncContext *func_ctx,
-                       uint32 tbl_idx,
-                       LLVMValueRef elem_idx)
+aot_check_table_access(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                       uint32 tbl_idx, LLVMValueRef elem_idx)
 {
     LLVMValueRef offset, tbl_sz, cmp_elem_idx;
     LLVMBasicBlockRef check_elem_idx_succ;
@@ -147,7 +141,7 @@ aot_check_table_access(AOTCompContext *comp_ctx,
 
     /* Throw exception if elem index >= table size */
     if (!(check_elem_idx_succ = LLVMAppendBasicBlockInContext(
-            comp_ctx->context, func_ctx->func, "check_elem_idx_succ"))) {
+              comp_ctx->context, func_ctx->func, "check_elem_idx_succ"))) {
         aot_set_last_error("llvm add basic block failed.");
         goto fail;
     }
@@ -166,8 +160,7 @@ fail:
 }
 
 bool
-aot_compile_op_table_get(AOTCompContext *comp_ctx,
-                         AOTFuncContext *func_ctx,
+aot_compile_op_table_get(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                          uint32 tbl_idx)
 {
     LLVMValueRef elem_idx, offset, table_elem, func_idx;
@@ -198,14 +191,14 @@ aot_compile_op_table_get(AOTCompContext *comp_ctx,
     }
 
     /* Load function index */
-    if (!(table_elem = LLVMBuildGEP(comp_ctx->builder, table_elem, &elem_idx,
-                                    1, "table_elem"))) {
+    if (!(table_elem = LLVMBuildGEP(comp_ctx->builder, table_elem, &elem_idx, 1,
+                                    "table_elem"))) {
         HANDLE_FAILURE("LLVMBuildNUWAdd");
         goto fail;
     }
 
     if (!(func_idx =
-            LLVMBuildLoad(comp_ctx->builder, table_elem, "func_idx"))) {
+              LLVMBuildLoad(comp_ctx->builder, table_elem, "func_idx"))) {
         HANDLE_FAILURE("LLVMBuildLoad");
         goto fail;
     }
@@ -218,8 +211,7 @@ fail:
 }
 
 bool
-aot_compile_op_table_set(AOTCompContext *comp_ctx,
-                         AOTFuncContext *func_ctx,
+aot_compile_op_table_set(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                          uint32 tbl_idx)
 {
     LLVMValueRef val, elem_idx, offset, table_elem;
@@ -251,8 +243,8 @@ aot_compile_op_table_set(AOTCompContext *comp_ctx,
     }
 
     /* Load function index */
-    if (!(table_elem = LLVMBuildGEP(comp_ctx->builder, table_elem, &elem_idx,
-                                    1, "table_elem"))) {
+    if (!(table_elem = LLVMBuildGEP(comp_ctx->builder, table_elem, &elem_idx, 1,
+                                    "table_elem"))) {
         HANDLE_FAILURE("LLVMBuildGEP");
         goto fail;
     }
@@ -268,10 +260,8 @@ fail:
 }
 
 bool
-aot_compile_op_table_init(AOTCompContext *comp_ctx,
-                          AOTFuncContext *func_ctx,
-                          uint32 tbl_idx,
-                          uint32 tbl_seg_idx)
+aot_compile_op_table_init(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                          uint32 tbl_idx, uint32 tbl_seg_idx)
 
 {
     LLVMValueRef func, param_values[6], value;
@@ -318,10 +308,8 @@ fail:
 }
 
 bool
-aot_compile_op_table_copy(AOTCompContext *comp_ctx,
-                          AOTFuncContext *func_ctx,
-                          uint32 src_tbl_idx,
-                          uint32 dst_tbl_idx)
+aot_compile_op_table_copy(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                          uint32 src_tbl_idx, uint32 dst_tbl_idx)
 {
     LLVMTypeRef param_types[6], ret_type, func_type, func_ptr_type;
     LLVMValueRef func, param_values[6], value;
@@ -367,8 +355,7 @@ fail:
 }
 
 bool
-aot_compile_op_table_size(AOTCompContext *comp_ctx,
-                          AOTFuncContext *func_ctx,
+aot_compile_op_table_size(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                           uint32 tbl_idx)
 {
     LLVMValueRef offset, tbl_sz;
@@ -404,8 +391,7 @@ fail:
 }
 
 bool
-aot_compile_op_table_grow(AOTCompContext *comp_ctx,
-                          AOTFuncContext *func_ctx,
+aot_compile_op_table_grow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                           uint32 tbl_idx)
 {
     LLVMTypeRef param_types[4], ret_type, func_type, func_ptr_type;
@@ -445,8 +431,7 @@ fail:
 }
 
 bool
-aot_compile_op_table_fill(AOTCompContext *comp_ctx,
-                          AOTFuncContext *func_ctx,
+aot_compile_op_table_fill(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                           uint32 tbl_idx)
 {
     LLVMTypeRef param_types[5], ret_type, func_type, func_ptr_type;

--- a/core/iwasm/compilation/aot_emit_table.h
+++ b/core/iwasm/compilation/aot_emit_table.h
@@ -14,55 +14,43 @@ extern "C" {
 #endif
 
 bool
-aot_compile_op_elem_drop(AOTCompContext *comp_ctx,
-                         AOTFuncContext *func_ctx,
+aot_compile_op_elem_drop(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                          uint32 tbl_seg_idx);
 
 bool
-aot_compile_op_table_get(AOTCompContext *comp_ctx,
-                         AOTFuncContext *func_ctx,
+aot_compile_op_table_get(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                          uint32 tbl_idx);
 
 bool
-aot_compile_op_table_set(AOTCompContext *comp_ctx,
-                         AOTFuncContext *func_ctx,
+aot_compile_op_table_set(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                          uint32 tbl_idx);
 
 bool
-aot_compile_op_table_init(AOTCompContext *comp_ctx,
-                          AOTFuncContext *func_ctx,
-                          uint32 tbl_idx,
-                          uint32 tbl_seg_idx);
+aot_compile_op_table_init(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                          uint32 tbl_idx, uint32 tbl_seg_idx);
 
 bool
-aot_compile_op_table_copy(AOTCompContext *comp_ctx,
-                          AOTFuncContext *func_ctx,
-                          uint32 src_tbl_idx,
-                          uint32 dst_tbl_idx);
+aot_compile_op_table_copy(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                          uint32 src_tbl_idx, uint32 dst_tbl_idx);
 
 bool
-aot_compile_op_table_size(AOTCompContext *comp_ctx,
-                          AOTFuncContext *func_ctx,
+aot_compile_op_table_size(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                           uint32 tbl_idx);
 
 bool
-aot_compile_op_table_grow(AOTCompContext *comp_ctx,
-                          AOTFuncContext *func_ctx,
+aot_compile_op_table_grow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                           uint32 tbl_idx);
 
 bool
-aot_compile_op_table_fill(AOTCompContext *comp_ctx,
-                          AOTFuncContext *func_ctx,
+aot_compile_op_table_fill(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                           uint32 tbl_idx);
 
 uint64
 get_tbl_inst_offset(const AOTCompContext *comp_ctx,
-                    const AOTFuncContext *func_ctx,
-                    uint32 tbl_idx);
+                    const AOTFuncContext *func_ctx, uint32 tbl_idx);
 
 LLVMValueRef
-aot_compile_get_tbl_inst(AOTCompContext *comp_ctx,
-                         AOTFuncContext *func_ctx,
+aot_compile_get_tbl_inst(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                          uint32 tbl_idx);
 
 #ifdef __cplusplus

--- a/core/iwasm/compilation/aot_emit_variable.c
+++ b/core/iwasm/compilation/aot_emit_variable.c
@@ -7,13 +7,14 @@
 #include "aot_emit_exception.h"
 #include "../aot/aot_runtime.h"
 
-#define CHECK_LOCAL(idx) do {                               \
-    if (idx >= func_ctx->aot_func->func_type->param_count   \
-               + func_ctx->aot_func->local_count) {         \
-      aot_set_last_error("local index out of range");       \
-      return false;                                         \
-    }                                                       \
-  } while (0)
+#define CHECK_LOCAL(idx)                                      \
+    do {                                                      \
+        if (idx >= func_ctx->aot_func->func_type->param_count \
+                       + func_ctx->aot_func->local_count) {   \
+            aot_set_last_error("local index out of range");   \
+            return false;                                     \
+        }                                                     \
+    } while (0)
 
 static uint8
 get_local_type(AOTFuncContext *func_ctx, uint32 local_idx)
@@ -21,8 +22,8 @@ get_local_type(AOTFuncContext *func_ctx, uint32 local_idx)
     AOTFunc *aot_func = func_ctx->aot_func;
     uint32 param_count = aot_func->func_type->param_count;
     return local_idx < param_count
-           ? aot_func->func_type->types[local_idx]
-           : aot_func->local_types[local_idx - param_count];
+               ? aot_func->func_type->types[local_idx]
+               : aot_func->local_types[local_idx - param_count];
 }
 
 bool
@@ -36,8 +37,7 @@ aot_compile_op_get_local(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     CHECK_LOCAL(local_idx);
 
     snprintf(name, sizeof(name), "%s%d%s", "local", local_idx, "#");
-    if (!(value = LLVMBuildLoad(comp_ctx->builder,
-                                func_ctx->locals[local_idx],
+    if (!(value = LLVMBuildLoad(comp_ctx->builder, func_ctx->locals[local_idx],
                                 name))) {
         aot_set_last_error("llvm build load fail");
         return false;
@@ -45,7 +45,8 @@ aot_compile_op_get_local(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
     PUSH(value, get_local_type(func_ctx, local_idx));
 
-    aot_value = func_ctx->block_stack.block_list_end->value_stack.value_list_end;
+    aot_value =
+        func_ctx->block_stack.block_list_end->value_stack.value_list_end;
     aot_value->is_local = true;
     aot_value->local_idx = local_idx;
     return true;
@@ -64,8 +65,7 @@ aot_compile_op_set_local(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
     POP(value, get_local_type(func_ctx, local_idx));
 
-    if (!LLVMBuildStore(comp_ctx->builder,
-                        value,
+    if (!LLVMBuildStore(comp_ctx->builder, value,
                         func_ctx->locals[local_idx])) {
         aot_set_last_error("llvm build store fail");
         return false;
@@ -91,8 +91,7 @@ aot_compile_op_tee_local(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
     POP(value, type);
 
-    if (!LLVMBuildStore(comp_ctx->builder,
-                        value,
+    if (!LLVMBuildStore(comp_ctx->builder, value,
                         func_ctx->locals[local_idx])) {
         aot_set_last_error("llvm build store fail");
         return false;
@@ -128,15 +127,16 @@ compile_global(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         global_type = comp_data->import_globals[global_idx].type;
     }
     else {
-        global_offset = global_base_offset
+        global_offset =
+            global_base_offset
             + comp_data->globals[global_idx - import_global_count].data_offset;
-        global_type =
-            comp_data->globals[global_idx - import_global_count].type;
+        global_type = comp_data->globals[global_idx - import_global_count].type;
     }
 
     offset = I32_CONST(global_offset);
-    if (!(global_ptr = LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->aot_inst,
-                                            &offset, 1, "global_ptr_tmp"))) {
+    if (!(global_ptr =
+              LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->aot_inst,
+                                   &offset, 1, "global_ptr_tmp"))) {
         aot_set_last_error("llvm build in bounds gep failed.");
         return false;
     }
@@ -164,15 +164,15 @@ compile_global(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             break;
     }
 
-    if (!(global_ptr = LLVMBuildBitCast(comp_ctx->builder, global_ptr,
-                                        ptr_type, "global_ptr"))) {
+    if (!(global_ptr = LLVMBuildBitCast(comp_ctx->builder, global_ptr, ptr_type,
+                                        "global_ptr"))) {
         aot_set_last_error("llvm build bit cast failed.");
         return false;
     }
 
     if (!is_set) {
-        if (!(global = LLVMBuildLoad(comp_ctx->builder,
-                                     global_ptr, "global"))) {
+        if (!(global =
+                  LLVMBuildLoad(comp_ctx->builder, global_ptr, "global"))) {
             aot_set_last_error("llvm build load failed.");
             return false;
         }
@@ -184,61 +184,56 @@ compile_global(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         POP(global, global_type);
 
         if (is_aux_stack && comp_ctx->enable_aux_stack_check) {
-            LLVMBasicBlockRef block_curr = LLVMGetInsertBlock(comp_ctx->builder);
+            LLVMBasicBlockRef block_curr =
+                LLVMGetInsertBlock(comp_ctx->builder);
             LLVMBasicBlockRef check_overflow_succ, check_underflow_succ;
             LLVMValueRef cmp;
 
             /* Add basic blocks */
-            if (!(check_overflow_succ =
-                        LLVMAppendBasicBlockInContext(comp_ctx->context,
-                                                      func_ctx->func,
-                                                      "check_overflow_succ"))) {
+            if (!(check_overflow_succ = LLVMAppendBasicBlockInContext(
+                      comp_ctx->context, func_ctx->func,
+                      "check_overflow_succ"))) {
                 aot_set_last_error("llvm add basic block failed.");
                 return false;
             }
             LLVMMoveBasicBlockAfter(check_overflow_succ, block_curr);
 
-            if (!(check_underflow_succ =
-                        LLVMAppendBasicBlockInContext(comp_ctx->context,
-                                                      func_ctx->func,
-                                                      "check_underflow_succ"))) {
+            if (!(check_underflow_succ = LLVMAppendBasicBlockInContext(
+                      comp_ctx->context, func_ctx->func,
+                      "check_underflow_succ"))) {
                 aot_set_last_error("llvm add basic block failed.");
                 return false;
             }
             LLVMMoveBasicBlockAfter(check_underflow_succ, check_overflow_succ);
 
             /* Check aux stack overflow */
-            if (!(cmp = LLVMBuildICmp(comp_ctx->builder, LLVMIntULE,
-                                      global, func_ctx->aux_stack_bound,
-                                      "cmp"))) {
+            if (!(cmp = LLVMBuildICmp(comp_ctx->builder, LLVMIntULE, global,
+                                      func_ctx->aux_stack_bound, "cmp"))) {
                 aot_set_last_error("llvm build icmp failed.");
                 return false;
             }
-            if (!aot_emit_exception(comp_ctx, func_ctx,
-                                    EXCE_AUX_STACK_OVERFLOW,
+            if (!aot_emit_exception(comp_ctx, func_ctx, EXCE_AUX_STACK_OVERFLOW,
                                     true, cmp, check_overflow_succ)) {
                 return false;
             }
 
             /* Check aux stack underflow */
             LLVMPositionBuilderAtEnd(comp_ctx->builder, check_overflow_succ);
-            if (!(cmp = LLVMBuildICmp(comp_ctx->builder, LLVMIntUGT,
-                                      global, func_ctx->aux_stack_bottom,
-                                      "cmp"))) {
+            if (!(cmp = LLVMBuildICmp(comp_ctx->builder, LLVMIntUGT, global,
+                                      func_ctx->aux_stack_bottom, "cmp"))) {
                 aot_set_last_error("llvm build icmp failed.");
                 return false;
             }
             if (!aot_emit_exception(comp_ctx, func_ctx,
-                                    EXCE_AUX_STACK_UNDERFLOW,
-                                    true, cmp, check_underflow_succ)) {
+                                    EXCE_AUX_STACK_UNDERFLOW, true, cmp,
+                                    check_underflow_succ)) {
                 return false;
             }
 
             LLVMPositionBuilderAtEnd(comp_ctx->builder, check_underflow_succ);
         }
 
-        if (!(res = LLVMBuildStore(comp_ctx->builder,
-                                   global, global_ptr))) {
+        if (!(res = LLVMBuildStore(comp_ctx->builder, global, global_ptr))) {
             aot_set_last_error("llvm build store failed.");
             return false;
         }
@@ -264,4 +259,3 @@ aot_compile_op_set_global(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 {
     return compile_global(comp_ctx, func_ctx, global_idx, true, is_aux_stack);
 }
-

--- a/core/iwasm/compilation/aot_emit_variable.h
+++ b/core/iwasm/compilation/aot_emit_variable.h
@@ -37,4 +37,3 @@ aot_compile_op_set_global(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 #endif
 
 #endif /* end of _AOT_EMIT_VARIABLE_H_ */
-

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -57,7 +57,7 @@ aot_add_llvm_func(AOTCompContext *comp_ctx, AOTFuncType *aot_func_type,
     /* Extra wasm function results(except the first one)'s address are
      * appended to aot function parameters. */
     if (aot_func_type->result_count > 1)
-      param_count += aot_func_type->result_count - 1;
+        param_count += aot_func_type->result_count - 1;
 
     /* Initialize parameter types of the LLVM function */
     size = sizeof(LLVMTypeRef) * ((uint64)param_count);
@@ -73,23 +73,24 @@ aot_add_llvm_func(AOTCompContext *comp_ctx, AOTFuncType *aot_func_type,
         param_types[j++] = TO_LLVM_TYPE(aot_func_type->types[i]);
     /* Extra results' address */
     for (i = 1; i < aot_func_type->result_count; i++, j++) {
-      param_types[j] =
-          TO_LLVM_TYPE(aot_func_type->types[aot_func_type->param_count + i]);
-      if (!(param_types[j] = LLVMPointerType(param_types[j], 0))) {
-          aot_set_last_error("llvm get pointer type failed.");
-          goto fail;
-      }
+        param_types[j] =
+            TO_LLVM_TYPE(aot_func_type->types[aot_func_type->param_count + i]);
+        if (!(param_types[j] = LLVMPointerType(param_types[j], 0))) {
+            aot_set_last_error("llvm get pointer type failed.");
+            goto fail;
+        }
     }
 
     /* Resolve return type of the LLVM function */
     if (aot_func_type->result_count)
-        ret_type = TO_LLVM_TYPE(aot_func_type->types[aot_func_type->param_count]);
+        ret_type =
+            TO_LLVM_TYPE(aot_func_type->types[aot_func_type->param_count]);
     else
         ret_type = VOID_TYPE;
 
     /* Resolve function prototype */
-    if (!(func_type = LLVMFunctionType(ret_type, param_types,
-                                       param_count, false))) {
+    if (!(func_type =
+              LLVMFunctionType(ret_type, param_types, param_count, false))) {
         aot_set_last_error("create LLVM function type failed.");
         goto fail;
     }
@@ -163,13 +164,13 @@ aot_create_func_block(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     aot_block->param_count = param_count;
     memcpy(aot_block->param_types, aot_func_type->types, param_count);
     aot_block->result_count = result_count;
-    memcpy(aot_block->result_types, aot_func_type->types + param_count, result_count);
+    memcpy(aot_block->result_types, aot_func_type->types + param_count,
+           result_count);
     aot_block->wasm_code_end = func->code + func->code_size;
 
     /* Add function entry block */
-    if (!(aot_block->llvm_entry_block =
-                LLVMAppendBasicBlockInContext(comp_ctx->context, func_ctx->func,
-                                              "func_begin"))) {
+    if (!(aot_block->llvm_entry_block = LLVMAppendBasicBlockInContext(
+              comp_ctx->context, func_ctx->func, "func_begin"))) {
         aot_set_last_error("add LLVM basic block failed.");
         goto fail;
     }
@@ -190,8 +191,9 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     WASMModule *module = comp_ctx->comp_data->wasm_module;
     WASMFunction *func = module->functions[func_index];
     LLVMTypeRef bound_check_type;
-    bool mem_space_unchanged = (!func->has_op_memory_grow && !func->has_op_func_call)
-                               || (!module->possible_memory_grow);
+    bool mem_space_unchanged =
+        (!func->has_op_memory_grow && !func->has_op_func_call)
+        || (!module->possible_memory_grow);
 #if WASM_ENABLE_SHARED_MEMORY != 0
     bool is_shared_memory;
 #endif
@@ -205,7 +207,7 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         memory_count = 1;
 
     if (!(func_ctx->mem_info =
-            wasm_runtime_malloc(sizeof(AOTMemInfo) * memory_count))) {
+              wasm_runtime_malloc(sizeof(AOTMemInfo) * memory_count))) {
         return false;
     }
     memset(func_ctx->mem_info, 0, sizeof(AOTMemInfo));
@@ -213,8 +215,8 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     /* Currently we only create memory info for memory 0 */
     /* Load memory base address */
 #if WASM_ENABLE_SHARED_MEMORY != 0
-    is_shared_memory = comp_ctx->comp_data->memories[0].memory_flags & 0x02
-                       ? true : false;
+    is_shared_memory =
+        comp_ctx->comp_data->memories[0].memory_flags & 0x02 ? true : false;
     if (is_shared_memory) {
         LLVMValueRef shared_mem_addr;
         offset = I32_CONST(offsetof(AOTModuleInstance, memories));
@@ -225,56 +227,52 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
         /* aot_inst->memories */
         if (!(shared_mem_addr =
-                LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->aot_inst,
-                                     &offset, 1, "shared_mem_addr_offset"))) {
+                  LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->aot_inst,
+                                       &offset, 1, "shared_mem_addr_offset"))) {
             aot_set_last_error("llvm build in bounds gep failed");
             return false;
         }
         if (!(shared_mem_addr =
-                LLVMBuildBitCast(comp_ctx->builder,
-                                 shared_mem_addr, int8_ptr_type,
-                                 "shared_mem_addr_ptr"))) {
+                  LLVMBuildBitCast(comp_ctx->builder, shared_mem_addr,
+                                   int8_ptr_type, "shared_mem_addr_ptr"))) {
             aot_set_last_error("llvm build bit cast failed");
             return false;
         }
         /* aot_inst->memories[0] */
-        if (!(shared_mem_addr =
-                LLVMBuildLoad(comp_ctx->builder,
-                              shared_mem_addr, "shared_mem_addr"))) {
+        if (!(shared_mem_addr = LLVMBuildLoad(
+                  comp_ctx->builder, shared_mem_addr, "shared_mem_addr"))) {
             aot_set_last_error("llvm build load failed");
             return false;
         }
         if (!(shared_mem_addr =
-                LLVMBuildBitCast(comp_ctx->builder,
-                                 shared_mem_addr, int8_ptr_type,
-                                 "shared_mem_addr_ptr"))) {
+                  LLVMBuildBitCast(comp_ctx->builder, shared_mem_addr,
+                                   int8_ptr_type, "shared_mem_addr_ptr"))) {
             aot_set_last_error("llvm build bit cast failed");
             return false;
         }
-        if (!(shared_mem_addr =
-                LLVMBuildLoad(comp_ctx->builder,
-                              shared_mem_addr, "shared_mem_addr"))) {
+        if (!(shared_mem_addr = LLVMBuildLoad(
+                  comp_ctx->builder, shared_mem_addr, "shared_mem_addr"))) {
             aot_set_last_error("llvm build load failed");
             return false;
         }
         offset = I32_CONST(offsetof(AOTMemoryInstance, memory_data.ptr));
         if (!(func_ctx->mem_info[0].mem_base_addr =
-                LLVMBuildInBoundsGEP(comp_ctx->builder, shared_mem_addr,
-                                     &offset, 1, "mem_base_addr_offset"))) {
+                  LLVMBuildInBoundsGEP(comp_ctx->builder, shared_mem_addr,
+                                       &offset, 1, "mem_base_addr_offset"))) {
             aot_set_last_error("llvm build in bounds gep failed");
             return false;
         }
         offset = I32_CONST(offsetof(AOTMemoryInstance, cur_page_count));
         if (!(func_ctx->mem_info[0].mem_cur_page_count_addr =
-                LLVMBuildInBoundsGEP(comp_ctx->builder, shared_mem_addr,
-                                     &offset, 1, "mem_cur_page_offset"))) {
+                  LLVMBuildInBoundsGEP(comp_ctx->builder, shared_mem_addr,
+                                       &offset, 1, "mem_cur_page_offset"))) {
             aot_set_last_error("llvm build in bounds gep failed");
             return false;
         }
         offset = I32_CONST(offsetof(AOTMemoryInstance, memory_data_size));
         if (!(func_ctx->mem_info[0].mem_data_size_addr =
-                LLVMBuildInBoundsGEP(comp_ctx->builder, shared_mem_addr,
-                                     &offset, 1, "mem_data_size_offset"))) {
+                  LLVMBuildInBoundsGEP(comp_ctx->builder, shared_mem_addr,
+                                       &offset, 1, "mem_data_size_offset"))) {
             aot_set_last_error("llvm build in bounds gep failed");
             return false;
         }
@@ -285,24 +283,24 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         offset = I32_CONST(offsetof(AOTModuleInstance, global_table_data)
                            + offsetof(AOTMemoryInstance, memory_data.ptr));
         if (!(func_ctx->mem_info[0].mem_base_addr =
-                    LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->aot_inst,
-                                         &offset, 1, "mem_base_addr_offset"))) {
+                  LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->aot_inst,
+                                       &offset, 1, "mem_base_addr_offset"))) {
             aot_set_last_error("llvm build in bounds gep failed");
             return false;
         }
         offset = I32_CONST(offsetof(AOTModuleInstance, global_table_data)
                            + offsetof(AOTMemoryInstance, cur_page_count));
         if (!(func_ctx->mem_info[0].mem_cur_page_count_addr =
-                    LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->aot_inst,
-                                         &offset, 1, "mem_cur_page_offset"))) {
+                  LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->aot_inst,
+                                       &offset, 1, "mem_cur_page_offset"))) {
             aot_set_last_error("llvm build in bounds gep failed");
             return false;
         }
         offset = I32_CONST(offsetof(AOTModuleInstance, global_table_data)
                            + offsetof(AOTMemoryInstance, memory_data_size));
         if (!(func_ctx->mem_info[0].mem_data_size_addr =
-                    LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->aot_inst,
-                                         &offset, 1, "mem_data_size_offset"))) {
+                  LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->aot_inst,
+                                       &offset, 1, "mem_data_size_offset"))) {
             aot_set_last_error("llvm build in bounds gep failed");
             return false;
         }
@@ -310,46 +308,41 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     /* Store mem info base address before cast */
     mem_info_base = func_ctx->mem_info[0].mem_base_addr;
 
-    if (!(func_ctx->mem_info[0].mem_base_addr =
-                LLVMBuildBitCast(comp_ctx->builder,
-                                 func_ctx->mem_info[0].mem_base_addr,
-                                 int8_ptr_type, "mem_base_addr_ptr"))) {
+    if (!(func_ctx->mem_info[0].mem_base_addr = LLVMBuildBitCast(
+              comp_ctx->builder, func_ctx->mem_info[0].mem_base_addr,
+              int8_ptr_type, "mem_base_addr_ptr"))) {
         aot_set_last_error("llvm build bit cast failed");
         return false;
     }
-    if (!(func_ctx->mem_info[0].mem_cur_page_count_addr =
-                LLVMBuildBitCast(comp_ctx->builder,
-                                 func_ctx->mem_info[0].mem_cur_page_count_addr,
-                                 INT32_PTR_TYPE, "mem_cur_page_ptr"))) {
+    if (!(func_ctx->mem_info[0].mem_cur_page_count_addr = LLVMBuildBitCast(
+              comp_ctx->builder, func_ctx->mem_info[0].mem_cur_page_count_addr,
+              INT32_PTR_TYPE, "mem_cur_page_ptr"))) {
         aot_set_last_error("llvm build bit cast failed");
         return false;
     }
-    if (!(func_ctx->mem_info[0].mem_data_size_addr =
-                LLVMBuildBitCast(comp_ctx->builder,
-                                 func_ctx->mem_info[0].mem_data_size_addr,
-                                 INT32_PTR_TYPE, "mem_data_size_ptr"))) {
+    if (!(func_ctx->mem_info[0].mem_data_size_addr = LLVMBuildBitCast(
+              comp_ctx->builder, func_ctx->mem_info[0].mem_data_size_addr,
+              INT32_PTR_TYPE, "mem_data_size_ptr"))) {
         aot_set_last_error("llvm build bit cast failed");
         return false;
     }
     if (mem_space_unchanged) {
-        if (!(func_ctx->mem_info[0].mem_base_addr =
-                    LLVMBuildLoad(comp_ctx->builder,
-                                  func_ctx->mem_info[0].mem_base_addr,
-                                  "mem_base_addr"))) {
+        if (!(func_ctx->mem_info[0].mem_base_addr = LLVMBuildLoad(
+                  comp_ctx->builder, func_ctx->mem_info[0].mem_base_addr,
+                  "mem_base_addr"))) {
             aot_set_last_error("llvm build load failed");
             return false;
         }
         if (!(func_ctx->mem_info[0].mem_cur_page_count_addr =
-                    LLVMBuildLoad(comp_ctx->builder,
-                                  func_ctx->mem_info[0].mem_cur_page_count_addr,
-                                  "mem_cur_page_count"))) {
+                  LLVMBuildLoad(comp_ctx->builder,
+                                func_ctx->mem_info[0].mem_cur_page_count_addr,
+                                "mem_cur_page_count"))) {
             aot_set_last_error("llvm build load failed");
             return false;
         }
-        if (!(func_ctx->mem_info[0].mem_data_size_addr =
-                    LLVMBuildLoad(comp_ctx->builder,
-                                  func_ctx->mem_info[0].mem_data_size_addr,
-                                  "mem_data_size"))) {
+        if (!(func_ctx->mem_info[0].mem_data_size_addr = LLVMBuildLoad(
+                  comp_ctx->builder, func_ctx->mem_info[0].mem_data_size_addr,
+                  "mem_data_size"))) {
             aot_set_last_error("llvm build load failed");
             return false;
         }
@@ -358,10 +351,9 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     else if (is_shared_memory) {
         /* The base address for shared memory will never changed,
             we can load the value here */
-        if (!(func_ctx->mem_info[0].mem_base_addr =
-                    LLVMBuildLoad(comp_ctx->builder,
-                                  func_ctx->mem_info[0].mem_base_addr,
-                                  "mem_base_addr"))) {
+        if (!(func_ctx->mem_info[0].mem_base_addr = LLVMBuildLoad(
+                  comp_ctx->builder, func_ctx->mem_info[0].mem_base_addr,
+                  "mem_base_addr"))) {
             aot_set_last_error("llvm build load failed");
             return false;
         }
@@ -369,29 +361,29 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 #endif
 
     bound_check_type = (comp_ctx->pointer_size == sizeof(uint64))
-                       ? INT64_PTR_TYPE : INT32_PTR_TYPE;
+                           ? INT64_PTR_TYPE
+                           : INT32_PTR_TYPE;
 
     /* Load memory bound check constants */
     offset = I32_CONST(offsetof(AOTMemoryInstance, mem_bound_check_1byte)
                        - offsetof(AOTMemoryInstance, memory_data.ptr));
     if (!(func_ctx->mem_info[0].mem_bound_check_1byte =
-                LLVMBuildInBoundsGEP(comp_ctx->builder, mem_info_base,
-                                     &offset, 1, "bound_check_1byte_offset"))) {
+              LLVMBuildInBoundsGEP(comp_ctx->builder, mem_info_base, &offset, 1,
+                                   "bound_check_1byte_offset"))) {
         aot_set_last_error("llvm build in bounds gep failed");
         return false;
     }
-    if (!(func_ctx->mem_info[0].mem_bound_check_1byte =
-                LLVMBuildBitCast(comp_ctx->builder,
-                                 func_ctx->mem_info[0].mem_bound_check_1byte,
-                                 bound_check_type, "bound_check_1byte_ptr"))) {
+    if (!(func_ctx->mem_info[0].mem_bound_check_1byte = LLVMBuildBitCast(
+              comp_ctx->builder, func_ctx->mem_info[0].mem_bound_check_1byte,
+              bound_check_type, "bound_check_1byte_ptr"))) {
         aot_set_last_error("llvm build bit cast failed");
         return false;
     }
     if (mem_space_unchanged) {
         if (!(func_ctx->mem_info[0].mem_bound_check_1byte =
-                LLVMBuildLoad(comp_ctx->builder,
-                              func_ctx->mem_info[0].mem_bound_check_1byte,
-                              "bound_check_1byte"))) {
+                  LLVMBuildLoad(comp_ctx->builder,
+                                func_ctx->mem_info[0].mem_bound_check_1byte,
+                                "bound_check_1byte"))) {
             aot_set_last_error("llvm build load failed");
             return false;
         }
@@ -400,23 +392,22 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     offset = I32_CONST(offsetof(AOTMemoryInstance, mem_bound_check_2bytes)
                        - offsetof(AOTMemoryInstance, memory_data.ptr));
     if (!(func_ctx->mem_info[0].mem_bound_check_2bytes =
-                LLVMBuildInBoundsGEP(comp_ctx->builder, mem_info_base,
-                                     &offset, 1, "bound_check_2bytes_offset"))) {
+              LLVMBuildInBoundsGEP(comp_ctx->builder, mem_info_base, &offset, 1,
+                                   "bound_check_2bytes_offset"))) {
         aot_set_last_error("llvm build in bounds gep failed");
         return false;
     }
-    if (!(func_ctx->mem_info[0].mem_bound_check_2bytes =
-                LLVMBuildBitCast(comp_ctx->builder,
-                                 func_ctx->mem_info[0].mem_bound_check_2bytes,
-                                 bound_check_type, "bound_check_2bytes_ptr"))) {
+    if (!(func_ctx->mem_info[0].mem_bound_check_2bytes = LLVMBuildBitCast(
+              comp_ctx->builder, func_ctx->mem_info[0].mem_bound_check_2bytes,
+              bound_check_type, "bound_check_2bytes_ptr"))) {
         aot_set_last_error("llvm build bit cast failed");
         return false;
     }
     if (mem_space_unchanged) {
         if (!(func_ctx->mem_info[0].mem_bound_check_2bytes =
-                LLVMBuildLoad(comp_ctx->builder,
-                              func_ctx->mem_info[0].mem_bound_check_2bytes,
-                              "bound_check_2bytes"))) {
+                  LLVMBuildLoad(comp_ctx->builder,
+                                func_ctx->mem_info[0].mem_bound_check_2bytes,
+                                "bound_check_2bytes"))) {
             aot_set_last_error("llvm build load failed");
             return false;
         }
@@ -425,23 +416,22 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     offset = I32_CONST(offsetof(AOTMemoryInstance, mem_bound_check_4bytes)
                        - offsetof(AOTMemoryInstance, memory_data.ptr));
     if (!(func_ctx->mem_info[0].mem_bound_check_4bytes =
-                LLVMBuildInBoundsGEP(comp_ctx->builder, mem_info_base,
-                                     &offset, 1, "bound_check_4bytes_offset"))) {
+              LLVMBuildInBoundsGEP(comp_ctx->builder, mem_info_base, &offset, 1,
+                                   "bound_check_4bytes_offset"))) {
         aot_set_last_error("llvm build in bounds gep failed");
         return false;
     }
-    if (!(func_ctx->mem_info[0].mem_bound_check_4bytes =
-                LLVMBuildBitCast(comp_ctx->builder,
-                                 func_ctx->mem_info[0].mem_bound_check_4bytes,
-                                 bound_check_type, "bound_check_4bytes_ptr"))) {
+    if (!(func_ctx->mem_info[0].mem_bound_check_4bytes = LLVMBuildBitCast(
+              comp_ctx->builder, func_ctx->mem_info[0].mem_bound_check_4bytes,
+              bound_check_type, "bound_check_4bytes_ptr"))) {
         aot_set_last_error("llvm build bit cast failed");
         return false;
     }
     if (mem_space_unchanged) {
         if (!(func_ctx->mem_info[0].mem_bound_check_4bytes =
-                LLVMBuildLoad(comp_ctx->builder,
-                              func_ctx->mem_info[0].mem_bound_check_4bytes,
-                              "bound_check_4bytes"))) {
+                  LLVMBuildLoad(comp_ctx->builder,
+                                func_ctx->mem_info[0].mem_bound_check_4bytes,
+                                "bound_check_4bytes"))) {
             aot_set_last_error("llvm build load failed");
             return false;
         }
@@ -450,23 +440,22 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     offset = I32_CONST(offsetof(AOTMemoryInstance, mem_bound_check_8bytes)
                        - offsetof(AOTMemoryInstance, memory_data.ptr));
     if (!(func_ctx->mem_info[0].mem_bound_check_8bytes =
-                LLVMBuildInBoundsGEP(comp_ctx->builder, mem_info_base,
-                                     &offset, 1, "bound_check_8bytes_offset"))) {
+              LLVMBuildInBoundsGEP(comp_ctx->builder, mem_info_base, &offset, 1,
+                                   "bound_check_8bytes_offset"))) {
         aot_set_last_error("llvm build in bounds gep failed");
         return false;
     }
-    if (!(func_ctx->mem_info[0].mem_bound_check_8bytes =
-                LLVMBuildBitCast(comp_ctx->builder,
-                                 func_ctx->mem_info[0].mem_bound_check_8bytes,
-                                 bound_check_type, "bound_check_8bytes_ptr"))) {
+    if (!(func_ctx->mem_info[0].mem_bound_check_8bytes = LLVMBuildBitCast(
+              comp_ctx->builder, func_ctx->mem_info[0].mem_bound_check_8bytes,
+              bound_check_type, "bound_check_8bytes_ptr"))) {
         aot_set_last_error("llvm build bit cast failed");
         return false;
     }
     if (mem_space_unchanged) {
         if (!(func_ctx->mem_info[0].mem_bound_check_8bytes =
-                LLVMBuildLoad(comp_ctx->builder,
-                              func_ctx->mem_info[0].mem_bound_check_8bytes,
-                              "bound_check_8bytes"))) {
+                  LLVMBuildLoad(comp_ctx->builder,
+                                func_ctx->mem_info[0].mem_bound_check_8bytes,
+                                "bound_check_8bytes"))) {
             aot_set_last_error("llvm build load failed");
             return false;
         }
@@ -475,23 +464,22 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     offset = I32_CONST(offsetof(AOTMemoryInstance, mem_bound_check_16bytes)
                        - offsetof(AOTMemoryInstance, memory_data.ptr));
     if (!(func_ctx->mem_info[0].mem_bound_check_16bytes =
-                LLVMBuildInBoundsGEP(comp_ctx->builder, mem_info_base,
-                                     &offset, 1, "bound_check_16bytes_offset"))) {
+              LLVMBuildInBoundsGEP(comp_ctx->builder, mem_info_base, &offset, 1,
+                                   "bound_check_16bytes_offset"))) {
         aot_set_last_error("llvm build in bounds gep failed");
         return false;
     }
-    if (!(func_ctx->mem_info[0].mem_bound_check_16bytes =
-                LLVMBuildBitCast(comp_ctx->builder,
-                                 func_ctx->mem_info[0].mem_bound_check_16bytes,
-                                 bound_check_type, "bound_check_16bytes_ptr"))) {
+    if (!(func_ctx->mem_info[0].mem_bound_check_16bytes = LLVMBuildBitCast(
+              comp_ctx->builder, func_ctx->mem_info[0].mem_bound_check_16bytes,
+              bound_check_type, "bound_check_16bytes_ptr"))) {
         aot_set_last_error("llvm build bit cast failed");
         return false;
     }
     if (mem_space_unchanged) {
         if (!(func_ctx->mem_info[0].mem_bound_check_16bytes =
-                LLVMBuildLoad(comp_ctx->builder,
-                              func_ctx->mem_info[0].mem_bound_check_16bytes,
-                              "bound_check_16bytes"))) {
+                  LLVMBuildLoad(comp_ctx->builder,
+                                func_ctx->mem_info[0].mem_bound_check_16bytes,
+                                "bound_check_16bytes"))) {
             aot_set_last_error("llvm build load failed");
             return false;
         }
@@ -506,10 +494,8 @@ create_cur_exception(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
     LLVMValueRef offset;
 
     offset = I32_CONST(offsetof(AOTModuleInstance, cur_exception));
-    func_ctx->cur_exception = LLVMBuildInBoundsGEP(comp_ctx->builder,
-                                                   func_ctx->aot_inst,
-                                                   &offset, 1,
-                                                   "cur_execption");
+    func_ctx->cur_exception = LLVMBuildInBoundsGEP(
+        comp_ctx->builder, func_ctx->aot_inst, &offset, 1, "cur_execption");
     if (!func_ctx->cur_exception) {
         aot_set_last_error("llvm build in bounds gep failed.");
         return false;
@@ -518,17 +504,15 @@ create_cur_exception(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 }
 
 static bool
-create_func_type_indexes(AOTCompContext *comp_ctx,
-                         AOTFuncContext *func_ctx)
+create_func_type_indexes(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 {
     LLVMValueRef offset, func_type_indexes_ptr;
     LLVMTypeRef int32_ptr_type;
 
     offset = I32_CONST(offsetof(AOTModuleInstance, func_type_indexes.ptr));
-    func_type_indexes_ptr = LLVMBuildInBoundsGEP(comp_ctx->builder,
-                                                 func_ctx->aot_inst,
-                                                 &offset, 1,
-                                                 "func_type_indexes_ptr");
+    func_type_indexes_ptr =
+        LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->aot_inst, &offset, 1,
+                             "func_type_indexes_ptr");
     if (!func_type_indexes_ptr) {
         aot_set_last_error("llvm build add failed.");
         return false;
@@ -539,18 +523,16 @@ create_func_type_indexes(AOTCompContext *comp_ctx,
         return false;
     }
 
-    func_ctx->func_type_indexes = LLVMBuildBitCast(comp_ctx->builder,
-                                                   func_type_indexes_ptr,
-                                                   int32_ptr_type,
-                                                   "func_type_indexes_tmp");
+    func_ctx->func_type_indexes =
+        LLVMBuildBitCast(comp_ctx->builder, func_type_indexes_ptr,
+                         int32_ptr_type, "func_type_indexes_tmp");
     if (!func_ctx->func_type_indexes) {
         aot_set_last_error("llvm build bit cast failed.");
         return false;
     }
 
-    func_ctx->func_type_indexes = LLVMBuildLoad(comp_ctx->builder,
-                                                func_ctx->func_type_indexes,
-                                                "func_type_indexes");
+    func_ctx->func_type_indexes = LLVMBuildLoad(
+        comp_ctx->builder, func_ctx->func_type_indexes, "func_type_indexes");
     if (!func_ctx->func_type_indexes) {
         aot_set_last_error("llvm build load failed.");
         return false;
@@ -564,29 +546,30 @@ create_func_ptrs(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
     LLVMValueRef offset;
 
     offset = I32_CONST(offsetof(AOTModuleInstance, func_ptrs));
-    func_ctx->func_ptrs = LLVMBuildInBoundsGEP(comp_ctx->builder,
-                                                func_ctx->aot_inst,
-                                                &offset, 1, "func_ptrs_offset");
+    func_ctx->func_ptrs = LLVMBuildInBoundsGEP(
+        comp_ctx->builder, func_ctx->aot_inst, &offset, 1, "func_ptrs_offset");
     if (!func_ctx->func_ptrs) {
         aot_set_last_error("llvm build in bounds gep failed.");
         return false;
     }
-    func_ctx->func_ptrs = LLVMBuildBitCast(comp_ctx->builder, func_ctx->func_ptrs,
-                                           comp_ctx->exec_env_type, "func_ptrs_tmp");
+    func_ctx->func_ptrs =
+        LLVMBuildBitCast(comp_ctx->builder, func_ctx->func_ptrs,
+                         comp_ctx->exec_env_type, "func_ptrs_tmp");
     if (!func_ctx->func_ptrs) {
         aot_set_last_error("llvm build bit cast failed.");
         return false;
     }
 
-    func_ctx->func_ptrs = LLVMBuildLoad(comp_ctx->builder, func_ctx->func_ptrs,
-                                        "func_ptrs_ptr");
+    func_ctx->func_ptrs =
+        LLVMBuildLoad(comp_ctx->builder, func_ctx->func_ptrs, "func_ptrs_ptr");
     if (!func_ctx->func_ptrs) {
         aot_set_last_error("llvm build load failed.");
         return false;
     }
 
-    func_ctx->func_ptrs = LLVMBuildBitCast(comp_ctx->builder, func_ctx->func_ptrs,
-                                           comp_ctx->exec_env_type, "func_ptrs");
+    func_ctx->func_ptrs =
+        LLVMBuildBitCast(comp_ctx->builder, func_ctx->func_ptrs,
+                         comp_ctx->exec_env_type, "func_ptrs");
     if (!func_ctx->func_ptrs) {
         aot_set_last_error("llvm build bit cast failed.");
         return false;
@@ -617,10 +600,10 @@ aot_create_func_context(AOTCompData *comp_data, AOTCompContext *comp_ctx,
     uint32 i, j = 0;
 
     /* Allocate memory for the function context */
-    size = offsetof(AOTFuncContext, locals) + sizeof(LLVMValueRef) *
-                    ((uint64)aot_func_type->param_count + func->local_count);
-    if (size >= UINT32_MAX
-        || !(func_ctx = wasm_runtime_malloc((uint32)size))) {
+    size = offsetof(AOTFuncContext, locals)
+           + sizeof(LLVMValueRef)
+                 * ((uint64)aot_func_type->param_count + func->local_count);
+    if (size >= UINT32_MAX || !(func_ctx = wasm_runtime_malloc((uint32)size))) {
         aot_set_last_error("allocate memory failed.");
         return NULL;
     }
@@ -634,8 +617,8 @@ aot_create_func_context(AOTCompData *comp_data, AOTCompContext *comp_ctx,
         goto fail;
 
     /* Create function's first AOTBlock */
-    if (!(aot_block = aot_create_func_block(comp_ctx, func_ctx,
-                                            func, aot_func_type)))
+    if (!(aot_block =
+              aot_create_func_block(comp_ctx, func_ctx, func, aot_func_type)))
         goto fail;
 
 #if WASM_ENABLE_DEBUG_AOT != 0
@@ -653,23 +636,23 @@ aot_create_func_context(AOTCompData *comp_data, AOTCompContext *comp_ctx,
     /* Get aot inst address, the layout of exec_env is:
        exec_env->next, exec_env->prev, exec_env->module_inst, and argv_buf */
     if (!(aot_inst_addr =
-                LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->exec_env,
-                                     &aot_inst_offset, 1, "aot_inst_addr"))) {
+              LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->exec_env,
+                                   &aot_inst_offset, 1, "aot_inst_addr"))) {
         aot_set_last_error("llvm build in bounds gep failed");
         goto fail;
     }
 
     /* Load aot inst */
-    if (!(func_ctx->aot_inst = LLVMBuildLoad(comp_ctx->builder,
-                                             aot_inst_addr, "aot_inst"))) {
+    if (!(func_ctx->aot_inst =
+              LLVMBuildLoad(comp_ctx->builder, aot_inst_addr, "aot_inst"))) {
         aot_set_last_error("llvm build load failed");
         goto fail;
     }
 
     /* Get argv buffer address */
     if (!(argv_buf_addr =
-                LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->exec_env,
-                                     &argv_buf_offset, 1, "argv_buf_addr"))) {
+              LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->exec_env,
+                                   &argv_buf_offset, 1, "argv_buf_addr"))) {
         aot_set_last_error("llvm build in bounds gep failed");
         goto fail;
     }
@@ -686,91 +669,83 @@ aot_create_func_context(AOTCompData *comp_data, AOTCompContext *comp_ctx,
         goto fail;
     }
 
-    if (!(func_ctx->argv_buf = LLVMBuildLoad(comp_ctx->builder,
-                                             argv_buf_addr, "argv_buf"))) {
+    if (!(func_ctx->argv_buf =
+              LLVMBuildLoad(comp_ctx->builder, argv_buf_addr, "argv_buf"))) {
         aot_set_last_error("llvm build load failed");
         goto fail;
     }
 
     /* Get native stack boundary address */
-    if (!(stack_bound_addr =
-            LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->exec_env,
-                                 &stack_bound_offset, 1, "stack_bound_addr"))) {
+    if (!(stack_bound_addr = LLVMBuildInBoundsGEP(
+              comp_ctx->builder, func_ctx->exec_env, &stack_bound_offset, 1,
+              "stack_bound_addr"))) {
         aot_set_last_error("llvm build in bounds gep failed");
         goto fail;
     }
 
-    if (!(func_ctx->native_stack_bound =
-            LLVMBuildLoad(comp_ctx->builder,
-                          stack_bound_addr, "native_stack_bound"))) {
+    if (!(func_ctx->native_stack_bound = LLVMBuildLoad(
+              comp_ctx->builder, stack_bound_addr, "native_stack_bound"))) {
         aot_set_last_error("llvm build load failed");
         goto fail;
     }
 
     /* Get aux stack boundary address */
-    if (!(aux_stack_bound_addr =
-            LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->exec_env,
-                                 &aux_stack_bound_offset, 1,
-                                 "aux_stack_bound_addr"))) {
+    if (!(aux_stack_bound_addr = LLVMBuildInBoundsGEP(
+              comp_ctx->builder, func_ctx->exec_env, &aux_stack_bound_offset, 1,
+              "aux_stack_bound_addr"))) {
         aot_set_last_error("llvm build in bounds gep failed");
         goto fail;
     }
 
     if (!(aux_stack_bound_addr =
-            LLVMBuildBitCast(comp_ctx->builder,
-                             aux_stack_bound_addr,
-                             INT32_PTR_TYPE, "aux_stack_bound_ptr"))) {
+              LLVMBuildBitCast(comp_ctx->builder, aux_stack_bound_addr,
+                               INT32_PTR_TYPE, "aux_stack_bound_ptr"))) {
         aot_set_last_error("llvm build bit cast failed");
         goto fail;
     }
 
-    if (!(func_ctx->aux_stack_bound =
-            LLVMBuildLoad(comp_ctx->builder,
-                          aux_stack_bound_addr, "aux_stack_bound"))) {
+    if (!(func_ctx->aux_stack_bound = LLVMBuildLoad(
+              comp_ctx->builder, aux_stack_bound_addr, "aux_stack_bound"))) {
         aot_set_last_error("llvm build load failed");
         goto fail;
     }
 
     /* Get aux stack bottom address */
-    if (!(aux_stack_bottom_addr =
-            LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->exec_env,
-                                 &aux_stack_bottom_offset, 1,
-                                 "aux_stack_bottom_addr"))) {
+    if (!(aux_stack_bottom_addr = LLVMBuildInBoundsGEP(
+              comp_ctx->builder, func_ctx->exec_env, &aux_stack_bottom_offset,
+              1, "aux_stack_bottom_addr"))) {
         aot_set_last_error("llvm build in bounds gep failed");
         goto fail;
     }
 
     if (!(aux_stack_bottom_addr =
-            LLVMBuildBitCast(comp_ctx->builder,
-                             aux_stack_bottom_addr,
-                             INT32_PTR_TYPE, "aux_stack_bottom_ptr"))) {
+              LLVMBuildBitCast(comp_ctx->builder, aux_stack_bottom_addr,
+                               INT32_PTR_TYPE, "aux_stack_bottom_ptr"))) {
         aot_set_last_error("llvm build bit cast failed");
         goto fail;
     }
-    if (!(func_ctx->aux_stack_bottom =
-            LLVMBuildLoad(comp_ctx->builder,
-                          aux_stack_bottom_addr, "aux_stack_bottom"))) {
+    if (!(func_ctx->aux_stack_bottom = LLVMBuildLoad(
+              comp_ctx->builder, aux_stack_bottom_addr, "aux_stack_bottom"))) {
         aot_set_last_error("llvm build load failed");
         goto fail;
     }
 
-    if (!(native_symbol_addr =
-            LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->exec_env,
-                                 &native_symbol_offset, 1, "native_symbol_addr"))) {
+    if (!(native_symbol_addr = LLVMBuildInBoundsGEP(
+              comp_ctx->builder, func_ctx->exec_env, &native_symbol_offset, 1,
+              "native_symbol_addr"))) {
         aot_set_last_error("llvm build in bounds gep failed");
         goto fail;
     }
 
-    if (!(func_ctx->native_symbol =
-            LLVMBuildLoad(comp_ctx->builder, native_symbol_addr,
-                          "native_symbol_tmp"))) {
+    if (!(func_ctx->native_symbol = LLVMBuildLoad(
+              comp_ctx->builder, native_symbol_addr, "native_symbol_tmp"))) {
         aot_set_last_error("llvm build bit cast failed");
         goto fail;
     }
 
     if (!(func_ctx->native_symbol =
-            LLVMBuildBitCast(comp_ctx->builder, func_ctx->native_symbol,
-                             comp_ctx->exec_env_type, "native_symbol"))) {
+              LLVMBuildBitCast(comp_ctx->builder, func_ctx->native_symbol,
+                               comp_ctx->exec_env_type, "native_symbol"))) {
         aot_set_last_error("llvm build bit cast failed");
         goto fail;
     }
@@ -779,14 +754,12 @@ aot_create_func_context(AOTCompData *comp_data, AOTCompContext *comp_ctx,
         snprintf(local_name, sizeof(local_name), "l%d", i);
         func_ctx->locals[i] =
             LLVMBuildAlloca(comp_ctx->builder,
-                            TO_LLVM_TYPE(aot_func_type->types[i]),
-                            local_name);
+                            TO_LLVM_TYPE(aot_func_type->types[i]), local_name);
         if (!func_ctx->locals[i]) {
             aot_set_last_error("llvm build alloca failed.");
             goto fail;
         }
-        if (!LLVMBuildStore(comp_ctx->builder,
-                            LLVMGetParam(func_ctx->func, j),
+        if (!LLVMBuildStore(comp_ctx->builder, LLVMGetParam(func_ctx->func, j),
                             func_ctx->locals[i])) {
             aot_set_last_error("llvm build store failed.");
             goto fail;
@@ -837,18 +810,19 @@ aot_create_func_context(AOTCompData *comp_data, AOTCompContext *comp_ctx,
     }
 
     if (aot_func_type->param_count + func->local_count > 0) {
-        func_ctx->last_alloca = func_ctx->locals[aot_func_type->param_count
-                                                 + func->local_count - 1];
+        func_ctx->last_alloca =
+            func_ctx
+                ->locals[aot_func_type->param_count + func->local_count - 1];
         if (!(func_ctx->last_alloca =
-                    LLVMBuildBitCast(comp_ctx->builder, func_ctx->last_alloca,
-                                     INT8_PTR_TYPE, "stack_ptr"))) {
+                  LLVMBuildBitCast(comp_ctx->builder, func_ctx->last_alloca,
+                                   INT8_PTR_TYPE, "stack_ptr"))) {
             aot_set_last_error("llvm build bit cast failed.");
             goto fail;
         }
     }
     else {
-        if (!(func_ctx->last_alloca = LLVMBuildAlloca(comp_ctx->builder, INT8_TYPE,
-                                                      "stack_ptr"))) {
+        if (!(func_ctx->last_alloca =
+                  LLVMBuildAlloca(comp_ctx->builder, INT8_TYPE, "stack_ptr"))) {
             aot_set_last_error("llvm build alloca failed.");
             goto fail;
         }
@@ -912,7 +886,7 @@ aot_create_func_contexts(AOTCompData *comp_data, AOTCompContext *comp_ctx)
     uint32 i;
 
     /* Allocate memory */
-    size = sizeof(AOTFuncContext*) * (uint64)comp_data->func_count;
+    size = sizeof(AOTFuncContext *) * (uint64)comp_data->func_count;
     if (size >= UINT32_MAX
         || !(func_ctxes = wasm_runtime_malloc((uint32)size))) {
         aot_set_last_error("allocate memory failed.");
@@ -924,8 +898,8 @@ aot_create_func_contexts(AOTCompData *comp_data, AOTCompContext *comp_ctx)
     /* Create each function context */
     for (i = 0; i < comp_data->func_count; i++) {
         AOTFunc *func = comp_data->funcs[i];
-        if (!(func_ctxes[i] = aot_create_func_context(comp_data, comp_ctx,
-                                                      func, i))) {
+        if (!(func_ctxes[i] =
+                  aot_create_func_context(comp_data, comp_ctx, func, i))) {
             aot_destroy_func_contexts(func_ctxes, comp_data->func_count);
             return NULL;
         }
@@ -952,14 +926,16 @@ aot_set_llvm_basic_types(AOTLLVMTypes *basic_types, LLVMContextRef context)
 
     if (basic_types->int8_ptr_type) {
         basic_types->int8_pptr_type =
-          LLVMPointerType(basic_types->int8_ptr_type, 0);
+            LLVMPointerType(basic_types->int8_ptr_type, 0);
     }
 
     basic_types->int16_ptr_type = LLVMPointerType(basic_types->int16_type, 0);
     basic_types->int32_ptr_type = LLVMPointerType(basic_types->int32_type, 0);
     basic_types->int64_ptr_type = LLVMPointerType(basic_types->int64_type, 0);
-    basic_types->float32_ptr_type = LLVMPointerType(basic_types->float32_type, 0);
-    basic_types->float64_ptr_type = LLVMPointerType(basic_types->float64_type, 0);
+    basic_types->float32_ptr_type =
+        LLVMPointerType(basic_types->float32_type, 0);
+    basic_types->float64_ptr_type =
+        LLVMPointerType(basic_types->float64_type, 0);
 
     basic_types->i8x16_vec_type = LLVMVectorType(basic_types->int8_type, 16);
     basic_types->i16x8_vec_type = LLVMVectorType(basic_types->int16_type, 8);
@@ -976,31 +952,25 @@ aot_set_llvm_basic_types(AOTLLVMTypes *basic_types, LLVMContextRef context)
     basic_types->funcref_type = LLVMInt32TypeInContext(context);
     basic_types->externref_type = LLVMInt32TypeInContext(context);
 
-    return (basic_types->int8_ptr_type
-            && basic_types->int8_pptr_type
-            && basic_types->int16_ptr_type
-            && basic_types->int32_ptr_type
-            && basic_types->int64_ptr_type
-            && basic_types->float32_ptr_type
-            && basic_types->float64_ptr_type
-            && basic_types->i8x16_vec_type
-            && basic_types->i16x8_vec_type
-            && basic_types->i32x4_vec_type
-            && basic_types->i64x2_vec_type
-            && basic_types->f32x4_vec_type
-            && basic_types->f64x2_vec_type
-            && basic_types->i1x2_vec_type
-            && basic_types->meta_data_type
-            && basic_types->funcref_type
-            && basic_types->externref_type) ? true : false;
+    return (basic_types->int8_ptr_type && basic_types->int8_pptr_type
+            && basic_types->int16_ptr_type && basic_types->int32_ptr_type
+            && basic_types->int64_ptr_type && basic_types->float32_ptr_type
+            && basic_types->float64_ptr_type && basic_types->i8x16_vec_type
+            && basic_types->i16x8_vec_type && basic_types->i32x4_vec_type
+            && basic_types->i64x2_vec_type && basic_types->f32x4_vec_type
+            && basic_types->f64x2_vec_type && basic_types->i1x2_vec_type
+            && basic_types->meta_data_type && basic_types->funcref_type
+            && basic_types->externref_type)
+               ? true
+               : false;
 }
 
 static bool
 aot_create_llvm_consts(AOTLLVMConsts *consts, AOTCompContext *comp_ctx)
 {
-#define CREATE_I1_CONST(name, value)                                          \
-    if (!(consts->i1_##name =                                                 \
-            LLVMConstInt(comp_ctx->basic_types.int1_type, value, true)))      \
+#define CREATE_I1_CONST(name, value)                                       \
+    if (!(consts->i1_##name =                                              \
+              LLVMConstInt(comp_ctx->basic_types.int1_type, value, true))) \
         return false;
 
     CREATE_I1_CONST(zero, 0)
@@ -1016,8 +986,8 @@ aot_create_llvm_consts(AOTLLVMConsts *consts, AOTCompContext *comp_ctx)
     if (!(consts->f64_zero = F64_CONST(0)))
         return false;
 
-#define CREATE_I32_CONST(name, value)                                         \
-    if (!(consts->i32_##name = LLVMConstInt(I32_TYPE, value, true)))          \
+#define CREATE_I32_CONST(name, value)                                \
+    if (!(consts->i32_##name = LLVMConstInt(I32_TYPE, value, true))) \
         return false;
 
     CREATE_I32_CONST(min, (uint32)INT32_MIN)
@@ -1042,8 +1012,8 @@ aot_create_llvm_consts(AOTLLVMConsts *consts, AOTCompContext *comp_ctx)
     CREATE_I32_CONST(32, 32)
 #undef CREATE_I32_CONST
 
-#define CREATE_I64_CONST(name, value)                                         \
-    if (!(consts->i64_##name = LLVMConstInt(I64_TYPE, value, true)))          \
+#define CREATE_I64_CONST(name, value)                                \
+    if (!(consts->i64_##name = LLVMConstInt(I64_TYPE, value, true))) \
         return false;
 
     CREATE_I64_CONST(min, (uint64)INT64_MIN)
@@ -1053,10 +1023,10 @@ aot_create_llvm_consts(AOTLLVMConsts *consts, AOTCompContext *comp_ctx)
     CREATE_I64_CONST(64, 64)
 #undef CREATE_I64_CONST
 
-#define CREATE_V128_CONST(name, type)                                         \
-    if (!(consts->name##_vec_zero = LLVMConstNull(type)))                     \
-        return false;                                                         \
-    if (!(consts->name##_undef = LLVMGetUndef(type)))                         \
+#define CREATE_V128_CONST(name, type)                     \
+    if (!(consts->name##_vec_zero = LLVMConstNull(type))) \
+        return false;                                     \
+    if (!(consts->name##_undef = LLVMGetUndef(type)))     \
         return false;
 
     CREATE_V128_CONST(i8x16, V128_i8x16_TYPE)
@@ -1067,11 +1037,11 @@ aot_create_llvm_consts(AOTLLVMConsts *consts, AOTCompContext *comp_ctx)
     CREATE_V128_CONST(f64x2, V128_f64x2_TYPE)
 #undef CREATE_V128_CONST
 
-#define CREATE_VEC_ZERO_MASK(slot)                                            \
-    {                                                                         \
-        LLVMTypeRef type = LLVMVectorType(I32_TYPE, slot);                    \
-        if (!type || !(consts->i32x##slot##_zero = LLVMConstNull(type)))      \
-            return false;                                                     \
+#define CREATE_VEC_ZERO_MASK(slot)                                       \
+    {                                                                    \
+        LLVMTypeRef type = LLVMVectorType(I32_TYPE, slot);               \
+        if (!type || !(consts->i32x##slot##_zero = LLVMConstNull(type))) \
+            return false;                                                \
     }
 
     CREATE_VEC_ZERO_MASK(16)
@@ -1088,10 +1058,11 @@ typedef struct ArchItem {
     bool support_eb;
 } ArchItem;
 
+/* clang-format off */
 static ArchItem valid_archs[] = {
     { "x86_64", false },
     { "i386", false },
-    { "xtensa", false},
+    { "xtensa", false },
     { "mips", true },
     { "aarch64v8", false },
     { "aarch64v8.1", false },
@@ -1099,7 +1070,7 @@ static ArchItem valid_archs[] = {
     { "aarch64v8.3", false },
     { "aarch64v8.4", false },
     { "aarch64v8.5", false },
-    { "aarch64_bev8", false },   /* big endian */
+    { "aarch64_bev8", false }, /* big endian */
     { "aarch64_bev8.1", false },
     { "aarch64_bev8.2", false },
     { "aarch64_bev8.3", false },
@@ -1141,8 +1112,8 @@ static ArchItem valid_archs[] = {
     { "thumbv8m.base", true },
     { "thumbv8m.main", true },
     { "thumbv8.1m.main", true },
-    { "riscv32", true},
-    { "riscv64", true},
+    { "riscv32", true },
+    { "riscv64", true },
     { "arc", true }
 };
 
@@ -1158,6 +1129,7 @@ static const char *valid_abis[] = {
     "lp64f",
     "lp64d"
 };
+/* clang-format on */
 
 static void
 print_supported_targets()
@@ -1194,8 +1166,9 @@ check_target_arch(const char *target_arch)
         support_eb = valid_archs[i].support_eb;
 
         if (!strncmp(target_arch, arch, strlen(arch))
-            && ((support_eb && (!strcmp(target_arch + strlen(arch), "eb")
-                                || !strcmp(target_arch + strlen(arch), "")))
+            && ((support_eb
+                 && (!strcmp(target_arch + strlen(arch), "eb")
+                     || !strcmp(target_arch + strlen(arch), "")))
                 || (!support_eb && !strcmp(target_arch + strlen(arch), "")))) {
             return true;
         }
@@ -1214,7 +1187,6 @@ check_target_abi(const char *target_abi)
     return false;
 }
 
-
 static void
 get_target_arch_from_triple(const char *triple, char *arch_buf, uint32 buf_size)
 {
@@ -1229,22 +1201,19 @@ LLVMBool
 WAMRCreateMCJITCompilerForModule(LLVMExecutionEngineRef *OutJIT,
                                  LLVMModuleRef M,
                                  struct LLVMMCJITCompilerOptions *Options,
-                                 size_t SizeOfOptions,
-                                 char **OutError);
+                                 size_t SizeOfOptions, char **OutError);
 
-void LLVMAddPromoteMemoryToRegisterPass(LLVMPassManagerRef PM);
+void
+LLVMAddPromoteMemoryToRegisterPass(LLVMPassManagerRef PM);
 
 #if WASM_ENABLE_LAZY_JIT != 0
 void
-aot_handle_llvm_errmsg(char *error_buf,
-                       uint32 error_buf_size,
-                       const char *string,
-                       LLVMErrorRef error)
+aot_handle_llvm_errmsg(char *error_buf, uint32 error_buf_size,
+                       const char *string, LLVMErrorRef error)
 {
     char *err_msg = LLVMGetErrorMessage(error);
     if (error_buf != NULL) {
-        snprintf(error_buf, error_buf_size,
-                 "%s: %s", string, err_msg);
+        snprintf(error_buf, error_buf_size, "%s: %s", string, err_msg);
     }
     LLVMDisposeErrorMessage(err_msg);
 }
@@ -1256,13 +1225,13 @@ llvm_orcjit_create(AOTCompContext *comp_ctx)
     char *cpu = NULL;
     char *features = NULL;
     char *llvm_triple = NULL;
-    char buf[128] = {0};
+    char buf[128] = { 0 };
 
-    LLVMErrorRef         error;
-    LLVMTargetRef        llvm_targetref = NULL;
+    LLVMErrorRef error;
+    LLVMTargetRef llvm_targetref = NULL;
     LLVMTargetMachineRef tm_opt = NULL;
     LLVMTargetMachineRef tm_opt2 = NULL;
-    LLVMOrcLLLazyJITRef  lazy_orcjit = NULL;
+    LLVMOrcLLLazyJITRef lazy_orcjit = NULL;
     LLVMOrcJITTargetMachineBuilderRef tm_builder = NULL;
     LLVMOrcLLLazyJITBuilderRef lazy_orcjit_builder = NULL;
 #if LLVM_VERSION_MAJOR < 12
@@ -1301,24 +1270,20 @@ llvm_orcjit_create(AOTCompContext *comp_ctx)
         goto fail;
     }
 
-    LOG_VERBOSE("LLVM ORCJIT detected CPU \"%s\", with features \"%s\"\n",
-                cpu, features);
+    LOG_VERBOSE("LLVM ORCJIT detected CPU \"%s\", with features \"%s\"\n", cpu,
+                features);
 
-    tm_opt = LLVMCreateTargetMachine(llvm_targetref, llvm_triple,
-                                     cpu, features,
+    tm_opt = LLVMCreateTargetMachine(llvm_targetref, llvm_triple, cpu, features,
                                      LLVMCodeGenLevelAggressive,
-                                     LLVMRelocDefault,
-                                     LLVMCodeModelJITDefault);
+                                     LLVMRelocDefault, LLVMCodeModelJITDefault);
     if (!tm_opt) {
         snprintf(buf, sizeof(buf), "failed to create target machine.");
         goto fail;
     }
 
-    tm_opt2 = LLVMCreateTargetMachine(llvm_targetref, llvm_triple,
-                                      cpu, features,
-                                      LLVMCodeGenLevelAggressive,
-                                      LLVMRelocDefault,
-                                      LLVMCodeModelJITDefault);
+    tm_opt2 = LLVMCreateTargetMachine(
+        llvm_targetref, llvm_triple, cpu, features, LLVMCodeGenLevelAggressive,
+        LLVMRelocDefault, LLVMCodeModelJITDefault);
     if (!tm_opt2) {
         snprintf(buf, sizeof(buf), "failed to create target machine2.");
         goto fail;
@@ -1352,11 +1317,11 @@ llvm_orcjit_create(AOTCompContext *comp_ctx)
     lazy_orcjit_builder = NULL;
 
     error = LLVMOrcCreateDynamicLibrarySearchGeneratorForProcess(
-                &main_gen, LLVMOrcLLLazyJITGetGlobalPrefix(lazy_orcjit),
-                0, NULL);
+        &main_gen, LLVMOrcLLLazyJITGetGlobalPrefix(lazy_orcjit), 0, NULL);
     if (error) {
-        aot_handle_llvm_errmsg(buf, sizeof(buf),
-                "failed to create dynmaic library search generator", error);
+        aot_handle_llvm_errmsg(
+            buf, sizeof(buf),
+            "failed to create dynmaic library search generator", error);
         goto fail;
     }
 
@@ -1394,8 +1359,7 @@ fail:
 #endif /* WASM_ENABLE_LAZY_JIT != 0 */
 
 AOTCompContext *
-aot_create_comp_context(AOTCompData *comp_data,
-                        aot_comp_option_t option)
+aot_create_comp_context(AOTCompData *comp_data, aot_comp_option_t option)
 {
     AOTCompContext *comp_ctx, *ret = NULL;
 #if WASM_ENABLE_LAZY_JIT == 0
@@ -1406,7 +1370,8 @@ aot_create_comp_context(AOTCompData *comp_data,
     char *triple = NULL, *triple_norm, *arch, *abi;
     char *cpu = NULL, *features, buf[128];
     char *triple_norm_new = NULL, *cpu_new = NULL;
-    char *err = NULL, *fp_round= "round.tonearest", *fp_exce = "fpexcept.strict";
+    char *err = NULL, *fp_round = "round.tonearest",
+         *fp_exce = "fpexcept.strict";
     char triple_buf[32] = { 0 }, features_buf[128] = { 0 };
     uint32 opt_level, size_level;
     LLVMCodeModel code_model;
@@ -1444,7 +1409,7 @@ aot_create_comp_context(AOTCompData *comp_data,
     }
     /* Get a reference to the underlying LLVMContext */
     if (!(comp_ctx->context =
-            LLVMOrcThreadSafeContextGetContext(comp_ctx->ts_context))) {
+              LLVMOrcThreadSafeContextGetContext(comp_ctx->ts_context))) {
         aot_set_last_error("get context from LLVM ThreadSafeContext failed.");
         goto fail;
     }
@@ -1460,8 +1425,8 @@ aot_create_comp_context(AOTCompData *comp_data,
         goto fail;
     }
 
-    if (!(comp_ctx->module =
-                LLVMModuleCreateWithNameInContext("WASM Module", comp_ctx->context))) {
+    if (!(comp_ctx->module = LLVMModuleCreateWithNameInContext(
+              "WASM Module", comp_ctx->context))) {
         aot_set_last_error("create LLVM module failed.");
         goto fail;
     }
@@ -1477,9 +1442,9 @@ aot_create_comp_context(AOTCompData *comp_data,
     }
 
     LLVMAddModuleFlag(
-      comp_ctx->module, LLVMModuleFlagBehaviorWarning, "Debug Info Version",
-      strlen("Debug Info Version"),
-      LLVMValueAsMetadata(LLVMConstInt(LLVMInt32Type(), 3, false)));
+        comp_ctx->module, LLVMModuleFlagBehaviorWarning, "Debug Info Version",
+        strlen("Debug Info Version"),
+        LLVMValueAsMetadata(LLVMConstInt(LLVMInt32Type(), 3, false)));
 
     comp_ctx->debug_file = dwarf_gen_file_info(comp_ctx);
     if (!comp_ctx->debug_file) {
@@ -1523,9 +1488,9 @@ aot_create_comp_context(AOTCompData *comp_data,
 #if WASM_ENABLE_LAZY_JIT != 0
         /* Create LLLazyJIT Instance */
         if (!llvm_orcjit_create(comp_ctx)) {
-		    aot_set_last_error("create LLVM Lazy JIT Compiler failed.");
-			goto fail;
-		}
+            aot_set_last_error("create LLVM Lazy JIT Compiler failed.");
+            goto fail;
+        }
 
 #else
         /* Create LLVM execution engine */
@@ -1533,9 +1498,10 @@ aot_create_comp_context(AOTCompData *comp_data,
         jit_options.OptLevel = LLVMCodeGenLevelAggressive;
         jit_options.EnableFastISel = true;
         /*jit_options.CodeModel = LLVMCodeModelSmall;*/
-        if (WAMRCreateMCJITCompilerForModule
-                (&comp_ctx->exec_engine, comp_ctx->module,
-                 &jit_options, sizeof(jit_options), &err) != 0) {
+        if (WAMRCreateMCJITCompilerForModule(&comp_ctx->exec_engine,
+                                             comp_ctx->module, &jit_options,
+                                             sizeof(jit_options), &err)
+            != 0) {
             if (err) {
                 LLVMDisposeMessage(err);
                 err = NULL;
@@ -1544,7 +1510,7 @@ aot_create_comp_context(AOTCompData *comp_data,
             goto fail;
         }
         comp_ctx->target_machine =
-                LLVMGetExecutionEngineTargetMachine(comp_ctx->exec_engine);
+            LLVMGetExecutionEngineTargetMachine(comp_ctx->exec_engine);
 #endif
         comp_ctx->is_jit_mode = true;
 
@@ -1555,8 +1521,8 @@ aot_create_comp_context(AOTCompData *comp_data,
 #endif
 
 #if WASM_ENABLE_LAZY_JIT != 0
-        if (!(triple_jit =
-                (char *)LLVMOrcLLLazyJITGetTripleString(comp_ctx->lazy_orcjit))) {
+        if (!(triple_jit = (char *)LLVMOrcLLLazyJITGetTripleString(
+                  comp_ctx->lazy_orcjit))) {
             aot_set_last_error("can not get triple from the target machine");
             goto fail;
         }
@@ -1566,7 +1532,7 @@ aot_create_comp_context(AOTCompData *comp_data,
                                     sizeof(comp_ctx->target_arch));
 #else
         if (!(triple_jit =
-                LLVMGetTargetMachineTriple(comp_ctx->target_machine))) {
+                  LLVMGetTargetMachineTriple(comp_ctx->target_machine))) {
             aot_set_last_error("can not get triple from the target machine");
             goto fail;
         }
@@ -1607,8 +1573,9 @@ aot_create_comp_context(AOTCompData *comp_data,
             if (!strcmp(arch, "help"))
                 print_supported_targets();
             else
-                aot_set_last_error("Invalid target. "
-                                   "Use --target=help to list all supported targets");
+                aot_set_last_error(
+                    "Invalid target. "
+                    "Use --target=help to list all supported targets");
             goto fail;
         }
 
@@ -1617,8 +1584,9 @@ aot_create_comp_context(AOTCompData *comp_data,
             if (!strcmp(abi, "help"))
                 print_supported_abis();
             else
-                aot_set_last_error("Invalid target ABI. "
-                                   "Use --target-abi=help to list all supported ABI");
+                aot_set_last_error(
+                    "Invalid target ABI. "
+                    "Use --target-abi=help to list all supported ABI");
             goto fail;
         }
 
@@ -1658,10 +1626,12 @@ aot_create_comp_context(AOTCompData *comp_data,
 
             LLVMDisposeMessage(default_triple);
 
-            bh_assert(strlen(arch) + strlen(vendor_sys) + strlen(abi) < sizeof(triple_buf));
+            bh_assert(strlen(arch) + strlen(vendor_sys) + strlen(abi)
+                      < sizeof(triple_buf));
             memcpy(triple_buf, arch, strlen(arch));
             memcpy(triple_buf + strlen(arch), vendor_sys, strlen(vendor_sys));
-            memcpy(triple_buf + strlen(arch) + strlen(vendor_sys), abi, strlen(abi));
+            memcpy(triple_buf + strlen(arch) + strlen(vendor_sys), abi,
+                   strlen(abi));
             triple = triple_buf;
         }
 
@@ -1672,7 +1642,8 @@ aot_create_comp_context(AOTCompData *comp_data,
 
         if (!triple && !cpu) {
             /* Get a triple for the host machine */
-            if (!(triple_norm = triple_norm_new = LLVMGetDefaultTargetTriple())) {
+            if (!(triple_norm = triple_norm_new =
+                      LLVMGetDefaultTargetTriple())) {
                 aot_set_last_error("llvm get default target triple failed.");
                 goto fail;
             }
@@ -1684,7 +1655,8 @@ aot_create_comp_context(AOTCompData *comp_data,
         }
         else if (triple) {
             /* Normalize a target triple */
-            if (!(triple_norm = triple_norm_new = LLVMNormalizeTargetTriple(triple))) {
+            if (!(triple_norm = triple_norm_new =
+                      LLVMNormalizeTargetTriple(triple))) {
                 snprintf(buf, sizeof(buf),
                          "llvm normlalize target triple (%s) failed.", triple);
                 aot_set_last_error(buf);
@@ -1695,8 +1667,8 @@ aot_create_comp_context(AOTCompData *comp_data,
         }
         else {
             /* triple is NULL, cpu isn't NULL */
-            snprintf(buf, sizeof(buf),
-                    "target isn't specified for cpu %s.", cpu);
+            snprintf(buf, sizeof(buf), "target isn't specified for cpu %s.",
+                     cpu);
             aot_set_last_error(buf);
             goto fail;
         }
@@ -1711,12 +1683,13 @@ aot_create_comp_context(AOTCompData *comp_data,
                 goto fail;
             }
             LLVMAddModuleFlag(comp_ctx->module, LLVMModuleFlagBehaviorError,
-                          "target-abi", strlen("target-abi"), meta_target_abi);
+                              "target-abi", strlen("target-abi"),
+                              meta_target_abi);
 
             if (!strcmp(abi, "lp64d") || !strcmp(abi, "ilp32d")) {
                 if (features) {
-                    snprintf(features_buf, sizeof(features_buf),
-                             "%s%s", features, ",+d");
+                    snprintf(features_buf, sizeof(features_buf), "%s%s",
+                             features, ",+d");
                     features = features_buf;
                 }
                 else
@@ -1751,7 +1724,8 @@ aot_create_comp_context(AOTCompData *comp_data,
         }
         else {
             /* Unset by user, use default value */
-            if (strstr(comp_ctx->target_arch, "64") && !option->is_sgx_platform) {
+            if (strstr(comp_ctx->target_arch, "64")
+                && !option->is_sgx_platform) {
                 comp_ctx->enable_bound_check = false;
             }
             else {
@@ -1788,13 +1762,14 @@ aot_create_comp_context(AOTCompData *comp_data,
         }
 
         /* Report error if target isn't arc and hasn't asm backend.
-           For arc target, as it cannot emit to memory buffer of elf file currently,
-           we let it emit to assembly file instead, and then call arc-gcc to compile
+           For arc target, as it cannot emit to memory buffer of elf file
+           currently, we let it emit to assembly file instead, and then call
+           arc-gcc to compile
            asm file to elf file, and read elf file to memory buffer. */
         if (strncmp(comp_ctx->target_arch, "arc", 3)
             && !LLVMTargetHasAsmBackend(target)) {
-            snprintf(buf, sizeof(buf),
-                     "no asm backend for this target (%s).", LLVMGetTargetName(target));
+            snprintf(buf, sizeof(buf), "no asm backend for this target (%s).",
+                     LLVMGetTargetName(target));
             aot_set_last_error(buf);
             goto fail;
         }
@@ -1810,17 +1785,15 @@ aot_create_comp_context(AOTCompData *comp_data,
             code_model = LLVMCodeModelSmall;
 
         /* Create the target machine */
-        if (!(comp_ctx->target_machine =
-                    LLVMCreateTargetMachine(target, triple_norm, cpu, features,
-                                            opt_level, LLVMRelocStatic,
-                                            code_model))) {
+        if (!(comp_ctx->target_machine = LLVMCreateTargetMachine(
+                  target, triple_norm, cpu, features, opt_level,
+                  LLVMRelocStatic, code_model))) {
             aot_set_last_error("create LLVM target machine failed.");
             goto fail;
         }
     }
 
-    if (option->enable_simd
-        && strcmp(comp_ctx->target_arch, "x86_64") != 0
+    if (option->enable_simd && strcmp(comp_ctx->target_arch, "x86_64") != 0
         && strncmp(comp_ctx->target_arch, "aarch64", 7) != 0) {
         /* Disable simd if it isn't supported by target arch */
         option->enable_simd = false;
@@ -1848,7 +1821,7 @@ aot_create_comp_context(AOTCompData *comp_data,
     }
 
     if (!(target_data_ref =
-            LLVMCreateTargetDataLayout(comp_ctx->target_machine))) {
+              LLVMCreateTargetDataLayout(comp_ctx->target_machine))) {
         aot_set_last_error("create LLVM target data layout failed.");
         goto fail;
     }
@@ -1859,8 +1832,8 @@ aot_create_comp_context(AOTCompData *comp_data,
     if (option->output_format == AOT_LLVMIR_UNOPT_FILE)
         comp_ctx->optimize = false;
 
-    if (!(comp_ctx->pass_mgr = LLVMCreateFunctionPassManagerForModule
-                (comp_ctx->module))) {
+    if (!(comp_ctx->pass_mgr =
+              LLVMCreateFunctionPassManagerForModule(comp_ctx->module))) {
         aot_set_last_error("create LLVM pass manager failed.");
         goto fail;
     }
@@ -1881,7 +1854,7 @@ aot_create_comp_context(AOTCompData *comp_data,
         LLVMAddCFGSimplificationPass(comp_ctx->pass_mgr);
         if (!option->enable_thread_mgr) {
             /* These two passes may destroy the volatile semantics,
-                disable them when building as multi-thread mode */
+               disable them when building as multi-thread mode */
             LLVMAddGVNPass(comp_ctx->pass_mgr);
             LLVMAddLICMPass(comp_ctx->pass_mgr);
         }
@@ -1892,14 +1865,10 @@ aot_create_comp_context(AOTCompData *comp_data,
     }
 
     /* Create metadata for llvm float experimental constrained intrinsics */
-    if (!(comp_ctx->fp_rounding_mode =
-                LLVMMDStringInContext(comp_ctx->context,
-                                      fp_round,
-                                      (uint32)strlen(fp_round)))
-        || !(comp_ctx->fp_exception_behavior =
-                LLVMMDStringInContext(comp_ctx->context,
-                                      fp_exce,
-                                      (uint32)strlen(fp_exce)))) {
+    if (!(comp_ctx->fp_rounding_mode = LLVMMDStringInContext(
+              comp_ctx->context, fp_round, (uint32)strlen(fp_round)))
+        || !(comp_ctx->fp_exception_behavior = LLVMMDStringInContext(
+                 comp_ctx->context, fp_exce, (uint32)strlen(fp_exce)))) {
         aot_set_last_error("create float llvm metadata failed.");
         goto fail;
     }
@@ -1924,7 +1893,7 @@ aot_create_comp_context(AOTCompData *comp_data,
     comp_ctx->func_ctx_count = comp_data->func_count;
     if (comp_data->func_count > 0
         && !(comp_ctx->func_ctxes =
-                aot_create_func_contexts(comp_data, comp_ctx)))
+                 aot_create_func_contexts(comp_data, comp_ctx)))
         goto fail;
 
     if (cpu) {
@@ -2167,8 +2136,8 @@ aot_block_destroy(AOTBlock *block)
 }
 
 bool
-aot_checked_addr_list_add(AOTFuncContext *func_ctx,
-                          uint32 local_idx, uint32 offset, uint32 bytes)
+aot_checked_addr_list_add(AOTFuncContext *func_ctx, uint32 local_idx,
+                          uint32 offset, uint32 bytes)
 {
     AOTCheckedAddr *node = func_ctx->checked_addr_list;
 
@@ -2211,14 +2180,13 @@ aot_checked_addr_list_del(AOTFuncContext *func_ctx, uint32 local_idx)
 }
 
 bool
-aot_checked_addr_list_find(AOTFuncContext *func_ctx,
-                           uint32 local_idx, uint32 offset, uint32 bytes)
+aot_checked_addr_list_find(AOTFuncContext *func_ctx, uint32 local_idx,
+                           uint32 offset, uint32 bytes)
 {
     AOTCheckedAddr *node = func_ctx->checked_addr_list;
 
     while (node) {
-        if (node->local_idx == local_idx
-            && node->offset == offset
+        if (node->local_idx == local_idx && node->offset == offset
             && node->bytes >= bytes) {
             return true;
         }
@@ -2243,8 +2211,7 @@ aot_checked_addr_list_destroy(AOTFuncContext *func_ctx)
 }
 
 bool
-aot_build_zero_function_ret(AOTCompContext *comp_ctx,
-                            AOTFuncContext *func_ctx,
+aot_build_zero_function_ret(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                             AOTFuncType *func_type)
 {
     LLVMValueRef ret = NULL;
@@ -2265,7 +2232,7 @@ aot_build_zero_function_ret(AOTCompContext *comp_ctx,
                 break;
             case VALUE_TYPE_V128:
                 ret =
-                  LLVMBuildRet(comp_ctx->builder, LLVM_CONST(i64x2_vec_zero));
+                    LLVMBuildRet(comp_ctx->builder, LLVM_CONST(i64x2_vec_zero));
                 break;
             case VALUE_TYPE_FUNCREF:
             case VALUE_TYPE_EXTERNREF:
@@ -2284,7 +2251,8 @@ aot_build_zero_function_ret(AOTCompContext *comp_ctx,
         return false;
     }
 #if WASM_ENABLE_DEBUG_AOT != 0
-    LLVMMetadataRef return_location = dwarf_gen_func_ret_location(comp_ctx, func_ctx);
+    LLVMMetadataRef return_location =
+        dwarf_gen_func_ret_location(comp_ctx, func_ctx);
     LLVMInstructionSetDebugLoc(ret, return_location);
 #endif
     return true;
@@ -2292,12 +2260,9 @@ aot_build_zero_function_ret(AOTCompContext *comp_ctx,
 
 static LLVMValueRef
 __call_llvm_intrinsic(const AOTCompContext *comp_ctx,
-                      const AOTFuncContext *func_ctx,
-                      const char *name,
-                      LLVMTypeRef ret_type,
-                      LLVMTypeRef *param_types,
-                      int param_count,
-                      LLVMValueRef *param_values)
+                      const AOTFuncContext *func_ctx, const char *name,
+                      LLVMTypeRef ret_type, LLVMTypeRef *param_types,
+                      int param_count, LLVMValueRef *param_values)
 {
     LLVMValueRef func, ret;
     LLVMTypeRef func_type;
@@ -2318,7 +2283,7 @@ __call_llvm_intrinsic(const AOTCompContext *comp_ctx,
         }
         if (!(func_type = LLVMPointerType(func_type, 0))) {
             aot_set_last_error(
-              "create LLVM intrinsic function pointer type failed.");
+                "create LLVM intrinsic function pointer type failed.");
             return NULL;
         }
 
@@ -2329,7 +2294,7 @@ __call_llvm_intrinsic(const AOTCompContext *comp_ctx,
         }
 
         func_idx =
-          aot_get_native_symbol_index((AOTCompContext *)comp_ctx, symname);
+            aot_get_native_symbol_index((AOTCompContext *)comp_ctx, symname);
         if (func_idx < 0) {
             aot_set_last_error_v("get runtime intrinsc index failed: %s\n",
                                  name);
@@ -2347,7 +2312,8 @@ __call_llvm_intrinsic(const AOTCompContext *comp_ctx,
         if (!(func = LLVMGetNamedFunction(comp_ctx->module, name))) {
             if (!(func_type = LLVMFunctionType(ret_type, param_types,
                                                (uint32)param_count, false))) {
-                aot_set_last_error("create LLVM intrinsic function type failed.");
+                aot_set_last_error(
+                    "create LLVM intrinsic function type failed.");
                 return NULL;
             }
 
@@ -2370,12 +2336,9 @@ __call_llvm_intrinsic(const AOTCompContext *comp_ctx,
 
 LLVMValueRef
 aot_call_llvm_intrinsic(const AOTCompContext *comp_ctx,
-                        const AOTFuncContext *func_ctx,
-                        const char *intrinsic,
-                        LLVMTypeRef ret_type,
-                        LLVMTypeRef *param_types,
-                        int param_count,
-                        ...)
+                        const AOTFuncContext *func_ctx, const char *intrinsic,
+                        LLVMTypeRef ret_type, LLVMTypeRef *param_types,
+                        int param_count, ...)
 {
     LLVMValueRef *param_values, ret;
     va_list argptr;
@@ -2406,12 +2369,9 @@ aot_call_llvm_intrinsic(const AOTCompContext *comp_ctx,
 
 LLVMValueRef
 aot_call_llvm_intrinsic_v(const AOTCompContext *comp_ctx,
-                          const AOTFuncContext *func_ctx,
-                          const char *intrinsic,
-                          LLVMTypeRef ret_type,
-                          LLVMTypeRef *param_types,
-                          int param_count,
-                          va_list param_value_list)
+                          const AOTFuncContext *func_ctx, const char *intrinsic,
+                          LLVMTypeRef ret_type, LLVMTypeRef *param_types,
+                          int param_count, va_list param_value_list)
 {
     LLVMValueRef *param_values, ret;
     uint64 total_size;
@@ -2462,8 +2422,8 @@ aot_get_func_from_table(const AOTCompContext *comp_ctx, LLVMValueRef base,
         goto fail;
     }
 
-    if (!(func = LLVMBuildBitCast(comp_ctx->builder, func, func_type,
-                                  "func"))) {
+    if (!(func =
+              LLVMBuildBitCast(comp_ctx->builder, func, func_type, "func"))) {
         aot_set_last_error("cast function fialed.");
         goto fail;
     }

--- a/core/iwasm/compilation/aot_llvm.h
+++ b/core/iwasm/compilation/aot_llvm.h
@@ -33,163 +33,162 @@
 extern "C" {
 #endif
 
-
 /**
  * Value in the WASM operation stack, each stack element
  * is an LLVM value
  */
 typedef struct AOTValue {
-  struct AOTValue *next;
-  struct AOTValue *prev;
-  LLVMValueRef value;
-  /* VALUE_TYPE_I32/I64/F32/F64/VOID */
-  uint8 type;
-  bool is_local;
-  uint32 local_idx;
+    struct AOTValue *next;
+    struct AOTValue *prev;
+    LLVMValueRef value;
+    /* VALUE_TYPE_I32/I64/F32/F64/VOID */
+    uint8 type;
+    bool is_local;
+    uint32 local_idx;
 } AOTValue;
 
 /**
  * Value stack, represents stack elements in a WASM block
  */
 typedef struct AOTValueStack {
-  AOTValue *value_list_head;
-  AOTValue *value_list_end;
+    AOTValue *value_list_head;
+    AOTValue *value_list_end;
 } AOTValueStack;
 
 typedef struct AOTBlock {
-  struct AOTBlock *next;
-  struct AOTBlock *prev;
+    struct AOTBlock *next;
+    struct AOTBlock *prev;
 
-  /* Block index */
-  uint32 block_index;
-  /* LABEL_TYPE_BLOCK/LOOP/IF/FUNCTION */
-  uint32 label_type;
-  /* Whether it is reachable */
-  bool is_reachable;
-  /* Whether skip translation of wasm else branch */
-  bool skip_wasm_code_else;
+    /* Block index */
+    uint32 block_index;
+    /* LABEL_TYPE_BLOCK/LOOP/IF/FUNCTION */
+    uint32 label_type;
+    /* Whether it is reachable */
+    bool is_reachable;
+    /* Whether skip translation of wasm else branch */
+    bool skip_wasm_code_else;
 
-  /* code of else opcode of this block, if it is a IF block  */
-  uint8 *wasm_code_else;
-  /* code end of this block */
-  uint8 *wasm_code_end;
+    /* code of else opcode of this block, if it is a IF block  */
+    uint8 *wasm_code_else;
+    /* code end of this block */
+    uint8 *wasm_code_end;
 
-  /* LLVM label points to code begin */
-  LLVMBasicBlockRef llvm_entry_block;
-  /* LLVM label points to code else */
-  LLVMBasicBlockRef llvm_else_block;
-  /* LLVM label points to code end */
-  LLVMBasicBlockRef llvm_end_block;
+    /* LLVM label points to code begin */
+    LLVMBasicBlockRef llvm_entry_block;
+    /* LLVM label points to code else */
+    LLVMBasicBlockRef llvm_else_block;
+    /* LLVM label points to code end */
+    LLVMBasicBlockRef llvm_end_block;
 
-  /* WASM operation stack */
-  AOTValueStack value_stack;
+    /* WASM operation stack */
+    AOTValueStack value_stack;
 
-  /* Param count/types/PHIs of this block */
-  uint32 param_count;
-  uint8 *param_types;
-  LLVMValueRef *param_phis;
-  LLVMValueRef *else_param_phis;
+    /* Param count/types/PHIs of this block */
+    uint32 param_count;
+    uint8 *param_types;
+    LLVMValueRef *param_phis;
+    LLVMValueRef *else_param_phis;
 
-  /* Result count/types/PHIs of this block */
-  uint32 result_count;
-  uint8 *result_types;
-  LLVMValueRef *result_phis;
+    /* Result count/types/PHIs of this block */
+    uint32 result_count;
+    uint8 *result_types;
+    LLVMValueRef *result_phis;
 } AOTBlock;
 
 /**
  * Block stack, represents WASM block stack elements
  */
 typedef struct AOTBlockStack {
-  AOTBlock *block_list_head;
-  AOTBlock *block_list_end;
-  /* Current block index of each block type */
-  uint32 block_index[3];
+    AOTBlock *block_list_head;
+    AOTBlock *block_list_end;
+    /* Current block index of each block type */
+    uint32 block_index[3];
 } AOTBlockStack;
 
 typedef struct AOTCheckedAddr {
-  struct AOTCheckedAddr *next;
-  uint32 local_idx;
-  uint32 offset;
-  uint32 bytes;
+    struct AOTCheckedAddr *next;
+    uint32 local_idx;
+    uint32 offset;
+    uint32 bytes;
 } AOTCheckedAddr, *AOTCheckedAddrList;
 
 typedef struct AOTMemInfo {
-  LLVMValueRef mem_base_addr;
-  LLVMValueRef mem_data_size_addr;
-  LLVMValueRef mem_cur_page_count_addr;
-  LLVMValueRef mem_bound_check_1byte;
-  LLVMValueRef mem_bound_check_2bytes;
-  LLVMValueRef mem_bound_check_4bytes;
-  LLVMValueRef mem_bound_check_8bytes;
-  LLVMValueRef mem_bound_check_16bytes;
+    LLVMValueRef mem_base_addr;
+    LLVMValueRef mem_data_size_addr;
+    LLVMValueRef mem_cur_page_count_addr;
+    LLVMValueRef mem_bound_check_1byte;
+    LLVMValueRef mem_bound_check_2bytes;
+    LLVMValueRef mem_bound_check_4bytes;
+    LLVMValueRef mem_bound_check_8bytes;
+    LLVMValueRef mem_bound_check_16bytes;
 } AOTMemInfo;
 
 typedef struct AOTFuncContext {
-  AOTFunc *aot_func;
-  LLVMValueRef func;
-  LLVMTypeRef func_type;
-  AOTBlockStack block_stack;
+    AOTFunc *aot_func;
+    LLVMValueRef func;
+    LLVMTypeRef func_type;
+    AOTBlockStack block_stack;
 
-  LLVMValueRef exec_env;
-  LLVMValueRef aot_inst;
-  LLVMValueRef argv_buf;
-  LLVMValueRef native_stack_bound;
-  LLVMValueRef aux_stack_bound;
-  LLVMValueRef aux_stack_bottom;
-  LLVMValueRef native_symbol;
-  LLVMValueRef last_alloca;
-  LLVMValueRef func_ptrs;
+    LLVMValueRef exec_env;
+    LLVMValueRef aot_inst;
+    LLVMValueRef argv_buf;
+    LLVMValueRef native_stack_bound;
+    LLVMValueRef aux_stack_bound;
+    LLVMValueRef aux_stack_bottom;
+    LLVMValueRef native_symbol;
+    LLVMValueRef last_alloca;
+    LLVMValueRef func_ptrs;
 
-  AOTMemInfo *mem_info;
+    AOTMemInfo *mem_info;
 
-  LLVMValueRef cur_exception;
+    LLVMValueRef cur_exception;
 
-  bool mem_space_unchanged;
-  AOTCheckedAddrList checked_addr_list;
+    bool mem_space_unchanged;
+    AOTCheckedAddrList checked_addr_list;
 
-  LLVMBasicBlockRef got_exception_block;
-  LLVMBasicBlockRef func_return_block;
-  LLVMValueRef exception_id_phi;
-  LLVMValueRef func_type_indexes;
+    LLVMBasicBlockRef got_exception_block;
+    LLVMBasicBlockRef func_return_block;
+    LLVMValueRef exception_id_phi;
+    LLVMValueRef func_type_indexes;
 #if WASM_ENABLE_DEBUG_AOT != 0
-  LLVMMetadataRef debug_func;
+    LLVMMetadataRef debug_func;
 #endif
-  LLVMValueRef locals[1];
+    LLVMValueRef locals[1];
 } AOTFuncContext;
 
 typedef struct AOTLLVMTypes {
-  LLVMTypeRef int1_type;
-  LLVMTypeRef int8_type;
-  LLVMTypeRef int16_type;
-  LLVMTypeRef int32_type;
-  LLVMTypeRef int64_type;
-  LLVMTypeRef float32_type;
-  LLVMTypeRef float64_type;
-  LLVMTypeRef void_type;
+    LLVMTypeRef int1_type;
+    LLVMTypeRef int8_type;
+    LLVMTypeRef int16_type;
+    LLVMTypeRef int32_type;
+    LLVMTypeRef int64_type;
+    LLVMTypeRef float32_type;
+    LLVMTypeRef float64_type;
+    LLVMTypeRef void_type;
 
-  LLVMTypeRef int8_ptr_type;
-  LLVMTypeRef int8_pptr_type;
-  LLVMTypeRef int16_ptr_type;
-  LLVMTypeRef int32_ptr_type;
-  LLVMTypeRef int64_ptr_type;
-  LLVMTypeRef float32_ptr_type;
-  LLVMTypeRef float64_ptr_type;
+    LLVMTypeRef int8_ptr_type;
+    LLVMTypeRef int8_pptr_type;
+    LLVMTypeRef int16_ptr_type;
+    LLVMTypeRef int32_ptr_type;
+    LLVMTypeRef int64_ptr_type;
+    LLVMTypeRef float32_ptr_type;
+    LLVMTypeRef float64_ptr_type;
 
-  LLVMTypeRef v128_type;
-  LLVMTypeRef v128_ptr_type;
-  LLVMTypeRef i8x16_vec_type;
-  LLVMTypeRef i16x8_vec_type;
-  LLVMTypeRef i32x4_vec_type;
-  LLVMTypeRef i64x2_vec_type;
-  LLVMTypeRef f32x4_vec_type;
-  LLVMTypeRef f64x2_vec_type;
+    LLVMTypeRef v128_type;
+    LLVMTypeRef v128_ptr_type;
+    LLVMTypeRef i8x16_vec_type;
+    LLVMTypeRef i16x8_vec_type;
+    LLVMTypeRef i32x4_vec_type;
+    LLVMTypeRef i64x2_vec_type;
+    LLVMTypeRef f32x4_vec_type;
+    LLVMTypeRef f64x2_vec_type;
 
-  LLVMTypeRef i1x2_vec_type;
+    LLVMTypeRef i1x2_vec_type;
 
-  LLVMTypeRef meta_data_type;
+    LLVMTypeRef meta_data_type;
 
-  LLVMTypeRef funcref_type;
-  LLVMTypeRef externref_type;
+    LLVMTypeRef funcref_type;
+    LLVMTypeRef externref_type;
 } AOTLLVMTypes;
 
 typedef struct AOTLLVMConsts {
@@ -245,89 +244,89 @@ typedef struct AOTLLVMConsts {
  * Compiler context
  */
 typedef struct AOTCompContext {
-  AOTCompData *comp_data;
+    AOTCompData *comp_data;
 
-  /* LLVM variables required to emit LLVM IR */
-  LLVMContextRef context;
-  LLVMModuleRef module;
-  LLVMBuilderRef builder;
+    /* LLVM variables required to emit LLVM IR */
+    LLVMContextRef context;
+    LLVMModuleRef module;
+    LLVMBuilderRef builder;
 #if WASM_ENABLE_DEBUG_AOT
-  LLVMDIBuilderRef debug_builder;
-  LLVMMetadataRef debug_file;
-  LLVMMetadataRef debug_comp_unit;
+    LLVMDIBuilderRef debug_builder;
+    LLVMMetadataRef debug_file;
+    LLVMMetadataRef debug_comp_unit;
 #endif
-  LLVMTargetMachineRef target_machine;
-  char *target_cpu;
-  char target_arch[16];
-  unsigned pointer_size;
+    LLVMTargetMachineRef target_machine;
+    char *target_cpu;
+    char target_arch[16];
+    unsigned pointer_size;
 
-  /* Hardware intrinsic compability flags */
-  uint64 flags[8];
+    /* Hardware intrinsic compability flags */
+    uint64 flags[8];
 
-  /* LLVM execution engine required by JIT */
+    /* LLVM execution engine required by JIT */
 #if WASM_ENABLE_LAZY_JIT != 0
-  LLVMOrcLLLazyJITRef lazy_orcjit;
-  LLVMOrcThreadSafeContextRef ts_context;
-  LLVMOrcJITTargetMachineBuilderRef tm_builder;
+    LLVMOrcLLLazyJITRef lazy_orcjit;
+    LLVMOrcThreadSafeContextRef ts_context;
+    LLVMOrcJITTargetMachineBuilderRef tm_builder;
 #else
-  LLVMExecutionEngineRef exec_engine;
+    LLVMExecutionEngineRef exec_engine;
 #endif
-  bool is_jit_mode;
+    bool is_jit_mode;
 
-  /* AOT indirect mode flag & symbol list */
-  bool is_indirect_mode;
-  bh_list native_symbols;
+    /* AOT indirect mode flag & symbol list */
+    bool is_indirect_mode;
+    bh_list native_symbols;
 
-  /* Bulk memory feature */
-  bool enable_bulk_memory;
+    /* Bulk memory feature */
+    bool enable_bulk_memory;
 
-  /* Bounday Check */
-  bool enable_bound_check;
+    /* Bounday Check */
+    bool enable_bound_check;
 
-  /* 128-bit SIMD */
-  bool enable_simd;
+    /* 128-bit SIMD */
+    bool enable_simd;
 
-  /* Auxiliary stack overflow/underflow check */
-  bool enable_aux_stack_check;
+    /* Auxiliary stack overflow/underflow check */
+    bool enable_aux_stack_check;
 
-  /* Generate auxiliary stack frame */
-  bool enable_aux_stack_frame;
+    /* Generate auxiliary stack frame */
+    bool enable_aux_stack_frame;
 
-  /* Thread Manager */
-  bool enable_thread_mgr;
+    /* Thread Manager */
+    bool enable_thread_mgr;
 
-  /* Tail Call */
-  bool enable_tail_call;
+    /* Tail Call */
+    bool enable_tail_call;
 
-  /* Reference Types */
-  bool enable_ref_types;
+    /* Reference Types */
+    bool enable_ref_types;
 
-  /* Disable LLVM built-in intrinsics */
-  bool disable_llvm_intrinsics;
+    /* Disable LLVM built-in intrinsics */
+    bool disable_llvm_intrinsics;
 
-  /* Whether optimize the JITed code */
-  bool optimize;
+    /* Whether optimize the JITed code */
+    bool optimize;
 
-  /* LLVM pass manager to optimize the JITed code */
-  LLVMPassManagerRef pass_mgr;
+    /* LLVM pass manager to optimize the JITed code */
+    LLVMPassManagerRef pass_mgr;
 
-  /* LLVM floating-point rounding mode metadata */
-  LLVMValueRef fp_rounding_mode;
+    /* LLVM floating-point rounding mode metadata */
+    LLVMValueRef fp_rounding_mode;
 
-  /* LLVM floating-point exception behavior metadata */
-  LLVMValueRef fp_exception_behavior;
+    /* LLVM floating-point exception behavior metadata */
+    LLVMValueRef fp_exception_behavior;
 
-  /* LLVM data types */
-  AOTLLVMTypes basic_types;
-  LLVMTypeRef exec_env_type;
-  LLVMTypeRef aot_inst_type;
+    /* LLVM data types */
+    AOTLLVMTypes basic_types;
+    LLVMTypeRef exec_env_type;
+    LLVMTypeRef aot_inst_type;
 
-  /* LLVM const values */
-  AOTLLVMConsts llvm_consts;
+    /* LLVM const values */
+    AOTLLVMConsts llvm_consts;
 
-  /* Function contexts */
-  AOTFuncContext **func_ctxes;
-  uint32 func_ctx_count;
+    /* Function contexts */
+    AOTFuncContext **func_ctxes;
+    uint32 func_ctx_count;
 } AOTCompContext;
 
 enum {
@@ -337,7 +336,7 @@ enum {
     AOT_LLVMIR_OPT_FILE,
 };
 
-typedef struct AOTCompOption{
+typedef struct AOTCompOption {
     bool is_jit_mode;
     bool is_indirect_mode;
     char *target_arch;
@@ -360,8 +359,7 @@ typedef struct AOTCompOption{
 } AOTCompOption, *aot_comp_option_t;
 
 AOTCompContext *
-aot_create_comp_context(AOTCompData *comp_data,
-                        aot_comp_option_t option);
+aot_create_comp_context(AOTCompData *comp_data, aot_comp_option_t option);
 
 void
 aot_destroy_comp_context(AOTCompContext *comp_ctx);
@@ -372,7 +370,7 @@ aot_get_native_symbol_index(AOTCompContext *comp_ctx, const char *symbol);
 bool
 aot_compile_wasm(AOTCompContext *comp_ctx);
 
-uint8*
+uint8 *
 aot_emit_elf_file(AOTCompContext *comp_ctx, uint32 *p_elf_file_size);
 
 void
@@ -403,57 +401,46 @@ LLVMTypeRef
 wasm_type_to_llvm_type(AOTLLVMTypes *llvm_types, uint8 wasm_type);
 
 bool
-aot_checked_addr_list_add(AOTFuncContext *func_ctx,
-                          uint32 local_idx, uint32 offset, uint32 bytes);
+aot_checked_addr_list_add(AOTFuncContext *func_ctx, uint32 local_idx,
+                          uint32 offset, uint32 bytes);
 
 void
 aot_checked_addr_list_del(AOTFuncContext *func_ctx, uint32 local_idx);
 
 bool
-aot_checked_addr_list_find(AOTFuncContext *func_ctx,
-                           uint32 local_idx, uint32 offset, uint32 bytes);
+aot_checked_addr_list_find(AOTFuncContext *func_ctx, uint32 local_idx,
+                           uint32 offset, uint32 bytes);
 
 void
 aot_checked_addr_list_destroy(AOTFuncContext *func_ctx);
 
 bool
-aot_build_zero_function_ret(AOTCompContext *comp_ctx,
-                            AOTFuncContext *func_ctx,
+aot_build_zero_function_ret(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                             AOTFuncType *func_type);
 
 LLVMValueRef
 aot_call_llvm_intrinsic(const AOTCompContext *comp_ctx,
-                        const AOTFuncContext *func_ctx,
-                        const char *intrinsic,
-                        LLVMTypeRef ret_type,
-                        LLVMTypeRef *param_types,
-                        int param_count,
-                        ...);
+                        const AOTFuncContext *func_ctx, const char *intrinsic,
+                        LLVMTypeRef ret_type, LLVMTypeRef *param_types,
+                        int param_count, ...);
 
 LLVMValueRef
 aot_call_llvm_intrinsic_v(const AOTCompContext *comp_ctx,
-                          const AOTFuncContext *func_ctx,
-                          const char *intrinsic,
-                          LLVMTypeRef ret_type,
-                          LLVMTypeRef *param_types,
-                          int param_count,
-                          va_list param_value_list);
+                          const AOTFuncContext *func_ctx, const char *intrinsic,
+                          LLVMTypeRef ret_type, LLVMTypeRef *param_types,
+                          int param_count, va_list param_value_list);
 
 LLVMValueRef
-aot_get_func_from_table(const AOTCompContext *comp_ctx,
-                        LLVMValueRef base,
-                        LLVMTypeRef func_type,
-                        int32 index);
+aot_get_func_from_table(const AOTCompContext *comp_ctx, LLVMValueRef base,
+                        LLVMTypeRef func_type, int32 index);
 
 bool
 aot_check_simd_compatibility(const char *arch_c_str, const char *cpu_c_str);
 
 #if WASM_ENABLE_LAZY_JIT != 0
 void
-aot_handle_llvm_errmsg(char *error_buf,
-                       uint32 error_buf_size,
-                       const char *string,
-                       LLVMErrorRef error);
+aot_handle_llvm_errmsg(char *error_buf, uint32 error_buf_size,
+                       const char *string, LLVMErrorRef error);
 #endif
 
 #ifdef __cplusplus
@@ -461,4 +448,3 @@ aot_handle_llvm_errmsg(char *error_buf,
 #endif
 
 #endif /* end of _AOT_LLVM_H_ */
-

--- a/core/iwasm/compilation/aot_llvm_lazyjit.cpp
+++ b/core/iwasm/compilation/aot_llvm_lazyjit.cpp
@@ -15,8 +15,7 @@ void
 LLVMOrcDisposeLLJITBuilder(LLVMOrcLLJITBuilderRef Builder);
 
 LLVMErrorRef
-LLVMOrcCreateLLJIT(LLVMOrcLLJITRef *Result,
-                   LLVMOrcLLJITBuilderRef Builder);
+LLVMOrcCreateLLJIT(LLVMOrcLLJITRef *Result, LLVMOrcLLJITBuilderRef Builder);
 
 LLVMErrorRef
 LLVMOrcDisposeLLJIT(LLVMOrcLLJITRef J);
@@ -31,13 +30,11 @@ char
 LLVMOrcLLJITGetGlobalPrefix(LLVMOrcLLJITRef J);
 
 LLVMErrorRef
-LLVMOrcLLJITAddLLVMIRModule(LLVMOrcLLJITRef J,
-                            LLVMOrcJITDylibRef JD,
+LLVMOrcLLJITAddLLVMIRModule(LLVMOrcLLJITRef J, LLVMOrcJITDylibRef JD,
                             LLVMOrcThreadSafeModuleRef TSM);
 
 LLVMErrorRef
-LLVMOrcLLJITLookup(LLVMOrcLLJITRef J,
-                   LLVMOrcJITTargetAddress *Result,
+LLVMOrcLLJITLookup(LLVMOrcLLJITRef J, LLVMOrcJITTargetAddress *Result,
                    const char *Name);
 
 const char *
@@ -45,8 +42,7 @@ LLVMOrcLLJITGetTripleString(LLVMOrcLLJITRef J);
 
 void
 LLVMOrcLLJITBuilderSetJITTargetMachineBuilder(
-                        LLVMOrcLLJITBuilderRef Builder,
-                        LLVMOrcJITTargetMachineBuilderRef JTMB);
+    LLVMOrcLLJITBuilderRef Builder, LLVMOrcJITTargetMachineBuilderRef JTMB);
 
 char
 LLVMOrcLLJITGetGlobalPrefix(LLVMOrcLLJITRef J);
@@ -91,16 +87,14 @@ LLVMOrcDisposeLLLazyJIT(LLVMOrcLLLazyJITRef J)
 }
 
 LLVMErrorRef
-LLVMOrcLLLazyJITAddLLVMIRModule(LLVMOrcLLLazyJITRef J,
-                                LLVMOrcJITDylibRef JD,
+LLVMOrcLLLazyJITAddLLVMIRModule(LLVMOrcLLLazyJITRef J, LLVMOrcJITDylibRef JD,
                                 LLVMOrcThreadSafeModuleRef TSM)
 {
     return LLVMOrcLLJITAddLLVMIRModule(J, JD, TSM);
 }
 
 LLVMErrorRef
-LLVMOrcLLLazyJITLookup(LLVMOrcLLLazyJITRef J,
-                       LLVMOrcJITTargetAddress *Result,
+LLVMOrcLLLazyJITLookup(LLVMOrcLLLazyJITRef J, LLVMOrcJITTargetAddress *Result,
                        const char *Name)
 {
     return LLVMOrcLLJITLookup(J, Result, Name);
@@ -114,8 +108,7 @@ LLVMOrcLLLazyJITGetTripleString(LLVMOrcLLLazyJITRef J)
 
 void
 LLVMOrcLLLazyJITBuilderSetJITTargetMachineBuilder(
-                    LLVMOrcLLLazyJITBuilderRef Builder,
-                    LLVMOrcJITTargetMachineBuilderRef JTMB)
+    LLVMOrcLLLazyJITBuilderRef Builder, LLVMOrcJITTargetMachineBuilderRef JTMB)
 {
     return LLVMOrcLLJITBuilderSetJITTargetMachineBuilder(Builder, JTMB);
 }
@@ -125,4 +118,3 @@ LLVMOrcLLLazyJITGetGlobalPrefix(LLVMOrcLLLazyJITRef J)
 {
     return LLVMOrcLLJITGetGlobalPrefix(J);
 }
-

--- a/core/iwasm/compilation/aot_llvm_lazyjit.h
+++ b/core/iwasm/compilation/aot_llvm_lazyjit.h
@@ -14,7 +14,6 @@
 #include "llvm-c/LLJIT.h"
 #endif
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -49,13 +48,11 @@ char
 LLVMOrcLLLazyJITGetGlobalPrefix(LLVMOrcLLLazyJITRef J);
 
 LLVMErrorRef
-LLVMOrcLLLazyJITAddLLVMIRModule(LLVMOrcLLLazyJITRef J,
-                                LLVMOrcJITDylibRef JD,
+LLVMOrcLLLazyJITAddLLVMIRModule(LLVMOrcLLLazyJITRef J, LLVMOrcJITDylibRef JD,
                                 LLVMOrcThreadSafeModuleRef TSM);
 
 LLVMErrorRef
-LLVMOrcLLLazyJITLookup(LLVMOrcLLLazyJITRef J,
-                       LLVMOrcJITTargetAddress *Result,
+LLVMOrcLLLazyJITLookup(LLVMOrcLLLazyJITRef J, LLVMOrcJITTargetAddress *Result,
                        const char *Name);
 
 const char *
@@ -63,8 +60,7 @@ LLVMOrcLLLazyJITGetTripleString(LLVMOrcLLLazyJITRef J);
 
 void
 LLVMOrcLLLazyJITBuilderSetJITTargetMachineBuilder(
-                        LLVMOrcLLLazyJITBuilderRef Builder,
-                        LLVMOrcJITTargetMachineBuilderRef JTMB);
+    LLVMOrcLLLazyJITBuilderRef Builder, LLVMOrcJITTargetMachineBuilderRef JTMB);
 
 char
 LLVMOrcLLLazyJITGetGlobalPrefix(LLVMOrcLLLazyJITRef J);
@@ -74,4 +70,3 @@ LLVMOrcLLLazyJITGetGlobalPrefix(LLVMOrcLLLazyJITRef J);
 #endif
 
 #endif /* end of AOT_LLVM_LAZYJIT_H */
-

--- a/core/iwasm/compilation/debug/dwarf_extractor.h
+++ b/core/iwasm/compilation/debug/dwarf_extractor.h
@@ -11,8 +11,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
 typedef unsigned int LLDBLangType;
-#define LLDB_TO_LLVM_LANG_TYPE(lldb_lang_type)                                \
+#define LLDB_TO_LLVM_LANG_TYPE(lldb_lang_type) \
     (LLVMDWARFSourceLanguage)(((lldb_lang_type) > 0 ? (lldb_lang_type)-1 : 1))
 
 struct AOTCompData;
@@ -35,22 +36,19 @@ LLVMMetadataRef
 dwarf_gen_comp_unit_info(AOTCompContext *comp_ctx);
 
 LLVMMetadataRef
-dwarf_gen_func_info(AOTCompContext *comp_ctx, AOTFuncContext  *func_ctx);
+dwarf_gen_func_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx);
 
 LLVMMetadataRef
-dwarf_gen_location(AOTCompContext *comp_ctx,
-                   AOTFuncContext *func_ctx,
+dwarf_gen_location(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                    uint64_t vm_offset);
 
 LLVMMetadataRef
-dwarf_gen_func_ret_location(AOTCompContext *comp_ctx,
-                            AOTFuncContext *func_ctx);
+dwarf_gen_func_ret_location(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx);
 
 void
-dwarf_get_func_name(AOTCompContext *comp_ctx,
-                    AOTFuncContext *func_ctx,
-                    char *name,
-                    int len);
+dwarf_get_func_name(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                    char *name, int len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/iwasm/compilation/simd/simd_access_lanes.c
+++ b/core/iwasm/compilation/simd/simd_access_lanes.c
@@ -9,8 +9,7 @@
 #include "../../aot/aot_runtime.h"
 
 bool
-aot_compile_simd_shuffle(AOTCompContext *comp_ctx,
-                         AOTFuncContext *func_ctx,
+aot_compile_simd_shuffle(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                          const uint8 *frame_ip)
 {
     LLVMValueRef vec1, vec2, mask, result;
@@ -34,8 +33,8 @@ aot_compile_simd_shuffle(AOTCompContext *comp_ctx,
     }
 
     /* build a vector <16 x i32> */
-    if (!(mask =
-            simd_build_const_integer_vector(comp_ctx, I32_TYPE, values, 16))) {
+    if (!(mask = simd_build_const_integer_vector(comp_ctx, I32_TYPE, values,
+                                                 16))) {
         goto fail;
     }
 
@@ -54,8 +53,7 @@ fail:
 /*TODO: llvm.experimental.vector.*/
 /* shufflevector is not an option, since it requires *mask as a const */
 bool
-aot_compile_simd_swizzle_x86(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx)
+aot_compile_simd_swizzle_x86(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 {
     LLVMValueRef vector, mask, max_lanes, condition, mask_lanes, result;
     LLVMTypeRef param_types[2];
@@ -71,15 +69,17 @@ aot_compile_simd_swizzle_x86(AOTCompContext *comp_ctx,
     }
 
     /* icmp uge <16 x i8> mask, <16, 16, 16, 16, ...> */
-    if (!(max_lanes = simd_build_splat_const_integer_vector(
-            comp_ctx, INT8_TYPE, 16, 16))) {
+    if (!(max_lanes = simd_build_splat_const_integer_vector(comp_ctx, INT8_TYPE,
+                                                            16, 16))) {
         goto fail;
     }
 
-    /*  if the highest bit of every i8 of mask is 1, means doesn't pick up from vector */
-    /* select <16 x i1> %condition, <16 x i8> <0x80, 0x80, ...>, <16 x i8> %mask */
+    /* if the highest bit of every i8 of mask is 1, means doesn't pick up
+       from vector */
+    /* select <16 x i1> %condition, <16 x i8> <0x80, 0x80, ...>,
+              <16 x i8> %mask */
     if (!(mask_lanes = simd_build_splat_const_integer_vector(
-            comp_ctx, INT8_TYPE, 0x80, 16))) {
+              comp_ctx, INT8_TYPE, 0x80, 16))) {
         goto fail;
     }
 
@@ -89,8 +89,8 @@ aot_compile_simd_swizzle_x86(AOTCompContext *comp_ctx,
         goto fail;
     }
 
-    if (!(mask = LLVMBuildSelect(comp_ctx->builder, condition, mask_lanes,
-                                 mask, "mask"))) {
+    if (!(mask = LLVMBuildSelect(comp_ctx->builder, condition, mask_lanes, mask,
+                                 "mask"))) {
         HANDLE_FAILURE("LLVMBuildSelect");
         goto fail;
     }
@@ -98,8 +98,8 @@ aot_compile_simd_swizzle_x86(AOTCompContext *comp_ctx,
     param_types[0] = V128_i8x16_TYPE;
     param_types[1] = V128_i8x16_TYPE;
     if (!(result = aot_call_llvm_intrinsic(
-            comp_ctx, func_ctx, "llvm.x86.ssse3.pshuf.b.128", V128_i8x16_TYPE,
-            param_types, 2, vector, mask))) {
+              comp_ctx, func_ctx, "llvm.x86.ssse3.pshuf.b.128", V128_i8x16_TYPE,
+              param_types, 2, vector, mask))) {
         HANDLE_FAILURE("LLVMBuildCall");
         goto fail;
     }
@@ -122,7 +122,7 @@ aot_compile_simd_swizzle_common(AOTCompContext *comp_ctx,
                                 AOTFuncContext *func_ctx)
 {
     LLVMValueRef vector, mask, default_lane_value, condition, max_lane_id,
-      result, idx, id, replace_with_zero, elem, elem_or_zero, undef;
+        result, idx, id, replace_with_zero, elem, elem_or_zero, undef;
     uint8 i;
 
     if (!(mask = simd_pop_v128_and_bitcast(comp_ctx, func_ctx, V128_i8x16_TYPE,
@@ -142,7 +142,7 @@ aot_compile_simd_swizzle_common(AOTCompContext *comp_ctx,
 
     /* icmp uge <16 x i8> mask, <16, 16, 16, 16, ...> */
     if (!(max_lane_id = simd_build_splat_const_integer_vector(
-            comp_ctx, INT8_TYPE, 16, 16))) {
+              comp_ctx, INT8_TYPE, 16, 16))) {
         goto fail;
     }
 
@@ -152,9 +152,9 @@ aot_compile_simd_swizzle_common(AOTCompContext *comp_ctx,
         goto fail;
     }
 
-    /*  if the id is out of range (>=16), set the id as 0 */
+    /* if the id is out of range (>=16), set the id as 0 */
     if (!(default_lane_value = simd_build_splat_const_integer_vector(
-            comp_ctx, INT8_TYPE, 0, 16))) {
+              comp_ctx, INT8_TYPE, 0, 16))) {
         goto fail;
     }
 
@@ -172,8 +172,8 @@ aot_compile_simd_swizzle_common(AOTCompContext *comp_ctx,
         }
 
         if (!(replace_with_zero =
-                LLVMBuildExtractElement(comp_ctx->builder, condition,
-                                        I8_CONST(i), "replace_with_zero"))) {
+                  LLVMBuildExtractElement(comp_ctx->builder, condition,
+                                          I8_CONST(i), "replace_with_zero"))) {
             HANDLE_FAILURE("LLVMBuildExtractElement");
             goto fail;
         }
@@ -185,15 +185,15 @@ aot_compile_simd_swizzle_common(AOTCompContext *comp_ctx,
         }
 
         if (!(elem_or_zero =
-                LLVMBuildSelect(comp_ctx->builder, replace_with_zero,
-                                I8_CONST(0), elem, "elem_or_zero"))) {
+                  LLVMBuildSelect(comp_ctx->builder, replace_with_zero,
+                                  I8_CONST(0), elem, "elem_or_zero"))) {
             HANDLE_FAILURE("LLVMBuildSelect");
             goto fail;
         }
 
         if (!(undef =
-                LLVMBuildInsertElement(comp_ctx->builder, undef, elem_or_zero,
-                                       I8_CONST(i), "new_vector"))) {
+                  LLVMBuildInsertElement(comp_ctx->builder, undef, elem_or_zero,
+                                         I8_CONST(i), "new_vector"))) {
             HANDLE_FAILURE("LLVMBuildInsertElement");
             goto fail;
         }
@@ -224,13 +224,9 @@ aot_compile_simd_swizzle(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 }
 
 static bool
-aot_compile_simd_extract(AOTCompContext *comp_ctx,
-                         AOTFuncContext *func_ctx,
-                         uint8 lane_id,
-                         bool need_extend,
-                         bool is_signed,
-                         LLVMTypeRef vector_type,
-                         LLVMTypeRef result_type,
+aot_compile_simd_extract(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                         uint8 lane_id, bool need_extend, bool is_signed,
+                         LLVMTypeRef vector_type, LLVMTypeRef result_type,
                          unsigned aot_value_type)
 {
     LLVMValueRef vector, lane, result;
@@ -256,16 +252,16 @@ aot_compile_simd_extract(AOTCompContext *comp_ctx,
     if (need_extend) {
         if (is_signed) {
             /* sext <element_type> %element to <result_type> */
-            if (!(result = LLVMBuildSExt(comp_ctx->builder, result,
-                                         result_type, "ret"))) {
+            if (!(result = LLVMBuildSExt(comp_ctx->builder, result, result_type,
+                                         "ret"))) {
                 HANDLE_FAILURE("LLVMBuildSExt");
                 goto fail;
             }
         }
         else {
             /* sext <element_type> %element to <result_type> */
-            if (!(result = LLVMBuildZExt(comp_ctx->builder, result,
-                                         result_type, "ret"))) {
+            if (!(result = LLVMBuildZExt(comp_ctx->builder, result, result_type,
+                                         "ret"))) {
                 HANDLE_FAILURE("LLVMBuildZExt");
                 goto fail;
             }
@@ -281,8 +277,7 @@ fail:
 
 bool
 aot_compile_simd_extract_i8x16(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               uint8 lane_id,
+                               AOTFuncContext *func_ctx, uint8 lane_id,
                                bool is_signed)
 {
     return aot_compile_simd_extract(comp_ctx, func_ctx, lane_id, true,
@@ -292,8 +287,7 @@ aot_compile_simd_extract_i8x16(AOTCompContext *comp_ctx,
 
 bool
 aot_compile_simd_extract_i16x8(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               uint8 lane_id,
+                               AOTFuncContext *func_ctx, uint8 lane_id,
                                bool is_signed)
 {
     return aot_compile_simd_extract(comp_ctx, func_ctx, lane_id, true,
@@ -303,8 +297,7 @@ aot_compile_simd_extract_i16x8(AOTCompContext *comp_ctx,
 
 bool
 aot_compile_simd_extract_i32x4(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               uint8 lane_id)
+                               AOTFuncContext *func_ctx, uint8 lane_id)
 {
     return aot_compile_simd_extract(comp_ctx, func_ctx, lane_id, false, false,
                                     V128_i32x4_TYPE, I32_TYPE, VALUE_TYPE_I32);
@@ -312,8 +305,7 @@ aot_compile_simd_extract_i32x4(AOTCompContext *comp_ctx,
 
 bool
 aot_compile_simd_extract_i64x2(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               uint8 lane_id)
+                               AOTFuncContext *func_ctx, uint8 lane_id)
 {
     return aot_compile_simd_extract(comp_ctx, func_ctx, lane_id, false, false,
                                     V128_i64x2_TYPE, I64_TYPE, VALUE_TYPE_I64);
@@ -321,8 +313,7 @@ aot_compile_simd_extract_i64x2(AOTCompContext *comp_ctx,
 
 bool
 aot_compile_simd_extract_f32x4(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               uint8 lane_id)
+                               AOTFuncContext *func_ctx, uint8 lane_id)
 {
     return aot_compile_simd_extract(comp_ctx, func_ctx, lane_id, false, false,
                                     V128_f32x4_TYPE, F32_TYPE, VALUE_TYPE_F32);
@@ -330,20 +321,16 @@ aot_compile_simd_extract_f32x4(AOTCompContext *comp_ctx,
 
 bool
 aot_compile_simd_extract_f64x2(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               uint8 lane_id)
+                               AOTFuncContext *func_ctx, uint8 lane_id)
 {
     return aot_compile_simd_extract(comp_ctx, func_ctx, lane_id, false, false,
                                     V128_f64x2_TYPE, F64_TYPE, VALUE_TYPE_F64);
 }
 
 static bool
-aot_compile_simd_replace(AOTCompContext *comp_ctx,
-                         AOTFuncContext *func_ctx,
-                         uint8 lane_id,
-                         unsigned new_value_type,
-                         LLVMTypeRef vector_type,
-                         bool need_reduce,
+aot_compile_simd_replace(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                         uint8 lane_id, unsigned new_value_type,
+                         LLVMTypeRef vector_type, bool need_reduce,
                          LLVMTypeRef element_type)
 {
     LLVMValueRef vector, new_value, lane, result;
@@ -368,7 +355,8 @@ aot_compile_simd_replace(AOTCompContext *comp_ctx,
         }
     }
 
-    /* insertelement <vector_type> %vector, <element_type>  %element, i32 lane */
+    /* insertelement <vector_type> %vector, <element_type>  %element,
+                     i32 lane */
     if (!(result = LLVMBuildInsertElement(comp_ctx->builder, vector, new_value,
                                           lane, "new_vector"))) {
         HANDLE_FAILURE("LLVMBuildInsertElement");
@@ -383,60 +371,48 @@ fail:
 
 bool
 aot_compile_simd_replace_i8x16(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               uint8 lane_id)
+                               AOTFuncContext *func_ctx, uint8 lane_id)
 {
-    return aot_compile_simd_replace(comp_ctx, func_ctx, lane_id,
-                                    VALUE_TYPE_I32, V128_i8x16_TYPE, true,
-                                    INT8_TYPE);
+    return aot_compile_simd_replace(comp_ctx, func_ctx, lane_id, VALUE_TYPE_I32,
+                                    V128_i8x16_TYPE, true, INT8_TYPE);
 }
 
 bool
 aot_compile_simd_replace_i16x8(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               uint8 lane_id)
+                               AOTFuncContext *func_ctx, uint8 lane_id)
 {
-    return aot_compile_simd_replace(comp_ctx, func_ctx, lane_id,
-                                    VALUE_TYPE_I32, V128_i16x8_TYPE, true,
-                                    INT16_TYPE);
+    return aot_compile_simd_replace(comp_ctx, func_ctx, lane_id, VALUE_TYPE_I32,
+                                    V128_i16x8_TYPE, true, INT16_TYPE);
 }
 
 bool
 aot_compile_simd_replace_i32x4(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               uint8 lane_id)
+                               AOTFuncContext *func_ctx, uint8 lane_id)
 {
-    return aot_compile_simd_replace(comp_ctx, func_ctx, lane_id,
-                                    VALUE_TYPE_I32, V128_i32x4_TYPE, false,
-                                    I32_TYPE);
+    return aot_compile_simd_replace(comp_ctx, func_ctx, lane_id, VALUE_TYPE_I32,
+                                    V128_i32x4_TYPE, false, I32_TYPE);
 }
 
 bool
 aot_compile_simd_replace_i64x2(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               uint8 lane_id)
+                               AOTFuncContext *func_ctx, uint8 lane_id)
 {
-    return aot_compile_simd_replace(comp_ctx, func_ctx, lane_id,
-                                    VALUE_TYPE_I64, V128_i64x2_TYPE, false,
-                                    I64_TYPE);
+    return aot_compile_simd_replace(comp_ctx, func_ctx, lane_id, VALUE_TYPE_I64,
+                                    V128_i64x2_TYPE, false, I64_TYPE);
 }
 
 bool
 aot_compile_simd_replace_f32x4(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               uint8 lane_id)
+                               AOTFuncContext *func_ctx, uint8 lane_id)
 {
-    return aot_compile_simd_replace(comp_ctx, func_ctx, lane_id,
-                                    VALUE_TYPE_F32, V128_f32x4_TYPE, false,
-                                    F32_TYPE);
+    return aot_compile_simd_replace(comp_ctx, func_ctx, lane_id, VALUE_TYPE_F32,
+                                    V128_f32x4_TYPE, false, F32_TYPE);
 }
 
 bool
 aot_compile_simd_replace_f64x2(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               uint8 lane_id)
+                               AOTFuncContext *func_ctx, uint8 lane_id)
 {
-    return aot_compile_simd_replace(comp_ctx, func_ctx, lane_id,
-                                    VALUE_TYPE_F64, V128_f64x2_TYPE, false,
-                                    F64_TYPE);
+    return aot_compile_simd_replace(comp_ctx, func_ctx, lane_id, VALUE_TYPE_F64,
+                                    V128_f64x2_TYPE, false, F64_TYPE);
 }

--- a/core/iwasm/compilation/simd/simd_access_lanes.h
+++ b/core/iwasm/compilation/simd/simd_access_lanes.h
@@ -13,8 +13,7 @@ extern "C" {
 #endif
 
 bool
-aot_compile_simd_shuffle(AOTCompContext *comp_ctx,
-                         AOTFuncContext *func_ctx,
+aot_compile_simd_shuffle(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                          const uint8 *frame_ip);
 
 bool
@@ -22,84 +21,68 @@ aot_compile_simd_swizzle(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx);
 
 bool
 aot_compile_simd_extract_i8x16(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               uint8 lane_id,
+                               AOTFuncContext *func_ctx, uint8 lane_id,
                                bool is_signed);
 
 bool
 aot_compile_simd_extract_i16x8(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               uint8 lane_id,
+                               AOTFuncContext *func_ctx, uint8 lane_id,
                                bool is_signed);
 
 bool
 aot_compile_simd_extract_i32x4(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               uint8 lane_id);
+                               AOTFuncContext *func_ctx, uint8 lane_id);
 
 bool
 aot_compile_simd_extract_i64x2(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               uint8 lane_id);
+                               AOTFuncContext *func_ctx, uint8 lane_id);
 
 bool
 aot_compile_simd_extract_f32x4(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               uint8 lane_id);
+                               AOTFuncContext *func_ctx, uint8 lane_id);
 
 bool
 aot_compile_simd_extract_f64x2(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               uint8 lane_id);
+                               AOTFuncContext *func_ctx, uint8 lane_id);
 
 bool
 aot_compile_simd_replace_i8x16(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               uint8 lane_id);
+                               AOTFuncContext *func_ctx, uint8 lane_id);
 
 bool
 aot_compile_simd_replace_i16x8(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               uint8 lane_id);
+                               AOTFuncContext *func_ctx, uint8 lane_id);
 
 bool
 aot_compile_simd_replace_i32x4(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               uint8 lane_id);
+                               AOTFuncContext *func_ctx, uint8 lane_id);
 
 bool
 aot_compile_simd_replace_i64x2(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               uint8 lane_id);
+                               AOTFuncContext *func_ctx, uint8 lane_id);
 
 bool
 aot_compile_simd_replace_f32x4(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               uint8 lane_id);
+                               AOTFuncContext *func_ctx, uint8 lane_id);
 
 bool
 aot_compile_simd_replace_f64x2(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               uint8 lane_id);
+                               AOTFuncContext *func_ctx, uint8 lane_id);
 
 bool
-aot_compile_simd_load8_lane(AOTCompContext *comp_ctx,
-                            AOTFuncContext *func_ctx,
+aot_compile_simd_load8_lane(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                             uint8 lane_id);
 
 bool
-aot_compile_simd_load16_lane(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
+aot_compile_simd_load16_lane(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              uint8 lane_id);
 
 bool
-aot_compile_simd_load32_lane(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
+aot_compile_simd_load32_lane(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              uint8 lane_id);
 
 bool
-aot_compile_simd_load64_lane(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
+aot_compile_simd_load64_lane(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              uint8 lane_id);
 
 #ifdef __cplusplus

--- a/core/iwasm/compilation/simd/simd_bit_shifts.c
+++ b/core/iwasm/compilation/simd/simd_bit_shifts.c
@@ -16,10 +16,8 @@ enum integer_shift {
 };
 
 static bool
-simd_shift(AOTCompContext *comp_ctx,
-           AOTFuncContext *func_ctx,
-           IntShift shift_op,
-           enum integer_shift itype)
+simd_shift(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+           IntShift shift_op, enum integer_shift itype)
 {
     LLVMValueRef vector, offset, result = NULL;
     LLVMTypeRef vector_type[] = { V128_i8x16_TYPE, V128_i16x8_TYPE,
@@ -27,8 +25,7 @@ simd_shift(AOTCompContext *comp_ctx,
     LLVMTypeRef element_type[] = { INT8_TYPE, INT16_TYPE, I32_TYPE, I64_TYPE };
 
     LLVMValueRef undef[] = { LLVM_CONST(i8x16_undef), LLVM_CONST(i16x8_undef),
-                             LLVM_CONST(i32x4_undef),
-                             LLVM_CONST(i64x2_undef) };
+                             LLVM_CONST(i32x4_undef), LLVM_CONST(i64x2_undef) };
     LLVMValueRef mask[] = { LLVM_CONST(i8x16_vec_zero),
                             LLVM_CONST(i16x8_vec_zero),
                             LLVM_CONST(i32x4_vec_zero),
@@ -49,8 +46,8 @@ simd_shift(AOTCompContext *comp_ctx,
 
     /* offset mod LaneBits */
     if (!lane_bits[itype]
-        || !(offset = LLVMBuildSRem(comp_ctx->builder, offset,
-                                    lane_bits[itype], "offset_fix"))) {
+        || !(offset = LLVMBuildSRem(comp_ctx->builder, offset, lane_bits[itype],
+                                    "offset_fix"))) {
         HANDLE_FAILURE("LLVMBuildSRem");
         return false;
     }
@@ -72,15 +69,15 @@ simd_shift(AOTCompContext *comp_ctx,
 
     /* splat to a vector */
     if (!(offset =
-            LLVMBuildInsertElement(comp_ctx->builder, undef[itype], offset,
-                                   I32_ZERO, "offset_vector_base"))) {
+              LLVMBuildInsertElement(comp_ctx->builder, undef[itype], offset,
+                                     I32_ZERO, "offset_vector_base"))) {
         HANDLE_FAILURE("LLVMBuildInsertElement");
         return false;
     }
 
     if (!(offset =
-            LLVMBuildShuffleVector(comp_ctx->builder, offset, undef[itype],
-                                   mask[itype], "offset_vector"))) {
+              LLVMBuildShuffleVector(comp_ctx->builder, offset, undef[itype],
+                                     mask[itype], "offset_vector"))) {
         HANDLE_FAILURE("LLVMBuildShuffleVector");
         return false;
     }
@@ -119,32 +116,28 @@ fail:
 }
 
 bool
-aot_compile_simd_i8x16_shift(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
+aot_compile_simd_i8x16_shift(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              IntShift shift_op)
 {
     return simd_shift(comp_ctx, func_ctx, shift_op, e_shift_i8x16);
 }
 
 bool
-aot_compile_simd_i16x8_shift(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
+aot_compile_simd_i16x8_shift(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              IntShift shift_op)
 {
     return simd_shift(comp_ctx, func_ctx, shift_op, e_shift_i16x8);
 }
 
 bool
-aot_compile_simd_i32x4_shift(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
+aot_compile_simd_i32x4_shift(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              IntShift shift_op)
 {
     return simd_shift(comp_ctx, func_ctx, shift_op, e_shift_i32x4);
 }
 
 bool
-aot_compile_simd_i64x2_shift(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
+aot_compile_simd_i64x2_shift(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              IntShift shift_op)
 {
     return simd_shift(comp_ctx, func_ctx, shift_op, e_shift_i64x2);

--- a/core/iwasm/compilation/simd/simd_bit_shifts.h
+++ b/core/iwasm/compilation/simd/simd_bit_shifts.h
@@ -13,23 +13,19 @@ extern "C" {
 #endif
 
 bool
-aot_compile_simd_i8x16_shift(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
+aot_compile_simd_i8x16_shift(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              IntShift shift_op);
 
 bool
-aot_compile_simd_i16x8_shift(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
+aot_compile_simd_i16x8_shift(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              IntShift shift_op);
 
 bool
-aot_compile_simd_i32x4_shift(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
+aot_compile_simd_i32x4_shift(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              IntShift shift_op);
 
 bool
-aot_compile_simd_i64x2_shift(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
+aot_compile_simd_i64x2_shift(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              IntShift shift_op);
 
 #ifdef __cplusplus

--- a/core/iwasm/compilation/simd/simd_bitmask_extracts.c
+++ b/core/iwasm/compilation/simd/simd_bitmask_extracts.c
@@ -47,8 +47,8 @@ simd_build_bitmask(const AOTCompContext *comp_ctx,
 
     /* fill every bit in a lange with its sign bit */
     if (!(ashr_distance = simd_build_splat_const_integer_vector(
-            comp_ctx, element_type[itype], lane_bits[itype] - 1,
-            lanes[itype]))) {
+              comp_ctx, element_type[itype], lane_bits[itype] - 1,
+              lanes[itype]))) {
         goto fail;
     }
 
@@ -64,8 +64,8 @@ simd_build_bitmask(const AOTCompContext *comp_ctx,
     }
 
     if (e_bitmask_i64x2 != itype) {
-        if (!(vector = LLVMBuildSExt(comp_ctx->builder, vector,
-                                     vector_ext_type, "zext_to_i64"))) {
+        if (!(vector = LLVMBuildSExt(comp_ctx->builder, vector, vector_ext_type,
+                                     "zext_to_i64"))) {
             goto fail;
         }
     }
@@ -74,25 +74,25 @@ simd_build_bitmask(const AOTCompContext *comp_ctx,
         mask_element[i] = 0x1 << i;
     }
 
-    if (!(mask = simd_build_const_integer_vector(
-            comp_ctx, I64_TYPE, mask_element, lanes[itype]))) {
+    if (!(mask = simd_build_const_integer_vector(comp_ctx, I64_TYPE,
+                                                 mask_element, lanes[itype]))) {
         goto fail;
     }
 
     if (!(vector =
-            LLVMBuildAnd(comp_ctx->builder, vector, mask, "mask_bits"))) {
+              LLVMBuildAnd(comp_ctx->builder, vector, mask, "mask_bits"))) {
         HANDLE_FAILURE("LLVMBuildAnd");
         goto fail;
     }
 
     if (!(result =
-            aot_call_llvm_intrinsic(comp_ctx, func_ctx, intrinsic[itype],
-                                    I64_TYPE, &vector_ext_type, 1, vector))) {
+              aot_call_llvm_intrinsic(comp_ctx, func_ctx, intrinsic[itype],
+                                      I64_TYPE, &vector_ext_type, 1, vector))) {
         goto fail;
     }
 
     if (!(result =
-            LLVMBuildTrunc(comp_ctx->builder, result, I32_TYPE, "to_i32"))) {
+              LLVMBuildTrunc(comp_ctx->builder, result, I32_TYPE, "to_i32"))) {
         HANDLE_FAILURE("LLVMBuildTrunc");
         goto fail;
     }

--- a/core/iwasm/compilation/simd/simd_bitwise_ops.c
+++ b/core/iwasm/compilation/simd/simd_bitwise_ops.c
@@ -8,8 +8,7 @@
 #include "../../aot/aot_runtime.h"
 
 static bool
-v128_bitwise_two_component(AOTCompContext *comp_ctx,
-                           AOTFuncContext *func_ctx,
+v128_bitwise_two_component(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                            V128Bitwise bitwise_op)
 {
     LLVMValueRef vector1, vector2, result;
@@ -27,7 +26,7 @@ v128_bitwise_two_component(AOTCompContext *comp_ctx,
             break;
         case V128_OR:
             if (!(result =
-                    LLVMBuildOr(comp_ctx->builder, vector1, vector2, "or"))) {
+                      LLVMBuildOr(comp_ctx->builder, vector1, vector2, "or"))) {
                 HANDLE_FAILURE("LLVMBuildAnd");
                 goto fail;
             }
@@ -95,7 +94,7 @@ v128_bitwise_bitselect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
     POP_V128(vector1);
 
     if (!(vector1 =
-            LLVMBuildAnd(comp_ctx->builder, vector1, vector3, "a_and_c"))) {
+              LLVMBuildAnd(comp_ctx->builder, vector1, vector3, "a_and_c"))) {
         HANDLE_FAILURE("LLVMBuildAdd");
         goto fail;
     }
@@ -106,13 +105,13 @@ v128_bitwise_bitselect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
     }
 
     if (!(vector2 =
-            LLVMBuildAnd(comp_ctx->builder, vector2, vector3, "b_and_c"))) {
+              LLVMBuildAnd(comp_ctx->builder, vector2, vector3, "b_and_c"))) {
         HANDLE_FAILURE("LLVMBuildAdd");
         goto fail;
     }
 
     if (!(result =
-            LLVMBuildOr(comp_ctx->builder, vector1, vector2, "a_or_b"))) {
+              LLVMBuildOr(comp_ctx->builder, vector1, vector2, "a_or_b"))) {
         HANDLE_FAILURE("LLVMBuildOr");
         goto fail;
     }
@@ -126,8 +125,7 @@ fail:
 
 bool
 aot_compile_simd_v128_bitwise(AOTCompContext *comp_ctx,
-                              AOTFuncContext *func_ctx,
-                              V128Bitwise bitwise_op)
+                              AOTFuncContext *func_ctx, V128Bitwise bitwise_op)
 {
     switch (bitwise_op) {
         case V128_AND:

--- a/core/iwasm/compilation/simd/simd_bitwise_ops.h
+++ b/core/iwasm/compilation/simd/simd_bitwise_ops.h
@@ -14,8 +14,7 @@ extern "C" {
 
 bool
 aot_compile_simd_v128_bitwise(AOTCompContext *comp_ctx,
-                              AOTFuncContext *func_ctx,
-                              V128Bitwise bitwise_op);
+                              AOTFuncContext *func_ctx, V128Bitwise bitwise_op);
 
 #ifdef __cplusplus
 } /* end of extern "C" */

--- a/core/iwasm/compilation/simd/simd_bool_reductions.c
+++ b/core/iwasm/compilation/simd/simd_bool_reductions.c
@@ -16,8 +16,7 @@ enum integer_all_true {
 };
 
 static bool
-simd_all_true(AOTCompContext *comp_ctx,
-              AOTFuncContext *func_ctx,
+simd_all_true(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
               enum integer_all_true itype)
 {
     LLVMValueRef vector, result;
@@ -56,14 +55,14 @@ simd_all_true(AOTCompContext *comp_ctx,
     }
 
     /* check zero */
-    if (!(result = aot_call_llvm_intrinsic(comp_ctx, func_ctx,
-                                           intrinsic[itype], INT1_TYPE,
-                                           &vector_i1_type, 1, result))) {
+    if (!(result =
+              aot_call_llvm_intrinsic(comp_ctx, func_ctx, intrinsic[itype],
+                                      INT1_TYPE, &vector_i1_type, 1, result))) {
         goto fail;
     }
 
     if (!(result =
-            LLVMBuildZExt(comp_ctx->builder, result, I32_TYPE, "to_i32"))) {
+              LLVMBuildZExt(comp_ctx->builder, result, I32_TYPE, "to_i32"))) {
         HANDLE_FAILURE("LLVMBuildZExt");
         goto fail;
     }
@@ -120,13 +119,13 @@ aot_compile_simd_v128_any_true(AOTCompContext *comp_ctx,
     }
 
     if (!(result = aot_call_llvm_intrinsic(
-            comp_ctx, func_ctx, "llvm.vector.reduce.or.v128i1", INT1_TYPE,
-            &vector_type, 1, vector))) {
+              comp_ctx, func_ctx, "llvm.vector.reduce.or.v128i1", INT1_TYPE,
+              &vector_type, 1, vector))) {
         goto fail;
     }
 
     if (!(result =
-            LLVMBuildZExt(comp_ctx->builder, result, I32_TYPE, "to_i32"))) {
+              LLVMBuildZExt(comp_ctx->builder, result, I32_TYPE, "to_i32"))) {
         HANDLE_FAILURE("LLVMBuildZExt");
         goto fail;
     }

--- a/core/iwasm/compilation/simd/simd_common.c
+++ b/core/iwasm/compilation/simd/simd_common.c
@@ -7,8 +7,7 @@
 
 LLVMValueRef
 simd_pop_v128_and_bitcast(const AOTCompContext *comp_ctx,
-                          const AOTFuncContext *func_ctx,
-                          LLVMTypeRef vec_type,
+                          const AOTFuncContext *func_ctx, LLVMTypeRef vec_type,
                           const char *name)
 {
     LLVMValueRef number;
@@ -16,7 +15,7 @@ simd_pop_v128_and_bitcast(const AOTCompContext *comp_ctx,
     POP_V128(number);
 
     if (!(number =
-            LLVMBuildBitCast(comp_ctx->builder, number, vec_type, name))) {
+              LLVMBuildBitCast(comp_ctx->builder, number, vec_type, name))) {
         HANDLE_FAILURE("LLVMBuildBitCast");
         goto fail;
     }
@@ -28,8 +27,7 @@ fail:
 
 bool
 simd_bitcast_and_push_v128(const AOTCompContext *comp_ctx,
-                           const AOTFuncContext *func_ctx,
-                           LLVMValueRef vector,
+                           const AOTFuncContext *func_ctx, LLVMValueRef vector,
                            const char *name)
 {
     if (!(vector = LLVMBuildBitCast(comp_ctx->builder, vector, V128_i64x2_TYPE,
@@ -66,8 +64,7 @@ simd_lane_id_to_llvm_value(AOTCompContext *comp_ctx, uint8 lane_id)
 LLVMValueRef
 simd_build_const_integer_vector(const AOTCompContext *comp_ctx,
                                 const LLVMTypeRef element_type,
-                                const int *element_value,
-                                uint32 length)
+                                const int *element_value, uint32 length)
 {
     LLVMValueRef vector = NULL;
     LLVMValueRef *elements;
@@ -79,7 +76,7 @@ simd_build_const_integer_vector(const AOTCompContext *comp_ctx,
 
     for (i = 0; i < length; i++) {
         if (!(elements[i] =
-                LLVMConstInt(element_type, element_value[i], true))) {
+                  LLVMConstInt(element_type, element_value[i], true))) {
             HANDLE_FAILURE("LLVMConstInst");
             goto fail;
         }
@@ -98,8 +95,7 @@ fail:
 LLVMValueRef
 simd_build_splat_const_integer_vector(const AOTCompContext *comp_ctx,
                                       const LLVMTypeRef element_type,
-                                      const int64 element_value,
-                                      uint32 length)
+                                      const int64 element_value, uint32 length)
 {
     LLVMValueRef vector = NULL, element;
     LLVMValueRef *elements;
@@ -131,8 +127,7 @@ fail:
 LLVMValueRef
 simd_build_splat_const_float_vector(const AOTCompContext *comp_ctx,
                                     const LLVMTypeRef element_type,
-                                    const float element_value,
-                                    uint32 length)
+                                    const float element_value, uint32 length)
 {
     LLVMValueRef vector = NULL, element;
     LLVMValueRef *elements;

--- a/core/iwasm/compilation/simd/simd_common.h
+++ b/core/iwasm/compilation/simd/simd_common.h
@@ -17,14 +17,12 @@ is_target_x86(AOTCompContext *comp_ctx)
 
 LLVMValueRef
 simd_pop_v128_and_bitcast(const AOTCompContext *comp_ctx,
-                          const AOTFuncContext *func_ctx,
-                          LLVMTypeRef vec_type,
+                          const AOTFuncContext *func_ctx, LLVMTypeRef vec_type,
                           const char *name);
 
 bool
 simd_bitcast_and_push_v128(const AOTCompContext *comp_ctx,
-                           const AOTFuncContext *func_ctx,
-                           LLVMValueRef vector,
+                           const AOTFuncContext *func_ctx, LLVMValueRef vector,
                            const char *name);
 
 LLVMValueRef
@@ -33,18 +31,15 @@ simd_lane_id_to_llvm_value(AOTCompContext *comp_ctx, uint8 lane_id);
 LLVMValueRef
 simd_build_const_integer_vector(const AOTCompContext *comp_ctx,
                                 const LLVMTypeRef element_type,
-                                const int *element_value,
-                                uint32 length);
+                                const int *element_value, uint32 length);
 
 LLVMValueRef
 simd_build_splat_const_integer_vector(const AOTCompContext *comp_ctx,
                                       const LLVMTypeRef element_type,
-                                      const int64 element_value,
-                                      uint32 length);
+                                      const int64 element_value, uint32 length);
 
 LLVMValueRef
 simd_build_splat_const_float_vector(const AOTCompContext *comp_ctx,
                                     const LLVMTypeRef element_type,
-                                    const float element_value,
-                                    uint32 length);
+                                    const float element_value, uint32 length);
 #endif /* _SIMD_COMMON_H_ */

--- a/core/iwasm/compilation/simd/simd_comparisons.c
+++ b/core/iwasm/compilation/simd/simd_comparisons.c
@@ -86,10 +86,8 @@ fail:
 }
 
 static bool
-interger_vector_compare(AOTCompContext *comp_ctx,
-                        AOTFuncContext *func_ctx,
-                        IntCond cond,
-                        LLVMTypeRef vector_type)
+interger_vector_compare(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                        IntCond cond, LLVMTypeRef vector_type)
 {
     LLVMValueRef vec1, vec2, result;
     LLVMIntPredicate int_pred;
@@ -110,14 +108,14 @@ interger_vector_compare(AOTCompContext *comp_ctx,
     }
     /* icmp <N x iX> %vec1, %vec2 */
     if (!(result =
-            LLVMBuildICmp(comp_ctx->builder, int_pred, vec1, vec2, "cmp"))) {
+              LLVMBuildICmp(comp_ctx->builder, int_pred, vec1, vec2, "cmp"))) {
         HANDLE_FAILURE("LLVMBuildICmp");
         goto fail;
     }
 
     /* sext <N x i1> %result to <N x iX> */
     if (!(result =
-            LLVMBuildSExt(comp_ctx->builder, result, vector_type, "ext"))) {
+              LLVMBuildSExt(comp_ctx->builder, result, vector_type, "ext"))) {
         HANDLE_FAILURE("LLVMBuildSExt");
         goto fail;
     }
@@ -138,41 +136,35 @@ fail:
 
 bool
 aot_compile_simd_i8x16_compare(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               IntCond cond)
+                               AOTFuncContext *func_ctx, IntCond cond)
 {
     return interger_vector_compare(comp_ctx, func_ctx, cond, V128_i8x16_TYPE);
 }
 
 bool
 aot_compile_simd_i16x8_compare(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               IntCond cond)
+                               AOTFuncContext *func_ctx, IntCond cond)
 {
     return interger_vector_compare(comp_ctx, func_ctx, cond, V128_i16x8_TYPE);
 }
 
 bool
 aot_compile_simd_i32x4_compare(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               IntCond cond)
+                               AOTFuncContext *func_ctx, IntCond cond)
 {
     return interger_vector_compare(comp_ctx, func_ctx, cond, V128_i32x4_TYPE);
 }
 
 bool
 aot_compile_simd_i64x2_compare(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               IntCond cond)
+                               AOTFuncContext *func_ctx, IntCond cond)
 {
     return interger_vector_compare(comp_ctx, func_ctx, cond, V128_i64x2_TYPE);
 }
 
 static bool
-float_vector_compare(AOTCompContext *comp_ctx,
-                     AOTFuncContext *func_ctx,
-                     FloatCond cond,
-                     LLVMTypeRef vector_type,
+float_vector_compare(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                     FloatCond cond, LLVMTypeRef vector_type,
                      LLVMTypeRef result_type)
 {
     LLVMValueRef vec1, vec2, result;
@@ -194,14 +186,14 @@ float_vector_compare(AOTCompContext *comp_ctx,
     }
     /* fcmp <N x iX> %vec1, %vec2 */
     if (!(result =
-            LLVMBuildFCmp(comp_ctx->builder, real_pred, vec1, vec2, "cmp"))) {
+              LLVMBuildFCmp(comp_ctx->builder, real_pred, vec1, vec2, "cmp"))) {
         HANDLE_FAILURE("LLVMBuildFCmp");
         goto fail;
     }
 
     /* sext <N x i1> %result to <N x iX> */
     if (!(result =
-            LLVMBuildSExt(comp_ctx->builder, result, result_type, "ext"))) {
+              LLVMBuildSExt(comp_ctx->builder, result, result_type, "ext"))) {
         HANDLE_FAILURE("LLVMBuildSExt");
         goto fail;
     }
@@ -222,8 +214,7 @@ fail:
 
 bool
 aot_compile_simd_f32x4_compare(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               FloatCond cond)
+                               AOTFuncContext *func_ctx, FloatCond cond)
 {
     return float_vector_compare(comp_ctx, func_ctx, cond, V128_f32x4_TYPE,
                                 V128_i32x4_TYPE);
@@ -231,8 +222,7 @@ aot_compile_simd_f32x4_compare(AOTCompContext *comp_ctx,
 
 bool
 aot_compile_simd_f64x2_compare(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               FloatCond cond)
+                               AOTFuncContext *func_ctx, FloatCond cond)
 {
     return float_vector_compare(comp_ctx, func_ctx, cond, V128_f64x2_TYPE,
                                 V128_i64x2_TYPE);

--- a/core/iwasm/compilation/simd/simd_comparisons.h
+++ b/core/iwasm/compilation/simd/simd_comparisons.h
@@ -14,33 +14,27 @@ extern "C" {
 
 bool
 aot_compile_simd_i8x16_compare(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               IntCond cond);
+                               AOTFuncContext *func_ctx, IntCond cond);
 
 bool
 aot_compile_simd_i16x8_compare(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               IntCond cond);
+                               AOTFuncContext *func_ctx, IntCond cond);
 
 bool
 aot_compile_simd_i32x4_compare(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               IntCond cond);
+                               AOTFuncContext *func_ctx, IntCond cond);
 
 bool
 aot_compile_simd_i64x2_compare(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               IntCond cond);
+                               AOTFuncContext *func_ctx, IntCond cond);
 
 bool
 aot_compile_simd_f32x4_compare(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               FloatCond cond);
+                               AOTFuncContext *func_ctx, FloatCond cond);
 
 bool
 aot_compile_simd_f64x2_compare(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               FloatCond cond);
+                               AOTFuncContext *func_ctx, FloatCond cond);
 
 #ifdef __cplusplus
 } /* end of extern "C" */

--- a/core/iwasm/compilation/simd/simd_construct_values.c
+++ b/core/iwasm/compilation/simd/simd_construct_values.c
@@ -10,8 +10,7 @@
 #include "../../aot/aot_runtime.h"
 
 bool
-aot_compile_simd_v128_const(AOTCompContext *comp_ctx,
-                            AOTFuncContext *func_ctx,
+aot_compile_simd_v128_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                             const uint8 *imm_bytes)
 {
     uint64 imm1, imm2;
@@ -26,8 +25,8 @@ aot_compile_simd_v128_const(AOTCompContext *comp_ctx,
     }
 
     if (!(agg1 =
-            LLVMBuildInsertElement(comp_ctx->builder, LLVM_CONST(i64x2_undef),
-                                   first_long, I32_ZERO, "agg1"))) {
+              LLVMBuildInsertElement(comp_ctx->builder, LLVM_CONST(i64x2_undef),
+                                     first_long, I32_ZERO, "agg1"))) {
         HANDLE_FAILURE("LLVMBuildInsertElement");
         goto fail;
     }
@@ -51,8 +50,7 @@ fail:
 }
 
 bool
-aot_compile_simd_splat(AOTCompContext *comp_ctx,
-                       AOTFuncContext *func_ctx,
+aot_compile_simd_splat(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                        uint8 opcode)
 {
     uint32 opcode_index = opcode - SIMD_i8x16_splat;
@@ -63,9 +61,8 @@ aot_compile_simd_splat(AOTCompContext *comp_ctx,
         LLVM_CONST(f32x4_undef), LLVM_CONST(f64x2_undef),
     };
     LLVMValueRef masks[] = {
-        LLVM_CONST(i32x16_zero), LLVM_CONST(i32x8_zero),
-        LLVM_CONST(i32x4_zero),  LLVM_CONST(i32x2_zero),
-        LLVM_CONST(i32x4_zero),  LLVM_CONST(i32x2_zero),
+        LLVM_CONST(i32x16_zero), LLVM_CONST(i32x8_zero), LLVM_CONST(i32x4_zero),
+        LLVM_CONST(i32x2_zero),  LLVM_CONST(i32x4_zero), LLVM_CONST(i32x2_zero),
     };
 
     switch (opcode) {
@@ -75,7 +72,7 @@ aot_compile_simd_splat(AOTCompContext *comp_ctx,
             POP_I32(input);
             /* trunc i32 %input to i8 */
             value =
-              LLVMBuildTrunc(comp_ctx->builder, input, INT8_TYPE, "trunc");
+                LLVMBuildTrunc(comp_ctx->builder, input, INT8_TYPE, "trunc");
             break;
         }
         case SIMD_i16x8_splat:
@@ -84,7 +81,7 @@ aot_compile_simd_splat(AOTCompContext *comp_ctx,
             POP_I32(input);
             /* trunc i32 %input to i16 */
             value =
-              LLVMBuildTrunc(comp_ctx->builder, input, INT16_TYPE, "trunc");
+                LLVMBuildTrunc(comp_ctx->builder, input, INT16_TYPE, "trunc");
             break;
         }
         case SIMD_i32x4_splat:
@@ -118,23 +115,21 @@ aot_compile_simd_splat(AOTCompContext *comp_ctx,
     }
 
     /* insertelement <n x ty> undef, ty %value, i32 0 */
-    if (!(base =
-            LLVMBuildInsertElement(comp_ctx->builder, undefs[opcode_index],
-                                   value, I32_ZERO, "base"))) {
+    if (!(base = LLVMBuildInsertElement(comp_ctx->builder, undefs[opcode_index],
+                                        value, I32_ZERO, "base"))) {
         HANDLE_FAILURE("LLVMBuildInsertElement");
         goto fail;
     }
 
     /* shufflevector <ty1> %base, <ty2> undef, <n x i32> zeroinitializer */
     if (!(new_vector = LLVMBuildShuffleVector(
-            comp_ctx->builder, base, undefs[opcode_index], masks[opcode_index],
-            "new_vector"))) {
+              comp_ctx->builder, base, undefs[opcode_index],
+              masks[opcode_index], "new_vector"))) {
         HANDLE_FAILURE("LLVMBuildShuffleVector");
         goto fail;
     }
 
-    return simd_bitcast_and_push_v128(comp_ctx, func_ctx, new_vector,
-                                      "result");
+    return simd_bitcast_and_push_v128(comp_ctx, func_ctx, new_vector, "result");
 fail:
     return false;
 }

--- a/core/iwasm/compilation/simd/simd_construct_values.h
+++ b/core/iwasm/compilation/simd/simd_construct_values.h
@@ -13,13 +13,11 @@ extern "C" {
 #endif
 
 bool
-aot_compile_simd_v128_const(AOTCompContext *comp_ctx,
-                            AOTFuncContext *func_ctx,
+aot_compile_simd_v128_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                             const uint8 *imm_bytes);
 
 bool
-aot_compile_simd_splat(AOTCompContext *comp_ctx,
-                       AOTFuncContext *func_ctx,
+aot_compile_simd_splat(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                        uint8 splat_opcode);
 
 #ifdef __cplusplus

--- a/core/iwasm/compilation/simd/simd_conversions.h
+++ b/core/iwasm/compilation/simd/simd_conversions.h
@@ -14,35 +14,29 @@ extern "C" {
 
 bool
 aot_compile_simd_i8x16_narrow_i16x8(AOTCompContext *comp_ctx,
-                                    AOTFuncContext *func_ctx,
-                                    bool is_signed);
+                                    AOTFuncContext *func_ctx, bool is_signed);
 
 bool
 aot_compile_simd_i16x8_narrow_i32x4(AOTCompContext *comp_ctx,
-                                    AOTFuncContext *func_ctx,
-                                    bool is_signed);
+                                    AOTFuncContext *func_ctx, bool is_signed);
 
 bool
 aot_compile_simd_i32x4_narrow_i64x2(AOTCompContext *comp_ctx,
-                                    AOTFuncContext *func_ctx,
-                                    bool is_signed);
+                                    AOTFuncContext *func_ctx, bool is_signed);
 
 bool
 aot_compile_simd_i16x8_extend_i8x16(AOTCompContext *comp_ctx,
-                                    AOTFuncContext *func_ctx,
-                                    bool is_low,
+                                    AOTFuncContext *func_ctx, bool is_low,
                                     bool is_signed);
 
 bool
 aot_compile_simd_i32x4_extend_i16x8(AOTCompContext *comp_ctx,
-                                    AOTFuncContext *func_ctx,
-                                    bool is_low,
+                                    AOTFuncContext *func_ctx, bool is_low,
                                     bool is_signed);
 
 bool
 aot_compile_simd_i64x2_extend_i32x4(AOTCompContext *comp_ctx,
-                                    AOTFuncContext *func_ctx,
-                                    bool lower_half,
+                                    AOTFuncContext *func_ctx, bool lower_half,
                                     bool is_signed);
 
 bool
@@ -57,13 +51,11 @@ aot_compile_simd_i32x4_trunc_sat_f64x2(AOTCompContext *comp_ctx,
 
 bool
 aot_compile_simd_f32x4_convert_i32x4(AOTCompContext *comp_ctx,
-                                     AOTFuncContext *func_ctx,
-                                     bool is_signed);
+                                     AOTFuncContext *func_ctx, bool is_signed);
 
 bool
 aot_compile_simd_f64x2_convert_i32x4(AOTCompContext *comp_ctx,
-                                     AOTFuncContext *func_ctx,
-                                     bool is_signed);
+                                     AOTFuncContext *func_ctx, bool is_signed);
 bool
 aot_compile_simd_i16x8_extadd_pairwise_i8x16(AOTCompContext *comp_ctx,
                                              AOTFuncContext *func_ctx,
@@ -79,20 +71,17 @@ aot_compile_simd_i16x8_q15mulr_sat(AOTCompContext *comp_ctx,
 
 bool
 aot_compile_simd_i16x8_extmul_i8x16(AOTCompContext *comp_ctx,
-                                    AOTFuncContext *func_ctx,
-                                    bool is_low,
+                                    AOTFuncContext *func_ctx, bool is_low,
                                     bool is_signed);
 
 bool
 aot_compile_simd_i32x4_extmul_i16x8(AOTCompContext *comp_ctx,
-                                    AOTFuncContext *func_ctx,
-                                    bool is_low,
+                                    AOTFuncContext *func_ctx, bool is_low,
                                     bool is_signed);
 
 bool
 aot_compile_simd_i64x2_extmul_i32x4(AOTCompContext *comp_ctx,
-                                    AOTFuncContext *func_ctx,
-                                    bool lower_half,
+                                    AOTFuncContext *func_ctx, bool lower_half,
                                     bool is_signed);
 #ifdef __cplusplus
 } /* end of extern "C" */

--- a/core/iwasm/compilation/simd/simd_floating_point.c
+++ b/core/iwasm/compilation/simd/simd_floating_point.c
@@ -10,15 +10,13 @@
 #include "../../aot/aot_runtime.h"
 
 static bool
-simd_v128_float_arith(AOTCompContext *comp_ctx,
-                      AOTFuncContext *func_ctx,
-                      FloatArithmetic arith_op,
-                      LLVMTypeRef vector_type)
+simd_v128_float_arith(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                      FloatArithmetic arith_op, LLVMTypeRef vector_type)
 {
     LLVMValueRef lhs, rhs, result = NULL;
 
     if (!(rhs =
-            simd_pop_v128_and_bitcast(comp_ctx, func_ctx, vector_type, "rhs"))
+              simd_pop_v128_and_bitcast(comp_ctx, func_ctx, vector_type, "rhs"))
         || !(lhs = simd_pop_v128_and_bitcast(comp_ctx, func_ctx, vector_type,
                                              "lhs"))) {
         return false;
@@ -43,7 +41,7 @@ simd_v128_float_arith(AOTCompContext *comp_ctx,
 
     if (!result) {
         HANDLE_FAILURE(
-          "LLVMBuildFAdd/LLVMBuildFSub/LLVMBuildFMul/LLVMBuildFDiv");
+            "LLVMBuildFAdd/LLVMBuildFSub/LLVMBuildFMul/LLVMBuildFDiv");
         return false;
     }
 
@@ -51,26 +49,21 @@ simd_v128_float_arith(AOTCompContext *comp_ctx,
 }
 
 bool
-aot_compile_simd_f32x4_arith(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
+aot_compile_simd_f32x4_arith(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              FloatArithmetic arith_op)
 {
-    return simd_v128_float_arith(comp_ctx, func_ctx, arith_op,
-                                 V128_f32x4_TYPE);
+    return simd_v128_float_arith(comp_ctx, func_ctx, arith_op, V128_f32x4_TYPE);
 }
 
 bool
-aot_compile_simd_f64x2_arith(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
+aot_compile_simd_f64x2_arith(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              FloatArithmetic arith_op)
 {
-    return simd_v128_float_arith(comp_ctx, func_ctx, arith_op,
-                                 V128_f64x2_TYPE);
+    return simd_v128_float_arith(comp_ctx, func_ctx, arith_op, V128_f64x2_TYPE);
 }
 
 static bool
-simd_v128_float_neg(AOTCompContext *comp_ctx,
-                    AOTFuncContext *func_ctx,
+simd_v128_float_neg(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                     LLVMTypeRef vector_type)
 {
     LLVMValueRef vector, result;
@@ -101,10 +94,8 @@ aot_compile_simd_f64x2_neg(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 }
 
 static bool
-simd_float_intrinsic(AOTCompContext *comp_ctx,
-                     AOTFuncContext *func_ctx,
-                     LLVMTypeRef vector_type,
-                     const char *intrinsic)
+simd_float_intrinsic(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                     LLVMTypeRef vector_type, const char *intrinsic)
 {
     LLVMValueRef vector, result;
     LLVMTypeRef param_types[1] = { vector_type };
@@ -115,8 +106,8 @@ simd_float_intrinsic(AOTCompContext *comp_ctx,
     }
 
     if (!(result =
-            aot_call_llvm_intrinsic(comp_ctx, func_ctx, intrinsic, vector_type,
-                                    param_types, 1, vector))) {
+              aot_call_llvm_intrinsic(comp_ctx, func_ctx, intrinsic,
+                                      vector_type, param_types, 1, vector))) {
         HANDLE_FAILURE("LLVMBuildCall");
         return false;
     }
@@ -139,16 +130,14 @@ aot_compile_simd_f64x2_abs(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 }
 
 bool
-aot_compile_simd_f32x4_round(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx)
+aot_compile_simd_f32x4_round(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 {
     return simd_float_intrinsic(comp_ctx, func_ctx, V128_f32x4_TYPE,
                                 "llvm.round.v4f32");
 }
 
 bool
-aot_compile_simd_f64x2_round(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx)
+aot_compile_simd_f64x2_round(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 {
     return simd_float_intrinsic(comp_ctx, func_ctx, V128_f64x2_TYPE,
                                 "llvm.round.v2f64");
@@ -183,32 +172,28 @@ aot_compile_simd_f64x2_ceil(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 }
 
 bool
-aot_compile_simd_f32x4_floor(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx)
+aot_compile_simd_f32x4_floor(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 {
     return simd_float_intrinsic(comp_ctx, func_ctx, V128_f32x4_TYPE,
                                 "llvm.floor.v4f32");
 }
 
 bool
-aot_compile_simd_f64x2_floor(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx)
+aot_compile_simd_f64x2_floor(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 {
     return simd_float_intrinsic(comp_ctx, func_ctx, V128_f64x2_TYPE,
                                 "llvm.floor.v2f64");
 }
 
 bool
-aot_compile_simd_f32x4_trunc(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx)
+aot_compile_simd_f32x4_trunc(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 {
     return simd_float_intrinsic(comp_ctx, func_ctx, V128_f32x4_TYPE,
                                 "llvm.trunc.v4f32");
 }
 
 bool
-aot_compile_simd_f64x2_trunc(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx)
+aot_compile_simd_f64x2_trunc(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 {
     return simd_float_intrinsic(comp_ctx, func_ctx, V128_f64x2_TYPE,
                                 "llvm.trunc.v2f64");
@@ -231,16 +216,14 @@ aot_compile_simd_f64x2_nearest(AOTCompContext *comp_ctx,
 }
 
 static bool
-simd_float_cmp(AOTCompContext *comp_ctx,
-               AOTFuncContext *func_ctx,
-               FloatArithmetic arith_op,
-               LLVMTypeRef vector_type)
+simd_float_cmp(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+               FloatArithmetic arith_op, LLVMTypeRef vector_type)
 {
     LLVMValueRef lhs, rhs, result;
     LLVMRealPredicate op = FLOAT_MIN == arith_op ? LLVMRealULT : LLVMRealUGT;
 
     if (!(rhs =
-            simd_pop_v128_and_bitcast(comp_ctx, func_ctx, vector_type, "rhs"))
+              simd_pop_v128_and_bitcast(comp_ctx, func_ctx, vector_type, "rhs"))
         || !(lhs = simd_pop_v128_and_bitcast(comp_ctx, func_ctx, vector_type,
                                              "lhs"))) {
         return false;
@@ -252,7 +235,7 @@ simd_float_cmp(AOTCompContext *comp_ctx,
     }
 
     if (!(result =
-            LLVMBuildSelect(comp_ctx->builder, result, lhs, rhs, "select"))) {
+              LLVMBuildSelect(comp_ctx->builder, result, lhs, rhs, "select"))) {
         HANDLE_FAILURE("LLVMBuildSelect");
         return false;
     }
@@ -260,11 +243,11 @@ simd_float_cmp(AOTCompContext *comp_ctx,
     return simd_bitcast_and_push_v128(comp_ctx, func_ctx, result, "result");
 }
 
-/*TODO: sugggest non-IA platforms check with "llvm.minimum.*" and "llvm.maximum.*" firstly */
+/*TODO: sugggest non-IA platforms check with "llvm.minimum.*" and
+ * "llvm.maximum.*" firstly */
 bool
 aot_compile_simd_f32x4_min_max(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               bool run_min)
+                               AOTFuncContext *func_ctx, bool run_min)
 {
     return simd_float_cmp(comp_ctx, func_ctx, run_min ? FLOAT_MIN : FLOAT_MAX,
                           V128_f32x4_TYPE);
@@ -272,18 +255,15 @@ aot_compile_simd_f32x4_min_max(AOTCompContext *comp_ctx,
 
 bool
 aot_compile_simd_f64x2_min_max(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               bool run_min)
+                               AOTFuncContext *func_ctx, bool run_min)
 {
     return simd_float_cmp(comp_ctx, func_ctx, run_min ? FLOAT_MIN : FLOAT_MAX,
                           V128_f64x2_TYPE);
 }
 
 static bool
-simd_float_pmin_max(AOTCompContext *comp_ctx,
-                    AOTFuncContext *func_ctx,
-                    LLVMTypeRef vector_type,
-                    const char *intrinsic)
+simd_float_pmin_max(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                    LLVMTypeRef vector_type, const char *intrinsic)
 {
     LLVMValueRef lhs, rhs, result;
     LLVMTypeRef param_types[2];
@@ -292,15 +272,15 @@ simd_float_pmin_max(AOTCompContext *comp_ctx,
     param_types[1] = vector_type;
 
     if (!(rhs =
-            simd_pop_v128_and_bitcast(comp_ctx, func_ctx, vector_type, "rhs"))
+              simd_pop_v128_and_bitcast(comp_ctx, func_ctx, vector_type, "rhs"))
         || !(lhs = simd_pop_v128_and_bitcast(comp_ctx, func_ctx, vector_type,
                                              "lhs"))) {
         return false;
     }
 
     if (!(result =
-            aot_call_llvm_intrinsic(comp_ctx, func_ctx, intrinsic, vector_type,
-                                    param_types, 2, lhs, rhs))) {
+              aot_call_llvm_intrinsic(comp_ctx, func_ctx, intrinsic,
+                                      vector_type, param_types, 2, lhs, rhs))) {
         return false;
     }
 
@@ -309,8 +289,7 @@ simd_float_pmin_max(AOTCompContext *comp_ctx,
 
 bool
 aot_compile_simd_f32x4_pmin_pmax(AOTCompContext *comp_ctx,
-                                 AOTFuncContext *func_ctx,
-                                 bool run_min)
+                                 AOTFuncContext *func_ctx, bool run_min)
 {
     return simd_float_pmin_max(comp_ctx, func_ctx, V128_f32x4_TYPE,
                                run_min ? "llvm.minnum.v4f32"
@@ -319,8 +298,7 @@ aot_compile_simd_f32x4_pmin_pmax(AOTCompContext *comp_ctx,
 
 bool
 aot_compile_simd_f64x2_pmin_pmax(AOTCompContext *comp_ctx,
-                                 AOTFuncContext *func_ctx,
-                                 bool run_min)
+                                 AOTFuncContext *func_ctx, bool run_min)
 {
     return simd_float_pmin_max(comp_ctx, func_ctx, V128_f64x2_TYPE,
                                run_min ? "llvm.minnum.v2f64"
@@ -340,8 +318,8 @@ aot_compile_simd_f64x2_demote(AOTCompContext *comp_ctx,
 
     if (!(elem_0 = LLVMBuildExtractElement(comp_ctx->builder, vector,
                                            LLVM_CONST(i32_zero), "elem_0"))
-        || !(elem_1 = LLVMBuildExtractElement(
-               comp_ctx->builder, vector, LLVM_CONST(i32_one), "elem_1"))) {
+        || !(elem_1 = LLVMBuildExtractElement(comp_ctx->builder, vector,
+                                              LLVM_CONST(i32_one), "elem_1"))) {
         HANDLE_FAILURE("LLVMBuildExtractElement");
         return false;
     }
@@ -355,12 +333,12 @@ aot_compile_simd_f64x2_demote(AOTCompContext *comp_ctx,
         return false;
     }
 
-    if (!(result = LLVMBuildInsertElement(
-            comp_ctx->builder, LLVM_CONST(f32x4_vec_zero), elem_0,
-            LLVM_CONST(i32_zero), "new_vector_0"))
+    if (!(result = LLVMBuildInsertElement(comp_ctx->builder,
+                                          LLVM_CONST(f32x4_vec_zero), elem_0,
+                                          LLVM_CONST(i32_zero), "new_vector_0"))
         || !(result =
-               LLVMBuildInsertElement(comp_ctx->builder, result, elem_1,
-                                      LLVM_CONST(i32_one), "new_vector_1"))) {
+                 LLVMBuildInsertElement(comp_ctx->builder, result, elem_1,
+                                        LLVM_CONST(i32_one), "new_vector_1"))) {
         HANDLE_FAILURE("LLVMBuildInsertElement");
         return false;
     }
@@ -381,27 +359,27 @@ aot_compile_simd_f32x4_promote(AOTCompContext *comp_ctx,
 
     if (!(elem_0 = LLVMBuildExtractElement(comp_ctx->builder, vector,
                                            LLVM_CONST(i32_zero), "elem_0"))
-        || !(elem_1 = LLVMBuildExtractElement(
-               comp_ctx->builder, vector, LLVM_CONST(i32_one), "elem_1"))) {
+        || !(elem_1 = LLVMBuildExtractElement(comp_ctx->builder, vector,
+                                              LLVM_CONST(i32_one), "elem_1"))) {
         HANDLE_FAILURE("LLVMBuildExtractElement");
         return false;
     }
 
     /* fpext <f32> elem to <f64> */
     if (!(elem_0 =
-            LLVMBuildFPExt(comp_ctx->builder, elem_0, F64_TYPE, "elem_0_ext"))
+              LLVMBuildFPExt(comp_ctx->builder, elem_0, F64_TYPE, "elem_0_ext"))
         || !(elem_1 = LLVMBuildFPExt(comp_ctx->builder, elem_1, F64_TYPE,
                                      "elem_1_ext"))) {
         HANDLE_FAILURE("LLVMBuildFPExt");
         return false;
     }
 
-    if (!(result = LLVMBuildInsertElement(
-            comp_ctx->builder, LLVM_CONST(f64x2_vec_zero), elem_0,
-            LLVM_CONST(i32_zero), "new_vector_0"))
+    if (!(result = LLVMBuildInsertElement(comp_ctx->builder,
+                                          LLVM_CONST(f64x2_vec_zero), elem_0,
+                                          LLVM_CONST(i32_zero), "new_vector_0"))
         || !(result =
-               LLVMBuildInsertElement(comp_ctx->builder, result, elem_1,
-                                      LLVM_CONST(i32_one), "new_vector_1"))) {
+                 LLVMBuildInsertElement(comp_ctx->builder, result, elem_1,
+                                        LLVM_CONST(i32_one), "new_vector_1"))) {
         HANDLE_FAILURE("LLVMBuildInsertElement");
         return false;
     }

--- a/core/iwasm/compilation/simd/simd_floating_point.h
+++ b/core/iwasm/compilation/simd/simd_floating_point.h
@@ -13,13 +13,11 @@ extern "C" {
 #endif
 
 bool
-aot_compile_simd_f32x4_arith(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
+aot_compile_simd_f32x4_arith(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              FloatArithmetic arith_op);
 
 bool
-aot_compile_simd_f64x2_arith(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
+aot_compile_simd_f64x2_arith(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              FloatArithmetic arith_op);
 
 bool
@@ -43,20 +41,16 @@ aot_compile_simd_f64x2_round(AOTCompContext *comp_ctx,
                              AOTFuncContext *func_ctx);
 
 bool
-aot_compile_simd_f32x4_sqrt(AOTCompContext *comp_ctx,
-                            AOTFuncContext *func_ctx);
+aot_compile_simd_f32x4_sqrt(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx);
 
 bool
-aot_compile_simd_f64x2_sqrt(AOTCompContext *comp_ctx,
-                            AOTFuncContext *func_ctx);
+aot_compile_simd_f64x2_sqrt(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx);
 
 bool
-aot_compile_simd_f32x4_ceil(AOTCompContext *comp_ctx,
-                            AOTFuncContext *func_ctx);
+aot_compile_simd_f32x4_ceil(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx);
 
 bool
-aot_compile_simd_f64x2_ceil(AOTCompContext *comp_ctx,
-                            AOTFuncContext *func_ctx);
+aot_compile_simd_f64x2_ceil(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx);
 
 bool
 aot_compile_simd_f32x4_floor(AOTCompContext *comp_ctx,
@@ -84,23 +78,19 @@ aot_compile_simd_f64x2_nearest(AOTCompContext *comp_ctx,
 
 bool
 aot_compile_simd_f32x4_min_max(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               bool run_min);
+                               AOTFuncContext *func_ctx, bool run_min);
 
 bool
 aot_compile_simd_f64x2_min_max(AOTCompContext *comp_ctx,
-                               AOTFuncContext *func_ctx,
-                               bool run_min);
+                               AOTFuncContext *func_ctx, bool run_min);
 
 bool
 aot_compile_simd_f32x4_pmin_pmax(AOTCompContext *comp_ctx,
-                                 AOTFuncContext *func_ctx,
-                                 bool run_min);
+                                 AOTFuncContext *func_ctx, bool run_min);
 
 bool
 aot_compile_simd_f64x2_pmin_pmax(AOTCompContext *comp_ctx,
-                                 AOTFuncContext *func_ctx,
-                                 bool run_min);
+                                 AOTFuncContext *func_ctx, bool run_min);
 
 bool
 aot_compile_simd_f64x2_demote(AOTCompContext *comp_ctx,

--- a/core/iwasm/compilation/simd/simd_int_arith.c
+++ b/core/iwasm/compilation/simd/simd_int_arith.c
@@ -9,15 +9,13 @@
 #include "../../aot/aot_runtime.h"
 
 static bool
-simd_integer_arith(AOTCompContext *comp_ctx,
-                   AOTFuncContext *func_ctx,
-                   V128Arithmetic arith_op,
-                   LLVMTypeRef vector_type)
+simd_integer_arith(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                   V128Arithmetic arith_op, LLVMTypeRef vector_type)
 {
     LLVMValueRef lhs, rhs, result = NULL;
 
     if (!(rhs =
-            simd_pop_v128_and_bitcast(comp_ctx, func_ctx, vector_type, "rhs"))
+              simd_pop_v128_and_bitcast(comp_ctx, func_ctx, vector_type, "rhs"))
         || !(lhs = simd_pop_v128_and_bitcast(comp_ctx, func_ctx, vector_type,
                                              "lhs"))) {
         return false;
@@ -47,32 +45,28 @@ simd_integer_arith(AOTCompContext *comp_ctx,
 }
 
 bool
-aot_compile_simd_i8x16_arith(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
+aot_compile_simd_i8x16_arith(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              V128Arithmetic arith_op)
 {
     return simd_integer_arith(comp_ctx, func_ctx, arith_op, V128_i8x16_TYPE);
 }
 
 bool
-aot_compile_simd_i16x8_arith(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
+aot_compile_simd_i16x8_arith(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              V128Arithmetic arith_op)
 {
     return simd_integer_arith(comp_ctx, func_ctx, arith_op, V128_i16x8_TYPE);
 }
 
 bool
-aot_compile_simd_i32x4_arith(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
+aot_compile_simd_i32x4_arith(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              V128Arithmetic arith_op)
 {
     return simd_integer_arith(comp_ctx, func_ctx, arith_op, V128_i32x4_TYPE);
 }
 
 bool
-aot_compile_simd_i64x2_arith(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
+aot_compile_simd_i64x2_arith(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              V128Arithmetic arith_op)
 {
     return simd_integer_arith(comp_ctx, func_ctx, arith_op, V128_i64x2_TYPE);
@@ -84,7 +78,7 @@ simd_neg(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx, LLVMTypeRef type)
     LLVMValueRef vector, result;
 
     if (!(vector =
-            simd_pop_v128_and_bitcast(comp_ctx, func_ctx, type, "vector"))) {
+              simd_pop_v128_and_bitcast(comp_ctx, func_ctx, type, "vector"))) {
         return false;
     }
 
@@ -141,17 +135,14 @@ aot_compile_simd_i8x16_popcnt(AOTCompContext *comp_ctx,
 }
 
 static bool
-simd_v128_cmp(AOTCompContext *comp_ctx,
-              AOTFuncContext *func_ctx,
-              LLVMTypeRef vector_type,
-              V128Arithmetic arith_op,
-              bool is_signed)
+simd_v128_cmp(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+              LLVMTypeRef vector_type, V128Arithmetic arith_op, bool is_signed)
 {
     LLVMValueRef lhs, rhs, result;
     LLVMIntPredicate op;
 
     if (!(rhs =
-            simd_pop_v128_and_bitcast(comp_ctx, func_ctx, vector_type, "rhs"))
+              simd_pop_v128_and_bitcast(comp_ctx, func_ctx, vector_type, "rhs"))
         || !(lhs = simd_pop_v128_and_bitcast(comp_ctx, func_ctx, vector_type,
                                              "lhs"))) {
         return false;
@@ -170,7 +161,7 @@ simd_v128_cmp(AOTCompContext *comp_ctx,
     }
 
     if (!(result =
-            LLVMBuildSelect(comp_ctx->builder, result, lhs, rhs, "select"))) {
+              LLVMBuildSelect(comp_ctx->builder, result, lhs, rhs, "select"))) {
         HANDLE_FAILURE("LLVMBuildSelect");
         return false;
     }
@@ -179,30 +170,24 @@ simd_v128_cmp(AOTCompContext *comp_ctx,
 }
 
 bool
-aot_compile_simd_i8x16_cmp(AOTCompContext *comp_ctx,
-                           AOTFuncContext *func_ctx,
-                           V128Arithmetic arith_op,
-                           bool is_signed)
+aot_compile_simd_i8x16_cmp(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                           V128Arithmetic arith_op, bool is_signed)
 {
     return simd_v128_cmp(comp_ctx, func_ctx, V128_i8x16_TYPE, arith_op,
                          is_signed);
 }
 
 bool
-aot_compile_simd_i16x8_cmp(AOTCompContext *comp_ctx,
-                           AOTFuncContext *func_ctx,
-                           V128Arithmetic arith_op,
-                           bool is_signed)
+aot_compile_simd_i16x8_cmp(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                           V128Arithmetic arith_op, bool is_signed)
 {
     return simd_v128_cmp(comp_ctx, func_ctx, V128_i16x8_TYPE, arith_op,
                          is_signed);
 }
 
 bool
-aot_compile_simd_i32x4_cmp(AOTCompContext *comp_ctx,
-                           AOTFuncContext *func_ctx,
-                           V128Arithmetic arith_op,
-                           bool is_signed)
+aot_compile_simd_i32x4_cmp(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                           V128Arithmetic arith_op, bool is_signed)
 {
     return simd_v128_cmp(comp_ctx, func_ctx, V128_i32x4_TYPE, arith_op,
                          is_signed);
@@ -210,10 +195,8 @@ aot_compile_simd_i32x4_cmp(AOTCompContext *comp_ctx,
 
 /* llvm.abs.* */
 static bool
-simd_v128_abs(AOTCompContext *comp_ctx,
-              AOTFuncContext *func_ctx,
-              char *intrinsic,
-              LLVMTypeRef vector_type)
+simd_v128_abs(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+              char *intrinsic, LLVMTypeRef vector_type)
 {
     LLVMValueRef vector, result;
     LLVMTypeRef param_types[] = { vector_type, INT1_TYPE };
@@ -236,29 +219,25 @@ simd_v128_abs(AOTCompContext *comp_ctx,
 bool
 aot_compile_simd_i8x16_abs(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 {
-    return simd_v128_abs(comp_ctx, func_ctx, "llvm.abs.v16i8",
-                         V128_i8x16_TYPE);
+    return simd_v128_abs(comp_ctx, func_ctx, "llvm.abs.v16i8", V128_i8x16_TYPE);
 }
 
 bool
 aot_compile_simd_i16x8_abs(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 {
-    return simd_v128_abs(comp_ctx, func_ctx, "llvm.abs.v8i16",
-                         V128_i16x8_TYPE);
+    return simd_v128_abs(comp_ctx, func_ctx, "llvm.abs.v8i16", V128_i16x8_TYPE);
 }
 
 bool
 aot_compile_simd_i32x4_abs(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 {
-    return simd_v128_abs(comp_ctx, func_ctx, "llvm.abs.v4i32",
-                         V128_i32x4_TYPE);
+    return simd_v128_abs(comp_ctx, func_ctx, "llvm.abs.v4i32", V128_i32x4_TYPE);
 }
 
 bool
 aot_compile_simd_i64x2_abs(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 {
-    return simd_v128_abs(comp_ctx, func_ctx, "llvm.abs.v2i64",
-                         V128_i64x2_TYPE);
+    return simd_v128_abs(comp_ctx, func_ctx, "llvm.abs.v2i64", V128_i64x2_TYPE);
 }
 
 enum integer_avgr_u {
@@ -270,8 +249,7 @@ enum integer_avgr_u {
 /* TODO: try int_x86_mmx_pavg_b and int_x86_mmx_pavg_w */
 /* (v1 + v2 + 1) / 2 */
 static bool
-simd_v128_avg(AOTCompContext *comp_ctx,
-              AOTFuncContext *func_ctx,
+simd_v128_avg(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
               enum integer_avgr_u itype)
 {
     LLVMValueRef lhs, rhs, ones, result;
@@ -324,8 +302,8 @@ simd_v128_avg(AOTCompContext *comp_ctx,
         return false;
     }
 
-    if (!(result = LLVMBuildTrunc(comp_ctx->builder, result,
-                                  vector_type[itype], "to_orig_type"))) {
+    if (!(result = LLVMBuildTrunc(comp_ctx->builder, result, vector_type[itype],
+                                  "to_orig_type"))) {
         HANDLE_FAILURE("LLVMBuildTrunc");
         return false;
     }
@@ -406,8 +384,8 @@ aot_compile_simd_i32x4_dot_i16x8(AOTCompContext *comp_ctx,
         return false;
     }
 
-    if (!(zero =
-            simd_build_splat_const_integer_vector(comp_ctx, I32_TYPE, 0, 8))) {
+    if (!(zero = simd_build_splat_const_integer_vector(comp_ctx, I32_TYPE, 0,
+                                                       8))) {
         return false;
     }
 

--- a/core/iwasm/compilation/simd/simd_int_arith.h
+++ b/core/iwasm/compilation/simd/simd_int_arith.h
@@ -13,23 +13,19 @@ extern "C" {
 #endif
 
 bool
-aot_compile_simd_i8x16_arith(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
+aot_compile_simd_i8x16_arith(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              V128Arithmetic cond);
 
 bool
-aot_compile_simd_i16x8_arith(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
+aot_compile_simd_i16x8_arith(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              V128Arithmetic cond);
 
 bool
-aot_compile_simd_i32x4_arith(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
+aot_compile_simd_i32x4_arith(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              V128Arithmetic cond);
 
 bool
-aot_compile_simd_i64x2_arith(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
+aot_compile_simd_i64x2_arith(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              V128Arithmetic cond);
 
 bool
@@ -49,22 +45,16 @@ aot_compile_simd_i8x16_popcnt(AOTCompContext *comp_ctx,
                               AOTFuncContext *func_ctx);
 
 bool
-aot_compile_simd_i8x16_cmp(AOTCompContext *comp_ctx,
-                           AOTFuncContext *func_ctx,
-                           V128Arithmetic arith_op,
-                           bool is_signed);
+aot_compile_simd_i8x16_cmp(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                           V128Arithmetic arith_op, bool is_signed);
 
 bool
-aot_compile_simd_i16x8_cmp(AOTCompContext *comp_ctx,
-                           AOTFuncContext *func_ctx,
-                           V128Arithmetic arith_op,
-                           bool is_signed);
+aot_compile_simd_i16x8_cmp(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                           V128Arithmetic arith_op, bool is_signed);
 
 bool
-aot_compile_simd_i32x4_cmp(AOTCompContext *comp_ctx,
-                           AOTFuncContext *func_ctx,
-                           V128Arithmetic arith_op,
-                           bool is_signed);
+aot_compile_simd_i32x4_cmp(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                           V128Arithmetic arith_op, bool is_signed);
 
 bool
 aot_compile_simd_i8x16_abs(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx);

--- a/core/iwasm/compilation/simd/simd_load_store.c
+++ b/core/iwasm/compilation/simd/simd_load_store.c
@@ -12,12 +12,8 @@
 
 /* data_length in bytes */
 static LLVMValueRef
-simd_load(AOTCompContext *comp_ctx,
-          AOTFuncContext *func_ctx,
-          uint32 align,
-          uint32 offset,
-          uint32 data_length,
-          LLVMTypeRef ptr_type)
+simd_load(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx, uint32 align,
+          uint32 offset, uint32 data_length, LLVMTypeRef ptr_type)
 {
     LLVMValueRef maddr, data;
 
@@ -44,15 +40,13 @@ simd_load(AOTCompContext *comp_ctx,
 }
 
 bool
-aot_compile_simd_v128_load(AOTCompContext *comp_ctx,
-                           AOTFuncContext *func_ctx,
-                           uint32 align,
-                           uint32 offset)
+aot_compile_simd_v128_load(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                           uint32 align, uint32 offset)
 {
     LLVMValueRef result;
 
-    if (!(result =
-            simd_load(comp_ctx, func_ctx, align, offset, 16, V128_PTR_TYPE))) {
+    if (!(result = simd_load(comp_ctx, func_ctx, align, offset, 16,
+                             V128_PTR_TYPE))) {
         return false;
     }
 
@@ -64,11 +58,8 @@ fail:
 }
 
 bool
-aot_compile_simd_load_extend(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
-                             uint8 opcode,
-                             uint32 align,
-                             uint32 offset)
+aot_compile_simd_load_extend(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                             uint8 opcode, uint32 align, uint32 offset)
 {
     LLVMValueRef sub_vector, result;
     uint32 opcode_index = opcode - SIMD_v128_load8x8_s;
@@ -119,11 +110,8 @@ aot_compile_simd_load_extend(AOTCompContext *comp_ctx,
 }
 
 bool
-aot_compile_simd_load_splat(AOTCompContext *comp_ctx,
-                            AOTFuncContext *func_ctx,
-                            uint8 opcode,
-                            uint32 align,
-                            uint32 offset)
+aot_compile_simd_load_splat(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                            uint8 opcode, uint32 align, uint32 offset)
 {
     uint32 opcode_index = opcode - SIMD_v128_load8_splat;
     LLVMValueRef element, result;
@@ -152,8 +140,8 @@ aot_compile_simd_load_splat(AOTCompContext *comp_ctx,
     }
 
     if (!(result =
-            LLVMBuildInsertElement(comp_ctx->builder, undefs[opcode_index],
-                                   element, I32_ZERO, "base"))) {
+              LLVMBuildInsertElement(comp_ctx->builder, undefs[opcode_index],
+                                     element, I32_ZERO, "base"))) {
         HANDLE_FAILURE("LLVMBuildInsertElement");
         return false;
     }
@@ -169,11 +157,8 @@ aot_compile_simd_load_splat(AOTCompContext *comp_ctx,
 }
 
 bool
-aot_compile_simd_load_lane(AOTCompContext *comp_ctx,
-                           AOTFuncContext *func_ctx,
-                           uint8 opcode,
-                           uint32 align,
-                           uint32 offset,
+aot_compile_simd_load_lane(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                           uint8 opcode, uint32 align, uint32 offset,
                            uint8 lane_id)
 {
     LLVMValueRef element, vector;
@@ -188,7 +173,7 @@ aot_compile_simd_load_lane(AOTCompContext *comp_ctx,
     bh_assert(opcode_index < 4);
 
     if (!(vector = simd_pop_v128_and_bitcast(
-            comp_ctx, func_ctx, vector_types[opcode_index], "src"))) {
+              comp_ctx, func_ctx, vector_types[opcode_index], "src"))) {
         return false;
     }
 
@@ -208,11 +193,8 @@ aot_compile_simd_load_lane(AOTCompContext *comp_ctx,
 }
 
 bool
-aot_compile_simd_load_zero(AOTCompContext *comp_ctx,
-                           AOTFuncContext *func_ctx,
-                           uint8 opcode,
-                           uint32 align,
-                           uint32 offset)
+aot_compile_simd_load_zero(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                           uint8 opcode, uint32 align, uint32 offset)
 {
     LLVMValueRef element, result, mask;
     uint32 opcode_index = opcode - SIMD_v128_load32_zero;
@@ -242,8 +224,8 @@ aot_compile_simd_load_zero(AOTCompContext *comp_ctx,
     }
 
     if (!(result =
-            LLVMBuildInsertElement(comp_ctx->builder, undef[opcode_index],
-                                   element, I32_ZERO, "vector"))) {
+              LLVMBuildInsertElement(comp_ctx->builder, undef[opcode_index],
+                                     element, I32_ZERO, "vector"))) {
         HANDLE_FAILURE("LLVMBuildInsertElement");
         return false;
     }
@@ -267,12 +249,8 @@ aot_compile_simd_load_zero(AOTCompContext *comp_ctx,
 
 /* data_length in bytes */
 static bool
-simd_store(AOTCompContext *comp_ctx,
-           AOTFuncContext *func_ctx,
-           uint32 align,
-           uint32 offset,
-           uint32 data_length,
-           LLVMValueRef value,
+simd_store(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx, uint32 align,
+           uint32 offset, uint32 data_length, LLVMValueRef value,
            LLVMTypeRef value_ptr_type)
 {
     LLVMValueRef maddr, result;
@@ -298,10 +276,8 @@ simd_store(AOTCompContext *comp_ctx,
 }
 
 bool
-aot_compile_simd_v128_store(AOTCompContext *comp_ctx,
-                            AOTFuncContext *func_ctx,
-                            uint32 align,
-                            uint32 offset)
+aot_compile_simd_v128_store(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                            uint32 align, uint32 offset)
 {
     LLVMValueRef value;
 
@@ -314,11 +290,8 @@ fail:
 }
 
 bool
-aot_compile_simd_store_lane(AOTCompContext *comp_ctx,
-                            AOTFuncContext *func_ctx,
-                            uint8 opcode,
-                            uint32 align,
-                            uint32 offset,
+aot_compile_simd_store_lane(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                            uint8 opcode, uint32 align, uint32 offset,
                             uint8 lane_id)
 {
     LLVMValueRef element, vector;
@@ -333,7 +306,7 @@ aot_compile_simd_store_lane(AOTCompContext *comp_ctx,
     bh_assert(opcode_index < 4);
 
     if (!(vector = simd_pop_v128_and_bitcast(
-            comp_ctx, func_ctx, vector_types[opcode_index], "src"))) {
+              comp_ctx, func_ctx, vector_types[opcode_index], "src"))) {
         return false;
     }
 

--- a/core/iwasm/compilation/simd/simd_load_store.h
+++ b/core/iwasm/compilation/simd/simd_load_store.h
@@ -13,52 +13,33 @@ extern "C" {
 #endif
 
 bool
-aot_compile_simd_v128_load(AOTCompContext *comp_ctx,
-                           AOTFuncContext *func_ctx,
-                           uint32 align,
-                           uint32 offset);
+aot_compile_simd_v128_load(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                           uint32 align, uint32 offset);
 
 bool
-aot_compile_simd_load_extend(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx,
-                             uint8 opcode,
-                             uint32 align,
-                             uint32 offset);
+aot_compile_simd_load_extend(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                             uint8 opcode, uint32 align, uint32 offset);
 
 bool
-aot_compile_simd_load_splat(AOTCompContext *comp_ctx,
-                            AOTFuncContext *func_ctx,
-                            uint8 opcode,
-                            uint32 align,
-                            uint32 offset);
+aot_compile_simd_load_splat(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                            uint8 opcode, uint32 align, uint32 offset);
 
 bool
-aot_compile_simd_load_lane(AOTCompContext *comp_ctx,
-                           AOTFuncContext *func_ctx,
-                           uint8 opcode,
-                           uint32 align,
-                           uint32 offset,
+aot_compile_simd_load_lane(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                           uint8 opcode, uint32 align, uint32 offset,
                            uint8 lane_id);
 
 bool
-aot_compile_simd_load_zero(AOTCompContext *comp_ctx,
-                           AOTFuncContext *func_ctx,
-                           uint8 opcode,
-                           uint32 align,
-                           uint32 offset);
+aot_compile_simd_load_zero(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                           uint8 opcode, uint32 align, uint32 offset);
 
 bool
-aot_compile_simd_v128_store(AOTCompContext *comp_ctx,
-                            AOTFuncContext *func_ctx,
-                            uint32 align,
-                            uint32 offset);
+aot_compile_simd_v128_store(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                            uint32 align, uint32 offset);
 
 bool
-aot_compile_simd_store_lane(AOTCompContext *comp_ctx,
-                            AOTFuncContext *func_ctx,
-                            uint8 opcode,
-                            uint32 align,
-                            uint32 offset,
+aot_compile_simd_store_lane(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                            uint8 opcode, uint32 align, uint32 offset,
                             uint8 lane_id);
 
 #ifdef __cplusplus

--- a/core/iwasm/compilation/simd/simd_sat_int_arith.c
+++ b/core/iwasm/compilation/simd/simd_sat_int_arith.c
@@ -9,16 +9,14 @@
 #include "../../aot/aot_runtime.h"
 
 static bool
-simd_sat_int_arith(AOTCompContext *comp_ctx,
-                   AOTFuncContext *func_ctx,
-                   LLVMTypeRef vector_type,
-                   const char *intrinsics)
+simd_sat_int_arith(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                   LLVMTypeRef vector_type, const char *intrinsics)
 {
     LLVMValueRef lhs, rhs, result;
     LLVMTypeRef param_types[2];
 
     if (!(rhs =
-            simd_pop_v128_and_bitcast(comp_ctx, func_ctx, vector_type, "rhs"))
+              simd_pop_v128_and_bitcast(comp_ctx, func_ctx, vector_type, "rhs"))
         || !(lhs = simd_pop_v128_and_bitcast(comp_ctx, func_ctx, vector_type,
                                              "lhs"))) {
         return false;
@@ -28,8 +26,8 @@ simd_sat_int_arith(AOTCompContext *comp_ctx,
     param_types[1] = vector_type;
 
     if (!(result =
-            aot_call_llvm_intrinsic(comp_ctx, func_ctx, intrinsics,
-                                    vector_type, param_types, 2, lhs, rhs))) {
+              aot_call_llvm_intrinsic(comp_ctx, func_ctx, intrinsics,
+                                      vector_type, param_types, 2, lhs, rhs))) {
         HANDLE_FAILURE("LLVMBuildCall");
         return false;
     }
@@ -40,8 +38,7 @@ simd_sat_int_arith(AOTCompContext *comp_ctx,
 bool
 aot_compile_simd_i8x16_saturate(AOTCompContext *comp_ctx,
                                 AOTFuncContext *func_ctx,
-                                V128Arithmetic arith_op,
-                                bool is_signed)
+                                V128Arithmetic arith_op, bool is_signed)
 {
     char *intrinsics[][2] = {
         { "llvm.sadd.sat.v16i8", "llvm.uadd.sat.v16i8" },
@@ -56,8 +53,7 @@ aot_compile_simd_i8x16_saturate(AOTCompContext *comp_ctx,
 bool
 aot_compile_simd_i16x8_saturate(AOTCompContext *comp_ctx,
                                 AOTFuncContext *func_ctx,
-                                V128Arithmetic arith_op,
-                                bool is_signed)
+                                V128Arithmetic arith_op, bool is_signed)
 {
     char *intrinsics[][2] = {
         { "llvm.sadd.sat.v8i16", "llvm.uadd.sat.v8i16" },
@@ -72,8 +68,7 @@ aot_compile_simd_i16x8_saturate(AOTCompContext *comp_ctx,
 bool
 aot_compile_simd_i32x4_saturate(AOTCompContext *comp_ctx,
                                 AOTFuncContext *func_ctx,
-                                V128Arithmetic arith_op,
-                                bool is_signed)
+                                V128Arithmetic arith_op, bool is_signed)
 {
     char *intrinsics[][2] = {
         { "llvm.sadd.sat.v4i32", "llvm.uadd.sat.v4i32" },

--- a/core/iwasm/compilation/simd/simd_sat_int_arith.h
+++ b/core/iwasm/compilation/simd/simd_sat_int_arith.h
@@ -15,20 +15,17 @@ extern "C" {
 bool
 aot_compile_simd_i8x16_saturate(AOTCompContext *comp_ctx,
                                 AOTFuncContext *func_ctx,
-                                V128Arithmetic arith_op,
-                                bool is_signed);
+                                V128Arithmetic arith_op, bool is_signed);
 
 bool
 aot_compile_simd_i16x8_saturate(AOTCompContext *comp_ctx,
                                 AOTFuncContext *func_ctx,
-                                V128Arithmetic arith_op,
-                                bool is_signed);
+                                V128Arithmetic arith_op, bool is_signed);
 
 bool
 aot_compile_simd_i32x4_saturate(AOTCompContext *comp_ctx,
                                 AOTFuncContext *func_ctx,
-                                V128Arithmetic arith_op,
-                                bool is_signed);
+                                V128Arithmetic arith_op, bool is_signed);
 #ifdef __cplusplus
 } /* end of extern "C" */
 #endif

--- a/core/iwasm/libraries/debug-engine/debug_engine.c
+++ b/core/iwasm/libraries/debug-engine/debug_engine.c
@@ -59,14 +59,13 @@ control_thread_routine(void *arg)
     control_thread->debug_engine = g_debug_engine;
     control_thread->debug_instance = debug_inst;
     strcpy(control_thread->ip_addr, g_debug_engine->ip_addr);
-    control_thread->port =
-        g_debug_engine->process_base_port + debug_inst->id;
+    control_thread->port = g_debug_engine->process_base_port + debug_inst->id;
 
     LOG_WARNING("control thread of debug object %p start at %s:%d\n",
                 debug_inst, control_thread->ip_addr, control_thread->port);
 
     control_thread->server =
-      wasm_launch_gdbserver(control_thread->ip_addr, control_thread->port);
+        wasm_launch_gdbserver(control_thread->ip_addr, control_thread->port);
     if (!control_thread->server) {
         LOG_ERROR("Failed to create debug server\n");
         os_cond_signal(&exec_env->wait_cond);
@@ -110,7 +109,7 @@ wasm_debug_control_thread_create(WASMDebugInstance *debug_instance)
     bh_assert(exec_env);
 
     if (!(control_thread =
-            wasm_runtime_malloc(sizeof(WASMDebugControlThread)))) {
+              wasm_runtime_malloc(sizeof(WASMDebugControlThread)))) {
         LOG_ERROR("WASM Debug Engine error: failed to allocate memory");
         return NULL;
     }
@@ -123,8 +122,9 @@ wasm_debug_control_thread_create(WASMDebugInstance *debug_instance)
 
     os_mutex_lock(&exec_env->wait_lock);
 
-    if (0 != os_thread_create(&control_thread->tid, control_thread_routine,
-                              debug_instance, APP_THREAD_STACK_SIZE_MAX)) {
+    if (0
+        != os_thread_create(&control_thread->tid, control_thread_routine,
+                            debug_instance, APP_THREAD_STACK_SIZE_MAX)) {
         os_mutex_unlock(&control_thread->wait_lock);
         goto fail1;
     }
@@ -153,8 +153,7 @@ wasm_debug_control_thread_destroy(WASMDebugInstance *debug_instance)
 {
     WASMDebugControlThread *control_thread = debug_instance->control_thread;
     LOG_VERBOSE("control thread of debug object %p stop at %s:%d\n",
-                debug_instance, control_thread->ip_addr,
-                control_thread->port);
+                debug_instance, control_thread->ip_addr, control_thread->port);
     control_thread->status = STOPPED;
     os_mutex_lock(&control_thread->wait_lock);
     wasm_close_gdbserver(control_thread->server);
@@ -200,9 +199,9 @@ wasm_debug_engine_init(char *ip_addr, int platform_port, int process_port)
     if (g_debug_engine) {
         process_port -= 1;
         g_debug_engine->platform_port =
-          platform_port > 0 ? platform_port : 1234;
+            platform_port > 0 ? platform_port : 1234;
         g_debug_engine->process_base_port =
-          process_port > 0 ? process_port : 6169;
+            process_port > 0 ? process_port : 6169;
         if (ip_addr)
             sprintf(g_debug_engine->ip_addr, "%s", ip_addr);
         else
@@ -277,7 +276,7 @@ static WASMDebugInstance *
 wasm_cluster_get_debug_instance(WASMDebugEngine *engine, WASMCluster *cluster)
 {
     WASMDebugInstance *instance =
-      bh_list_first_elem(&engine->debug_instance_list);
+        bh_list_first_elem(&engine->debug_instance_list);
     while (instance) {
         if (instance->cluster == cluster)
             return instance;
@@ -343,8 +342,7 @@ wasm_debug_instance_get_current_env(WASMDebugInstance *instance)
 #if WASM_ENABLE_LIBC_WASI != 0
 bool
 wasm_debug_instance_get_current_object_name(WASMDebugInstance *instance,
-                                            char name_buffer[],
-                                            int len)
+                                            char name_buffer[], int len)
 {
     WASMExecEnv *exec_env;
     WASIArguments *wasi_args;
@@ -392,8 +390,8 @@ wasm_debug_instance_get_tid(WASMDebugInstance *instance)
 }
 
 int
-wasm_debug_instance_get_tids(WASMDebugInstance *instance,
-                             uint64 tids[], int len)
+wasm_debug_instance_get_tids(WASMDebugInstance *instance, uint64 tids[],
+                             int len)
 {
     WASMExecEnv *exec_env;
     int i = 0;
@@ -411,8 +409,8 @@ wasm_debug_instance_get_tids(WASMDebugInstance *instance,
 }
 
 uint64
-wasm_debug_instance_wait_thread(WASMDebugInstance *instance,
-                                uint64 tid, uint32 *status)
+wasm_debug_instance_wait_thread(WASMDebugInstance *instance, uint64 tid,
+                                uint32 *status)
 {
     WASMExecEnv *exec_env;
     WASMExecEnv *last_exec_env = NULL;
@@ -454,13 +452,12 @@ wasm_debug_instance_get_pc(WASMDebugInstance *instance)
         return 0;
 
     exec_env = wasm_debug_instance_get_current_env(instance);
-    if ((exec_env->cur_frame != NULL)
-        && (exec_env->cur_frame->ip != NULL)) {
+    if ((exec_env->cur_frame != NULL) && (exec_env->cur_frame->ip != NULL)) {
         WASMModuleInstance *module_inst =
-          (WASMModuleInstance *)exec_env->module_inst;
+            (WASMModuleInstance *)exec_env->module_inst;
         return WASM_ADDR(
-          WasmObj, instance->id,
-          (exec_env->cur_frame->ip - module_inst->module->load_addr));
+            WasmObj, instance->id,
+            (exec_env->cur_frame->ip - module_inst->module->load_addr));
     }
     return 0;
 }
@@ -519,7 +516,8 @@ wasm_debug_instance_get_memregion(WASMDebugInstance *instance, uint64 addr)
                 sprintf(mem_info->permisson, "%s", "rx");
             }
             break;
-        case WasmMemory: {
+        case WasmMemory:
+        {
             memory = module_inst->default_memory;
 
             if (memory) {
@@ -549,8 +547,8 @@ wasm_debug_instance_destroy_memregion(WASMDebugInstance *instance,
 }
 
 bool
-wasm_debug_instance_get_obj_mem(WASMDebugInstance *instance,
-                                uint64 offset, char *buf, uint64 *size)
+wasm_debug_instance_get_obj_mem(WASMDebugInstance *instance, uint64 offset,
+                                char *buf, uint64 *size)
 {
     WASMExecEnv *exec_env;
     WASMModuleInstance *module_inst;
@@ -567,14 +565,14 @@ wasm_debug_instance_get_obj_mem(WASMDebugInstance *instance,
     if (offset + *size > module_inst->module->load_size) {
         LOG_VERBOSE("wasm_debug_instance_get_data_mem size over flow!\n");
         *size = module_inst->module->load_size >= offset
-                  ? module_inst->module->load_size - offset
-                  : 0;
+                    ? module_inst->module->load_size - offset
+                    : 0;
     }
 
     bh_memcpy_s(buf, *size, module_inst->module->load_addr + offset, *size);
 
     WASMDebugBreakPoint *breakpoint =
-      bh_list_first_elem(&instance->break_point_list);
+        bh_list_first_elem(&instance->break_point_list);
 
     while (breakpoint) {
         if (offset <= breakpoint->addr && breakpoint->addr < offset + *size) {
@@ -585,12 +583,12 @@ wasm_debug_instance_get_obj_mem(WASMDebugInstance *instance,
     }
 
     WASMFastOPCodeNode *fast_opcode =
-      bh_list_first_elem(&module_inst->module->fast_opcode_list);
+        bh_list_first_elem(&module_inst->module->fast_opcode_list);
     while (fast_opcode) {
         if (offset <= fast_opcode->offset
             && fast_opcode->offset < offset + *size) {
             *(uint8 *)(buf + (fast_opcode->offset - offset)) =
-              fast_opcode->orig_op;
+                fast_opcode->orig_op;
         }
         fast_opcode = bh_list_elem_next(fast_opcode);
     }
@@ -599,8 +597,8 @@ wasm_debug_instance_get_obj_mem(WASMDebugInstance *instance,
 }
 
 bool
-wasm_debug_instance_get_linear_mem(WASMDebugInstance *instance,
-                                   uint64 offset, char *buf, uint64 *size)
+wasm_debug_instance_get_linear_mem(WASMDebugInstance *instance, uint64 offset,
+                                   char *buf, uint64 *size)
 {
     WASMExecEnv *exec_env;
     WASMModuleInstance *module_inst;
@@ -621,8 +619,7 @@ wasm_debug_instance_get_linear_mem(WASMDebugInstance *instance,
         num_bytes_per_page = memory->num_bytes_per_page;
         linear_mem_size = num_bytes_per_page * memory->cur_page_count;
         if (offset + *size > linear_mem_size) {
-            LOG_VERBOSE(
-              "wasm_debug_instance_get_linear_mem size over flow!\n");
+            LOG_VERBOSE("wasm_debug_instance_get_linear_mem size over flow!\n");
             *size = linear_mem_size >= offset ? linear_mem_size - offset : 0;
         }
         bh_memcpy_s(buf, *size, memory->memory_data + offset, *size);
@@ -632,8 +629,8 @@ wasm_debug_instance_get_linear_mem(WASMDebugInstance *instance,
 }
 
 bool
-wasm_debug_instance_set_linear_mem(WASMDebugInstance *instance,
-                                   uint64 offset, char *buf, uint64 *size)
+wasm_debug_instance_set_linear_mem(WASMDebugInstance *instance, uint64 offset,
+                                   char *buf, uint64 *size)
 {
     WASMExecEnv *exec_env;
     WASMModuleInstance *module_inst;
@@ -654,8 +651,7 @@ wasm_debug_instance_set_linear_mem(WASMDebugInstance *instance,
         num_bytes_per_page = memory->num_bytes_per_page;
         linear_mem_size = num_bytes_per_page * memory->cur_page_count;
         if (offset + *size > linear_mem_size) {
-            LOG_VERBOSE(
-              "wasm_debug_instance_get_linear_mem size over flow!\n");
+            LOG_VERBOSE("wasm_debug_instance_get_linear_mem size over flow!\n");
             *size = linear_mem_size >= offset ? linear_mem_size - offset : 0;
         }
         bh_memcpy_s(memory->memory_data + offset, *size, buf, *size);
@@ -665,17 +661,17 @@ wasm_debug_instance_set_linear_mem(WASMDebugInstance *instance,
 }
 
 bool
-wasm_debug_instance_get_mem(WASMDebugInstance *instance,
-                            uint64 addr, char *buf, uint64 *size)
+wasm_debug_instance_get_mem(WASMDebugInstance *instance, uint64 addr, char *buf,
+                            uint64 *size)
 {
     switch (WASM_ADDR_TYPE(addr)) {
         case WasmMemory:
             return wasm_debug_instance_get_linear_mem(
-              instance, WASM_ADDR_OFFSET(addr), buf, size);
+                instance, WASM_ADDR_OFFSET(addr), buf, size);
             break;
         case WasmObj:
             return wasm_debug_instance_get_obj_mem(
-              instance, WASM_ADDR_OFFSET(addr), buf, size);
+                instance, WASM_ADDR_OFFSET(addr), buf, size);
             break;
         default:
             return false;
@@ -683,13 +679,13 @@ wasm_debug_instance_get_mem(WASMDebugInstance *instance,
 }
 
 bool
-wasm_debug_instance_set_mem(WASMDebugInstance *instance,
-                            uint64 addr, char *buf, uint64 *size)
+wasm_debug_instance_set_mem(WASMDebugInstance *instance, uint64 addr, char *buf,
+                            uint64 *size)
 {
     switch (WASM_ADDR_TYPE(addr)) {
         case WasmMemory:
             return wasm_debug_instance_set_linear_mem(
-              instance, WASM_ADDR_OFFSET(addr), buf, size);
+                instance, WASM_ADDR_OFFSET(addr), buf, size);
             break;
         case WasmObj:
         default:
@@ -713,8 +709,8 @@ wasm_exec_env_get_instance(WASMExecEnv *exec_env)
 }
 
 int
-wasm_debug_instance_get_call_stack_pcs(WASMDebugInstance *instance,
-                                       uint64 tid, uint64 buf[], uint64 size)
+wasm_debug_instance_get_call_stack_pcs(WASMDebugInstance *instance, uint64 tid,
+                                       uint64 buf[], uint64 size)
 {
     WASMExecEnv *exec_env;
     struct WASMInterpFrame *frame;
@@ -727,13 +723,13 @@ wasm_debug_instance_get_call_stack_pcs(WASMDebugInstance *instance,
     while (exec_env) {
         if (exec_env->handle == tid) {
             WASMModuleInstance *module_inst =
-              (WASMModuleInstance *)exec_env->module_inst;
+                (WASMModuleInstance *)exec_env->module_inst;
             frame = exec_env->cur_frame;
             while (frame && i < size) {
                 if (frame->ip != NULL) {
                     buf[i++] =
-                      WASM_ADDR(WasmObj, instance->id,
-                                (frame->ip - module_inst->module->load_addr));
+                        WASM_ADDR(WasmObj, instance->id,
+                                  (frame->ip - module_inst->module->load_addr));
                 }
                 frame = frame->prev_frame;
             }
@@ -745,8 +741,8 @@ wasm_debug_instance_get_call_stack_pcs(WASMDebugInstance *instance,
 }
 
 bool
-wasm_debug_instance_add_breakpoint(WASMDebugInstance *instance,
-                                   uint64 addr, uint64 length)
+wasm_debug_instance_add_breakpoint(WASMDebugInstance *instance, uint64 addr,
+                                   uint64 length)
 {
     WASMExecEnv *exec_env;
     WASMModuleInstance *module_inst;
@@ -769,23 +765,20 @@ wasm_debug_instance_add_breakpoint(WASMDebugInstance *instance,
         if (offset + sizeof(break_instr) <= module_inst->module->load_size) {
             WASMDebugBreakPoint *breakpoint;
             if (!(breakpoint =
-                    wasm_runtime_malloc(sizeof(WASMDebugBreakPoint)))) {
-                LOG_ERROR(
-                  "WASM Debug Engine error: failed to allocate memory");
+                      wasm_runtime_malloc(sizeof(WASMDebugBreakPoint)))) {
+                LOG_ERROR("WASM Debug Engine error: failed to allocate memory");
                 return false;
             }
             memset(breakpoint, 0, sizeof(WASMDebugBreakPoint));
             breakpoint->addr = offset;
             /* TODO: how to if more than one breakpoints are set
                      at the same addr? */
-            bh_memcpy_s(&breakpoint->orignal_data,
-                        (uint32)sizeof(break_instr),
+            bh_memcpy_s(&breakpoint->orignal_data, (uint32)sizeof(break_instr),
                         module_inst->module->load_addr + offset,
                         (uint32)sizeof(break_instr));
 
             bh_memcpy_s(module_inst->module->load_addr + offset,
-                        (uint32)sizeof(break_instr),
-                        break_instr,
+                        (uint32)sizeof(break_instr), break_instr,
                         (uint32)sizeof(break_instr));
 
             bh_list_insert(&instance->break_point_list, breakpoint);
@@ -796,8 +789,8 @@ wasm_debug_instance_add_breakpoint(WASMDebugInstance *instance,
 }
 
 bool
-wasm_debug_instance_remove_breakpoint(WASMDebugInstance *instance,
-                                      uint64 addr, uint64 length)
+wasm_debug_instance_remove_breakpoint(WASMDebugInstance *instance, uint64 addr,
+                                      uint64 length)
 {
     WASMExecEnv *exec_env;
     WASMModuleInstance *module_inst;
@@ -819,10 +812,9 @@ wasm_debug_instance_remove_breakpoint(WASMDebugInstance *instance,
     if (length >= sizeof(break_instr)) {
         if (offset + sizeof(break_instr) <= module_inst->module->load_size) {
             WASMDebugBreakPoint *breakpoint =
-              bh_list_first_elem(&instance->break_point_list);
+                bh_list_first_elem(&instance->break_point_list);
             while (breakpoint) {
-                WASMDebugBreakPoint *next_break =
-                  bh_list_elem_next(breakpoint);
+                WASMDebugBreakPoint *next_break = bh_list_elem_next(breakpoint);
                 if (breakpoint->addr == offset) {
                     /* TODO: how to if more than one breakpoints are set
                        at the same addr? */
@@ -901,9 +893,8 @@ wasm_debug_instance_singlestep(WASMDebugInstance *instance, uint64 tid)
 }
 
 bool
-wasm_debug_instance_get_local(WASMDebugInstance *instance,
-                              int frame_index, int local_index,
-                              char buf[], int *size)
+wasm_debug_instance_get_local(WASMDebugInstance *instance, int frame_index,
+                              int local_index, char buf[], int *size)
 {
     WASMExecEnv *exec_env;
     struct WASMInterpFrame *frame;
@@ -961,9 +952,8 @@ wasm_debug_instance_get_local(WASMDebugInstance *instance,
 }
 
 bool
-wasm_debug_instance_get_global(WASMDebugInstance *instance,
-                               int frame_index, int global_index,
-                               char buf[], int *size)
+wasm_debug_instance_get_global(WASMDebugInstance *instance, int frame_index,
+                               int global_index, char buf[], int *size)
 {
     WASMExecEnv *exec_env;
     struct WASMInterpFrame *frame;
@@ -1003,9 +993,9 @@ wasm_debug_instance_get_global(WASMDebugInstance *instance,
     global_addr = global_data + global->data_offset;
 #else
     global_addr = global->import_global_inst
-                    ? global->import_module_inst->global_data
-                        + global->import_global_inst->data_offset
-                    : global_data + global->data_offset;
+                      ? global->import_module_inst->global_data
+                            + global->import_global_inst->data_offset
+                      : global_data + global->data_offset;
 #endif
     global_type = global->type;
 
@@ -1028,8 +1018,7 @@ wasm_debug_instance_get_global(WASMDebugInstance *instance,
 }
 
 uint64
-wasm_debug_instance_mmap(WASMDebugInstance *instance,
-                         uint32 size, int map_port)
+wasm_debug_instance_mmap(WASMDebugInstance *instance, uint32 size, int map_port)
 {
     WASMExecEnv *exec_env;
     WASMModuleInstance *module_inst;

--- a/core/iwasm/libraries/debug-engine/debug_engine.h
+++ b/core/iwasm/libraries/debug-engine/debug_engine.h
@@ -67,10 +67,10 @@ typedef enum WasmAddressType {
     WasmInvalid = 0x03
 } WasmAddressType;
 
-#define WASM_ADDR(type, id, offset)                                         \
+#define WASM_ADDR(type, id, offset) \
     (((uint64)type << 62) | ((uint64)0 << 32) | ((uint64)offset << 0))
 
-#define WASM_ADDR_TYPE(addr)   (((addr)&0xC000000000000000) >> 62)
+#define WASM_ADDR_TYPE(addr) (((addr)&0xC000000000000000) >> 62)
 #define WASM_ADDR_OFFSET(addr) (((addr)&0x00000000FFFFFFFF))
 
 #define INVALIED_ADDR (0xFFFFFFFFFFFFFFFF)
@@ -96,7 +96,6 @@ wasm_debug_set_engine_active(bool active);
 bool
 wasm_debug_get_engine_active(void);
 
-
 uint64
 wasm_debug_instance_get_pid(WASMDebugInstance *instance);
 
@@ -104,8 +103,8 @@ uint64
 wasm_debug_instance_get_tid(WASMDebugInstance *instance);
 
 int
-wasm_debug_instance_get_tids(WASMDebugInstance *instance,
-                             uint64 tids[], int len);
+wasm_debug_instance_get_tids(WASMDebugInstance *instance, uint64 tids[],
+                             int len);
 
 void
 wasm_debug_instance_set_cur_thread(WASMDebugInstance *instance, uint64 tid);
@@ -124,32 +123,32 @@ wasm_debug_instance_destroy_memregion(WASMDebugInstance *instance,
                                       WASMDebugMemoryInfo *mem_info);
 
 bool
-wasm_debug_instance_get_obj_mem(WASMDebugInstance *instance,
-                                uint64 addr, char *buf, uint64 *size);
+wasm_debug_instance_get_obj_mem(WASMDebugInstance *instance, uint64 addr,
+                                char *buf, uint64 *size);
 
 bool
-wasm_debug_instance_get_linear_mem(WASMDebugInstance *instance,
-                                   uint64 addr, char *buf, uint64 *size);
+wasm_debug_instance_get_linear_mem(WASMDebugInstance *instance, uint64 addr,
+                                   char *buf, uint64 *size);
 
 bool
-wasm_debug_instance_get_mem(WASMDebugInstance *instance,
-                            uint64 addr, char *buf, uint64 *size);
+wasm_debug_instance_get_mem(WASMDebugInstance *instance, uint64 addr, char *buf,
+                            uint64 *size);
 
 bool
-wasm_debug_instance_set_mem(WASMDebugInstance *instance,
-                            uint64 addr, char *buf, uint64 *size);
+wasm_debug_instance_set_mem(WASMDebugInstance *instance, uint64 addr, char *buf,
+                            uint64 *size);
 
 int
-wasm_debug_instance_get_call_stack_pcs(WASMDebugInstance *instance,
-                                       uint64 tid, uint64 buf[], uint64 size);
+wasm_debug_instance_get_call_stack_pcs(WASMDebugInstance *instance, uint64 tid,
+                                       uint64 buf[], uint64 size);
 
 bool
-wasm_debug_instance_add_breakpoint(WASMDebugInstance *instance,
-                                   uint64 addr, uint64 length);
+wasm_debug_instance_add_breakpoint(WASMDebugInstance *instance, uint64 addr,
+                                   uint64 length);
 
 bool
-wasm_debug_instance_remove_breakpoint(WASMDebugInstance *instance,
-                                      uint64 addr, uint64 length);
+wasm_debug_instance_remove_breakpoint(WASMDebugInstance *instance, uint64 addr,
+                                      uint64 length);
 
 bool
 wasm_debug_instance_continue(WASMDebugInstance *instance);
@@ -158,21 +157,19 @@ bool
 wasm_debug_instance_kill(WASMDebugInstance *instance);
 
 uint64
-wasm_debug_instance_wait_thread(WASMDebugInstance *instance,
-                                uint64 tid, uint32 *status);
+wasm_debug_instance_wait_thread(WASMDebugInstance *instance, uint64 tid,
+                                uint32 *status);
 
 bool
 wasm_debug_instance_singlestep(WASMDebugInstance *instance, uint64 tid);
 
 bool
-wasm_debug_instance_get_local(WASMDebugInstance *instance,
-                              int frame_index, int local_index,
-                              char buf[], int *size);
+wasm_debug_instance_get_local(WASMDebugInstance *instance, int frame_index,
+                              int local_index, char buf[], int *size);
 
 bool
-wasm_debug_instance_get_global(WASMDebugInstance *instance,
-                               int frame_index, int global_index,
-                               char buf[], int *size);
+wasm_debug_instance_get_global(WASMDebugInstance *instance, int frame_index,
+                               int global_index, char buf[], int *size);
 
 #if WASM_ENABLE_LIBC_WASI != 0
 bool
@@ -181,8 +178,8 @@ wasm_debug_instance_get_current_object_name(WASMDebugInstance *instance,
 #endif
 
 uint64
-wasm_debug_instance_mmap(WASMDebugInstance *instance,
-                         uint32 size, int map_port);
+wasm_debug_instance_mmap(WASMDebugInstance *instance, uint32 size,
+                         int map_port);
 
 bool
 wasm_debug_instance_ummap(WASMDebugInstance *instance, uint64 addr);

--- a/core/iwasm/libraries/debug-engine/gdbserver.c
+++ b/core/iwasm/libraries/debug-engine/gdbserver.c
@@ -75,8 +75,9 @@ wasm_launch_gdbserver(char *host, int port)
     }
 
     ret = fcntl(listen_fd, F_SETFD, FD_CLOEXEC);
-    if(ret < 0) {
-        LOG_ERROR("wasm gdb server error: fcntl() failed on setting FD_CLOEXEC");
+    if (ret < 0) {
+        LOG_ERROR(
+            "wasm gdb server error: fcntl() failed on setting FD_CLOEXEC");
         goto fail;
     }
 

--- a/core/iwasm/libraries/debug-engine/handler.c
+++ b/core/iwasm/libraries/debug-engine/handler.c
@@ -55,13 +55,13 @@ process_xfer(WASMGDBServer *server, const char *name, char *args)
         *args++ = '\0';
 
     if (!strcmp(name, "libraries") && !strcmp(mode, "read")) {
-        //TODO: how to get current wasm file name?
+        // TODO: how to get current wasm file name?
         uint64_t addr = wasm_debug_instance_get_load_addr(
-          (WASMDebugInstance *)server->thread->debug_instance);
+            (WASMDebugInstance *)server->thread->debug_instance);
 #if WASM_ENABLE_LIBC_WASI != 0
         char objname[128];
         wasm_debug_instance_get_current_object_name(
-          (WASMDebugInstance *)server->thread->debug_instance, objname, 128);
+            (WASMDebugInstance *)server->thread->debug_instance, objname, 128);
         sprintf(tmpbuf,
                 "l<library-list><library name=\"%s\"><section "
                 "address=\"0x%lx\"/></library></library-list>",
@@ -88,8 +88,8 @@ porcess_wasm_local(WASMGDBServer *server, char *args)
     sprintf(tmpbuf, "E01");
     if (sscanf(args, "%d;%d", &frame_index, &local_index) == 2) {
         ret = wasm_debug_instance_get_local(
-          (WASMDebugInstance *)server->thread->debug_instance, frame_index,
-          local_index, buf, &size);
+            (WASMDebugInstance *)server->thread->debug_instance, frame_index,
+            local_index, buf, &size);
         if (ret && size > 0) {
             mem2hex(buf, tmpbuf, size);
         }
@@ -109,8 +109,8 @@ porcess_wasm_global(WASMGDBServer *server, char *args)
     sprintf(tmpbuf, "E01");
     if (sscanf(args, "%d;%d", &frame_index, &global_index) == 2) {
         ret = wasm_debug_instance_get_global(
-          (WASMDebugInstance *)server->thread->debug_instance, frame_index,
-          global_index, buf, &size);
+            (WASMDebugInstance *)server->thread->debug_instance, frame_index,
+            global_index, buf, &size);
         if (ret && size > 0) {
             mem2hex(buf, tmpbuf, size);
         }
@@ -133,14 +133,15 @@ handle_generay_query(WASMGDBServer *server, char *payload)
     if (!strcmp(name, "C")) {
         uint64_t pid, tid;
         pid = wasm_debug_instance_get_pid(
-          (WASMDebugInstance *)server->thread->debug_instance);
+            (WASMDebugInstance *)server->thread->debug_instance);
         tid = wasm_debug_instance_get_tid(
-          (WASMDebugInstance *)server->thread->debug_instance);
+            (WASMDebugInstance *)server->thread->debug_instance);
         snprintf(tmpbuf, sizeof(tmpbuf), "QCp%lx.%lx", pid, tid);
         write_packet(server, tmpbuf);
     }
     if (!strcmp(name, "Supported")) {
-        sprintf(tmpbuf, "qXfer:libraries:read+;PacketSize=%x;", MAX_PACKET_SIZE);
+        sprintf(tmpbuf, "qXfer:libraries:read+;PacketSize=%x;",
+                MAX_PACKET_SIZE);
         write_packet(server, tmpbuf);
     }
 
@@ -161,10 +162,9 @@ handle_generay_query(WASMGDBServer *server, char *payload)
     }
 
     if (!strcmp(name, "HostInfo")) {
-        //Todo: change vendor to Intel for outside tree？
+        // Todo: change vendor to Intel for outside tree？
         char triple[256];
-        mem2hex("wasm32-Ant-wasi-wasm", triple,
-                strlen("wasm32-Ant-wasi-wasm"));
+        mem2hex("wasm32-Ant-wasi-wasm", triple, strlen("wasm32-Ant-wasi-wasm"));
         sprintf(tmpbuf,
                 "vendor:Ant;ostype:wasi;arch:wasm32;"
                 "triple:%s;endian:little;ptrsize:4;",
@@ -183,14 +183,13 @@ handle_generay_query(WASMGDBServer *server, char *payload)
         write_packet(server, "");
     }
     if (!strcmp(name, "ProcessInfo")) {
-        //Todo: process id parent-pid
+        // Todo: process id parent-pid
         uint64_t pid;
         pid = wasm_debug_instance_get_pid(
-          (WASMDebugInstance *)server->thread->debug_instance);
+            (WASMDebugInstance *)server->thread->debug_instance);
         char triple[256];
-        //arch-vendor-os-env(format)
-        mem2hex("wasm32-Ant-wasi-wasm", triple,
-                strlen("wasm32-Ant-wasi-wasm"));
+        // arch-vendor-os-env(format)
+        mem2hex("wasm32-Ant-wasi-wasm", triple, strlen("wasm32-Ant-wasi-wasm"));
         sprintf(tmpbuf,
                 "pid:%lx;parent-pid:%lx;vendor:Ant;ostype:wasi;arch:wasm32;"
                 "triple:%s;endian:little;ptrsize:4;",
@@ -200,9 +199,9 @@ handle_generay_query(WASMGDBServer *server, char *payload)
     }
     if (!strcmp(name, "RegisterInfo0")) {
         sprintf(
-          tmpbuf,
-          "name:pc;alt-name:pc;bitsize:64;offset:0;encoding:uint;format:hex;"
-          "set:General Purpose Registers;gcc:16;dwarf:16;generic:pc;");
+            tmpbuf,
+            "name:pc;alt-name:pc;bitsize:64;offset:0;encoding:uint;format:hex;"
+            "set:General Purpose Registers;gcc:16;dwarf:16;generic:pc;");
         write_packet(server, tmpbuf);
     }
     else if (!strncmp(name, "RegisterInfo", strlen("RegisterInfo"))) {
@@ -215,24 +214,23 @@ handle_generay_query(WASMGDBServer *server, char *payload)
     if (args && (!strcmp(name, "MemoryRegionInfo"))) {
         uint64_t addr = strtol(args, NULL, 16);
         WASMDebugMemoryInfo *mem_info = wasm_debug_instance_get_memregion(
-          (WASMDebugInstance *)server->thread->debug_instance, addr);
+            (WASMDebugInstance *)server->thread->debug_instance, addr);
         if (mem_info) {
             char name[256];
             mem2hex(mem_info->name, name, strlen(mem_info->name));
             sprintf(tmpbuf, "start:%lx;size:%lx;permissions:%s;name:%s;",
-                    (uint64)mem_info->start, mem_info->size, mem_info->permisson, name);
+                    (uint64)mem_info->start, mem_info->size,
+                    mem_info->permisson, name);
             write_packet(server, tmpbuf);
             wasm_debug_instance_destroy_memregion(
-            (WASMDebugInstance *)server->thread->debug_instance, mem_info);
+                (WASMDebugInstance *)server->thread->debug_instance, mem_info);
         }
     }
 
     if (!strcmp(name, "WasmData")) {
-
     }
 
     if (!strcmp(name, "WasmMem")) {
-
     }
 
     if (!strcmp(name, "Symbol")) {
@@ -243,8 +241,8 @@ handle_generay_query(WASMGDBServer *server, char *payload)
         uint64_t tid = strtol(args, NULL, 16);
         uint64_t buf[1024 / sizeof(uint64_t)];
         uint64_t count = wasm_debug_instance_get_call_stack_pcs(
-          (WASMDebugInstance *)server->thread->debug_instance, tid, buf,
-          1024 / sizeof(uint64_t));
+            (WASMDebugInstance *)server->thread->debug_instance, tid, buf,
+            1024 / sizeof(uint64_t));
         if (count > 0) {
             mem2hex((char *)buf, tmpbuf, count * sizeof(uint64_t));
             write_packet(server, tmpbuf);
@@ -276,16 +274,17 @@ send_thread_stop_status(WASMGDBServer *server, uint32_t status, uint64_t tid)
         return;
     }
     tids_number = wasm_debug_instance_get_tids(
-      (WASMDebugInstance *)server->thread->debug_instance, tids, 20);
+        (WASMDebugInstance *)server->thread->debug_instance, tids, 20);
     uint64_t pc = wasm_debug_instance_get_pc(
-      (WASMDebugInstance *)server->thread->debug_instance);
+        (WASMDebugInstance *)server->thread->debug_instance);
 
     if (status == WAMR_SIG_SINGSTEP) {
         gdb_status = WAMR_SIG_TRAP;
     }
 
-    //TODO: how name a wasm thread?
-    len += sprintf(tmpbuf, "T%02xthread:%lx;name:%s;", gdb_status, tid, "nobody");
+    // TODO: how name a wasm thread?
+    len +=
+        sprintf(tmpbuf, "T%02xthread:%lx;name:%s;", gdb_status, tid, "nobody");
     if (tids_number > 0) {
         len += sprintf(tmpbuf + len, "threads:");
         while (i < tids_number) {
@@ -336,12 +335,12 @@ handle_v_packet(WASMGDBServer *server, char *payload)
                 *numstring++ = '\0';
                 uint64_t tid = strtol(numstring, NULL, 16);
                 wasm_debug_instance_set_cur_thread(
-                  (WASMDebugInstance *)server->thread->debug_instance, tid);
+                    (WASMDebugInstance *)server->thread->debug_instance, tid);
                 wasm_debug_instance_singlestep(
-                  (WASMDebugInstance *)server->thread->debug_instance, tid);
+                    (WASMDebugInstance *)server->thread->debug_instance, tid);
                 tid = wasm_debug_instance_wait_thread(
-                  (WASMDebugInstance *)server->thread->debug_instance, tid,
-                  &status);
+                    (WASMDebugInstance *)server->thread->debug_instance, tid,
+                    &status);
                 send_thread_stop_status(server, status, tid);
             }
         }
@@ -352,11 +351,11 @@ void
 handle_threadstop_request(WASMGDBServer *server, char *payload)
 {
     uint64_t tid = wasm_debug_instance_get_tid(
-      (WASMDebugInstance *)server->thread->debug_instance);
+        (WASMDebugInstance *)server->thread->debug_instance);
     uint32_t status;
 
     tid = wasm_debug_instance_wait_thread(
-      (WASMDebugInstance *)server->thread->debug_instance, tid, &status);
+        (WASMDebugInstance *)server->thread->debug_instance, tid, &status);
 
     send_thread_stop_status(server, status, tid);
 }
@@ -370,7 +369,7 @@ handle_set_current_thread(WASMGDBServer *server, char *payload)
         tid = strtol(payload, NULL, 16);
         if (tid > 0)
             wasm_debug_instance_set_cur_thread(
-              (WASMDebugInstance *)server->thread->debug_instance, tid);
+                (WASMDebugInstance *)server->thread->debug_instance, tid);
     }
     write_packet(server, "OK");
 }
@@ -385,7 +384,7 @@ handle_get_register(WASMGDBServer *server, char *payload)
         return;
     }
     uint64_t regdata = wasm_debug_instance_get_pc(
-      (WASMDebugInstance *)server->thread->debug_instance);
+        (WASMDebugInstance *)server->thread->debug_instance);
     mem2hex((void *)&regdata, tmpbuf, 8);
     tmpbuf[8 * 2] = '\0';
     write_packet(server, tmpbuf);
@@ -423,8 +422,8 @@ handle_get_read_memory(WASMGDBServer *server, char *payload)
         char *buff = wasm_runtime_malloc(mlen);
         if (buff) {
             ret = wasm_debug_instance_get_mem(
-              (WASMDebugInstance *)server->thread->debug_instance, maddr, buff,
-              &mlen);
+                (WASMDebugInstance *)server->thread->debug_instance, maddr,
+                buff, &mlen);
             if (ret) {
                 mem2hex(buff, tmpbuf, mlen);
             }
@@ -451,8 +450,8 @@ handle_get_write_memory(WASMGDBServer *server, char *payload)
         if (buff) {
             hex2mem(payload, buff, act_len);
             ret = wasm_debug_instance_set_mem(
-              (WASMDebugInstance *)server->thread->debug_instance, maddr, buff,
-              &mlen);
+                (WASMDebugInstance *)server->thread->debug_instance, maddr,
+                buff, &mlen);
             if (ret) {
                 sprintf(tmpbuf, "%s", "OK");
             }
@@ -470,8 +469,8 @@ handle_add_break(WASMGDBServer *server, char *payload)
     if (sscanf(payload, "%zx,%zx,%zx", &type, &addr, &length) == 3) {
         if (type == eBreakpointSoftware) {
             bool ret = wasm_debug_instance_add_breakpoint(
-              (WASMDebugInstance *)server->thread->debug_instance, addr,
-              length);
+                (WASMDebugInstance *)server->thread->debug_instance, addr,
+                length);
             if (ret)
                 write_packet(server, "OK");
             else
@@ -490,8 +489,8 @@ handle_remove_break(WASMGDBServer *server, char *payload)
     if (sscanf(payload, "%zx,%zx,%zx", &type, &addr, &length) == 3) {
         if (type == eBreakpointSoftware) {
             bool ret = wasm_debug_instance_remove_breakpoint(
-              (WASMDebugInstance *)server->thread->debug_instance, addr,
-              length);
+                (WASMDebugInstance *)server->thread->debug_instance, addr,
+                length);
             if (ret)
                 write_packet(server, "OK");
             else
@@ -509,13 +508,13 @@ handle_continue_request(WASMGDBServer *server, char *payload)
     uint32_t status;
 
     wasm_debug_instance_continue(
-      (WASMDebugInstance *)server->thread->debug_instance);
+        (WASMDebugInstance *)server->thread->debug_instance);
 
     tid = wasm_debug_instance_get_tid(
-      (WASMDebugInstance *)server->thread->debug_instance);
+        (WASMDebugInstance *)server->thread->debug_instance);
 
     tid = wasm_debug_instance_wait_thread(
-      (WASMDebugInstance *)server->thread->debug_instance, tid, &status);
+        (WASMDebugInstance *)server->thread->debug_instance, tid, &status);
 
     send_thread_stop_status(server, status, tid);
 }
@@ -527,13 +526,13 @@ handle_kill_request(WASMGDBServer *server, char *payload)
     uint32_t status;
 
     wasm_debug_instance_kill(
-      (WASMDebugInstance *)server->thread->debug_instance);
+        (WASMDebugInstance *)server->thread->debug_instance);
 
     tid = wasm_debug_instance_get_tid(
-      (WASMDebugInstance *)server->thread->debug_instance);
+        (WASMDebugInstance *)server->thread->debug_instance);
 
     tid = wasm_debug_instance_wait_thread(
-      (WASMDebugInstance *)server->thread->debug_instance, tid, &status);
+        (WASMDebugInstance *)server->thread->debug_instance, tid, &status);
 
     send_thread_stop_status(server, status, tid);
 }
@@ -572,7 +571,8 @@ handle_malloc(WASMGDBServer *server, char *payload)
             args++;
         }
         addr = wasm_debug_instance_mmap(
-          (WASMDebugInstance *)server->thread->debug_instance, size, map_port);
+            (WASMDebugInstance *)server->thread->debug_instance, size,
+            map_port);
         if (addr) {
             sprintf(tmpbuf, "%lx", addr);
         }
@@ -590,7 +590,7 @@ handle_free(WASMGDBServer *server, char *payload)
     addr = strtol(payload, NULL, 16);
 
     ret = wasm_debug_instance_ummap(
-      (WASMDebugInstance *)server->thread->debug_instance, addr);
+        (WASMDebugInstance *)server->thread->debug_instance, addr);
     if (ret) {
         sprintf(tmpbuf, "%s", "OK");
     }

--- a/core/iwasm/libraries/debug-engine/packets.c
+++ b/core/iwasm/libraries/debug-engine/packets.c
@@ -83,8 +83,7 @@ write_hex(WASMGDBServer *gdbserver, unsigned long hex)
 }
 
 void
-write_packet_bytes(WASMGDBServer *gdbserver,
-                   const uint8_t *data,
+write_packet_bytes(WASMGDBServer *gdbserver, const uint8_t *data,
                    size_t num_bytes)
 {
     uint8_t checksum;
@@ -106,10 +105,8 @@ write_packet(WASMGDBServer *gdbserver, const char *data)
 }
 
 void
-write_binary_packet(WASMGDBServer *gdbserver,
-                    const char *pfx,
-                    const uint8_t *data,
-                    ssize_t num_bytes)
+write_binary_packet(WASMGDBServer *gdbserver, const char *pfx,
+                    const uint8_t *data, ssize_t num_bytes)
 {
     uint8_t *buf;
     ssize_t pfx_num_chars = strlen(pfx);

--- a/core/iwasm/libraries/libc-builtin/libc_builtin_wrapper.c
+++ b/core/iwasm/libraries/libc-builtin/libc_builtin_wrapper.c
@@ -29,9 +29,10 @@ void
 wasm_runtime_set_llvm_stack(wasm_module_inst_t module, uint32 llvm_stack);
 
 uint32
-wasm_runtime_module_realloc(wasm_module_inst_t module, uint32 ptr,
-                            uint32 size, void **p_native_addr);
+wasm_runtime_module_realloc(wasm_module_inst_t module, uint32 ptr, uint32 size,
+                            void **p_native_addr);
 
+/* clang-format off */
 #define get_module_inst(exec_env) \
     wasm_runtime_get_module_inst(exec_env)
 
@@ -55,6 +56,7 @@ wasm_runtime_module_realloc(wasm_module_inst_t module, uint32 ptr,
 
 #define module_free(offset) \
     wasm_runtime_module_free(module_inst, offset)
+/* clang-format on */
 
 typedef int (*out_func_t)(int c, void *ctx);
 
@@ -66,15 +68,14 @@ enum pad_type {
 };
 
 typedef char *_va_list;
-#define _INTSIZEOF(n)       \
-    (((uint32)sizeof(n) +  3) & (uint32)~3)
-#define _va_arg(ap, t)      \
-    (*(t*)((ap += _INTSIZEOF(t)) - _INTSIZEOF(t)))
+#define _INTSIZEOF(n) (((uint32)sizeof(n) + 3) & (uint32)~3)
+#define _va_arg(ap, t) (*(t *)((ap += _INTSIZEOF(t)) - _INTSIZEOF(t)))
 
-#define CHECK_VA_ARG(ap, t) do {                        \
-    if ((uint8*)ap + _INTSIZEOF(t) > native_end_addr)   \
-        goto fail;                                      \
-} while (0)
+#define CHECK_VA_ARG(ap, t)                                \
+    do {                                                   \
+        if ((uint8 *)ap + _INTSIZEOF(t) > native_end_addr) \
+            goto fail;                                     \
+    } while (0)
 
 /**
  * @brief Output an unsigned int in hex format
@@ -86,10 +87,8 @@ typedef char *_va_list;
  * @return N/A
  */
 static void
-_printf_hex_uint(out_func_t out, void *ctx,
-                 const uint64 num, bool is_u64,
-                 enum pad_type padding,
-                 int min_width)
+_printf_hex_uint(out_func_t out, void *ctx, const uint64 num, bool is_u64,
+                 enum pad_type padding, int min_width)
 {
     int shift = sizeof(num) * 8;
     int found_largest_digit = 0;
@@ -97,14 +96,14 @@ _printf_hex_uint(out_func_t out, void *ctx,
     int digits = 0;
     char nibble;
 
-     while (shift >= 4) {
-         shift -= 4;
-         nibble = (num >> shift) & 0xf;
+    while (shift >= 4) {
+        shift -= 4;
+        nibble = (num >> shift) & 0xf;
 
         if (nibble || found_largest_digit || shift == 0) {
             found_largest_digit = 1;
             nibble = (char)(nibble + (nibble > 9 ? 87 : 48));
-            out((int) nibble, ctx);
+            out((int)nibble, ctx);
             digits++;
             continue;
         }
@@ -112,7 +111,8 @@ _printf_hex_uint(out_func_t out, void *ctx,
         if (remaining-- <= min_width) {
             if (padding == PAD_ZERO_BEFORE) {
                 out('0', ctx);
-            } else if (padding == PAD_SPACE_BEFORE) {
+            }
+            else if (padding == PAD_SPACE_BEFORE) {
                 out(' ', ctx);
             }
         }
@@ -136,10 +136,8 @@ _printf_hex_uint(out_func_t out, void *ctx,
  * @return N/A
  */
 static void
-_printf_dec_uint(out_func_t out, void *ctx,
-                 const uint32 num,
-                 enum pad_type padding,
-                 int min_width)
+_printf_dec_uint(out_func_t out, void *ctx, const uint32 num,
+                 enum pad_type padding, int min_width)
 {
     uint32 pos = 999999999;
     uint32 remainder = num;
@@ -155,17 +153,18 @@ _printf_dec_uint(out_func_t out, void *ctx,
     while (pos >= 9) {
         if (found_largest_digit || remainder > pos) {
             found_largest_digit = 1;
-            out((int) ((remainder / (pos + 1)) + 48), ctx);
+            out((int)((remainder / (pos + 1)) + 48), ctx);
             digits++;
-        } else if (remaining <= min_width && padding < PAD_SPACE_AFTER) {
-            out((int) (padding == PAD_ZERO_BEFORE ? '0' : ' '), ctx);
+        }
+        else if (remaining <= min_width && padding < PAD_SPACE_AFTER) {
+            out((int)(padding == PAD_ZERO_BEFORE ? '0' : ' '), ctx);
             digits++;
         }
         remaining--;
         remainder %= (pos + 1);
         pos /= 10;
     }
-    out((int) (remainder + 48), ctx);
+    out((int)(remainder + 48), ctx);
 
     if (padding == PAD_SPACE_AFTER) {
         remaining = min_width - digits;
@@ -193,8 +192,8 @@ _vprintf_wa(out_func_t out, void *ctx, const char *fmt, _va_list ap,
     int long_ctr = 0;
     uint8 *native_end_addr;
 
-    if (!wasm_runtime_get_native_addr_range(module_inst, (uint8*)ap,
-                                            NULL, &native_end_addr))
+    if (!wasm_runtime_get_native_addr_range(module_inst, (uint8 *)ap, NULL,
+                                            &native_end_addr))
         goto fail;
 
     /* fmt has already been adjusted if needed */
@@ -202,7 +201,7 @@ _vprintf_wa(out_func_t out, void *ctx, const char *fmt, _va_list ap,
     while (*fmt) {
         if (!might_format) {
             if (*fmt != '%') {
-                out((int) *fmt, ctx);
+                out((int)*fmt, ctx);
             }
             else {
                 might_format = 1;
@@ -213,179 +212,188 @@ _vprintf_wa(out_func_t out, void *ctx, const char *fmt, _va_list ap,
         }
         else {
             switch (*fmt) {
-            case '-':
-                padding = PAD_SPACE_AFTER;
-                goto still_might_format;
-
-            case '0':
-                if (min_width < 0 && padding == PAD_NONE) {
-                    padding = PAD_ZERO_BEFORE;
+                case '-':
+                    padding = PAD_SPACE_AFTER;
                     goto still_might_format;
+
+                case '0':
+                    if (min_width < 0 && padding == PAD_NONE) {
+                        padding = PAD_ZERO_BEFORE;
+                        goto still_might_format;
+                    }
+                    goto handle_1_to_9;
+                case '1':
+                case '2':
+                case '3':
+                case '4':
+                case '5':
+                case '6':
+                case '7':
+                case '8':
+                case '9':
+                handle_1_to_9:
+                    if (min_width < 0) {
+                        min_width = *fmt - '0';
+                    }
+                    else {
+                        min_width = 10 * min_width + *fmt - '0';
+                    }
+
+                    if (padding == PAD_NONE) {
+                        padding = PAD_SPACE_BEFORE;
+                    }
+                    goto still_might_format;
+
+                case 'l':
+                    long_ctr++;
+                    /* Fall through */
+                case 'z':
+                case 'h':
+                    /* FIXME: do nothing for these modifiers */
+                    goto still_might_format;
+
+                case 'd':
+                case 'i':
+                {
+                    int32 d;
+
+                    if (long_ctr < 2) {
+                        CHECK_VA_ARG(ap, int32);
+                        d = _va_arg(ap, int32);
+                    }
+                    else {
+                        int64 lld;
+                        CHECK_VA_ARG(ap, int64);
+                        lld = _va_arg(ap, int64);
+                        if (lld > INT32_MAX || lld < INT32_MIN) {
+                            print_err(out, ctx);
+                            break;
+                        }
+                        d = (int32)lld;
+                    }
+
+                    if (d < 0) {
+                        out((int)'-', ctx);
+                        d = -d;
+                        min_width--;
+                    }
+                    _printf_dec_uint(out, ctx, (uint32)d, padding, min_width);
+                    break;
                 }
-                goto handle_1_to_9;
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-            case '8':
-            case '9':
-handle_1_to_9:
-                if (min_width < 0) {
-                    min_width = *fmt - '0';
-                } else {
-                    min_width = 10 * min_width + *fmt - '0';
+                case 'u':
+                {
+                    uint32 u;
+
+                    if (long_ctr < 2) {
+                        CHECK_VA_ARG(ap, uint32);
+                        u = _va_arg(ap, uint32);
+                    }
+                    else {
+                        uint64 llu;
+                        CHECK_VA_ARG(ap, uint64);
+                        llu = _va_arg(ap, uint64);
+                        if (llu > INT32_MAX) {
+                            print_err(out, ctx);
+                            break;
+                        }
+                        u = (uint32)llu;
+                    }
+                    _printf_dec_uint(out, ctx, u, padding, min_width);
+                    break;
+                }
+                case 'p':
+                    out('0', ctx);
+                    out('x', ctx);
+                    /* left-pad pointers with zeros */
+                    padding = PAD_ZERO_BEFORE;
+                    min_width = 8;
+                    /* Fall through */
+                case 'x':
+                case 'X':
+                {
+                    uint64 x;
+                    bool is_ptr = (*fmt == 'p') ? true : false;
+
+                    if (long_ctr < 2) {
+                        CHECK_VA_ARG(ap, uint32);
+                        x = _va_arg(ap, uint32);
+                    }
+                    else {
+                        CHECK_VA_ARG(ap, uint64);
+                        x = _va_arg(ap, uint64);
+                    }
+                    _printf_hex_uint(out, ctx, x, !is_ptr, padding, min_width);
+                    break;
                 }
 
-                if (padding == PAD_NONE) {
-                    padding = PAD_SPACE_BEFORE;
-                }
-                goto still_might_format;
+                case 's':
+                {
+                    char *s;
+                    char *start;
+                    uint32 s_offset;
 
-            case 'l':
-                long_ctr++;
-                /* Fall through */
-            case 'z':
-            case 'h':
-                /* FIXME: do nothing for these modifiers */
-                goto still_might_format;
-
-            case 'd':
-            case 'i': {
-                int32 d;
-
-                if (long_ctr < 2) {
                     CHECK_VA_ARG(ap, int32);
-                    d = _va_arg(ap, int32);
-                }
-                else {
-                    int64 lld;
-                    CHECK_VA_ARG(ap, int64);
-                    lld = _va_arg(ap, int64);
-                    if (lld > INT32_MAX || lld < INT32_MIN) {
-                        print_err(out, ctx);
-                        break;
+                    s_offset = _va_arg(ap, uint32);
+
+                    if (!validate_app_str_addr(s_offset)) {
+                        return false;
                     }
-                    d = (int32)lld;
-                }
 
-                if (d < 0) {
-                    out((int)'-', ctx);
-                    d = -d;
-                    min_width--;
-                }
-                _printf_dec_uint(out, ctx, (uint32)d, padding, min_width);
-                break;
-            }
-            case 'u': {
-                uint32 u;
+                    s = start = addr_app_to_native(s_offset);
 
-                if (long_ctr < 2) {
-                    CHECK_VA_ARG(ap, uint32);
-                    u = _va_arg(ap, uint32);
-                }
-                else {
-                    uint64 llu;
-                    CHECK_VA_ARG(ap, uint64);
-                    llu = _va_arg(ap, uint64);
-                    if (llu > INT32_MAX) {
-                        print_err(out, ctx);
-                        break;
+                    while (*s)
+                        out((int)(*s++), ctx);
+
+                    if (padding == PAD_SPACE_AFTER) {
+                        int remaining = min_width - (int32)(s - start);
+                        while (remaining-- > 0) {
+                            out(' ', ctx);
+                        }
                     }
-                    u = (uint32)llu;
-                }
-                _printf_dec_uint(out, ctx, u, padding, min_width);
-                break;
-            }
-            case 'p':
-                out('0', ctx);
-                out('x', ctx);
-                /* left-pad pointers with zeros */
-                padding = PAD_ZERO_BEFORE;
-                min_width = 8;
-                /* Fall through */
-            case 'x':
-            case 'X': {
-                uint64 x;
-                bool is_ptr = (*fmt == 'p') ? true : false;
-
-                if (long_ctr < 2) {
-                    CHECK_VA_ARG(ap, uint32);
-                    x = _va_arg(ap, uint32);
-                } else {
-                    CHECK_VA_ARG(ap, uint64);
-                    x = _va_arg(ap, uint64);
-                }
-                _printf_hex_uint(out, ctx, x, !is_ptr, padding, min_width);
-                break;
-            }
-
-            case 's': {
-                char *s;
-                char *start;
-                uint32 s_offset;
-
-                CHECK_VA_ARG(ap, int32);
-                s_offset = _va_arg(ap, uint32);
-
-                if (!validate_app_str_addr(s_offset)) {
-                    return false;
+                    break;
                 }
 
-                s = start = addr_app_to_native(s_offset);
-
-                while (*s)
-                    out((int) (*s++), ctx);
-
-                if (padding == PAD_SPACE_AFTER) {
-                    int remaining = min_width - (int32)(s - start);
-                    while (remaining-- > 0) {
-                        out(' ', ctx);
-                    }
+                case 'c':
+                {
+                    int c;
+                    CHECK_VA_ARG(ap, int);
+                    c = _va_arg(ap, int);
+                    out(c, ctx);
+                    break;
                 }
-                break;
-            }
 
-            case 'c': {
-                int c;
-                CHECK_VA_ARG(ap, int);
-                c = _va_arg(ap, int);
-                out(c, ctx);
-                break;
-            }
+                case '%':
+                {
+                    out((int)'%', ctx);
+                    break;
+                }
 
-            case '%': {
-                out((int) '%', ctx);
-                break;
-            }
+                case 'f':
+                {
+                    float64 f64;
+                    char buf[16], *s;
 
-            case 'f': {
-                float64 f64;
-                char buf[16], *s;
+                    /* Make 8-byte aligned */
+                    ap = (_va_list)(((uintptr_t)ap + 7) & ~(uintptr_t)7);
+                    CHECK_VA_ARG(ap, float64);
+                    f64 = _va_arg(ap, float64);
+                    snprintf(buf, sizeof(buf), "%f", f64);
+                    s = buf;
+                    while (*s)
+                        out((int)(*s++), ctx);
+                    break;
+                }
 
-                /* Make 8-byte aligned */
-                ap = (_va_list)(((uintptr_t)ap + 7) & ~(uintptr_t)7);
-                CHECK_VA_ARG(ap, float64);
-                f64 = _va_arg(ap, float64);
-                snprintf(buf, sizeof(buf), "%f", f64);
-                s = buf;
-                while (*s)
-                    out((int) (*s++), ctx);
-                break;
-            }
-
-            default:
-                out((int) '%', ctx);
-                out((int) *fmt, ctx);
-                break;
+                default:
+                    out((int)'%', ctx);
+                    out((int)*fmt, ctx);
+                    break;
             }
 
             might_format = 0;
         }
 
-still_might_format:
+    still_might_format:
         ++fmt;
     }
     return true;
@@ -411,7 +419,8 @@ sprintf_out(int c, struct str_context *ctx)
 
     if (ctx->count == ctx->max - 1) {
         ctx->str[ctx->count++] = '\0';
-    } else {
+    }
+    else {
         ctx->str[ctx->count++] = (char)c;
     }
 
@@ -453,8 +462,7 @@ printf_out(int c, struct str_context *ctx)
 #endif
 
 static int
-printf_wrapper(wasm_exec_env_t exec_env,
-               const char * format, _va_list va_args)
+printf_wrapper(wasm_exec_env_t exec_env, const char *format, _va_list va_args)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     struct str_context ctx = { NULL, 0, 0 };
@@ -463,15 +471,16 @@ printf_wrapper(wasm_exec_env_t exec_env,
     if (!validate_native_addr(va_args, sizeof(int32)))
         return 0;
 
-    if (!_vprintf_wa((out_func_t)printf_out, &ctx, format, va_args, module_inst))
+    if (!_vprintf_wa((out_func_t)printf_out, &ctx, format, va_args,
+                     module_inst))
         return 0;
 
     return (int)ctx.count;
 }
 
 static int
-sprintf_wrapper(wasm_exec_env_t exec_env,
-                char *str, const char *format, _va_list va_args)
+sprintf_wrapper(wasm_exec_env_t exec_env, char *str, const char *format,
+                _va_list va_args)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uint8 *native_end_offset;
@@ -481,17 +490,18 @@ sprintf_wrapper(wasm_exec_env_t exec_env,
     if (!validate_native_addr(va_args, sizeof(uint32)))
         return 0;
 
-    if (!wasm_runtime_get_native_addr_range(module_inst, (uint8*)str,
-                                            NULL, &native_end_offset)) {
+    if (!wasm_runtime_get_native_addr_range(module_inst, (uint8 *)str, NULL,
+                                            &native_end_offset)) {
         wasm_runtime_set_exception(module_inst, "out of bounds memory access");
         return false;
     }
 
     ctx.str = str;
-    ctx.max = (uint32)(native_end_offset - (uint8*)str);
+    ctx.max = (uint32)(native_end_offset - (uint8 *)str);
     ctx.count = 0;
 
-    if (!_vprintf_wa((out_func_t)sprintf_out, &ctx, format, va_args, module_inst))
+    if (!_vprintf_wa((out_func_t)sprintf_out, &ctx, format, va_args,
+                     module_inst))
         return 0;
 
     if (ctx.count < ctx.max) {
@@ -516,7 +526,8 @@ snprintf_wrapper(wasm_exec_env_t exec_env, char *str, uint32 size,
     ctx.max = size;
     ctx.count = 0;
 
-    if (!_vprintf_wa((out_func_t)sprintf_out, &ctx, format, va_args, module_inst))
+    if (!_vprintf_wa((out_func_t)sprintf_out, &ctx, format, va_args,
+                     module_inst))
         return 0;
 
     if (ctx.count < ctx.max) {
@@ -551,7 +562,7 @@ strdup_wrapper(wasm_exec_env_t exec_env, const char *str)
     if (str) {
         len = (uint32)strlen(str) + 1;
 
-        str_ret_offset = module_malloc(len, (void**)&str_ret);
+        str_ret_offset = module_malloc(len, (void **)&str_ret);
         if (str_ret_offset) {
             bh_memcpy_s(str_ret, len, str, len);
         }
@@ -567,21 +578,21 @@ _strdup_wrapper(wasm_exec_env_t exec_env, const char *str)
 }
 
 static int32
-memcmp_wrapper(wasm_exec_env_t exec_env,
-               const void *s1, const void *s2, uint32 size)
+memcmp_wrapper(wasm_exec_env_t exec_env, const void *s1, const void *s2,
+               uint32 size)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
 
     /* s2 has been checked by runtime */
-    if (!validate_native_addr((void*)s1, size))
+    if (!validate_native_addr((void *)s1, size))
         return 0;
 
     return memcmp(s1, s2, size);
 }
 
 static uint32
-memcpy_wrapper(wasm_exec_env_t exec_env,
-               void *dst, const void *src, uint32 size)
+memcpy_wrapper(wasm_exec_env_t exec_env, void *dst, const void *src,
+               uint32 size)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uint32 dst_offset = addr_native_to_app(dst);
@@ -598,8 +609,7 @@ memcpy_wrapper(wasm_exec_env_t exec_env,
 }
 
 static uint32
-memmove_wrapper(wasm_exec_env_t exec_env,
-                void *dst, void *src, uint32 size)
+memmove_wrapper(wasm_exec_env_t exec_env, void *dst, void *src, uint32 size)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uint32 dst_offset = addr_native_to_app(dst);
@@ -616,8 +626,7 @@ memmove_wrapper(wasm_exec_env_t exec_env,
 }
 
 static uint32
-memset_wrapper(wasm_exec_env_t exec_env,
-               void *s, int32 c, uint32 size)
+memset_wrapper(wasm_exec_env_t exec_env, void *s, int32 c, uint32 size)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uint32 s_offset = addr_native_to_app(s);
@@ -630,8 +639,7 @@ memset_wrapper(wasm_exec_env_t exec_env,
 }
 
 static uint32
-strchr_wrapper(wasm_exec_env_t exec_env,
-               const char *s, int32 c)
+strchr_wrapper(wasm_exec_env_t exec_env, const char *s, int32 c)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     char *ret;
@@ -642,21 +650,20 @@ strchr_wrapper(wasm_exec_env_t exec_env,
 }
 
 static int32
-strcmp_wrapper(wasm_exec_env_t exec_env,
-               const char *s1, const char *s2)
+strcmp_wrapper(wasm_exec_env_t exec_env, const char *s1, const char *s2)
 {
     /* s1 and s2 have been checked by runtime */
     return strcmp(s1, s2);
 }
 
 static int32
-strncmp_wrapper(wasm_exec_env_t exec_env,
-                const char *s1, const char *s2, uint32 size)
+strncmp_wrapper(wasm_exec_env_t exec_env, const char *s1, const char *s2,
+                uint32 size)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
 
     /* s2 has been checked by runtime */
-    if (!validate_native_addr((void*)s1, size))
+    if (!validate_native_addr((void *)s1, size))
         return 0;
 
     return strncmp(s1, s2, size);
@@ -681,8 +688,8 @@ strcpy_wrapper(wasm_exec_env_t exec_env, char *dst, const char *src)
 }
 
 static uint32
-strncpy_wrapper(wasm_exec_env_t exec_env,
-                char *dst, const char *src, uint32 size)
+strncpy_wrapper(wasm_exec_env_t exec_env, char *dst, const char *src,
+                uint32 size)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
 
@@ -716,14 +723,14 @@ static uint32
 calloc_wrapper(wasm_exec_env_t exec_env, uint32 nmemb, uint32 size)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
-    uint64 total_size = (uint64) nmemb * (uint64) size;
+    uint64 total_size = (uint64)nmemb * (uint64)size;
     uint32 ret_offset = 0;
     uint8 *ret_ptr;
 
     if (total_size >= UINT32_MAX)
         return 0;
 
-    ret_offset = module_malloc((uint32)total_size, (void**)&ret_ptr);
+    ret_offset = module_malloc((uint32)total_size, (void **)&ret_ptr);
     if (ret_offset) {
         memset(ret_ptr, 0, (uint32)total_size);
     }
@@ -767,8 +774,8 @@ exit_wrapper(wasm_exec_env_t exec_env, int32 status)
 }
 
 static int32
-strtol_wrapper(wasm_exec_env_t exec_env,
-               const char *nptr, char **endptr, int32 base)
+strtol_wrapper(wasm_exec_env_t exec_env, const char *nptr, char **endptr,
+               int32 base)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     int32 num = 0;
@@ -778,14 +785,14 @@ strtol_wrapper(wasm_exec_env_t exec_env,
         return 0;
 
     num = (int32)strtol(nptr, endptr, base);
-    *(uint32*)endptr = addr_native_to_app(*endptr);
+    *(uint32 *)endptr = addr_native_to_app(*endptr);
 
     return num;
 }
 
 static uint32
-strtoul_wrapper(wasm_exec_env_t exec_env,
-                const char *nptr, char **endptr, int32 base)
+strtoul_wrapper(wasm_exec_env_t exec_env, const char *nptr, char **endptr,
+                int32 base)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uint32 num = 0;
@@ -801,13 +808,12 @@ strtoul_wrapper(wasm_exec_env_t exec_env,
 }
 
 static uint32
-memchr_wrapper(wasm_exec_env_t exec_env,
-               const void *s, int32 c, uint32 n)
+memchr_wrapper(wasm_exec_env_t exec_env, const void *s, int32 c, uint32 n)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     void *res;
 
-    if (!validate_native_addr((void*)s, n))
+    if (!validate_native_addr((void *)s, n))
         return 0;
 
     res = memchr(s, c, n);
@@ -815,32 +821,29 @@ memchr_wrapper(wasm_exec_env_t exec_env,
 }
 
 static int32
-strncasecmp_wrapper(wasm_exec_env_t exec_env,
-                    const char *s1, const char *s2, uint32 n)
+strncasecmp_wrapper(wasm_exec_env_t exec_env, const char *s1, const char *s2,
+                    uint32 n)
 {
     /* s1 and s2 have been checked by runtime */
     return strncasecmp(s1, s2, n);
 }
 
 static uint32
-strspn_wrapper(wasm_exec_env_t exec_env,
-               const char *s, const char *accept)
+strspn_wrapper(wasm_exec_env_t exec_env, const char *s, const char *accept)
 {
     /* s and accept have been checked by runtime */
     return (uint32)strspn(s, accept);
 }
 
 static uint32
-strcspn_wrapper(wasm_exec_env_t exec_env,
-                const char *s, const char *reject)
+strcspn_wrapper(wasm_exec_env_t exec_env, const char *s, const char *reject)
 {
     /* s and reject have been checked by runtime */
     return (uint32)strcspn(s, reject);
 }
 
 static uint32
-strstr_wrapper(wasm_exec_env_t exec_env,
-               const char *s, const char *find)
+strstr_wrapper(wasm_exec_env_t exec_env, const char *s, const char *find)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     /* s and find have been checked by runtime */
@@ -925,24 +928,19 @@ getTempRet0_wrapper(wasm_exec_env_t exec_env)
 static uint32
 llvm_bswap_i16_wrapper(wasm_exec_env_t exec_env, uint32 data)
 {
-    return (data & 0xFFFF0000)
-           | ((data & 0xFF) << 8)
-           | ((data & 0xFF00) >> 8);
+    return (data & 0xFFFF0000) | ((data & 0xFF) << 8) | ((data & 0xFF00) >> 8);
 }
 
 static uint32
 llvm_bswap_i32_wrapper(wasm_exec_env_t exec_env, uint32 data)
 {
-    return ((data & 0xFF) << 24)
-           | ((data & 0xFF00) << 8)
-           | ((data & 0xFF0000) >> 8)
-           | ((data & 0xFF000000) >> 24);
+    return ((data & 0xFF) << 24) | ((data & 0xFF00) << 8)
+           | ((data & 0xFF0000) >> 8) | ((data & 0xFF000000) >> 24);
 }
 
 static uint32
-bitshift64Lshr_wrapper(wasm_exec_env_t exec_env,
-                       uint32 uint64_part0, uint32 uint64_part1,
-                       uint32 bits)
+bitshift64Lshr_wrapper(wasm_exec_env_t exec_env, uint32 uint64_part0,
+                       uint32 uint64_part1, uint32 bits)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     union {
@@ -955,14 +953,13 @@ bitshift64Lshr_wrapper(wasm_exec_env_t exec_env,
 
     u.value >>= bits;
     /* return low 32bit and save high 32bit to temp ret */
-    wasm_runtime_set_temp_ret(module_inst, (uint32) (u.value >> 32));
-    return (uint32) u.value;
+    wasm_runtime_set_temp_ret(module_inst, (uint32)(u.value >> 32));
+    return (uint32)u.value;
 }
 
 static uint32
-bitshift64Shl_wrapper(wasm_exec_env_t exec_env,
-                      uint32 int64_part0, uint32 int64_part1,
-                      uint32 bits)
+bitshift64Shl_wrapper(wasm_exec_env_t exec_env, uint32 int64_part0,
+                      uint32 int64_part1, uint32 bits)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     union {
@@ -975,8 +972,8 @@ bitshift64Shl_wrapper(wasm_exec_env_t exec_env,
 
     u.value <<= bits;
     /* return low 32bit and save high 32bit to temp ret */
-    wasm_runtime_set_temp_ret(module_inst, (uint32) (u.value >> 32));
-    return (uint32) u.value;
+    wasm_runtime_set_temp_ret(module_inst, (uint32)(u.value >> 32));
+    return (uint32)u.value;
 }
 
 static void
@@ -996,8 +993,8 @@ llvm_stacksave_wrapper(wasm_exec_env_t exec_env)
 }
 
 static uint32
-emscripten_memcpy_big_wrapper(wasm_exec_env_t exec_env,
-                              void *dst, const void *src, uint32 size)
+emscripten_memcpy_big_wrapper(wasm_exec_env_t exec_env, void *dst,
+                              const void *src, uint32 size)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uint32 dst_offset = addr_native_to_app(dst);
@@ -1038,8 +1035,7 @@ nullFunc_X_wrapper(wasm_exec_env_t exec_env, int32 code)
 }
 
 static uint32
-__cxa_allocate_exception_wrapper(wasm_exec_env_t exec_env,
-                                 uint32 thrown_size)
+__cxa_allocate_exception_wrapper(wasm_exec_env_t exec_env, uint32 thrown_size)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uint32 exception = module_malloc(thrown_size, NULL);
@@ -1050,16 +1046,12 @@ __cxa_allocate_exception_wrapper(wasm_exec_env_t exec_env,
 }
 
 static void
-__cxa_begin_catch_wrapper(wasm_exec_env_t exec_env,
-                          void *exception_object)
-{
-}
+__cxa_begin_catch_wrapper(wasm_exec_env_t exec_env, void *exception_object)
+{}
 
 static void
-__cxa_throw_wrapper(wasm_exec_env_t exec_env,
-                    void *thrown_exception,
-                    void *tinfo,
-                    uint32 table_elem_idx)
+__cxa_throw_wrapper(wasm_exec_env_t exec_env, void *thrown_exception,
+                    void *tinfo, uint32 table_elem_idx)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     char buf[32];
@@ -1074,8 +1066,8 @@ struct timespec_app {
 };
 
 static uint32
-clock_gettime_wrapper(wasm_exec_env_t exec_env,
-                      uint32 clk_id, struct timespec_app *ts_app)
+clock_gettime_wrapper(wasm_exec_env_t exec_env, uint32 clk_id,
+                      struct timespec_app *ts_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uint64 time;
@@ -1103,7 +1095,6 @@ static void
 print_wrapper(wasm_exec_env_t exec_env)
 {
     os_printf("in specttest.print()\n");
-
 }
 
 static void
@@ -1137,8 +1128,10 @@ print_f64_wrapper(wasm_exec_env_t exec_env, double f64)
 }
 #endif /* WASM_ENABLE_SPEC_TEST */
 
-#define REG_NATIVE_FUNC(func_name, signature)  \
-    { #func_name, func_name##_wrapper, signature, NULL }
+#define REG_NATIVE_FUNC(func_name, signature)            \
+    {                                                    \
+#func_name, func_name##_wrapper, signature, NULL \
+    }
 
 static NativeSymbol native_symbols_libc_builtin[] = {
     REG_NATIVE_FUNC(printf, "($*)i"),
@@ -1281,4 +1274,3 @@ wasm_native_lookup_libc_builtin_global(const char *module_name,
 
     return false;
 }
-

--- a/core/iwasm/libraries/libc-emcc/libc_emcc_wrapper.c
+++ b/core/iwasm/libraries/libc-emcc/libc_emcc_wrapper.c
@@ -11,6 +11,7 @@
 #include "sys/syscall.h"
 #endif
 
+/* clang-format off */
 #define get_module_inst(exec_env) \
     wasm_runtime_get_module_inst(exec_env)
 
@@ -34,15 +35,15 @@
 
 #define module_free(offset) \
     wasm_runtime_module_free(module_inst, offset)
+/* clang-format on */
 
 extern bool
-wasm_runtime_call_indirect(wasm_exec_env_t exec_env,
-                           uint32 element_idx,
+wasm_runtime_call_indirect(wasm_exec_env_t exec_env, uint32 element_idx,
                            uint32 argc, uint32 argv[]);
 
 static void
-invoke_viiii_wrapper(wasm_exec_env_t exec_env, uint32 elem_idx,
-                     int arg0, int arg1, int arg2, int arg3)
+invoke_viiii_wrapper(wasm_exec_env_t exec_env, uint32 elem_idx, int arg0,
+                     int arg1, int arg2, int arg3)
 {
     uint32 argv[4];
     bool ret;
@@ -56,8 +57,8 @@ invoke_viiii_wrapper(wasm_exec_env_t exec_env, uint32 elem_idx,
 }
 
 static void
-invoke_viii_wrapper(wasm_exec_env_t exec_env, uint32 elem_idx,
-                    int arg0, int arg1, int arg2)
+invoke_viii_wrapper(wasm_exec_env_t exec_env, uint32 elem_idx, int arg0,
+                    int arg1, int arg2)
 {
     uint32 argv[4];
     bool ret;
@@ -70,8 +71,8 @@ invoke_viii_wrapper(wasm_exec_env_t exec_env, uint32 elem_idx,
 }
 
 static void
-invoke_vii_wrapper(wasm_exec_env_t exec_env,
-                   uint32 elem_idx, int arg0, int arg1)
+invoke_vii_wrapper(wasm_exec_env_t exec_env, uint32 elem_idx, int arg0,
+                   int arg1)
 {
     uint32 argv[4];
     bool ret;
@@ -83,8 +84,7 @@ invoke_vii_wrapper(wasm_exec_env_t exec_env,
 }
 
 static void
-invoke_vi_wrapper(wasm_exec_env_t exec_env,
-                  uint32 elem_idx, int arg0)
+invoke_vi_wrapper(wasm_exec_env_t exec_env, uint32 elem_idx, int arg0)
 {
     uint32 argv[4];
     bool ret;
@@ -95,8 +95,8 @@ invoke_vi_wrapper(wasm_exec_env_t exec_env,
 }
 
 static int
-invoke_iii_wrapper(wasm_exec_env_t exec_env,
-                   uint32 elem_idx, int arg0, int arg1)
+invoke_iii_wrapper(wasm_exec_env_t exec_env, uint32 elem_idx, int arg0,
+                   int arg1)
 {
     uint32 argv[4];
     bool ret;
@@ -108,8 +108,7 @@ invoke_iii_wrapper(wasm_exec_env_t exec_env,
 }
 
 static int
-invoke_ii_wrapper(wasm_exec_env_t exec_env,
-                  uint32 elem_idx, int arg0)
+invoke_ii_wrapper(wasm_exec_env_t exec_env, uint32 elem_idx, int arg0)
 {
     uint32 argv[4];
     bool ret;
@@ -144,8 +143,8 @@ struct stat_emcc {
 };
 
 static int
-open_wrapper(wasm_exec_env_t exec_env, const char *pathname,
-             int flags, int mode)
+open_wrapper(wasm_exec_env_t exec_env, const char *pathname, int flags,
+             int mode)
 {
     if (pathname == NULL)
         return -1;
@@ -153,8 +152,7 @@ open_wrapper(wasm_exec_env_t exec_env, const char *pathname,
 }
 
 static int
-__sys_read_wrapper(wasm_exec_env_t exec_env,
-                   int fd, void *buf, uint32 count)
+__sys_read_wrapper(wasm_exec_env_t exec_env, int fd, void *buf, uint32 count)
 {
     return read(fd, buf, count);
 }
@@ -183,15 +181,14 @@ statbuf_native2app(const struct stat *statbuf_native,
 }
 
 static int
-__sys_stat64_wrapper(wasm_exec_env_t exec_env,
-                     const char *pathname,
+__sys_stat64_wrapper(wasm_exec_env_t exec_env, const char *pathname,
                      struct stat_emcc *statbuf_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     int ret;
     struct stat statbuf;
 
-    if (!validate_native_addr((void*)statbuf_app, sizeof(struct stat_emcc)))
+    if (!validate_native_addr((void *)statbuf_app, sizeof(struct stat_emcc)))
         return -1;
 
     if (pathname == NULL)
@@ -204,14 +201,14 @@ __sys_stat64_wrapper(wasm_exec_env_t exec_env,
 }
 
 static int
-__sys_fstat64_wrapper(wasm_exec_env_t exec_env,
-                      int fd, struct stat_emcc *statbuf_app)
+__sys_fstat64_wrapper(wasm_exec_env_t exec_env, int fd,
+                      struct stat_emcc *statbuf_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     int ret;
     struct stat statbuf;
 
-    if (!validate_native_addr((void*)statbuf_app, sizeof(struct stat_emcc)))
+    if (!validate_native_addr((void *)statbuf_app, sizeof(struct stat_emcc)))
         return -1;
 
     if (fd <= 0)
@@ -224,16 +221,15 @@ __sys_fstat64_wrapper(wasm_exec_env_t exec_env,
 }
 
 static int
-mmap_wrapper(wasm_exec_env_t exec_env,
-             void *addr, int length, int prot, int flags,
-             int fd, int64 offset)
+mmap_wrapper(wasm_exec_env_t exec_env, void *addr, int length, int prot,
+             int flags, int fd, int64 offset)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uint32 buf_offset;
     char *buf;
     int size_read;
 
-    buf_offset = module_malloc(length, (void**)&buf);
+    buf_offset = module_malloc(length, (void **)&buf);
     if (buf_offset == 0)
         return -1;
 
@@ -275,16 +271,14 @@ getentropy_wrapper(wasm_exec_env_t exec_env, void *buffer, uint32 length)
 }
 
 static int
-setjmp_wrapper(wasm_exec_env_t exec_env,
-               void *jmp_buf)
+setjmp_wrapper(wasm_exec_env_t exec_env, void *jmp_buf)
 {
     os_printf("setjmp() called\n");
     return 0;
 }
 
 static void
-longjmp_wrapper(wasm_exec_env_t exec_env,
-               void *jmp_buf, int val)
+longjmp_wrapper(wasm_exec_env_t exec_env, void *jmp_buf, int val)
 {
     os_printf("longjmp() called\n");
 }
@@ -305,9 +299,7 @@ get_free_file_slot()
 }
 
 static int
-fopen_wrapper(wasm_exec_env_t exec_env,
-              const char *pathname,
-              const char *mode)
+fopen_wrapper(wasm_exec_env_t exec_env, const char *pathname, const char *mode)
 {
     FILE *file;
     int file_id;
@@ -327,8 +319,8 @@ fopen_wrapper(wasm_exec_env_t exec_env,
 }
 
 static uint32
-fread_wrapper(wasm_exec_env_t exec_env,
-              void *ptr, uint32 size, uint32 nmemb, int file_id)
+fread_wrapper(wasm_exec_env_t exec_env, void *ptr, uint32 size, uint32 nmemb,
+              int file_id)
 {
     FILE *file;
 
@@ -343,8 +335,7 @@ fread_wrapper(wasm_exec_env_t exec_env,
 }
 
 static int
-fseeko_wrapper(wasm_exec_env_t exec_env,
-               int file_id, int64 offset, int whence)
+fseeko_wrapper(wasm_exec_env_t exec_env, int file_id, int64 offset, int whence)
 {
     FILE *file;
 
@@ -359,9 +350,8 @@ fseeko_wrapper(wasm_exec_env_t exec_env,
 }
 
 static uint32
-emcc_fwrite_wrapper(wasm_exec_env_t exec_env,
-                    const void *ptr, uint32 size, uint32 nmemb,
-                    int file_id)
+emcc_fwrite_wrapper(wasm_exec_env_t exec_env, const void *ptr, uint32 size,
+                    uint32 nmemb, int file_id)
 {
     FILE *file;
 
@@ -403,8 +393,7 @@ fclose_wrapper(wasm_exec_env_t exec_env, int file_id)
 }
 
 static int
-__sys_mkdir_wrapper(wasm_exec_env_t exec_env,
-                    const char *pathname, int mode)
+__sys_mkdir_wrapper(wasm_exec_env_t exec_env, const char *pathname, int mode)
 {
     if (!pathname)
         return -1;
@@ -522,8 +511,10 @@ emscripten_thread_sleep_wrapper(wasm_exec_env_t exec_env, double timeout_ms)
 
 #endif /* end of BH_PLATFORM_LINUX_SGX */
 
-#define REG_NATIVE_FUNC(func_name, signature)  \
+/* clang-format off */
+#define REG_NATIVE_FUNC(func_name, signature) \
     { #func_name, func_name##_wrapper, signature, NULL }
+/* clang-format off */
 
 static NativeSymbol native_symbols_libc_emcc[] = {
     REG_NATIVE_FUNC(invoke_viiii, "(iiiii)"),

--- a/core/iwasm/libraries/libc-uvwasi/libc_uvwasi_wrapper.c
+++ b/core/iwasm/libraries/libc-uvwasi/libc_uvwasi_wrapper.c
@@ -7,6 +7,7 @@
 #include "bh_platform.h"
 #include "wasm_export.h"
 
+/* clang-format off */
 #define get_module_inst(exec_env) \
     wasm_runtime_get_module_inst(exec_env)
 
@@ -30,6 +31,7 @@
 
 #define module_free(offset) \
     wasm_runtime_module_free(module_inst, offset)
+/* clang-format on */
 
 #define wasi_errno_t uvwasi_errno_t
 #define wasi_fd_t uvwasi_fd_t
@@ -117,8 +119,8 @@ wasi_args_get(wasm_exec_env_t exec_env, uint32 *argv_offsets, char *argv_buf)
 }
 
 static wasi_errno_t
-wasi_args_sizes_get(wasm_exec_env_t exec_env,
-                    uint32 *argc_app, uint32 *argv_buf_size_app)
+wasi_args_sizes_get(wasm_exec_env_t exec_env, uint32 *argc_app,
+                    uint32 *argv_buf_size_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -132,7 +134,6 @@ wasi_args_sizes_get(wasm_exec_env_t exec_env,
         || !validate_native_addr(argv_buf_size_app, sizeof(uint32)))
         return (wasi_errno_t)-1;
 
-
     err = uvwasi_args_sizes_get(uvwasi, &argc, &argv_buf_size);
     if (err)
         return err;
@@ -143,8 +144,7 @@ wasi_args_sizes_get(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_clock_res_get(wasm_exec_env_t exec_env,
-                   wasi_clockid_t clock_id,
+wasi_clock_res_get(wasm_exec_env_t exec_env, wasi_clockid_t clock_id,
                    wasi_timestamp_t *resolution)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
@@ -157,10 +157,8 @@ wasi_clock_res_get(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_clock_time_get(wasm_exec_env_t exec_env,
-                    wasi_clockid_t clock_id,
-                    wasi_timestamp_t precision,
-                    wasi_timestamp_t *time)
+wasi_clock_time_get(wasm_exec_env_t exec_env, wasi_clockid_t clock_id,
+                    wasi_timestamp_t precision, wasi_timestamp_t *time)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -172,8 +170,8 @@ wasi_clock_time_get(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_environ_get(wasm_exec_env_t exec_env,
-                 uint32 *environ_offsets, char *environ_buf)
+wasi_environ_get(wasm_exec_env_t exec_env, uint32 *environ_offsets,
+                 char *environ_buf)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -217,8 +215,8 @@ wasi_environ_get(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_environ_sizes_get(wasm_exec_env_t exec_env,
-                       uint32 *environ_count_app, uint32 *environ_buf_size_app)
+wasi_environ_sizes_get(wasm_exec_env_t exec_env, uint32 *environ_count_app,
+                       uint32 *environ_buf_size_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -242,8 +240,8 @@ wasi_environ_sizes_get(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_fd_prestat_get(wasm_exec_env_t exec_env,
-                    wasi_fd_t fd, wasi_prestat_app_t *prestat_app)
+wasi_fd_prestat_get(wasm_exec_env_t exec_env, wasi_fd_t fd,
+                    wasi_prestat_app_t *prestat_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -266,8 +264,8 @@ wasi_fd_prestat_get(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_fd_prestat_dir_name(wasm_exec_env_t exec_env,
-                         wasi_fd_t fd, char *path, uint32 path_len)
+wasi_fd_prestat_dir_name(wasm_exec_env_t exec_env, wasi_fd_t fd, char *path,
+                         uint32 path_len)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -303,9 +301,8 @@ wasi_fd_datasync(wasm_exec_env_t exec_env, wasi_fd_t fd)
 }
 
 static wasi_errno_t
-wasi_fd_pread(wasm_exec_env_t exec_env,
-              wasi_fd_t fd, iovec_app_t *iovec_app, uint32 iovs_len,
-              wasi_filesize_t offset, uint32 *nread_app)
+wasi_fd_pread(wasm_exec_env_t exec_env, wasi_fd_t fd, iovec_app_t *iovec_app,
+              uint32 iovs_len, wasi_filesize_t offset, uint32 *nread_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -335,12 +332,11 @@ wasi_fd_pread(wasm_exec_env_t exec_env,
             err = (wasi_errno_t)-1;
             goto fail;
         }
-        iovec->buf = (void*)addr_app_to_native(iovec_app->buf_offset);
+        iovec->buf = (void *)addr_app_to_native(iovec_app->buf_offset);
         iovec->buf_len = iovec_app->buf_len;
     }
 
-    err = uvwasi_fd_pread(uvwasi, fd, iovec_begin,
-                          iovs_len, offset, &nread);
+    err = uvwasi_fd_pread(uvwasi, fd, iovec_begin, iovs_len, offset, &nread);
     if (err)
         goto fail;
 
@@ -355,8 +351,8 @@ fail:
 }
 
 static wasi_errno_t
-wasi_fd_pwrite(wasm_exec_env_t exec_env,
-               wasi_fd_t fd, const iovec_app_t *iovec_app, uint32 iovs_len,
+wasi_fd_pwrite(wasm_exec_env_t exec_env, wasi_fd_t fd,
+               const iovec_app_t *iovec_app, uint32 iovs_len,
                wasi_filesize_t offset, uint32 *nwritten_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
@@ -373,7 +369,7 @@ wasi_fd_pwrite(wasm_exec_env_t exec_env,
     total_size = sizeof(iovec_app_t) * (uint64)iovs_len;
     if (!validate_native_addr(nwritten_app, (uint32)sizeof(uint32))
         || total_size >= UINT32_MAX
-        || !validate_native_addr((void*)iovec_app, (uint32)total_size))
+        || !validate_native_addr((void *)iovec_app, (uint32)total_size))
         return (wasi_errno_t)-1;
 
     total_size = sizeof(wasi_ciovec_t) * (uint64)iovs_len;
@@ -387,12 +383,12 @@ wasi_fd_pwrite(wasm_exec_env_t exec_env,
             err = (wasi_errno_t)-1;
             goto fail;
         }
-        ciovec->buf = (char*)addr_app_to_native(iovec_app->buf_offset);
+        ciovec->buf = (char *)addr_app_to_native(iovec_app->buf_offset);
         ciovec->buf_len = iovec_app->buf_len;
     }
 
-    err = uvwasi_fd_pwrite(uvwasi, fd, ciovec_begin,
-                           iovs_len, offset, &nwritten);
+    err =
+        uvwasi_fd_pwrite(uvwasi, fd, ciovec_begin, iovs_len, offset, &nwritten);
     if (err)
         goto fail;
 
@@ -407,9 +403,8 @@ fail:
 }
 
 static wasi_errno_t
-wasi_fd_read(wasm_exec_env_t exec_env,
-             wasi_fd_t fd, const iovec_app_t *iovec_app, uint32 iovs_len,
-             uint32 *nread_app)
+wasi_fd_read(wasm_exec_env_t exec_env, wasi_fd_t fd,
+             const iovec_app_t *iovec_app, uint32 iovs_len, uint32 *nread_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -425,7 +420,7 @@ wasi_fd_read(wasm_exec_env_t exec_env,
     total_size = sizeof(iovec_app_t) * (uint64)iovs_len;
     if (!validate_native_addr(nread_app, (uint32)sizeof(uint32))
         || total_size >= UINT32_MAX
-        || !validate_native_addr((void*)iovec_app, (uint32)total_size))
+        || !validate_native_addr((void *)iovec_app, (uint32)total_size))
         return (wasi_errno_t)-1;
 
     total_size = sizeof(wasi_iovec_t) * (uint64)iovs_len;
@@ -439,12 +434,11 @@ wasi_fd_read(wasm_exec_env_t exec_env,
             err = (wasi_errno_t)-1;
             goto fail;
         }
-        iovec->buf = (void*)addr_app_to_native(iovec_app->buf_offset);
+        iovec->buf = (void *)addr_app_to_native(iovec_app->buf_offset);
         iovec->buf_len = iovec_app->buf_len;
     }
 
-    err = uvwasi_fd_read(uvwasi, fd,
-                               iovec_begin, iovs_len, &nread);
+    err = uvwasi_fd_read(uvwasi, fd, iovec_begin, iovs_len, &nread);
     if (err)
         goto fail;
 
@@ -471,9 +465,8 @@ wasi_fd_renumber(wasm_exec_env_t exec_env, wasi_fd_t from, wasi_fd_t to)
 }
 
 static wasi_errno_t
-wasi_fd_seek(wasm_exec_env_t exec_env,
-             wasi_fd_t fd, wasi_filedelta_t offset, wasi_whence_t whence,
-             wasi_filesize_t *newoffset)
+wasi_fd_seek(wasm_exec_env_t exec_env, wasi_fd_t fd, wasi_filedelta_t offset,
+             wasi_whence_t whence, wasi_filesize_t *newoffset)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -488,8 +481,7 @@ wasi_fd_seek(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_fd_tell(wasm_exec_env_t exec_env,
-             wasi_fd_t fd, wasi_filesize_t *newoffset)
+wasi_fd_tell(wasm_exec_env_t exec_env, wasi_fd_t fd, wasi_filesize_t *newoffset)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -504,8 +496,8 @@ wasi_fd_tell(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_fd_fdstat_get(wasm_exec_env_t exec_env,
-                   wasi_fd_t fd, wasi_fdstat_t *fdstat_app)
+wasi_fd_fdstat_get(wasm_exec_env_t exec_env, wasi_fd_t fd,
+                   wasi_fdstat_t *fdstat_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -527,8 +519,8 @@ wasi_fd_fdstat_get(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_fd_fdstat_set_flags(wasm_exec_env_t exec_env,
-                         wasi_fd_t fd, wasi_fdflags_t flags)
+wasi_fd_fdstat_set_flags(wasm_exec_env_t exec_env, wasi_fd_t fd,
+                         wasi_fdflags_t flags)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -540,8 +532,7 @@ wasi_fd_fdstat_set_flags(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_fd_fdstat_set_rights(wasm_exec_env_t exec_env,
-                          wasi_fd_t fd,
+wasi_fd_fdstat_set_rights(wasm_exec_env_t exec_env, wasi_fd_t fd,
                           wasi_rights_t fs_rights_base,
                           wasi_rights_t fs_rights_inheriting)
 {
@@ -551,8 +542,8 @@ wasi_fd_fdstat_set_rights(wasm_exec_env_t exec_env,
     if (!uvwasi)
         return (wasi_errno_t)-1;
 
-    return uvwasi_fd_fdstat_set_rights(uvwasi, fd,
-                                       fs_rights_base, fs_rights_inheriting);
+    return uvwasi_fd_fdstat_set_rights(uvwasi, fd, fs_rights_base,
+                                       fs_rights_inheriting);
 }
 
 static wasi_errno_t
@@ -586,7 +577,7 @@ wasi_fd_write(wasm_exec_env_t exec_env, wasi_fd_t fd,
     total_size = sizeof(iovec_app_t) * (uint64)iovs_len;
     if (!validate_native_addr(nwritten_app, (uint32)sizeof(uint32))
         || total_size >= UINT32_MAX
-        || !validate_native_addr((void*)iovec_app, (uint32)total_size))
+        || !validate_native_addr((void *)iovec_app, (uint32)total_size))
         return (wasi_errno_t)-1;
 
     total_size = sizeof(wasi_ciovec_t) * (uint64)iovs_len;
@@ -600,7 +591,7 @@ wasi_fd_write(wasm_exec_env_t exec_env, wasi_fd_t fd,
             err = (wasi_errno_t)-1;
             goto fail;
         }
-        ciovec->buf = (char*)addr_app_to_native(iovec_app->buf_offset);
+        ciovec->buf = (char *)addr_app_to_native(iovec_app->buf_offset);
         ciovec->buf_len = iovec_app->buf_len;
     }
 
@@ -643,11 +634,8 @@ fail:
 }
 
 static wasi_errno_t
-wasi_fd_advise(wasm_exec_env_t exec_env,
-               wasi_fd_t fd,
-               wasi_filesize_t offset,
-               wasi_filesize_t len,
-               wasi_advice_t advice)
+wasi_fd_advise(wasm_exec_env_t exec_env, wasi_fd_t fd, wasi_filesize_t offset,
+               wasi_filesize_t len, wasi_advice_t advice)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -659,9 +647,7 @@ wasi_fd_advise(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_fd_allocate(wasm_exec_env_t exec_env,
-                 wasi_fd_t fd,
-                 wasi_filesize_t offset,
+wasi_fd_allocate(wasm_exec_env_t exec_env, wasi_fd_t fd, wasi_filesize_t offset,
                  wasi_filesize_t len)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
@@ -674,8 +660,8 @@ wasi_fd_allocate(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_path_create_directory(wasm_exec_env_t exec_env,
-                           wasi_fd_t fd, const char *path, uint32 path_len)
+wasi_path_create_directory(wasm_exec_env_t exec_env, wasi_fd_t fd,
+                           const char *path, uint32 path_len)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -687,12 +673,10 @@ wasi_path_create_directory(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_path_link(wasm_exec_env_t exec_env,
-               wasi_fd_t old_fd,
-               wasi_lookupflags_t old_flags,
-               const char *old_path, uint32 old_path_len,
-               wasi_fd_t new_fd,
-               const char *new_path, uint32 new_path_len)
+wasi_path_link(wasm_exec_env_t exec_env, wasi_fd_t old_fd,
+               wasi_lookupflags_t old_flags, const char *old_path,
+               uint32 old_path_len, wasi_fd_t new_fd, const char *new_path,
+               uint32 new_path_len)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -700,20 +684,15 @@ wasi_path_link(wasm_exec_env_t exec_env,
     if (!uvwasi)
         return (wasi_errno_t)-1;
 
-    return uvwasi_path_link(uvwasi,
-                            old_fd, old_flags, old_path, old_path_len,
+    return uvwasi_path_link(uvwasi, old_fd, old_flags, old_path, old_path_len,
                             new_fd, new_path, new_path_len);
 }
 
 static wasi_errno_t
-wasi_path_open(wasm_exec_env_t exec_env,
-               wasi_fd_t dirfd,
-               wasi_lookupflags_t dirflags,
-               const char *path, uint32 path_len,
-               wasi_oflags_t oflags,
-               wasi_rights_t fs_rights_base,
-               wasi_rights_t fs_rights_inheriting,
-               wasi_fdflags_t fs_flags,
+wasi_path_open(wasm_exec_env_t exec_env, wasi_fd_t dirfd,
+               wasi_lookupflags_t dirflags, const char *path, uint32 path_len,
+               wasi_oflags_t oflags, wasi_rights_t fs_rights_base,
+               wasi_rights_t fs_rights_inheriting, wasi_fdflags_t fs_flags,
                wasi_fd_t *fd_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
@@ -727,25 +706,16 @@ wasi_path_open(wasm_exec_env_t exec_env,
     if (!validate_native_addr(fd_app, sizeof(wasi_fd_t)))
         return (wasi_errno_t)-1;
 
-    err = uvwasi_path_open(uvwasi,
-                           dirfd, dirflags,
-                           path, path_len,
-                           oflags,
-                           fs_rights_base,
-                           fs_rights_inheriting,
-                           fs_flags,
-                           &fd);
+    err = uvwasi_path_open(uvwasi, dirfd, dirflags, path, path_len, oflags,
+                           fs_rights_base, fs_rights_inheriting, fs_flags, &fd);
 
     *fd_app = fd;
     return err;
 }
 
 static wasi_errno_t
-wasi_fd_readdir(wasm_exec_env_t exec_env,
-                wasi_fd_t fd,
-                void *buf, uint32 buf_len,
-                wasi_dircookie_t cookie,
-                uint32 *bufused_app)
+wasi_fd_readdir(wasm_exec_env_t exec_env, wasi_fd_t fd, void *buf,
+                uint32 buf_len, wasi_dircookie_t cookie, uint32 *bufused_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -758,8 +728,7 @@ wasi_fd_readdir(wasm_exec_env_t exec_env,
     if (!validate_native_addr(bufused_app, sizeof(uint32)))
         return (wasi_errno_t)-1;
 
-    err = uvwasi_fd_readdir(uvwasi, fd,
-                            buf, buf_len, cookie, &bufused);
+    err = uvwasi_fd_readdir(uvwasi, fd, buf, buf_len, cookie, &bufused);
     if (err)
         return err;
 
@@ -768,10 +737,8 @@ wasi_fd_readdir(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_path_readlink(wasm_exec_env_t exec_env,
-                   wasi_fd_t fd,
-                   const char *path, uint32 path_len,
-                   char *buf, uint32 buf_len,
+wasi_path_readlink(wasm_exec_env_t exec_env, wasi_fd_t fd, const char *path,
+                   uint32 path_len, char *buf, uint32 buf_len,
                    uint32 *bufused_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
@@ -785,9 +752,8 @@ wasi_path_readlink(wasm_exec_env_t exec_env,
     if (!validate_native_addr(bufused_app, sizeof(uint32)))
         return (wasi_errno_t)-1;
 
-    err = uvwasi_path_readlink(uvwasi, fd,
-                               path, path_len,
-                               buf, buf_len, &bufused);
+    err = uvwasi_path_readlink(uvwasi, fd, path, path_len, buf, buf_len,
+                               &bufused);
     if (err)
         return err;
 
@@ -796,9 +762,9 @@ wasi_path_readlink(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_path_rename(wasm_exec_env_t exec_env,
-                 wasi_fd_t old_fd, const char *old_path, uint32 old_path_len,
-                 wasi_fd_t new_fd, const char *new_path, uint32 new_path_len)
+wasi_path_rename(wasm_exec_env_t exec_env, wasi_fd_t old_fd,
+                 const char *old_path, uint32 old_path_len, wasi_fd_t new_fd,
+                 const char *new_path, uint32 new_path_len)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -806,14 +772,13 @@ wasi_path_rename(wasm_exec_env_t exec_env,
     if (!uvwasi)
         return (wasi_errno_t)-1;
 
-    return uvwasi_path_rename(uvwasi,
-                              old_fd, old_path, old_path_len,
-                              new_fd, new_path, new_path_len);
+    return uvwasi_path_rename(uvwasi, old_fd, old_path, old_path_len, new_fd,
+                              new_path, new_path_len);
 }
 
 static wasi_errno_t
-wasi_fd_filestat_get(wasm_exec_env_t exec_env,
-                     wasi_fd_t fd, wasi_filestat_t *filestat)
+wasi_fd_filestat_get(wasm_exec_env_t exec_env, wasi_fd_t fd,
+                     wasi_filestat_t *filestat)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -828,10 +793,8 @@ wasi_fd_filestat_get(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_fd_filestat_set_times(wasm_exec_env_t exec_env,
-                           wasi_fd_t fd,
-                           wasi_timestamp_t st_atim,
-                           wasi_timestamp_t st_mtim,
+wasi_fd_filestat_set_times(wasm_exec_env_t exec_env, wasi_fd_t fd,
+                           wasi_timestamp_t st_atim, wasi_timestamp_t st_mtim,
                            wasi_fstflags_t fstflags)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
@@ -840,13 +803,11 @@ wasi_fd_filestat_set_times(wasm_exec_env_t exec_env,
     if (!uvwasi)
         return (wasi_errno_t)-1;
 
-    return uvwasi_fd_filestat_set_times(uvwasi, fd,
-                                        st_atim, st_mtim, fstflags);
+    return uvwasi_fd_filestat_set_times(uvwasi, fd, st_atim, st_mtim, fstflags);
 }
 
 static wasi_errno_t
-wasi_fd_filestat_set_size(wasm_exec_env_t exec_env,
-                          wasi_fd_t fd,
+wasi_fd_filestat_set_size(wasm_exec_env_t exec_env, wasi_fd_t fd,
                           wasi_filesize_t st_size)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
@@ -859,11 +820,9 @@ wasi_fd_filestat_set_size(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_path_filestat_get(wasm_exec_env_t exec_env,
-                       wasi_fd_t fd,
-                       wasi_lookupflags_t flags,
-                       const char *path, uint32 path_len,
-                       wasi_filestat_t *filestat)
+wasi_path_filestat_get(wasm_exec_env_t exec_env, wasi_fd_t fd,
+                       wasi_lookupflags_t flags, const char *path,
+                       uint32 path_len, wasi_filestat_t *filestat)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -874,18 +833,15 @@ wasi_path_filestat_get(wasm_exec_env_t exec_env,
     if (!validate_native_addr(filestat, sizeof(wasi_filestat_t)))
         return (wasi_errno_t)-1;
 
-    return uvwasi_path_filestat_get(uvwasi, fd,
-                                    flags, path, path_len, filestat);
+    return uvwasi_path_filestat_get(uvwasi, fd, flags, path, path_len,
+                                    filestat);
 }
 
 static wasi_errno_t
-wasi_path_filestat_set_times(wasm_exec_env_t exec_env,
-                             wasi_fd_t fd,
-                             wasi_lookupflags_t flags,
-                             const char *path, uint32 path_len,
-                             wasi_timestamp_t st_atim,
-                             wasi_timestamp_t st_mtim,
-                             wasi_fstflags_t fstflags)
+wasi_path_filestat_set_times(wasm_exec_env_t exec_env, wasi_fd_t fd,
+                             wasi_lookupflags_t flags, const char *path,
+                             uint32 path_len, wasi_timestamp_t st_atim,
+                             wasi_timestamp_t st_mtim, wasi_fstflags_t fstflags)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -893,15 +849,14 @@ wasi_path_filestat_set_times(wasm_exec_env_t exec_env,
     if (!uvwasi)
         return (wasi_errno_t)-1;
 
-    return uvwasi_path_filestat_set_times(uvwasi, fd,
-                                          flags, path, path_len,
+    return uvwasi_path_filestat_set_times(uvwasi, fd, flags, path, path_len,
                                           st_atim, st_mtim, fstflags);
 }
 
 static wasi_errno_t
-wasi_path_symlink(wasm_exec_env_t exec_env,
-                  const char *old_path, uint32 old_path_len,
-                  wasi_fd_t fd, const char *new_path, uint32 new_path_len)
+wasi_path_symlink(wasm_exec_env_t exec_env, const char *old_path,
+                  uint32 old_path_len, wasi_fd_t fd, const char *new_path,
+                  uint32 new_path_len)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -909,14 +864,13 @@ wasi_path_symlink(wasm_exec_env_t exec_env,
     if (!uvwasi)
         return (wasi_errno_t)-1;
 
-    return uvwasi_path_symlink(uvwasi,
-                               old_path, old_path_len, fd,
-                               new_path, new_path_len);
+    return uvwasi_path_symlink(uvwasi, old_path, old_path_len, fd, new_path,
+                               new_path_len);
 }
 
 static wasi_errno_t
-wasi_path_unlink_file(wasm_exec_env_t exec_env,
-                      wasi_fd_t fd, const char *path, uint32 path_len)
+wasi_path_unlink_file(wasm_exec_env_t exec_env, wasi_fd_t fd, const char *path,
+                      uint32 path_len)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -928,8 +882,8 @@ wasi_path_unlink_file(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_path_remove_directory(wasm_exec_env_t exec_env,
-                           wasi_fd_t fd, const char *path, uint32 path_len)
+wasi_path_remove_directory(wasm_exec_env_t exec_env, wasi_fd_t fd,
+                           const char *path, uint32 path_len)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -941,9 +895,8 @@ wasi_path_remove_directory(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_poll_oneoff(wasm_exec_env_t exec_env,
-                 const wasi_subscription_t *in, wasi_event_t *out,
-                 uint32 nsubscriptions, uint32 *nevents_app)
+wasi_poll_oneoff(wasm_exec_env_t exec_env, const wasi_subscription_t *in,
+                 wasi_event_t *out, uint32 nsubscriptions, uint32 *nevents_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -953,13 +906,12 @@ wasi_poll_oneoff(wasm_exec_env_t exec_env,
     if (!uvwasi)
         return (wasi_errno_t)-1;
 
-    if (!validate_native_addr((void*)in, sizeof(wasi_subscription_t))
+    if (!validate_native_addr((void *)in, sizeof(wasi_subscription_t))
         || !validate_native_addr(out, sizeof(wasi_event_t))
         || !validate_native_addr(nevents_app, sizeof(uint32)))
         return (wasi_errno_t)-1;
 
-    err = uvwasi_poll_oneoff(uvwasi, in, out,
-                             nsubscriptions, &nevents);
+    err = uvwasi_poll_oneoff(uvwasi, in, out, nsubscriptions, &nevents);
     if (err)
         return err;
 
@@ -997,12 +949,9 @@ wasi_random_get(wasm_exec_env_t exec_env, void *buf, uint32 buf_len)
 }
 
 static wasi_errno_t
-wasi_sock_recv(wasm_exec_env_t exec_env,
-               wasi_fd_t sock,
-               iovec_app_t *ri_data, uint32 ri_data_len,
-               wasi_riflags_t ri_flags,
-               uint32 *ro_datalen_app,
-               wasi_roflags_t *ro_flags)
+wasi_sock_recv(wasm_exec_env_t exec_env, wasi_fd_t sock, iovec_app_t *ri_data,
+               uint32 ri_data_len, wasi_riflags_t ri_flags,
+               uint32 *ro_datalen_app, wasi_roflags_t *ro_flags)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -1033,18 +982,16 @@ wasi_sock_recv(wasm_exec_env_t exec_env,
             err = (wasi_errno_t)-1;
             goto fail;
         }
-        iovec->buf = (void*)addr_app_to_native(ri_data->buf_offset);
+        iovec->buf = (void *)addr_app_to_native(ri_data->buf_offset);
         iovec->buf_len = ri_data->buf_len;
     }
 
-    err = uvwasi_sock_recv(uvwasi, sock,
-                           iovec_begin, ri_data_len,
-                           ri_flags, &ro_datalen,
-                           ro_flags);
+    err = uvwasi_sock_recv(uvwasi, sock, iovec_begin, ri_data_len, ri_flags,
+                           &ro_datalen, ro_flags);
     if (err)
         goto fail;
 
-    *(uint32*)ro_datalen_app = (uint32)ro_datalen;
+    *(uint32 *)ro_datalen_app = (uint32)ro_datalen;
 
     /* success */
     err = 0;
@@ -1055,11 +1002,9 @@ fail:
 }
 
 static wasi_errno_t
-wasi_sock_send(wasm_exec_env_t exec_env,
-               wasi_fd_t sock,
+wasi_sock_send(wasm_exec_env_t exec_env, wasi_fd_t sock,
                const iovec_app_t *si_data, uint32 si_data_len,
-               wasi_siflags_t si_flags,
-               uint32 *so_datalen_app)
+               wasi_siflags_t si_flags, uint32 *so_datalen_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -1075,7 +1020,7 @@ wasi_sock_send(wasm_exec_env_t exec_env,
     total_size = sizeof(iovec_app_t) * (uint64)si_data_len;
     if (!validate_native_addr(so_datalen_app, sizeof(uint32))
         || total_size >= UINT32_MAX
-        || !validate_native_addr((void*)si_data, (uint32)total_size))
+        || !validate_native_addr((void *)si_data, (uint32)total_size))
         return (wasi_errno_t)-1;
 
     total_size = sizeof(wasi_ciovec_t) * (uint64)si_data_len;
@@ -1089,13 +1034,12 @@ wasi_sock_send(wasm_exec_env_t exec_env,
             err = (wasi_errno_t)-1;
             goto fail;
         }
-        ciovec->buf = (char*)addr_app_to_native(si_data->buf_offset);
+        ciovec->buf = (char *)addr_app_to_native(si_data->buf_offset);
         ciovec->buf_len = si_data->buf_len;
     }
 
-    err = uvwasi_sock_send(uvwasi, sock,
-                           ciovec_begin, si_data_len,
-                           si_flags, &so_datalen);
+    err = uvwasi_sock_send(uvwasi, sock, ciovec_begin, si_data_len, si_flags,
+                           &so_datalen);
     if (err)
         goto fail;
 
@@ -1110,8 +1054,7 @@ fail:
 }
 
 static wasi_errno_t
-wasi_sock_shutdown(wasm_exec_env_t exec_env,
-                   wasi_fd_t sock, wasi_sdflags_t how)
+wasi_sock_shutdown(wasm_exec_env_t exec_env, wasi_fd_t sock, wasi_sdflags_t how)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     uvwasi_t *uvwasi = get_wasi_ctx(module_inst);
@@ -1131,8 +1074,10 @@ wasi_sched_yield(wasm_exec_env_t exec_env)
     return uvwasi_sched_yield(uvwasi);
 }
 
-#define REG_NATIVE_FUNC(func_name, signature)     \
+/* clang-format off */
+#define REG_NATIVE_FUNC(func_name, signature) \
     { #func_name, wasi_##func_name, signature, NULL }
+/* clang-format on */
 
 static NativeSymbol native_symbols_libc_wasi[] = {
     REG_NATIVE_FUNC(args_get, "(**)i"),
@@ -1188,4 +1133,3 @@ get_libc_wasi_export_apis(NativeSymbol **p_libc_wasi_apis)
     *p_libc_wasi_apis = native_symbols_libc_wasi;
     return sizeof(native_symbols_libc_wasi) / sizeof(NativeSymbol);
 }
-

--- a/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
+++ b/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
@@ -10,6 +10,7 @@
 void
 wasm_runtime_set_exception(wasm_module_inst_t module, const char *exception);
 
+/* clang-format off */
 #define get_module_inst(exec_env) \
     wasm_runtime_get_module_inst(exec_env)
 
@@ -33,6 +34,7 @@ wasm_runtime_set_exception(wasm_module_inst_t module, const char *exception);
 
 #define module_free(offset) \
     wasm_runtime_module_free(module_inst, offset)
+/* clang-format on */
 
 typedef struct wasi_prestat_app {
     wasi_preopentype_t pr_type;
@@ -52,14 +54,13 @@ typedef struct WASIContext {
     char **argv_list;
     char *env_buf;
     char **env_list;
-} *wasi_ctx_t;
+} * wasi_ctx_t;
 
 wasi_ctx_t
 wasm_runtime_get_wasi_ctx(wasm_module_inst_t module_inst);
 
 static inline struct fd_table *
-wasi_ctx_get_curfds(wasm_module_inst_t module_inst,
-                    wasi_ctx_t wasi_ctx)
+wasi_ctx_get_curfds(wasm_module_inst_t module_inst, wasi_ctx_t wasi_ctx)
 {
     if (!wasi_ctx)
         return NULL;
@@ -67,8 +68,7 @@ wasi_ctx_get_curfds(wasm_module_inst_t module_inst,
 }
 
 static inline struct argv_environ_values *
-wasi_ctx_get_argv_environ(wasm_module_inst_t module_inst,
-                          wasi_ctx_t wasi_ctx)
+wasi_ctx_get_argv_environ(wasm_module_inst_t module_inst, wasi_ctx_t wasi_ctx)
 {
     if (!wasi_ctx)
         return NULL;
@@ -76,8 +76,7 @@ wasi_ctx_get_argv_environ(wasm_module_inst_t module_inst,
 }
 
 static inline struct fd_prestats *
-wasi_ctx_get_prestats(wasm_module_inst_t module_inst,
-                      wasi_ctx_t wasi_ctx)
+wasi_ctx_get_prestats(wasm_module_inst_t module_inst, wasi_ctx_t wasi_ctx)
 {
     if (!wasi_ctx)
         return NULL;
@@ -90,7 +89,7 @@ wasi_args_get(wasm_exec_env_t exec_env, uint32 *argv_offsets, char *argv_buf)
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
     struct argv_environ_values *argv_environ =
-                wasi_ctx_get_argv_environ(module_inst, wasi_ctx);
+        wasi_ctx_get_argv_environ(module_inst, wasi_ctx);
     size_t argc, argv_buf_size, i;
     char **argv;
     uint64 total_size;
@@ -110,7 +109,7 @@ wasi_args_get(wasm_exec_env_t exec_env, uint32 *argv_offsets, char *argv_buf)
         || !validate_native_addr(argv_buf, (uint32)argv_buf_size))
         return (wasi_errno_t)-1;
 
-    total_size = sizeof(char*) * ((uint64)argc + 1);
+    total_size = sizeof(char *) * ((uint64)argc + 1);
     if (total_size >= UINT32_MAX
         || !(argv = wasm_runtime_malloc((uint32)total_size)))
         return (wasi_errno_t)-1;
@@ -130,8 +129,8 @@ wasi_args_get(wasm_exec_env_t exec_env, uint32 *argv_offsets, char *argv_buf)
 }
 
 static wasi_errno_t
-wasi_args_sizes_get(wasm_exec_env_t exec_env,
-                    uint32 *argc_app, uint32 *argv_buf_size_app)
+wasi_args_sizes_get(wasm_exec_env_t exec_env, uint32 *argc_app,
+                    uint32 *argv_buf_size_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -148,8 +147,7 @@ wasi_args_sizes_get(wasm_exec_env_t exec_env,
 
     argv_environ = wasi_ctx->argv_environ;
 
-    err = wasmtime_ssp_args_sizes_get(argv_environ,
-                                      &argc, &argv_buf_size);
+    err = wasmtime_ssp_args_sizes_get(argv_environ, &argc, &argv_buf_size);
     if (err)
         return err;
 
@@ -173,7 +171,7 @@ wasi_clock_res_get(wasm_exec_env_t exec_env,
 
 static wasi_errno_t
 wasi_clock_time_get(wasm_exec_env_t exec_env,
-                    wasi_clockid_t clock_id, /* uint32 clock_id */
+                    wasi_clockid_t clock_id,    /* uint32 clock_id */
                     wasi_timestamp_t precision, /* uint64 precision */
                     wasi_timestamp_t *time /* uint64 *time */)
 {
@@ -186,13 +184,13 @@ wasi_clock_time_get(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_environ_get(wasm_exec_env_t exec_env,
-                 uint32 *environ_offsets, char *environ_buf)
+wasi_environ_get(wasm_exec_env_t exec_env, uint32 *environ_offsets,
+                 char *environ_buf)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
     struct argv_environ_values *argv_environ =
-                wasi_ctx_get_argv_environ(module_inst, wasi_ctx);
+        wasi_ctx_get_argv_environ(module_inst, wasi_ctx);
     size_t environ_count, environ_buf_size, i;
     uint64 total_size;
     char **environs;
@@ -201,8 +199,8 @@ wasi_environ_get(wasm_exec_env_t exec_env,
     if (!wasi_ctx)
         return (wasi_errno_t)-1;
 
-    err = wasmtime_ssp_environ_sizes_get(argv_environ,
-                                         &environ_count, &environ_buf_size);
+    err = wasmtime_ssp_environ_sizes_get(argv_environ, &environ_count,
+                                         &environ_buf_size);
     if (err)
         return err;
 
@@ -213,7 +211,7 @@ wasi_environ_get(wasm_exec_env_t exec_env,
         || !validate_native_addr(environ_buf, (uint32)environ_buf_size))
         return (wasi_errno_t)-1;
 
-    total_size = sizeof(char*) * (((uint64)environ_count + 1));
+    total_size = sizeof(char *) * (((uint64)environ_count + 1));
 
     if (total_size >= UINT32_MAX
         || !(environs = wasm_runtime_malloc((uint32)total_size)))
@@ -234,13 +232,13 @@ wasi_environ_get(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_environ_sizes_get(wasm_exec_env_t exec_env,
-                       uint32 *environ_count_app, uint32 *environ_buf_size_app)
+wasi_environ_sizes_get(wasm_exec_env_t exec_env, uint32 *environ_count_app,
+                       uint32 *environ_buf_size_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
     struct argv_environ_values *argv_environ =
-                wasi_ctx_get_argv_environ(module_inst, wasi_ctx);
+        wasi_ctx_get_argv_environ(module_inst, wasi_ctx);
     size_t environ_count, environ_buf_size;
     wasi_errno_t err;
 
@@ -251,8 +249,8 @@ wasi_environ_sizes_get(wasm_exec_env_t exec_env,
         || !validate_native_addr(environ_buf_size_app, sizeof(uint32)))
         return (wasi_errno_t)-1;
 
-    err = wasmtime_ssp_environ_sizes_get(argv_environ,
-                                         &environ_count, &environ_buf_size);
+    err = wasmtime_ssp_environ_sizes_get(argv_environ, &environ_count,
+                                         &environ_buf_size);
     if (err)
         return err;
 
@@ -263,8 +261,8 @@ wasi_environ_sizes_get(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_fd_prestat_get(wasm_exec_env_t exec_env,
-                    wasi_fd_t fd, wasi_prestat_app_t *prestat_app)
+wasi_fd_prestat_get(wasm_exec_env_t exec_env, wasi_fd_t fd,
+                    wasi_prestat_app_t *prestat_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -288,8 +286,8 @@ wasi_fd_prestat_get(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_fd_prestat_dir_name(wasm_exec_env_t exec_env,
-                         wasi_fd_t fd, char *path, uint32 path_len)
+wasi_fd_prestat_dir_name(wasm_exec_env_t exec_env, wasi_fd_t fd, char *path,
+                         uint32 path_len)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -298,8 +296,7 @@ wasi_fd_prestat_dir_name(wasm_exec_env_t exec_env,
     if (!wasi_ctx)
         return (wasi_errno_t)-1;
 
-    return wasmtime_ssp_fd_prestat_dir_name(prestats,
-                                            fd, path, path_len);
+    return wasmtime_ssp_fd_prestat_dir_name(prestats, fd, path, path_len);
 }
 
 static wasi_errno_t
@@ -330,9 +327,8 @@ wasi_fd_datasync(wasm_exec_env_t exec_env, wasi_fd_t fd)
 }
 
 static wasi_errno_t
-wasi_fd_pread(wasm_exec_env_t exec_env,
-              wasi_fd_t fd, iovec_app_t *iovec_app, uint32 iovs_len,
-              wasi_filesize_t offset, uint32 *nread_app)
+wasi_fd_pread(wasm_exec_env_t exec_env, wasi_fd_t fd, iovec_app_t *iovec_app,
+              uint32 iovs_len, wasi_filesize_t offset, uint32 *nread_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -364,12 +360,12 @@ wasi_fd_pread(wasm_exec_env_t exec_env,
             err = (wasi_errno_t)-1;
             goto fail;
         }
-        iovec->buf = (void*)addr_app_to_native(iovec_app->buf_offset);
+        iovec->buf = (void *)addr_app_to_native(iovec_app->buf_offset);
         iovec->buf_len = iovec_app->buf_len;
     }
 
-    err = wasmtime_ssp_fd_pread(curfds, fd, iovec_begin,
-                                iovs_len, offset, &nread);
+    err = wasmtime_ssp_fd_pread(curfds, fd, iovec_begin, iovs_len, offset,
+                                &nread);
     if (err)
         goto fail;
 
@@ -384,8 +380,8 @@ fail:
 }
 
 static wasi_errno_t
-wasi_fd_pwrite(wasm_exec_env_t exec_env,
-               wasi_fd_t fd, const iovec_app_t *iovec_app, uint32 iovs_len,
+wasi_fd_pwrite(wasm_exec_env_t exec_env, wasi_fd_t fd,
+               const iovec_app_t *iovec_app, uint32 iovs_len,
                wasi_filesize_t offset, uint32 *nwritten_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
@@ -403,7 +399,7 @@ wasi_fd_pwrite(wasm_exec_env_t exec_env,
     total_size = sizeof(iovec_app_t) * (uint64)iovs_len;
     if (!validate_native_addr(nwritten_app, (uint32)sizeof(uint32))
         || total_size >= UINT32_MAX
-        || !validate_native_addr((void*)iovec_app, (uint32)total_size))
+        || !validate_native_addr((void *)iovec_app, (uint32)total_size))
         return (wasi_errno_t)-1;
 
     total_size = sizeof(wasi_ciovec_t) * (uint64)iovs_len;
@@ -418,12 +414,12 @@ wasi_fd_pwrite(wasm_exec_env_t exec_env,
             err = (wasi_errno_t)-1;
             goto fail;
         }
-        ciovec->buf = (char*)addr_app_to_native(iovec_app->buf_offset);
+        ciovec->buf = (char *)addr_app_to_native(iovec_app->buf_offset);
         ciovec->buf_len = iovec_app->buf_len;
     }
 
-    err = wasmtime_ssp_fd_pwrite(curfds, fd, ciovec_begin,
-                                 iovs_len, offset, &nwritten);
+    err = wasmtime_ssp_fd_pwrite(curfds, fd, ciovec_begin, iovs_len, offset,
+                                 &nwritten);
     if (err)
         goto fail;
 
@@ -438,9 +434,8 @@ fail:
 }
 
 static wasi_errno_t
-wasi_fd_read(wasm_exec_env_t exec_env,
-             wasi_fd_t fd, const iovec_app_t *iovec_app, uint32 iovs_len,
-             uint32 *nread_app)
+wasi_fd_read(wasm_exec_env_t exec_env, wasi_fd_t fd,
+             const iovec_app_t *iovec_app, uint32 iovs_len, uint32 *nread_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -457,7 +452,7 @@ wasi_fd_read(wasm_exec_env_t exec_env,
     total_size = sizeof(iovec_app_t) * (uint64)iovs_len;
     if (!validate_native_addr(nread_app, (uint32)sizeof(uint32))
         || total_size >= UINT32_MAX
-        || !validate_native_addr((void*)iovec_app, (uint32)total_size))
+        || !validate_native_addr((void *)iovec_app, (uint32)total_size))
         return (wasi_errno_t)-1;
 
     total_size = sizeof(wasi_iovec_t) * (uint64)iovs_len;
@@ -472,12 +467,11 @@ wasi_fd_read(wasm_exec_env_t exec_env,
             err = (wasi_errno_t)-1;
             goto fail;
         }
-        iovec->buf = (void*)addr_app_to_native(iovec_app->buf_offset);
+        iovec->buf = (void *)addr_app_to_native(iovec_app->buf_offset);
         iovec->buf_len = iovec_app->buf_len;
     }
 
-    err = wasmtime_ssp_fd_read(curfds, fd,
-                               iovec_begin, iovs_len, &nread);
+    err = wasmtime_ssp_fd_read(curfds, fd, iovec_begin, iovs_len, &nread);
     if (err)
         goto fail;
 
@@ -506,9 +500,8 @@ wasi_fd_renumber(wasm_exec_env_t exec_env, wasi_fd_t from, wasi_fd_t to)
 }
 
 static wasi_errno_t
-wasi_fd_seek(wasm_exec_env_t exec_env,
-             wasi_fd_t fd, wasi_filedelta_t offset, wasi_whence_t whence,
-             wasi_filesize_t *newoffset)
+wasi_fd_seek(wasm_exec_env_t exec_env, wasi_fd_t fd, wasi_filedelta_t offset,
+             wasi_whence_t whence, wasi_filesize_t *newoffset)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -524,8 +517,7 @@ wasi_fd_seek(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_fd_tell(wasm_exec_env_t exec_env,
-             wasi_fd_t fd, wasi_filesize_t *newoffset)
+wasi_fd_tell(wasm_exec_env_t exec_env, wasi_fd_t fd, wasi_filesize_t *newoffset)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -541,8 +533,8 @@ wasi_fd_tell(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_fd_fdstat_get(wasm_exec_env_t exec_env,
-                   wasi_fd_t fd, wasi_fdstat_t *fdstat_app)
+wasi_fd_fdstat_get(wasm_exec_env_t exec_env, wasi_fd_t fd,
+                   wasi_fdstat_t *fdstat_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -565,8 +557,8 @@ wasi_fd_fdstat_get(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_fd_fdstat_set_flags(wasm_exec_env_t exec_env,
-                         wasi_fd_t fd, wasi_fdflags_t flags)
+wasi_fd_fdstat_set_flags(wasm_exec_env_t exec_env, wasi_fd_t fd,
+                         wasi_fdflags_t flags)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -579,8 +571,7 @@ wasi_fd_fdstat_set_flags(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_fd_fdstat_set_rights(wasm_exec_env_t exec_env,
-                          wasi_fd_t fd,
+wasi_fd_fdstat_set_rights(wasm_exec_env_t exec_env, wasi_fd_t fd,
                           wasi_rights_t fs_rights_base,
                           wasi_rights_t fs_rights_inheriting)
 {
@@ -591,8 +582,8 @@ wasi_fd_fdstat_set_rights(wasm_exec_env_t exec_env,
     if (!wasi_ctx)
         return (wasi_errno_t)-1;
 
-    return wasmtime_ssp_fd_fdstat_set_rights(curfds, fd,
-                                             fs_rights_base, fs_rights_inheriting);
+    return wasmtime_ssp_fd_fdstat_set_rights(curfds, fd, fs_rights_base,
+                                             fs_rights_inheriting);
 }
 
 static wasi_errno_t
@@ -628,7 +619,7 @@ wasi_fd_write(wasm_exec_env_t exec_env, wasi_fd_t fd,
     total_size = sizeof(iovec_app_t) * (uint64)iovs_len;
     if (!validate_native_addr(nwritten_app, (uint32)sizeof(uint32))
         || total_size >= UINT32_MAX
-        || !validate_native_addr((void*)iovec_app, (uint32)total_size))
+        || !validate_native_addr((void *)iovec_app, (uint32)total_size))
         return (wasi_errno_t)-1;
 
     total_size = sizeof(wasi_ciovec_t) * (uint64)iovs_len;
@@ -643,12 +634,11 @@ wasi_fd_write(wasm_exec_env_t exec_env, wasi_fd_t fd,
             err = (wasi_errno_t)-1;
             goto fail;
         }
-        ciovec->buf = (char*)addr_app_to_native(iovec_app->buf_offset);
+        ciovec->buf = (char *)addr_app_to_native(iovec_app->buf_offset);
         ciovec->buf_len = iovec_app->buf_len;
     }
 
-    err = wasmtime_ssp_fd_write(curfds, fd,
-                                ciovec_begin, iovs_len, &nwritten);
+    err = wasmtime_ssp_fd_write(curfds, fd, ciovec_begin, iovs_len, &nwritten);
     if (err)
         goto fail;
 
@@ -663,11 +653,8 @@ fail:
 }
 
 static wasi_errno_t
-wasi_fd_advise(wasm_exec_env_t exec_env,
-               wasi_fd_t fd,
-               wasi_filesize_t offset,
-               wasi_filesize_t len,
-               wasi_advice_t advice)
+wasi_fd_advise(wasm_exec_env_t exec_env, wasi_fd_t fd, wasi_filesize_t offset,
+               wasi_filesize_t len, wasi_advice_t advice)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -680,9 +667,7 @@ wasi_fd_advise(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_fd_allocate(wasm_exec_env_t exec_env,
-                 wasi_fd_t fd,
-                 wasi_filesize_t offset,
+wasi_fd_allocate(wasm_exec_env_t exec_env, wasi_fd_t fd, wasi_filesize_t offset,
                  wasi_filesize_t len)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
@@ -696,8 +681,8 @@ wasi_fd_allocate(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_path_create_directory(wasm_exec_env_t exec_env,
-                           wasi_fd_t fd, const char *path, uint32 path_len)
+wasi_path_create_directory(wasm_exec_env_t exec_env, wasi_fd_t fd,
+                           const char *path, uint32 path_len)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -706,17 +691,14 @@ wasi_path_create_directory(wasm_exec_env_t exec_env,
     if (!wasi_ctx)
         return (wasi_errno_t)-1;
 
-    return wasmtime_ssp_path_create_directory(curfds, fd,
-                                              path, path_len);
+    return wasmtime_ssp_path_create_directory(curfds, fd, path, path_len);
 }
 
 static wasi_errno_t
-wasi_path_link(wasm_exec_env_t exec_env,
-               wasi_fd_t old_fd,
-               wasi_lookupflags_t old_flags,
-               const char *old_path, uint32 old_path_len,
-               wasi_fd_t new_fd,
-               const char *new_path, uint32 new_path_len)
+wasi_path_link(wasm_exec_env_t exec_env, wasi_fd_t old_fd,
+               wasi_lookupflags_t old_flags, const char *old_path,
+               uint32 old_path_len, wasi_fd_t new_fd, const char *new_path,
+               uint32 new_path_len)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -726,20 +708,15 @@ wasi_path_link(wasm_exec_env_t exec_env,
     if (!wasi_ctx)
         return (wasi_errno_t)-1;
 
-    return wasmtime_ssp_path_link(curfds, prestats,
-                                  old_fd, old_flags, old_path, old_path_len,
-                                  new_fd, new_path, new_path_len);
+    return wasmtime_ssp_path_link(curfds, prestats, old_fd, old_flags, old_path,
+                                  old_path_len, new_fd, new_path, new_path_len);
 }
 
 static wasi_errno_t
-wasi_path_open(wasm_exec_env_t exec_env,
-               wasi_fd_t dirfd,
-               wasi_lookupflags_t dirflags,
-               const char *path, uint32 path_len,
-               wasi_oflags_t oflags,
-               wasi_rights_t fs_rights_base,
-               wasi_rights_t fs_rights_inheriting,
-               wasi_fdflags_t fs_flags,
+wasi_path_open(wasm_exec_env_t exec_env, wasi_fd_t dirfd,
+               wasi_lookupflags_t dirflags, const char *path, uint32 path_len,
+               wasi_oflags_t oflags, wasi_rights_t fs_rights_base,
+               wasi_rights_t fs_rights_inheriting, wasi_fdflags_t fs_flags,
                wasi_fd_t *fd_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
@@ -754,25 +731,17 @@ wasi_path_open(wasm_exec_env_t exec_env,
     if (!validate_native_addr(fd_app, sizeof(wasi_fd_t)))
         return (wasi_errno_t)-1;
 
-    err = wasmtime_ssp_path_open(curfds,
-                                 dirfd, dirflags,
-                                 path, path_len,
-                                 oflags,
-                                 fs_rights_base,
-                                 fs_rights_inheriting,
-                                 fs_flags,
-                                 &fd);
+    err = wasmtime_ssp_path_open(curfds, dirfd, dirflags, path, path_len,
+                                 oflags, fs_rights_base, fs_rights_inheriting,
+                                 fs_flags, &fd);
 
     *fd_app = fd;
     return err;
 }
 
 static wasi_errno_t
-wasi_fd_readdir(wasm_exec_env_t exec_env,
-                wasi_fd_t fd,
-                void *buf, uint32 buf_len,
-                wasi_dircookie_t cookie,
-                uint32 *bufused_app)
+wasi_fd_readdir(wasm_exec_env_t exec_env, wasi_fd_t fd, void *buf,
+                uint32 buf_len, wasi_dircookie_t cookie, uint32 *bufused_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -786,8 +755,7 @@ wasi_fd_readdir(wasm_exec_env_t exec_env,
     if (!validate_native_addr(bufused_app, sizeof(uint32)))
         return (wasi_errno_t)-1;
 
-    err = wasmtime_ssp_fd_readdir(curfds, fd,
-                                  buf, buf_len, cookie, &bufused);
+    err = wasmtime_ssp_fd_readdir(curfds, fd, buf, buf_len, cookie, &bufused);
     if (err)
         return err;
 
@@ -796,10 +764,8 @@ wasi_fd_readdir(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_path_readlink(wasm_exec_env_t exec_env,
-                   wasi_fd_t fd,
-                   const char *path, uint32 path_len,
-                   char *buf, uint32 buf_len,
+wasi_path_readlink(wasm_exec_env_t exec_env, wasi_fd_t fd, const char *path,
+                   uint32 path_len, char *buf, uint32 buf_len,
                    uint32 *bufused_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
@@ -814,9 +780,8 @@ wasi_path_readlink(wasm_exec_env_t exec_env,
     if (!validate_native_addr(bufused_app, sizeof(uint32)))
         return (wasi_errno_t)-1;
 
-    err = wasmtime_ssp_path_readlink(curfds, fd,
-                                     path, path_len,
-                                     buf, buf_len, &bufused);
+    err = wasmtime_ssp_path_readlink(curfds, fd, path, path_len, buf, buf_len,
+                                     &bufused);
     if (err)
         return err;
 
@@ -825,9 +790,9 @@ wasi_path_readlink(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_path_rename(wasm_exec_env_t exec_env,
-                 wasi_fd_t old_fd, const char *old_path, uint32 old_path_len,
-                 wasi_fd_t new_fd, const char *new_path, uint32 new_path_len)
+wasi_path_rename(wasm_exec_env_t exec_env, wasi_fd_t old_fd,
+                 const char *old_path, uint32 old_path_len, wasi_fd_t new_fd,
+                 const char *new_path, uint32 new_path_len)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -836,14 +801,13 @@ wasi_path_rename(wasm_exec_env_t exec_env,
     if (!wasi_ctx)
         return (wasi_errno_t)-1;
 
-    return wasmtime_ssp_path_rename(curfds,
-                                    old_fd, old_path, old_path_len,
+    return wasmtime_ssp_path_rename(curfds, old_fd, old_path, old_path_len,
                                     new_fd, new_path, new_path_len);
 }
 
 static wasi_errno_t
-wasi_fd_filestat_get(wasm_exec_env_t exec_env,
-                     wasi_fd_t fd, wasi_filestat_t *filestat)
+wasi_fd_filestat_get(wasm_exec_env_t exec_env, wasi_fd_t fd,
+                     wasi_filestat_t *filestat)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -859,10 +823,8 @@ wasi_fd_filestat_get(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_fd_filestat_set_times(wasm_exec_env_t exec_env,
-                           wasi_fd_t fd,
-                           wasi_timestamp_t st_atim,
-                           wasi_timestamp_t st_mtim,
+wasi_fd_filestat_set_times(wasm_exec_env_t exec_env, wasi_fd_t fd,
+                           wasi_timestamp_t st_atim, wasi_timestamp_t st_mtim,
                            wasi_fstflags_t fstflags)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
@@ -872,13 +834,12 @@ wasi_fd_filestat_set_times(wasm_exec_env_t exec_env,
     if (!wasi_ctx)
         return (wasi_errno_t)-1;
 
-    return wasmtime_ssp_fd_filestat_set_times(curfds, fd,
-                                              st_atim, st_mtim, fstflags);
+    return wasmtime_ssp_fd_filestat_set_times(curfds, fd, st_atim, st_mtim,
+                                              fstflags);
 }
 
 static wasi_errno_t
-wasi_fd_filestat_set_size(wasm_exec_env_t exec_env,
-                          wasi_fd_t fd,
+wasi_fd_filestat_set_size(wasm_exec_env_t exec_env, wasi_fd_t fd,
                           wasi_filesize_t st_size)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
@@ -892,11 +853,9 @@ wasi_fd_filestat_set_size(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_path_filestat_get(wasm_exec_env_t exec_env,
-                       wasi_fd_t fd,
-                       wasi_lookupflags_t flags,
-                       const char *path, uint32 path_len,
-                       wasi_filestat_t *filestat)
+wasi_path_filestat_get(wasm_exec_env_t exec_env, wasi_fd_t fd,
+                       wasi_lookupflags_t flags, const char *path,
+                       uint32 path_len, wasi_filestat_t *filestat)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -908,18 +867,15 @@ wasi_path_filestat_get(wasm_exec_env_t exec_env,
     if (!validate_native_addr(filestat, sizeof(wasi_filestat_t)))
         return (wasi_errno_t)-1;
 
-    return wasmtime_ssp_path_filestat_get(curfds, fd,
-                                          flags, path, path_len, filestat);
+    return wasmtime_ssp_path_filestat_get(curfds, fd, flags, path, path_len,
+                                          filestat);
 }
 
 static wasi_errno_t
-wasi_path_filestat_set_times(wasm_exec_env_t exec_env,
-                             wasi_fd_t fd,
-                             wasi_lookupflags_t flags,
-                             const char *path, uint32 path_len,
-                             wasi_timestamp_t st_atim,
-                             wasi_timestamp_t st_mtim,
-                             wasi_fstflags_t fstflags)
+wasi_path_filestat_set_times(wasm_exec_env_t exec_env, wasi_fd_t fd,
+                             wasi_lookupflags_t flags, const char *path,
+                             uint32 path_len, wasi_timestamp_t st_atim,
+                             wasi_timestamp_t st_mtim, wasi_fstflags_t fstflags)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -928,15 +884,14 @@ wasi_path_filestat_set_times(wasm_exec_env_t exec_env,
     if (!wasi_ctx)
         return (wasi_errno_t)-1;
 
-    return wasmtime_ssp_path_filestat_set_times(curfds, fd,
-                                                flags, path, path_len,
-                                                st_atim, st_mtim, fstflags);
+    return wasmtime_ssp_path_filestat_set_times(
+        curfds, fd, flags, path, path_len, st_atim, st_mtim, fstflags);
 }
 
 static wasi_errno_t
-wasi_path_symlink(wasm_exec_env_t exec_env,
-                  const char *old_path, uint32 old_path_len,
-                  wasi_fd_t fd, const char *new_path, uint32 new_path_len)
+wasi_path_symlink(wasm_exec_env_t exec_env, const char *old_path,
+                  uint32 old_path_len, wasi_fd_t fd, const char *new_path,
+                  uint32 new_path_len)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -946,14 +901,13 @@ wasi_path_symlink(wasm_exec_env_t exec_env,
     if (!wasi_ctx)
         return (wasi_errno_t)-1;
 
-    return wasmtime_ssp_path_symlink(curfds, prestats,
-                                     old_path, old_path_len, fd,
-                                     new_path, new_path_len);
+    return wasmtime_ssp_path_symlink(curfds, prestats, old_path, old_path_len,
+                                     fd, new_path, new_path_len);
 }
 
 static wasi_errno_t
-wasi_path_unlink_file(wasm_exec_env_t exec_env,
-                      wasi_fd_t fd, const char *path, uint32 path_len)
+wasi_path_unlink_file(wasm_exec_env_t exec_env, wasi_fd_t fd, const char *path,
+                      uint32 path_len)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -966,8 +920,8 @@ wasi_path_unlink_file(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_path_remove_directory(wasm_exec_env_t exec_env,
-                           wasi_fd_t fd, const char *path, uint32 path_len)
+wasi_path_remove_directory(wasm_exec_env_t exec_env, wasi_fd_t fd,
+                           const char *path, uint32 path_len)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -980,9 +934,8 @@ wasi_path_remove_directory(wasm_exec_env_t exec_env,
 }
 
 static wasi_errno_t
-wasi_poll_oneoff(wasm_exec_env_t exec_env,
-                 const wasi_subscription_t *in, wasi_event_t *out,
-                 uint32 nsubscriptions, uint32 *nevents_app)
+wasi_poll_oneoff(wasm_exec_env_t exec_env, const wasi_subscription_t *in,
+                 wasi_event_t *out, uint32 nsubscriptions, uint32 *nevents_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -993,13 +946,12 @@ wasi_poll_oneoff(wasm_exec_env_t exec_env,
     if (!wasi_ctx)
         return (wasi_errno_t)-1;
 
-    if (!validate_native_addr((void*)in, sizeof(wasi_subscription_t))
+    if (!validate_native_addr((void *)in, sizeof(wasi_subscription_t))
         || !validate_native_addr(out, sizeof(wasi_event_t))
         || !validate_native_addr(nevents_app, sizeof(uint32)))
         return (wasi_errno_t)-1;
 
-    err = wasmtime_ssp_poll_oneoff(curfds, in, out,
-                                   nsubscriptions, &nevents);
+    err = wasmtime_ssp_poll_oneoff(curfds, in, out, nsubscriptions, &nevents);
     if (err)
         return err;
 
@@ -1035,12 +987,9 @@ wasi_random_get(wasm_exec_env_t exec_env, void *buf, uint32 buf_len)
 }
 
 static wasi_errno_t
-wasi_sock_recv(wasm_exec_env_t exec_env,
-               wasi_fd_t sock,
-               iovec_app_t *ri_data, uint32 ri_data_len,
-               wasi_riflags_t ri_flags,
-               uint32 *ro_datalen_app,
-               wasi_roflags_t *ro_flags)
+wasi_sock_recv(wasm_exec_env_t exec_env, wasi_fd_t sock, iovec_app_t *ri_data,
+               uint32 ri_data_len, wasi_riflags_t ri_flags,
+               uint32 *ro_datalen_app, wasi_roflags_t *ro_flags)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -1073,18 +1022,16 @@ wasi_sock_recv(wasm_exec_env_t exec_env,
             err = (wasi_errno_t)-1;
             goto fail;
         }
-        iovec->buf = (void*)addr_app_to_native(ri_data->buf_offset);
+        iovec->buf = (void *)addr_app_to_native(ri_data->buf_offset);
         iovec->buf_len = ri_data->buf_len;
     }
 
-    err = wasmtime_ssp_sock_recv(curfds, sock,
-                                 iovec_begin, ri_data_len,
-                                 ri_flags, &ro_datalen,
-                                 ro_flags);
+    err = wasmtime_ssp_sock_recv(curfds, sock, iovec_begin, ri_data_len,
+                                 ri_flags, &ro_datalen, ro_flags);
     if (err)
         goto fail;
 
-    *(uint32*)ro_datalen_app = (uint32)ro_datalen;
+    *(uint32 *)ro_datalen_app = (uint32)ro_datalen;
 
     /* success */
     err = 0;
@@ -1095,11 +1042,9 @@ fail:
 }
 
 static wasi_errno_t
-wasi_sock_send(wasm_exec_env_t exec_env,
-               wasi_fd_t sock,
+wasi_sock_send(wasm_exec_env_t exec_env, wasi_fd_t sock,
                const iovec_app_t *si_data, uint32 si_data_len,
-               wasi_siflags_t si_flags,
-               uint32 *so_datalen_app)
+               wasi_siflags_t si_flags, uint32 *so_datalen_app)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -1116,7 +1061,7 @@ wasi_sock_send(wasm_exec_env_t exec_env,
     total_size = sizeof(iovec_app_t) * (uint64)si_data_len;
     if (!validate_native_addr(so_datalen_app, sizeof(uint32))
         || total_size >= UINT32_MAX
-        || !validate_native_addr((void*)si_data, (uint32)total_size))
+        || !validate_native_addr((void *)si_data, (uint32)total_size))
         return (wasi_errno_t)-1;
 
     total_size = sizeof(wasi_ciovec_t) * (uint64)si_data_len;
@@ -1131,12 +1076,11 @@ wasi_sock_send(wasm_exec_env_t exec_env,
             err = (wasi_errno_t)-1;
             goto fail;
         }
-        ciovec->buf = (char*)addr_app_to_native(si_data->buf_offset);
+        ciovec->buf = (char *)addr_app_to_native(si_data->buf_offset);
         ciovec->buf_len = si_data->buf_len;
     }
 
-    err = wasmtime_ssp_sock_send(curfds, sock,
-                                 ciovec_begin, si_data_len,
+    err = wasmtime_ssp_sock_send(curfds, sock, ciovec_begin, si_data_len,
                                  si_flags, &so_datalen);
     if (err)
         goto fail;
@@ -1152,8 +1096,7 @@ fail:
 }
 
 static wasi_errno_t
-wasi_sock_shutdown(wasm_exec_env_t exec_env,
-                   wasi_fd_t sock, wasi_sdflags_t how)
+wasi_sock_shutdown(wasm_exec_env_t exec_env, wasi_fd_t sock, wasi_sdflags_t how)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -1171,8 +1114,10 @@ wasi_sched_yield(wasm_exec_env_t exec_env)
     return wasmtime_ssp_sched_yield();
 }
 
-#define REG_NATIVE_FUNC(func_name, signature)     \
+/* clang-format off */
+#define REG_NATIVE_FUNC(func_name, signature) \
     { #func_name, wasi_##func_name, signature, NULL }
+/* clang-format on */
 
 static NativeSymbol native_symbols_libc_wasi[] = {
     REG_NATIVE_FUNC(args_get, "(**)i"),
@@ -1228,4 +1173,3 @@ get_libc_wasi_export_apis(NativeSymbol **p_libc_wasi_apis)
     *p_libc_wasi_apis = native_symbols_libc_wasi;
     return sizeof(native_symbols_libc_wasi) / sizeof(NativeSymbol);
 }
-

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/include/wasmtime_ssp.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/include/wasmtime_ssp.h
@@ -1,6 +1,8 @@
 /*
- * Part of the Wasmtime Project, under the Apache License v2.0 with LLVM Exceptions.
- * See https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license information.
+ * Part of the Wasmtime Project, under the Apache License v2.0 with
+ * LLVM Exceptions. See
+ *   https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE
+ * for license information.
  *
  * This file declares an interface similar to WASI, but augmented to expose
  * some implementation details such as the curfds arguments that we pass
@@ -12,6 +14,8 @@
 
 #include <stddef.h>
 #include <stdint.h>
+
+/* clang-format off */
 
 #ifdef __cplusplus
 #ifndef _Static_assert
@@ -27,7 +31,6 @@
 #endif /* _Noreturn */
 extern "C" {
 #endif
-
 
 _Static_assert(_Alignof(int8_t) == 1, "non-wasi data layout");
 _Static_assert(_Alignof(uint8_t) == 1, "non-wasi data layout");
@@ -891,5 +894,6 @@ __wasi_errno_t wasmtime_ssp_sched_yield(void)
 
 #undef WASMTIME_SSP_SYSCALL_NAME
 
-#endif
+/* clang-format on */
 
+#endif /* end of WASMTIME_SSP_H */

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/locking.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/locking.h
@@ -1,5 +1,7 @@
-// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license information.
+// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM
+// Exceptions. See
+// https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license
+// information.
 //
 // Significant parts of this file are derived from cloudabi-utils. See
 // https://github.com/bytecodealliance/wasmtime/blob/main/lib/wasi/sandboxed-system-primitives/src/LICENSE
@@ -32,13 +34,13 @@
 #define LOCKS_SHARED(...) LOCK_ANNOTATE(shared_lock_function(__VA_ARGS__))
 
 #define TRYLOCKS_EXCLUSIVE(...) \
-  LOCK_ANNOTATE(exclusive_trylock_function(__VA_ARGS__))
+    LOCK_ANNOTATE(exclusive_trylock_function(__VA_ARGS__))
 #define TRYLOCKS_SHARED(...) LOCK_ANNOTATE(shared_trylock_function(__VA_ARGS__))
 
 #define UNLOCKS(...) LOCK_ANNOTATE(unlock_function(__VA_ARGS__))
 
 #define REQUIRES_EXCLUSIVE(...) \
-  LOCK_ANNOTATE(exclusive_locks_required(__VA_ARGS__))
+    LOCK_ANNOTATE(exclusive_locks_required(__VA_ARGS__))
 #define REQUIRES_SHARED(...) LOCK_ANNOTATE(shared_locks_required(__VA_ARGS__))
 #define REQUIRES_UNLOCKED(...) LOCK_ANNOTATE(locks_excluded(__VA_ARGS__))
 
@@ -50,8 +52,10 @@ struct LOCKABLE mutex {
     pthread_mutex_t object;
 };
 
+/* clang-format off */
 #define MUTEX_INITIALIZER \
-  { PTHREAD_MUTEX_INITIALIZER }
+    { PTHREAD_MUTEX_INITIALIZER }
+/* clang-format on */
 
 static inline bool
 mutex_init(struct mutex *lock) REQUIRES_UNLOCKED(*lock)
@@ -117,14 +121,15 @@ rwlock_destroy(struct rwlock *lock) UNLOCKS(*lock) NO_LOCK_ANALYSIS
 
 struct LOCKABLE cond {
     pthread_cond_t object;
-#if !CONFIG_HAS_PTHREAD_CONDATTR_SETCLOCK || \
-    !CONFIG_HAS_PTHREAD_COND_TIMEDWAIT_RELATIVE_NP
+#if !CONFIG_HAS_PTHREAD_CONDATTR_SETCLOCK \
+    || !CONFIG_HAS_PTHREAD_COND_TIMEDWAIT_RELATIVE_NP
     clockid_t clock;
 #endif
 };
 
 static inline bool
-cond_init_monotonic(struct cond *cond) {
+cond_init_monotonic(struct cond *cond)
+{
     bool ret = false;
 #if CONFIG_HAS_PTHREAD_CONDATTR_SETCLOCK
     pthread_condattr_t attr;
@@ -147,8 +152,8 @@ fail:
     ret = true;
 #endif
 
-#if !CONFIG_HAS_PTHREAD_CONDATTR_SETCLOCK || \
-    !CONFIG_HAS_PTHREAD_COND_TIMEDWAIT_RELATIVE_NP
+#if !CONFIG_HAS_PTHREAD_CONDATTR_SETCLOCK \
+    || !CONFIG_HAS_PTHREAD_COND_TIMEDWAIT_RELATIVE_NP
     cond->clock = CLOCK_MONOTONIC;
 #endif
     return ret;
@@ -159,28 +164,29 @@ cond_init_realtime(struct cond *cond)
 {
     if (pthread_cond_init(&cond->object, NULL) != 0)
         return false;
-#if !CONFIG_HAS_PTHREAD_CONDATTR_SETCLOCK || \
-    !CONFIG_HAS_PTHREAD_COND_TIMEDWAIT_RELATIVE_NP
+#if !CONFIG_HAS_PTHREAD_CONDATTR_SETCLOCK \
+    || !CONFIG_HAS_PTHREAD_COND_TIMEDWAIT_RELATIVE_NP
     cond->clock = CLOCK_REALTIME;
 #endif
     return true;
 }
 
 static inline void
-cond_destroy(struct cond *cond) {
+cond_destroy(struct cond *cond)
+{
     pthread_cond_destroy(&cond->object);
 }
 
 static inline void
-cond_signal(struct cond *cond) {
+cond_signal(struct cond *cond)
+{
     pthread_cond_signal(&cond->object);
 }
 
 #if !CONFIG_HAS_CLOCK_NANOSLEEP
 static inline bool
-cond_timedwait(struct cond *cond, struct mutex *lock,
-               uint64_t timeout, bool abstime)
-    REQUIRES_EXCLUSIVE(*lock) NO_LOCK_ANALYSIS
+cond_timedwait(struct cond *cond, struct mutex *lock, uint64_t timeout,
+               bool abstime) REQUIRES_EXCLUSIVE(*lock) NO_LOCK_ANALYSIS
 {
     int ret;
     struct timespec ts = {
@@ -220,8 +226,8 @@ cond_timedwait(struct cond *cond, struct mutex *lock,
     else {
 #if CONFIG_HAS_PTHREAD_COND_TIMEDWAIT_RELATIVE_NP
         /* Implementation supports relative timeouts. */
-        ret = pthread_cond_timedwait_relative_np(&cond->object,
-                                                 &lock->object, &ts);
+        ret = pthread_cond_timedwait_relative_np(&cond->object, &lock->object,
+                                                 &ts);
         bh_assert((ret == 0 || ret == ETIMEDOUT)
                   && "pthread_cond_timedwait_relative_np() failed");
         return ret == ETIMEDOUT;

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/numeric_limits.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/numeric_limits.h
@@ -1,5 +1,7 @@
-// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license information.
+// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM
+// Exceptions. See
+// https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license
+// information.
 //
 // Significant parts of this file are derived from cloudabi-utils. See
 // https://github.com/bytecodealliance/wasmtime/blob/main/lib/wasi/sandboxed-system-primitives/src/LICENSE
@@ -12,29 +14,29 @@
 #ifndef COMMON_LIMITS_H
 #define COMMON_LIMITS_H
 
-#define NUMERIC_MIN(t)                                  \
-  _Generic((t)0, char                                   \
-           : CHAR_MIN, signed char                      \
-           : SCHAR_MIN, unsigned char : 0, short        \
-           : SHRT_MIN, unsigned short : 0, int          \
-           : INT_MIN, unsigned int : 0, long            \
-           : LONG_MIN, unsigned long : 0, long long     \
-           : LLONG_MIN, unsigned long long : 0, default \
-           : (void)0)
+#define NUMERIC_MIN(t)                                    \
+    _Generic((t)0, char                                   \
+             : CHAR_MIN, signed char                      \
+             : SCHAR_MIN, unsigned char : 0, short        \
+             : SHRT_MIN, unsigned short : 0, int          \
+             : INT_MIN, unsigned int : 0, long            \
+             : LONG_MIN, unsigned long : 0, long long     \
+             : LLONG_MIN, unsigned long long : 0, default \
+             : (void)0)
 
-#define NUMERIC_MAX(t)                     \
-  _Generic((t)0, char                      \
-           : CHAR_MAX, signed char         \
-           : SCHAR_MAX, unsigned char      \
-           : UCHAR_MAX, short              \
-           : SHRT_MAX, unsigned short      \
-           : USHRT_MAX, int                \
-           : INT_MAX, unsigned int         \
-           : UINT_MAX, long                \
-           : LONG_MAX, unsigned long       \
-           : ULONG_MAX, long long          \
-           : LLONG_MAX, unsigned long long \
-           : ULLONG_MAX, default           \
-           : (void)0)
+#define NUMERIC_MAX(t)                       \
+    _Generic((t)0, char                      \
+             : CHAR_MAX, signed char         \
+             : SCHAR_MAX, unsigned char      \
+             : UCHAR_MAX, short              \
+             : SHRT_MAX, unsigned short      \
+             : USHRT_MAX, int                \
+             : INT_MAX, unsigned int         \
+             : UINT_MAX, long                \
+             : LONG_MAX, unsigned long       \
+             : ULONG_MAX, long long          \
+             : LLONG_MAX, unsigned long long \
+             : ULLONG_MAX, default           \
+             : (void)0)
 
 #endif

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -1,5 +1,7 @@
-// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license information.
+// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM
+// Exceptions. See
+// https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license
+// information.
 //
 // Significant parts of this file are derived from cloudabi-utils. See
 // https://github.com/bytecodealliance/wasmtime/blob/main/lib/wasi/sandboxed-system-primitives/src/LICENSE
@@ -61,1355 +63,1347 @@ static __thread struct argv_environ_values *argv_environ;
 #endif
 
 // Converts a POSIX error code to a CloudABI error code.
-static __wasi_errno_t convert_errno(int error) {
-  static const __wasi_errno_t errors[] = {
+static __wasi_errno_t
+convert_errno(int error)
+{
+    static const __wasi_errno_t errors[] = {
 #define X(v) [v] = __WASI_##v
-    X(E2BIG),
-    X(EACCES),
-    X(EADDRINUSE),
-    X(EADDRNOTAVAIL),
-    X(EAFNOSUPPORT),
-    X(EAGAIN),
-    X(EALREADY),
-    X(EBADF),
-    X(EBADMSG),
-    X(EBUSY),
-    X(ECANCELED),
-    X(ECHILD),
-    X(ECONNABORTED),
-    X(ECONNREFUSED),
-    X(ECONNRESET),
-    X(EDEADLK),
-    X(EDESTADDRREQ),
-    X(EDOM),
-    X(EDQUOT),
-    X(EEXIST),
-    X(EFAULT),
-    X(EFBIG),
-    X(EHOSTUNREACH),
-    X(EIDRM),
-    X(EILSEQ),
-    X(EINPROGRESS),
-    X(EINTR),
-    X(EINVAL),
-    X(EIO),
-    X(EISCONN),
-    X(EISDIR),
-    X(ELOOP),
-    X(EMFILE),
-    X(EMLINK),
-    X(EMSGSIZE),
-    X(EMULTIHOP),
-    X(ENAMETOOLONG),
-    X(ENETDOWN),
-    X(ENETRESET),
-    X(ENETUNREACH),
-    X(ENFILE),
-    X(ENOBUFS),
-    X(ENODEV),
-    X(ENOENT),
-    X(ENOEXEC),
-    X(ENOLCK),
-    X(ENOLINK),
-    X(ENOMEM),
-    X(ENOMSG),
-    X(ENOPROTOOPT),
-    X(ENOSPC),
-    X(ENOSYS),
+        X(E2BIG),
+        X(EACCES),
+        X(EADDRINUSE),
+        X(EADDRNOTAVAIL),
+        X(EAFNOSUPPORT),
+        X(EAGAIN),
+        X(EALREADY),
+        X(EBADF),
+        X(EBADMSG),
+        X(EBUSY),
+        X(ECANCELED),
+        X(ECHILD),
+        X(ECONNABORTED),
+        X(ECONNREFUSED),
+        X(ECONNRESET),
+        X(EDEADLK),
+        X(EDESTADDRREQ),
+        X(EDOM),
+        X(EDQUOT),
+        X(EEXIST),
+        X(EFAULT),
+        X(EFBIG),
+        X(EHOSTUNREACH),
+        X(EIDRM),
+        X(EILSEQ),
+        X(EINPROGRESS),
+        X(EINTR),
+        X(EINVAL),
+        X(EIO),
+        X(EISCONN),
+        X(EISDIR),
+        X(ELOOP),
+        X(EMFILE),
+        X(EMLINK),
+        X(EMSGSIZE),
+        X(EMULTIHOP),
+        X(ENAMETOOLONG),
+        X(ENETDOWN),
+        X(ENETRESET),
+        X(ENETUNREACH),
+        X(ENFILE),
+        X(ENOBUFS),
+        X(ENODEV),
+        X(ENOENT),
+        X(ENOEXEC),
+        X(ENOLCK),
+        X(ENOLINK),
+        X(ENOMEM),
+        X(ENOMSG),
+        X(ENOPROTOOPT),
+        X(ENOSPC),
+        X(ENOSYS),
 #ifdef ENOTCAPABLE
-    X(ENOTCAPABLE),
+        X(ENOTCAPABLE),
 #endif
-    X(ENOTCONN),
-    X(ENOTDIR),
-    X(ENOTEMPTY),
-    X(ENOTRECOVERABLE),
-    X(ENOTSOCK),
-    X(ENOTSUP),
-    X(ENOTTY),
-    X(ENXIO),
-    X(EOVERFLOW),
-    X(EOWNERDEAD),
-    X(EPERM),
-    X(EPIPE),
-    X(EPROTO),
-    X(EPROTONOSUPPORT),
-    X(EPROTOTYPE),
-    X(ERANGE),
-    X(EROFS),
-    X(ESPIPE),
-    X(ESRCH),
-    X(ESTALE),
-    X(ETIMEDOUT),
-    X(ETXTBSY),
-    X(EXDEV),
+        X(ENOTCONN),
+        X(ENOTDIR),
+        X(ENOTEMPTY),
+        X(ENOTRECOVERABLE),
+        X(ENOTSOCK),
+        X(ENOTSUP),
+        X(ENOTTY),
+        X(ENXIO),
+        X(EOVERFLOW),
+        X(EOWNERDEAD),
+        X(EPERM),
+        X(EPIPE),
+        X(EPROTO),
+        X(EPROTONOSUPPORT),
+        X(EPROTOTYPE),
+        X(ERANGE),
+        X(EROFS),
+        X(ESPIPE),
+        X(ESRCH),
+        X(ESTALE),
+        X(ETIMEDOUT),
+        X(ETXTBSY),
+        X(EXDEV),
 #undef X
 #if EOPNOTSUPP != ENOTSUP
-    [EOPNOTSUPP] = __WASI_ENOTSUP,
+        [EOPNOTSUPP] = __WASI_ENOTSUP,
 #endif
 #if EWOULDBLOCK != EAGAIN
-    [EWOULDBLOCK] = __WASI_EAGAIN,
+        [EWOULDBLOCK] = __WASI_EAGAIN,
 #endif
-  };
-  if (error < 0 || (size_t)error >= sizeof(errors) / sizeof(errors[0]) ||
-      errors[error] == 0)
-    return __WASI_ENOSYS;
-  return errors[error];
+    };
+    if (error < 0 || (size_t)error >= sizeof(errors) / sizeof(errors[0])
+        || errors[error] == 0)
+        return __WASI_ENOSYS;
+    return errors[error];
 }
 
 // Converts a POSIX timespec to a CloudABI timestamp.
-static __wasi_timestamp_t convert_timespec(
-    const struct timespec *ts
-) {
-  if (ts->tv_sec < 0)
-    return 0;
-  if ((__wasi_timestamp_t)ts->tv_sec >= UINT64_MAX / 1000000000)
-    return UINT64_MAX;
-  return (__wasi_timestamp_t)ts->tv_sec * 1000000000 + (__wasi_timestamp_t)ts->tv_nsec;
+static __wasi_timestamp_t
+convert_timespec(const struct timespec *ts)
+{
+    if (ts->tv_sec < 0)
+        return 0;
+    if ((__wasi_timestamp_t)ts->tv_sec >= UINT64_MAX / 1000000000)
+        return UINT64_MAX;
+    return (__wasi_timestamp_t)ts->tv_sec * 1000000000
+           + (__wasi_timestamp_t)ts->tv_nsec;
 }
 
 // Converts a CloudABI clock identifier to a POSIX clock identifier.
-static bool convert_clockid(
-    __wasi_clockid_t in,
-    clockid_t *out
-) {
-  switch (in) {
-    case __WASI_CLOCK_MONOTONIC:
-      *out = CLOCK_MONOTONIC;
-      return true;
-    case __WASI_CLOCK_PROCESS_CPUTIME_ID:
-      *out = CLOCK_PROCESS_CPUTIME_ID;
-      return true;
-    case __WASI_CLOCK_REALTIME:
-      *out = CLOCK_REALTIME;
-      return true;
-    case __WASI_CLOCK_THREAD_CPUTIME_ID:
-      *out = CLOCK_THREAD_CPUTIME_ID;
-      return true;
-    default:
-      return false;
-  }
+static bool
+convert_clockid(__wasi_clockid_t in, clockid_t *out)
+{
+    switch (in) {
+        case __WASI_CLOCK_MONOTONIC:
+            *out = CLOCK_MONOTONIC;
+            return true;
+        case __WASI_CLOCK_PROCESS_CPUTIME_ID:
+            *out = CLOCK_PROCESS_CPUTIME_ID;
+            return true;
+        case __WASI_CLOCK_REALTIME:
+            *out = CLOCK_REALTIME;
+            return true;
+        case __WASI_CLOCK_THREAD_CPUTIME_ID:
+            *out = CLOCK_THREAD_CPUTIME_ID;
+            return true;
+        default:
+            return false;
+    }
 }
 
-__wasi_errno_t wasmtime_ssp_clock_res_get(
-    __wasi_clockid_t clock_id,
-    __wasi_timestamp_t *resolution
-) {
-  clockid_t nclock_id;
-  if (!convert_clockid(clock_id, &nclock_id))
-    return __WASI_EINVAL;
-  struct timespec ts;
-  if (clock_getres(nclock_id, &ts) < 0)
-    return convert_errno(errno);
-  *resolution = convert_timespec(&ts);
-  return 0;
+__wasi_errno_t
+wasmtime_ssp_clock_res_get(__wasi_clockid_t clock_id,
+                           __wasi_timestamp_t *resolution)
+{
+    clockid_t nclock_id;
+    if (!convert_clockid(clock_id, &nclock_id))
+        return __WASI_EINVAL;
+    struct timespec ts;
+    if (clock_getres(nclock_id, &ts) < 0)
+        return convert_errno(errno);
+    *resolution = convert_timespec(&ts);
+    return 0;
 }
 
-__wasi_errno_t wasmtime_ssp_clock_time_get(
-    __wasi_clockid_t clock_id,
-    __wasi_timestamp_t precision,
-    __wasi_timestamp_t *time
-) {
-  clockid_t nclock_id;
-  if (!convert_clockid(clock_id, &nclock_id))
-    return __WASI_EINVAL;
-  struct timespec ts;
-  if (clock_gettime(nclock_id, &ts) < 0)
-    return convert_errno(errno);
-  *time = convert_timespec(&ts);
-  return 0;
+__wasi_errno_t
+wasmtime_ssp_clock_time_get(__wasi_clockid_t clock_id,
+                            __wasi_timestamp_t precision,
+                            __wasi_timestamp_t *time)
+{
+    clockid_t nclock_id;
+    if (!convert_clockid(clock_id, &nclock_id))
+        return __WASI_EINVAL;
+    struct timespec ts;
+    if (clock_gettime(nclock_id, &ts) < 0)
+        return convert_errno(errno);
+    *time = convert_timespec(&ts);
+    return 0;
 }
 
 struct fd_prestat {
-  const char *dir;
+    const char *dir;
 };
 
-bool fd_prestats_init(
-    struct fd_prestats *pt
-) {
-  if (!rwlock_init(&pt->lock))
-    return false;
-  pt->prestats = NULL;
-  pt->size = 0;
-  pt->used = 0;
+bool
+fd_prestats_init(struct fd_prestats *pt)
+{
+    if (!rwlock_init(&pt->lock))
+        return false;
+    pt->prestats = NULL;
+    pt->size = 0;
+    pt->used = 0;
 #if defined(WASMTIME_SSP_STATIC_CURFDS)
-  prestats = pt;
+    prestats = pt;
 #endif
-  return true;
+    return true;
 }
 
 // Grows the preopened resource table to a required lower bound and a
 // minimum number of free preopened resource table entries.
-static bool fd_prestats_grow(
-    struct fd_prestats *pt,
-    size_t min,
-    size_t incr
-) REQUIRES_EXCLUSIVE(pt->lock) {
-  if (pt->size <= min || pt->size < (pt->used + incr) * 2) {
-    // Keep on doubling the table size until we've met our constraints.
-    size_t size = pt->size == 0 ? 1 : pt->size;
-    while (size <= min || size < (pt->used + incr) * 2)
-      size *= 2;
+static bool
+fd_prestats_grow(struct fd_prestats *pt, size_t min, size_t incr)
+    REQUIRES_EXCLUSIVE(pt->lock)
+{
+    if (pt->size <= min || pt->size < (pt->used + incr) * 2) {
+        // Keep on doubling the table size until we've met our constraints.
+        size_t size = pt->size == 0 ? 1 : pt->size;
+        while (size <= min || size < (pt->used + incr) * 2)
+            size *= 2;
 
-    // Grow the file descriptor table's allocation.
-    struct fd_prestat *prestats = wasm_runtime_malloc((uint32)(sizeof(*prestats) * size));
-    if (prestats == NULL)
-      return false;
+        // Grow the file descriptor table's allocation.
+        struct fd_prestat *prestats =
+            wasm_runtime_malloc((uint32)(sizeof(*prestats) * size));
+        if (prestats == NULL)
+            return false;
 
-    if (pt->prestats && pt->size > 0) {
-      bh_memcpy_s(prestats, (uint32)(sizeof(*prestats) * size),
-                  pt->prestats, (uint32)(sizeof(*prestats) * pt->size));
+        if (pt->prestats && pt->size > 0) {
+            bh_memcpy_s(prestats, (uint32)(sizeof(*prestats) * size),
+                        pt->prestats, (uint32)(sizeof(*prestats) * pt->size));
+        }
+
+        if (pt->prestats)
+            wasm_runtime_free(pt->prestats);
+
+        // Mark all new file descriptors as unused.
+        for (size_t i = pt->size; i < size; ++i)
+            prestats[i].dir = NULL;
+        pt->prestats = prestats;
+        pt->size = size;
     }
-
-    if (pt->prestats)
-      wasm_runtime_free(pt->prestats);
-
-    // Mark all new file descriptors as unused.
-    for (size_t i = pt->size; i < size; ++i)
-      prestats[i].dir = NULL;
-    pt->prestats = prestats;
-    pt->size = size;
-  }
-  return true;
+    return true;
 }
 
 // Inserts a preopened resource record into the preopened resource table.
-bool fd_prestats_insert(
-    struct fd_prestats *pt,
-    const char *dir,
-    __wasi_fd_t fd
-) {
-  // Grow the preopened resource table if needed.
-  rwlock_wrlock(&pt->lock);
-  if (!fd_prestats_grow(pt, fd, 1)) {
+bool
+fd_prestats_insert(struct fd_prestats *pt, const char *dir, __wasi_fd_t fd)
+{
+    // Grow the preopened resource table if needed.
+    rwlock_wrlock(&pt->lock);
+    if (!fd_prestats_grow(pt, fd, 1)) {
+        rwlock_unlock(&pt->lock);
+        return false;
+    }
+
+    pt->prestats[fd].dir = bh_strdup(dir);
     rwlock_unlock(&pt->lock);
-    return false;
-  }
 
-  pt->prestats[fd].dir = bh_strdup(dir);
-  rwlock_unlock(&pt->lock);
+    if (pt->prestats[fd].dir == NULL)
+        return false;
 
-  if (pt->prestats[fd].dir == NULL)
-    return false;
-
-  return true;
+    return true;
 }
 
 // Looks up a preopened resource table entry by number.
-static __wasi_errno_t fd_prestats_get_entry(
-    struct fd_prestats *pt,
-    __wasi_fd_t fd,
-    struct fd_prestat **ret
-) REQUIRES_SHARED(pt->lock) {
-  // Test for file descriptor existence.
-  if (fd >= pt->size)
-    return __WASI_EBADF;
-  struct fd_prestat *prestat = &pt->prestats[fd];
-  if (prestat->dir == NULL)
-    return __WASI_EBADF;
+static __wasi_errno_t
+fd_prestats_get_entry(struct fd_prestats *pt, __wasi_fd_t fd,
+                      struct fd_prestat **ret) REQUIRES_SHARED(pt->lock)
+{
+    // Test for file descriptor existence.
+    if (fd >= pt->size)
+        return __WASI_EBADF;
+    struct fd_prestat *prestat = &pt->prestats[fd];
+    if (prestat->dir == NULL)
+        return __WASI_EBADF;
 
-  *ret = prestat;
-  return 0;
+    *ret = prestat;
+    return 0;
 }
 
 struct fd_object {
-  struct refcount refcount;
-  __wasi_filetype_t type;
-  int number;
+    struct refcount refcount;
+    __wasi_filetype_t type;
+    int number;
 
-  union {
-    // Data associated with directory file descriptors.
-    struct {
-      struct mutex lock;            // Lock to protect members below.
-      DIR *handle;                  // Directory handle.
-      __wasi_dircookie_t offset;  // Offset of the directory.
-    } directory;
-  };
+    union {
+        // Data associated with directory file descriptors.
+        struct {
+            struct mutex lock;         // Lock to protect members below.
+            DIR *handle;               // Directory handle.
+            __wasi_dircookie_t offset; // Offset of the directory.
+        } directory;
+    };
 };
 
 struct fd_entry {
-  struct fd_object *object;
-  __wasi_rights_t rights_base;
-  __wasi_rights_t rights_inheriting;
+    struct fd_object *object;
+    __wasi_rights_t rights_base;
+    __wasi_rights_t rights_inheriting;
 };
 
-bool fd_table_init(
-    struct fd_table *ft
-) {
-  if (!rwlock_init(&ft->lock))
-    return false;
-  ft->entries = NULL;
-  ft->size = 0;
-  ft->used = 0;
+bool
+fd_table_init(struct fd_table *ft)
+{
+    if (!rwlock_init(&ft->lock))
+        return false;
+    ft->entries = NULL;
+    ft->size = 0;
+    ft->used = 0;
 #if defined(WASMTIME_SSP_STATIC_CURFDS)
-  curfds = ft;
+    curfds = ft;
 #endif
-  return true;
+    return true;
 }
 
 // Looks up a file descriptor table entry by number and required rights.
-static __wasi_errno_t fd_table_get_entry(
-    struct fd_table *ft,
-    __wasi_fd_t fd,
-    __wasi_rights_t rights_base,
-    __wasi_rights_t rights_inheriting,
-    struct fd_entry **ret
-) REQUIRES_SHARED(ft->lock) {
-  // Test for file descriptor existence.
-  if (fd >= ft->size)
-    return __WASI_EBADF;
-  struct fd_entry *fe = &ft->entries[fd];
-  if (fe->object == NULL)
-    return __WASI_EBADF;
+static __wasi_errno_t
+fd_table_get_entry(struct fd_table *ft, __wasi_fd_t fd,
+                   __wasi_rights_t rights_base,
+                   __wasi_rights_t rights_inheriting, struct fd_entry **ret)
+    REQUIRES_SHARED(ft->lock)
+{
+    // Test for file descriptor existence.
+    if (fd >= ft->size)
+        return __WASI_EBADF;
+    struct fd_entry *fe = &ft->entries[fd];
+    if (fe->object == NULL)
+        return __WASI_EBADF;
 
-  // Validate rights.
-  if ((~fe->rights_base & rights_base) != 0 ||
-      (~fe->rights_inheriting & rights_inheriting) != 0)
-    return __WASI_ENOTCAPABLE;
-  *ret = fe;
-  return 0;
+    // Validate rights.
+    if ((~fe->rights_base & rights_base) != 0
+        || (~fe->rights_inheriting & rights_inheriting) != 0)
+        return __WASI_ENOTCAPABLE;
+    *ret = fe;
+    return 0;
 }
 
 // Grows the file descriptor table to a required lower bound and a
 // minimum number of free file descriptor table entries.
-static bool fd_table_grow(
-    struct fd_table *ft,
-    size_t min,
-    size_t incr
-) REQUIRES_EXCLUSIVE(ft->lock) {
-  if (ft->size <= min || ft->size < (ft->used + incr) * 2) {
-    // Keep on doubling the table size until we've met our constraints.
-    size_t size = ft->size == 0 ? 1 : ft->size;
-    while (size <= min || size < (ft->used + incr) * 2)
-      size *= 2;
+static bool
+fd_table_grow(struct fd_table *ft, size_t min, size_t incr)
+    REQUIRES_EXCLUSIVE(ft->lock)
+{
+    if (ft->size <= min || ft->size < (ft->used + incr) * 2) {
+        // Keep on doubling the table size until we've met our constraints.
+        size_t size = ft->size == 0 ? 1 : ft->size;
+        while (size <= min || size < (ft->used + incr) * 2)
+            size *= 2;
 
-    // Grow the file descriptor table's allocation.
-    struct fd_entry *entries = wasm_runtime_malloc((uint32)(sizeof(*entries) * size));
-    if (entries == NULL)
-      return false;
+        // Grow the file descriptor table's allocation.
+        struct fd_entry *entries =
+            wasm_runtime_malloc((uint32)(sizeof(*entries) * size));
+        if (entries == NULL)
+            return false;
 
-    if (ft->entries && ft->size > 0) {
-      bh_memcpy_s(entries, (uint32)(sizeof(*entries) * size),
-                  ft->entries, (uint32)(sizeof(*entries) * ft->size));
+        if (ft->entries && ft->size > 0) {
+            bh_memcpy_s(entries, (uint32)(sizeof(*entries) * size), ft->entries,
+                        (uint32)(sizeof(*entries) * ft->size));
+        }
+
+        if (ft->entries)
+            wasm_runtime_free(ft->entries);
+
+        // Mark all new file descriptors as unused.
+        for (size_t i = ft->size; i < size; ++i)
+            entries[i].object = NULL;
+        ft->entries = entries;
+        ft->size = size;
     }
-
-    if (ft->entries)
-      wasm_runtime_free(ft->entries);
-
-    // Mark all new file descriptors as unused.
-    for (size_t i = ft->size; i < size; ++i)
-      entries[i].object = NULL;
-    ft->entries = entries;
-    ft->size = size;
-  }
-  return true;
+    return true;
 }
 
 // Allocates a new file descriptor object.
-static __wasi_errno_t fd_object_new(
-    __wasi_filetype_t type,
-    struct fd_object **fo
-) TRYLOCKS_SHARED(0, (*fo)->refcount) {
-  *fo = wasm_runtime_malloc(sizeof(**fo));
-  if (*fo == NULL)
-    return __WASI_ENOMEM;
-  refcount_init(&(*fo)->refcount, 1);
-  (*fo)->type = type;
-  (*fo)->number = -1;
-  return 0;
+static __wasi_errno_t
+fd_object_new(__wasi_filetype_t type, struct fd_object **fo)
+    TRYLOCKS_SHARED(0, (*fo)->refcount)
+{
+    *fo = wasm_runtime_malloc(sizeof(**fo));
+    if (*fo == NULL)
+        return __WASI_ENOMEM;
+    refcount_init(&(*fo)->refcount, 1);
+    (*fo)->type = type;
+    (*fo)->number = -1;
+    return 0;
 }
 
 // Attaches a file descriptor to the file descriptor table.
-static void fd_table_attach(
-    struct fd_table *ft,
-    __wasi_fd_t fd,
-    struct fd_object *fo,
-    __wasi_rights_t rights_base,
-    __wasi_rights_t rights_inheriting
-) REQUIRES_EXCLUSIVE(ft->lock) CONSUMES(fo->refcount) {
-  assert(ft->size > fd && "File descriptor table too small");
-  struct fd_entry *fe = &ft->entries[fd];
-  assert(fe->object == NULL && "Attempted to overwrite an existing descriptor");
-  fe->object = fo;
-  fe->rights_base = rights_base;
-  fe->rights_inheriting = rights_inheriting;
-  ++ft->used;
-  assert(ft->size >= ft->used * 2 && "File descriptor too full");
+static void
+fd_table_attach(struct fd_table *ft, __wasi_fd_t fd, struct fd_object *fo,
+                __wasi_rights_t rights_base, __wasi_rights_t rights_inheriting)
+    REQUIRES_EXCLUSIVE(ft->lock) CONSUMES(fo->refcount)
+{
+    assert(ft->size > fd && "File descriptor table too small");
+    struct fd_entry *fe = &ft->entries[fd];
+    assert(fe->object == NULL
+           && "Attempted to overwrite an existing descriptor");
+    fe->object = fo;
+    fe->rights_base = rights_base;
+    fe->rights_inheriting = rights_inheriting;
+    ++ft->used;
+    assert(ft->size >= ft->used * 2 && "File descriptor too full");
 }
 
 // Detaches a file descriptor from the file descriptor table.
-static void fd_table_detach(
-    struct fd_table *ft,
-    __wasi_fd_t fd,
-    struct fd_object **fo
-) REQUIRES_EXCLUSIVE(ft->lock) PRODUCES((*fo)->refcount) {
-  assert(ft->size > fd && "File descriptor table too small");
-  struct fd_entry *fe = &ft->entries[fd];
-  *fo = fe->object;
-  assert(*fo != NULL && "Attempted to detach nonexistent descriptor");
-  fe->object = NULL;
-  assert(ft->used > 0 && "Reference count mismatch");
-  --ft->used;
+static void
+fd_table_detach(struct fd_table *ft, __wasi_fd_t fd, struct fd_object **fo)
+    REQUIRES_EXCLUSIVE(ft->lock) PRODUCES((*fo)->refcount)
+{
+    assert(ft->size > fd && "File descriptor table too small");
+    struct fd_entry *fe = &ft->entries[fd];
+    *fo = fe->object;
+    assert(*fo != NULL && "Attempted to detach nonexistent descriptor");
+    fe->object = NULL;
+    assert(ft->used > 0 && "Reference count mismatch");
+    --ft->used;
 }
 
 // Determines the type of a file descriptor and its maximum set of
 // rights that should be attached to it.
-static __wasi_errno_t fd_determine_type_rights(
-    int fd,
-    __wasi_filetype_t *type,
-    __wasi_rights_t *rights_base,
-    __wasi_rights_t *rights_inheriting
-) {
-  struct stat sb;
-  if (fstat(fd, &sb) < 0)
-    return convert_errno(errno);
-  if (S_ISBLK(sb.st_mode)) {
-    *type = __WASI_FILETYPE_BLOCK_DEVICE;
-    *rights_base = RIGHTS_BLOCK_DEVICE_BASE;
-    *rights_inheriting = RIGHTS_BLOCK_DEVICE_INHERITING;
-  } else if (S_ISCHR(sb.st_mode)) {
-    *type = __WASI_FILETYPE_CHARACTER_DEVICE;
-#if CONFIG_HAS_ISATTY
-    if (isatty(fd)) {
-      *rights_base = RIGHTS_TTY_BASE;
-      *rights_inheriting = RIGHTS_TTY_INHERITING;
-    } else
-#endif
-    {
-      *rights_base = RIGHTS_CHARACTER_DEVICE_BASE;
-      *rights_inheriting = RIGHTS_CHARACTER_DEVICE_INHERITING;
+static __wasi_errno_t
+fd_determine_type_rights(int fd, __wasi_filetype_t *type,
+                         __wasi_rights_t *rights_base,
+                         __wasi_rights_t *rights_inheriting)
+{
+    struct stat sb;
+    if (fstat(fd, &sb) < 0)
+        return convert_errno(errno);
+    if (S_ISBLK(sb.st_mode)) {
+        *type = __WASI_FILETYPE_BLOCK_DEVICE;
+        *rights_base = RIGHTS_BLOCK_DEVICE_BASE;
+        *rights_inheriting = RIGHTS_BLOCK_DEVICE_INHERITING;
     }
-  } else if (S_ISDIR(sb.st_mode)) {
-    *type = __WASI_FILETYPE_DIRECTORY;
-    *rights_base = RIGHTS_DIRECTORY_BASE;
-    *rights_inheriting = RIGHTS_DIRECTORY_INHERITING;
-  } else if (S_ISREG(sb.st_mode)) {
-    *type = __WASI_FILETYPE_REGULAR_FILE;
-    *rights_base = RIGHTS_REGULAR_FILE_BASE;
-    *rights_inheriting = RIGHTS_REGULAR_FILE_INHERITING;
-  } else if (S_ISSOCK(sb.st_mode)) {
-    int socktype;
-    socklen_t socktypelen = sizeof(socktype);
-    if (getsockopt(fd, SOL_SOCKET, SO_TYPE, &socktype, &socktypelen) < 0)
-      return convert_errno(errno);
-    switch (socktype) {
-      case SOCK_DGRAM:
-        *type = __WASI_FILETYPE_SOCKET_DGRAM;
-        break;
-      case SOCK_STREAM:
+    else if (S_ISCHR(sb.st_mode)) {
+        *type = __WASI_FILETYPE_CHARACTER_DEVICE;
+#if CONFIG_HAS_ISATTY
+        if (isatty(fd)) {
+            *rights_base = RIGHTS_TTY_BASE;
+            *rights_inheriting = RIGHTS_TTY_INHERITING;
+        }
+        else
+#endif
+        {
+            *rights_base = RIGHTS_CHARACTER_DEVICE_BASE;
+            *rights_inheriting = RIGHTS_CHARACTER_DEVICE_INHERITING;
+        }
+    }
+    else if (S_ISDIR(sb.st_mode)) {
+        *type = __WASI_FILETYPE_DIRECTORY;
+        *rights_base = RIGHTS_DIRECTORY_BASE;
+        *rights_inheriting = RIGHTS_DIRECTORY_INHERITING;
+    }
+    else if (S_ISREG(sb.st_mode)) {
+        *type = __WASI_FILETYPE_REGULAR_FILE;
+        *rights_base = RIGHTS_REGULAR_FILE_BASE;
+        *rights_inheriting = RIGHTS_REGULAR_FILE_INHERITING;
+    }
+    else if (S_ISSOCK(sb.st_mode)) {
+        int socktype;
+        socklen_t socktypelen = sizeof(socktype);
+        if (getsockopt(fd, SOL_SOCKET, SO_TYPE, &socktype, &socktypelen) < 0)
+            return convert_errno(errno);
+        switch (socktype) {
+            case SOCK_DGRAM:
+                *type = __WASI_FILETYPE_SOCKET_DGRAM;
+                break;
+            case SOCK_STREAM:
+                *type = __WASI_FILETYPE_SOCKET_STREAM;
+                break;
+            default:
+                return __WASI_EINVAL;
+        }
+        *rights_base = RIGHTS_SOCKET_BASE;
+        *rights_inheriting = RIGHTS_SOCKET_INHERITING;
+    }
+    else if (S_ISFIFO(sb.st_mode)) {
         *type = __WASI_FILETYPE_SOCKET_STREAM;
-        break;
-      default:
+        *rights_base = RIGHTS_SOCKET_BASE;
+        *rights_inheriting = RIGHTS_SOCKET_INHERITING;
+    }
+    else {
         return __WASI_EINVAL;
     }
-    *rights_base = RIGHTS_SOCKET_BASE;
-    *rights_inheriting = RIGHTS_SOCKET_INHERITING;
-  } else if (S_ISFIFO(sb.st_mode)) {
-    *type = __WASI_FILETYPE_SOCKET_STREAM;
-    *rights_base = RIGHTS_SOCKET_BASE;
-    *rights_inheriting = RIGHTS_SOCKET_INHERITING;
-  } else {
-    return __WASI_EINVAL;
-  }
 
-  // Strip off read/write bits based on the access mode.
-  switch (fcntl(fd, F_GETFL) & O_ACCMODE) {
-    case O_RDONLY:
-      *rights_base &= ~(__wasi_rights_t)__WASI_RIGHT_FD_WRITE;
-      break;
-    case O_WRONLY:
-      *rights_base &= ~(__wasi_rights_t)__WASI_RIGHT_FD_READ;
-      break;
-  }
-  return 0;
+    // Strip off read/write bits based on the access mode.
+    switch (fcntl(fd, F_GETFL) & O_ACCMODE) {
+        case O_RDONLY:
+            *rights_base &= ~(__wasi_rights_t)__WASI_RIGHT_FD_WRITE;
+            break;
+        case O_WRONLY:
+            *rights_base &= ~(__wasi_rights_t)__WASI_RIGHT_FD_READ;
+            break;
+    }
+    return 0;
 }
 
 // Returns the underlying file descriptor number of a file descriptor
 // object. This function can only be applied to objects that have an
 // underlying file descriptor number.
-static int fd_number(
-    const struct fd_object *fo
-) {
-  int number = fo->number;
-  assert(number >= 0 && "fd_number() called on virtual file descriptor");
-  return number;
+static int
+fd_number(const struct fd_object *fo)
+{
+    int number = fo->number;
+    assert(number >= 0 && "fd_number() called on virtual file descriptor");
+    return number;
 }
 
-#define CLOSE_NON_STD_FD(fd) do {  \
-    if (fd > 2)                    \
-      close(fd);                   \
-  } while (0)
+#define CLOSE_NON_STD_FD(fd) \
+    do {                     \
+        if (fd > 2)          \
+            close(fd);       \
+    } while (0)
 
 // Lowers the reference count on a file descriptor object. When the
 // reference count reaches zero, its resources are cleaned up.
-static void fd_object_release(
-    struct fd_object *fo
-) UNLOCKS(fo->refcount) {
-  if (refcount_release(&fo->refcount)) {
-    switch (fo->type) {
-      case __WASI_FILETYPE_DIRECTORY:
-        // For directories we may keep track of a DIR object. Calling
-        // closedir() on it also closes the underlying file descriptor.
-        mutex_destroy(&fo->directory.lock);
-        if (fo->directory.handle == NULL) {
-          CLOSE_NON_STD_FD(fd_number(fo));
-        } else {
-          closedir(fo->directory.handle);
+static void
+fd_object_release(struct fd_object *fo) UNLOCKS(fo->refcount)
+{
+    if (refcount_release(&fo->refcount)) {
+        switch (fo->type) {
+            case __WASI_FILETYPE_DIRECTORY:
+                // For directories we may keep track of a DIR object. Calling
+                // closedir() on it also closes the underlying file descriptor.
+                mutex_destroy(&fo->directory.lock);
+                if (fo->directory.handle == NULL) {
+                    CLOSE_NON_STD_FD(fd_number(fo));
+                }
+                else {
+                    closedir(fo->directory.handle);
+                }
+                break;
+            default:
+                CLOSE_NON_STD_FD(fd_number(fo));
+                break;
         }
-        break;
-      default:
-        CLOSE_NON_STD_FD(fd_number(fo));
-        break;
+        wasm_runtime_free(fo);
     }
-    wasm_runtime_free(fo);
-  }
 }
 
 // Inserts an already existing file descriptor into the file descriptor
 // table.
-bool fd_table_insert_existing(
-    struct fd_table *ft,
-    __wasi_fd_t in,
-    int out
-) {
-  __wasi_filetype_t type;
-  __wasi_rights_t rights_base, rights_inheriting;
-  struct fd_object *fo;
-  __wasi_errno_t error;
+bool
+fd_table_insert_existing(struct fd_table *ft, __wasi_fd_t in, int out)
+{
+    __wasi_filetype_t type;
+    __wasi_rights_t rights_base, rights_inheriting;
+    struct fd_object *fo;
+    __wasi_errno_t error;
 
-  if (fd_determine_type_rights(out, &type, &rights_base,
-                               &rights_inheriting) != 0)
-    return false;
+    if (fd_determine_type_rights(out, &type, &rights_base, &rights_inheriting)
+        != 0)
+        return false;
 
-  error = fd_object_new(type, &fo);
-  if (error != 0)
-    return false;
-  fo->number = out;
-  if (type == __WASI_FILETYPE_DIRECTORY) {
-    if (!mutex_init(&fo->directory.lock)) {
-      fd_object_release(fo);
-      return false;
+    error = fd_object_new(type, &fo);
+    if (error != 0)
+        return false;
+    fo->number = out;
+    if (type == __WASI_FILETYPE_DIRECTORY) {
+        if (!mutex_init(&fo->directory.lock)) {
+            fd_object_release(fo);
+            return false;
+        }
+        fo->directory.handle = NULL;
     }
-    fo->directory.handle = NULL;
-  }
 
-  // Grow the file descriptor table if needed.
-  rwlock_wrlock(&ft->lock);
-  if (!fd_table_grow(ft, in, 1)) {
+    // Grow the file descriptor table if needed.
+    rwlock_wrlock(&ft->lock);
+    if (!fd_table_grow(ft, in, 1)) {
+        rwlock_unlock(&ft->lock);
+        fd_object_release(fo);
+        return false;
+    }
+
+    fd_table_attach(ft, in, fo, rights_base, rights_inheriting);
     rwlock_unlock(&ft->lock);
-    fd_object_release(fo);
-    return false;
-  }
-
-  fd_table_attach(ft, in, fo, rights_base, rights_inheriting);
-  rwlock_unlock(&ft->lock);
-  return true;
+    return true;
 }
 
 // Picks an unused slot from the file descriptor table.
-static __wasi_fd_t fd_table_unused(
-    struct fd_table *ft
-) REQUIRES_SHARED(ft->lock) {
-  assert(ft->size > ft->used && "File descriptor table has no free slots");
-  for (;;) {
-    __wasi_fd_t fd = (__wasi_fd_t)random_uniform(ft->size);
-    if (ft->entries[fd].object == NULL)
-      return fd;
-  }
+static __wasi_fd_t
+fd_table_unused(struct fd_table *ft) REQUIRES_SHARED(ft->lock)
+{
+    assert(ft->size > ft->used && "File descriptor table has no free slots");
+    for (;;) {
+        __wasi_fd_t fd = (__wasi_fd_t)random_uniform(ft->size);
+        if (ft->entries[fd].object == NULL)
+            return fd;
+    }
 }
 
 // Inserts a file descriptor object into an unused slot of the file
 // descriptor table.
-static __wasi_errno_t fd_table_insert(
-    struct fd_table *ft,
-    struct fd_object *fo,
-    __wasi_rights_t rights_base,
-    __wasi_rights_t rights_inheriting,
-    __wasi_fd_t *out
-) REQUIRES_UNLOCKED(ft->lock) UNLOCKS(fo->refcount) {
-  // Grow the file descriptor table if needed.
-  rwlock_wrlock(&ft->lock);
-  if (!fd_table_grow(ft, 0, 1)) {
-    rwlock_unlock(&ft->lock);
-    fd_object_release(fo);
-    return convert_errno(errno);
-  }
+static __wasi_errno_t
+fd_table_insert(struct fd_table *ft, struct fd_object *fo,
+                __wasi_rights_t rights_base, __wasi_rights_t rights_inheriting,
+                __wasi_fd_t *out) REQUIRES_UNLOCKED(ft->lock)
+    UNLOCKS(fo->refcount)
+{
+    // Grow the file descriptor table if needed.
+    rwlock_wrlock(&ft->lock);
+    if (!fd_table_grow(ft, 0, 1)) {
+        rwlock_unlock(&ft->lock);
+        fd_object_release(fo);
+        return convert_errno(errno);
+    }
 
-  *out = fd_table_unused(ft);
-  fd_table_attach(ft, *out, fo, rights_base, rights_inheriting);
-  rwlock_unlock(&ft->lock);
-  return 0;
+    *out = fd_table_unused(ft);
+    fd_table_attach(ft, *out, fo, rights_base, rights_inheriting);
+    rwlock_unlock(&ft->lock);
+    return 0;
 }
 
 // Inserts a numerical file descriptor into the file descriptor table.
-static __wasi_errno_t fd_table_insert_fd(
-    struct fd_table *ft,
-    int in,
-    __wasi_filetype_t type,
-    __wasi_rights_t rights_base,
-    __wasi_rights_t rights_inheriting,
-    __wasi_fd_t *out
-) REQUIRES_UNLOCKED(ft->lock) {
-  struct fd_object *fo;
-  __wasi_errno_t error = fd_object_new(type, &fo);
+static __wasi_errno_t
+fd_table_insert_fd(struct fd_table *ft, int in, __wasi_filetype_t type,
+                   __wasi_rights_t rights_base,
+                   __wasi_rights_t rights_inheriting, __wasi_fd_t *out)
+    REQUIRES_UNLOCKED(ft->lock)
+{
+    struct fd_object *fo;
+    __wasi_errno_t error = fd_object_new(type, &fo);
 
-  if (error != 0) {
-    close(in);
-    return error;
-  }
-  fo->number = in;
-  if (type == __WASI_FILETYPE_DIRECTORY) {
-    if (!mutex_init(&fo->directory.lock)) {
-      fd_object_release(fo);
-      return (__wasi_errno_t)-1;
+    if (error != 0) {
+        close(in);
+        return error;
     }
-    fo->directory.handle = NULL;
-  }
-  return fd_table_insert(ft, fo, rights_base, rights_inheriting, out);
+    fo->number = in;
+    if (type == __WASI_FILETYPE_DIRECTORY) {
+        if (!mutex_init(&fo->directory.lock)) {
+            fd_object_release(fo);
+            return (__wasi_errno_t)-1;
+        }
+        fo->directory.handle = NULL;
+    }
+    return fd_table_insert(ft, fo, rights_base, rights_inheriting, out);
 }
 
-__wasi_errno_t wasmtime_ssp_fd_prestat_get(
+__wasi_errno_t
+wasmtime_ssp_fd_prestat_get(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_prestats *prestats,
 #endif
-    __wasi_fd_t fd,
-    __wasi_prestat_t *buf
-) {
-  rwlock_rdlock(&prestats->lock);
-  struct fd_prestat *prestat;
-  __wasi_errno_t error = fd_prestats_get_entry(prestats, fd, &prestat);
-  if (error != 0) {
-    rwlock_unlock(&prestats->lock);
-    return error;
-  }
-
-  *buf = (__wasi_prestat_t) {
-    .pr_type = __WASI_PREOPENTYPE_DIR,
-  };
-
-  buf->u.dir.pr_name_len = strlen(prestat->dir);
-
-  rwlock_unlock(&prestats->lock);
-
-  return 0;
-}
-
-__wasi_errno_t wasmtime_ssp_fd_prestat_dir_name(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
-    struct fd_prestats *prestats,
-#endif
-    __wasi_fd_t fd,
-    char *path,
-    size_t path_len
-) {
-  rwlock_rdlock(&prestats->lock);
-  struct fd_prestat *prestat;
-  __wasi_errno_t error = fd_prestats_get_entry(prestats, fd, &prestat);
-  if (error != 0) {
-    rwlock_unlock(&prestats->lock);
-    return error;
-  }
-  if (path_len != strlen(prestat->dir)) {
-    rwlock_unlock(&prestats->lock);
-    return EINVAL;
-  }
-
-  bh_memcpy_s(path, (uint32)path_len, prestat->dir, (uint32)path_len);
-
-  rwlock_unlock(&prestats->lock);
-
-  return 0;
-}
-
-__wasi_errno_t wasmtime_ssp_fd_close(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
-    struct fd_table *curfds,
-    struct fd_prestats *prestats,
-#endif
-    __wasi_fd_t fd
-) {
-  // Don't allow closing a pre-opened resource.
-  // TODO: Eventually, we do want to permit this, once libpreopen in
-  // userspace is capable of removing entries from its tables as well.
-  {
+    __wasi_fd_t fd, __wasi_prestat_t *buf)
+{
     rwlock_rdlock(&prestats->lock);
     struct fd_prestat *prestat;
     __wasi_errno_t error = fd_prestats_get_entry(prestats, fd, &prestat);
-    rwlock_unlock(&prestats->lock);
-    if (error == 0) {
-      return __WASI_ENOTSUP;
+    if (error != 0) {
+        rwlock_unlock(&prestats->lock);
+        return error;
     }
-  }
 
-  // Validate the file descriptor.
-  struct fd_table *ft = curfds;
-  rwlock_wrlock(&ft->lock);
-  struct fd_entry *fe;
-  __wasi_errno_t error = fd_table_get_entry(ft, fd, 0, 0, &fe);
-  if (error != 0) {
+    *buf = (__wasi_prestat_t){
+        .pr_type = __WASI_PREOPENTYPE_DIR,
+    };
+
+    buf->u.dir.pr_name_len = strlen(prestat->dir);
+
+    rwlock_unlock(&prestats->lock);
+
+    return 0;
+}
+
+__wasi_errno_t
+wasmtime_ssp_fd_prestat_dir_name(
+#if !defined(WASMTIME_SSP_STATIC_CURFDS)
+    struct fd_prestats *prestats,
+#endif
+    __wasi_fd_t fd, char *path, size_t path_len)
+{
+    rwlock_rdlock(&prestats->lock);
+    struct fd_prestat *prestat;
+    __wasi_errno_t error = fd_prestats_get_entry(prestats, fd, &prestat);
+    if (error != 0) {
+        rwlock_unlock(&prestats->lock);
+        return error;
+    }
+    if (path_len != strlen(prestat->dir)) {
+        rwlock_unlock(&prestats->lock);
+        return EINVAL;
+    }
+
+    bh_memcpy_s(path, (uint32)path_len, prestat->dir, (uint32)path_len);
+
+    rwlock_unlock(&prestats->lock);
+
+    return 0;
+}
+
+__wasi_errno_t
+wasmtime_ssp_fd_close(
+#if !defined(WASMTIME_SSP_STATIC_CURFDS)
+    struct fd_table *curfds, struct fd_prestats *prestats,
+#endif
+    __wasi_fd_t fd)
+{
+    // Don't allow closing a pre-opened resource.
+    // TODO: Eventually, we do want to permit this, once libpreopen in
+    // userspace is capable of removing entries from its tables as well.
+    {
+        rwlock_rdlock(&prestats->lock);
+        struct fd_prestat *prestat;
+        __wasi_errno_t error = fd_prestats_get_entry(prestats, fd, &prestat);
+        rwlock_unlock(&prestats->lock);
+        if (error == 0) {
+            return __WASI_ENOTSUP;
+        }
+    }
+
+    // Validate the file descriptor.
+    struct fd_table *ft = curfds;
+    rwlock_wrlock(&ft->lock);
+    struct fd_entry *fe;
+    __wasi_errno_t error = fd_table_get_entry(ft, fd, 0, 0, &fe);
+    if (error != 0) {
+        rwlock_unlock(&ft->lock);
+        return error;
+    }
+
+    // Remove it from the file descriptor table.
+    struct fd_object *fo;
+    fd_table_detach(ft, fd, &fo);
     rwlock_unlock(&ft->lock);
-    return error;
-  }
-
-  // Remove it from the file descriptor table.
-  struct fd_object *fo;
-  fd_table_detach(ft, fd, &fo);
-  rwlock_unlock(&ft->lock);
-  fd_object_release(fo);
-  return 0;
+    fd_object_release(fo);
+    return 0;
 }
 
 // Look up a file descriptor object in a locked file descriptor table
 // and increases its reference count.
-static __wasi_errno_t fd_object_get_locked(
-    struct fd_object **fo,
-    struct fd_table *ft,
-    __wasi_fd_t fd,
-    __wasi_rights_t rights_base,
-    __wasi_rights_t rights_inheriting
-) TRYLOCKS_EXCLUSIVE(0, (*fo)->refcount) REQUIRES_EXCLUSIVE(ft->lock) {
-  // Test whether the file descriptor number is valid.
-  struct fd_entry *fe;
-  __wasi_errno_t error =
-      fd_table_get_entry(ft, fd, rights_base, rights_inheriting, &fe);
-  if (error != 0)
-    return error;
+static __wasi_errno_t
+fd_object_get_locked(struct fd_object **fo, struct fd_table *ft, __wasi_fd_t fd,
+                     __wasi_rights_t rights_base,
+                     __wasi_rights_t rights_inheriting)
+    TRYLOCKS_EXCLUSIVE(0, (*fo)->refcount) REQUIRES_EXCLUSIVE(ft->lock)
+{
+    // Test whether the file descriptor number is valid.
+    struct fd_entry *fe;
+    __wasi_errno_t error =
+        fd_table_get_entry(ft, fd, rights_base, rights_inheriting, &fe);
+    if (error != 0)
+        return error;
 
-  // Increase the reference count on the file descriptor object. A copy
-  // of the rights are also stored, so callers can still access those if
-  // needed.
-  *fo = fe->object;
-  refcount_acquire(&(*fo)->refcount);
-  return 0;
+    // Increase the reference count on the file descriptor object. A copy
+    // of the rights are also stored, so callers can still access those if
+    // needed.
+    *fo = fe->object;
+    refcount_acquire(&(*fo)->refcount);
+    return 0;
 }
 
 // Temporarily locks the file descriptor table to look up a file
 // descriptor object, increases its reference count and drops the lock.
-static __wasi_errno_t fd_object_get(
-    struct fd_table *curfds,
-    struct fd_object **fo,
-    __wasi_fd_t fd,
-    __wasi_rights_t rights_base,
-    __wasi_rights_t rights_inheriting
-) TRYLOCKS_EXCLUSIVE(0, (*fo)->refcount) {
-  struct fd_table *ft = curfds;
-  rwlock_rdlock(&ft->lock);
-  __wasi_errno_t error =
-      fd_object_get_locked(fo, ft, fd, rights_base, rights_inheriting);
-  rwlock_unlock(&ft->lock);
-  return error;
+static __wasi_errno_t
+fd_object_get(struct fd_table *curfds, struct fd_object **fo, __wasi_fd_t fd,
+              __wasi_rights_t rights_base, __wasi_rights_t rights_inheriting)
+    TRYLOCKS_EXCLUSIVE(0, (*fo)->refcount)
+{
+    struct fd_table *ft = curfds;
+    rwlock_rdlock(&ft->lock);
+    __wasi_errno_t error =
+        fd_object_get_locked(fo, ft, fd, rights_base, rights_inheriting);
+    rwlock_unlock(&ft->lock);
+    return error;
 }
 
-__wasi_errno_t wasmtime_ssp_fd_datasync(
+__wasi_errno_t
+wasmtime_ssp_fd_datasync(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t fd
-) {
-  struct fd_object *fo;
-  __wasi_errno_t error =
-      fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_DATASYNC, 0);
-  if (error != 0)
-    return error;
+    __wasi_fd_t fd)
+{
+    struct fd_object *fo;
+    __wasi_errno_t error =
+        fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_DATASYNC, 0);
+    if (error != 0)
+        return error;
 
 #if CONFIG_HAS_FDATASYNC
-  int ret = fdatasync(fd_number(fo));
+    int ret = fdatasync(fd_number(fo));
 #else
-  int ret = fsync(fd_number(fo));
+    int ret = fsync(fd_number(fo));
 #endif
-  fd_object_release(fo);
-  if (ret < 0)
-    return convert_errno(errno);
-  return 0;
+    fd_object_release(fo);
+    if (ret < 0)
+        return convert_errno(errno);
+    return 0;
 }
 
-__wasi_errno_t wasmtime_ssp_fd_pread(
+__wasi_errno_t
+wasmtime_ssp_fd_pread(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t fd,
-    const __wasi_iovec_t *iov,
-    size_t iovcnt,
-    __wasi_filesize_t offset,
-    size_t *nread
-) {
-  if (iovcnt == 0)
-    return __WASI_EINVAL;
+    __wasi_fd_t fd, const __wasi_iovec_t *iov, size_t iovcnt,
+    __wasi_filesize_t offset, size_t *nread)
+{
+    if (iovcnt == 0)
+        return __WASI_EINVAL;
 
-  struct fd_object *fo;
-  __wasi_errno_t error = fd_object_get(curfds,
-      &fo, fd, __WASI_RIGHT_FD_READ, 0);
-  if (error != 0)
-    return error;
+    struct fd_object *fo;
+    __wasi_errno_t error =
+        fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_READ, 0);
+    if (error != 0)
+        return error;
 
 #if CONFIG_HAS_PREADV
-  ssize_t len =
-      preadv(fd_number(fo), (const struct iovec *)iov, (int)iovcnt, (off_t)offset);
-  fd_object_release(fo);
-  if (len < 0)
-    return convert_errno(errno);
-  *nread = (size_t)len;
-  return 0;
-#else
-  if (iovcnt == 1) {
-    ssize_t len = pread(fd_number(fo), iov->buf, iov->buf_len, offset);
+    ssize_t len = preadv(fd_number(fo), (const struct iovec *)iov, (int)iovcnt,
+                         (off_t)offset);
     fd_object_release(fo);
     if (len < 0)
-      return convert_errno(errno);
-    *nread = len;
+        return convert_errno(errno);
+    *nread = (size_t)len;
     return 0;
-  } else {
-    // Allocate a single buffer to fit all data.
-    size_t totalsize = 0;
-    for (size_t i = 0; i < iovcnt; ++i)
-      totalsize += iov[i].buf_len;
-    char *buf = wasm_runtime_malloc(totalsize);
-    if (buf == NULL) {
-      fd_object_release(fo);
-      return __WASI_ENOMEM;
+#else
+    if (iovcnt == 1) {
+        ssize_t len = pread(fd_number(fo), iov->buf, iov->buf_len, offset);
+        fd_object_release(fo);
+        if (len < 0)
+            return convert_errno(errno);
+        *nread = len;
+        return 0;
     }
+    else {
+        // Allocate a single buffer to fit all data.
+        size_t totalsize = 0;
+        for (size_t i = 0; i < iovcnt; ++i)
+            totalsize += iov[i].buf_len;
+        char *buf = wasm_runtime_malloc(totalsize);
+        if (buf == NULL) {
+            fd_object_release(fo);
+            return __WASI_ENOMEM;
+        }
 
-    // Perform a single read operation.
-    ssize_t len = pread(fd_number(fo), buf, totalsize, offset);
-    fd_object_release(fo);
-    if (len < 0) {
-      wasm_runtime_free(buf);
-      return convert_errno(errno);
-    }
+        // Perform a single read operation.
+        ssize_t len = pread(fd_number(fo), buf, totalsize, offset);
+        fd_object_release(fo);
+        if (len < 0) {
+            wasm_runtime_free(buf);
+            return convert_errno(errno);
+        }
 
-    // Copy data back to vectors.
-    size_t bufoff = 0;
-    for (size_t i = 0; i < iovcnt; ++i) {
-      if (bufoff + iov[i].buf_len < len) {
-        bh_memcpy_s(iov[i].buf, iov[i].buf_len, buf + bufoff, iov[i].buf_len);
-        bufoff += iov[i].buf_len;
-      } else {
-        bh_memcpy_s(iov[i].buf, iov[i].buf_len, buf + bufoff, len - bufoff);
-        break;
-      }
+        // Copy data back to vectors.
+        size_t bufoff = 0;
+        for (size_t i = 0; i < iovcnt; ++i) {
+            if (bufoff + iov[i].buf_len < len) {
+                bh_memcpy_s(iov[i].buf, iov[i].buf_len, buf + bufoff,
+                            iov[i].buf_len);
+                bufoff += iov[i].buf_len;
+            }
+            else {
+                bh_memcpy_s(iov[i].buf, iov[i].buf_len, buf + bufoff,
+                            len - bufoff);
+                break;
+            }
+        }
+        wasm_runtime_free(buf);
+        *nread = len;
+        return 0;
     }
-    wasm_runtime_free(buf);
-    *nread = len;
-    return 0;
-  }
 #endif
 }
 
-__wasi_errno_t wasmtime_ssp_fd_pwrite(
+__wasi_errno_t
+wasmtime_ssp_fd_pwrite(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t fd,
-    const __wasi_ciovec_t *iov,
-    size_t iovcnt,
-    __wasi_filesize_t offset,
-    size_t *nwritten
-) {
-  if (iovcnt == 0)
-    return __WASI_EINVAL;
+    __wasi_fd_t fd, const __wasi_ciovec_t *iov, size_t iovcnt,
+    __wasi_filesize_t offset, size_t *nwritten)
+{
+    if (iovcnt == 0)
+        return __WASI_EINVAL;
 
-  struct fd_object *fo;
-  __wasi_errno_t error = fd_object_get(curfds,
-      &fo, fd, __WASI_RIGHT_FD_WRITE, 0);
-  if (error != 0)
-    return error;
+    struct fd_object *fo;
+    __wasi_errno_t error =
+        fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_WRITE, 0);
+    if (error != 0)
+        return error;
 
-  ssize_t len;
+    ssize_t len;
 #if CONFIG_HAS_PWRITEV
-  len = pwritev(fd_number(fo), (const struct iovec *)iov, (int)iovcnt, (off_t)offset);
+    len = pwritev(fd_number(fo), (const struct iovec *)iov, (int)iovcnt,
+                  (off_t)offset);
 #else
-  if (iovcnt == 1) {
-    len = pwrite(fd_number(fo), iov->buf, iov->buf_len, offset);
-  } else {
-    // Allocate a single buffer to fit all data.
-    size_t totalsize = 0;
-    for (size_t i = 0; i < iovcnt; ++i)
-      totalsize += iov[i].buf_len;
-    char *buf = wasm_runtime_malloc(totalsize);
-    if (buf == NULL) {
-      fd_object_release(fo);
-      return __WASI_ENOMEM;
+    if (iovcnt == 1) {
+        len = pwrite(fd_number(fo), iov->buf, iov->buf_len, offset);
     }
-    size_t bufoff = 0;
-    for (size_t i = 0; i < iovcnt; ++i) {
-      bh_memcpy_s(buf + bufoff, totalsize - bufoff,
-                  iov[i].buf, iov[i].buf_len);
-      bufoff += iov[i].buf_len;
-    }
+    else {
+        // Allocate a single buffer to fit all data.
+        size_t totalsize = 0;
+        for (size_t i = 0; i < iovcnt; ++i)
+            totalsize += iov[i].buf_len;
+        char *buf = wasm_runtime_malloc(totalsize);
+        if (buf == NULL) {
+            fd_object_release(fo);
+            return __WASI_ENOMEM;
+        }
+        size_t bufoff = 0;
+        for (size_t i = 0; i < iovcnt; ++i) {
+            bh_memcpy_s(buf + bufoff, totalsize - bufoff, iov[i].buf,
+                        iov[i].buf_len);
+            bufoff += iov[i].buf_len;
+        }
 
-    // Perform a single write operation.
-    len = pwrite(fd_number(fo), buf, totalsize, offset);
-    wasm_runtime_free(buf);
-  }
+        // Perform a single write operation.
+        len = pwrite(fd_number(fo), buf, totalsize, offset);
+        wasm_runtime_free(buf);
+    }
 #endif
-  fd_object_release(fo);
-  if (len < 0)
-    return convert_errno(errno);
-  *nwritten = (size_t)len;
-  return 0;
+    fd_object_release(fo);
+    if (len < 0)
+        return convert_errno(errno);
+    *nwritten = (size_t)len;
+    return 0;
 }
 
-__wasi_errno_t wasmtime_ssp_fd_read(
+__wasi_errno_t
+wasmtime_ssp_fd_read(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t fd,
-    const __wasi_iovec_t *iov,
-    size_t iovcnt,
-    size_t *nread
-) {
-  struct fd_object *fo;
-  __wasi_errno_t error = fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_READ, 0);
-  if (error != 0)
-    return error;
+    __wasi_fd_t fd, const __wasi_iovec_t *iov, size_t iovcnt, size_t *nread)
+{
+    struct fd_object *fo;
+    __wasi_errno_t error =
+        fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_READ, 0);
+    if (error != 0)
+        return error;
 
-  ssize_t len = readv(fd_number(fo), (const struct iovec *)iov, (int)iovcnt);
-  fd_object_release(fo);
-  if (len < 0)
-    return convert_errno(errno);
-  *nread = (size_t)len;
-  return 0;
+    ssize_t len = readv(fd_number(fo), (const struct iovec *)iov, (int)iovcnt);
+    fd_object_release(fo);
+    if (len < 0)
+        return convert_errno(errno);
+    *nread = (size_t)len;
+    return 0;
 }
 
-__wasi_errno_t wasmtime_ssp_fd_renumber(
+__wasi_errno_t
+wasmtime_ssp_fd_renumber(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
-    struct fd_table *curfds,
-    struct fd_prestats *prestats,
+    struct fd_table *curfds, struct fd_prestats *prestats,
 #endif
-    __wasi_fd_t from,
-    __wasi_fd_t to
-) {
-  // Don't allow renumbering over a pre-opened resource.
-  // TODO: Eventually, we do want to permit this, once libpreopen in
-  // userspace is capable of removing entries from its tables as well.
-  {
-    rwlock_rdlock(&prestats->lock);
-    struct fd_prestat *prestat;
-    __wasi_errno_t error = fd_prestats_get_entry(prestats, to, &prestat);
+    __wasi_fd_t from, __wasi_fd_t to)
+{
+    // Don't allow renumbering over a pre-opened resource.
+    // TODO: Eventually, we do want to permit this, once libpreopen in
+    // userspace is capable of removing entries from its tables as well.
+    {
+        rwlock_rdlock(&prestats->lock);
+        struct fd_prestat *prestat;
+        __wasi_errno_t error = fd_prestats_get_entry(prestats, to, &prestat);
+        if (error != 0) {
+            error = fd_prestats_get_entry(prestats, from, &prestat);
+        }
+        rwlock_unlock(&prestats->lock);
+        if (error == 0) {
+            return __WASI_ENOTSUP;
+        }
+    }
+
+    struct fd_table *ft = curfds;
+    rwlock_wrlock(&ft->lock);
+    struct fd_entry *fe_from;
+    __wasi_errno_t error = fd_table_get_entry(ft, from, 0, 0, &fe_from);
     if (error != 0) {
-      error = fd_prestats_get_entry(prestats, from, &prestat);
+        rwlock_unlock(&ft->lock);
+        return error;
     }
-    rwlock_unlock(&prestats->lock);
-    if (error == 0) {
-      return __WASI_ENOTSUP;
+    struct fd_entry *fe_to;
+    error = fd_table_get_entry(ft, to, 0, 0, &fe_to);
+    if (error != 0) {
+        rwlock_unlock(&ft->lock);
+        return error;
     }
-  }
 
-  struct fd_table *ft = curfds;
-  rwlock_wrlock(&ft->lock);
-  struct fd_entry *fe_from;
-  __wasi_errno_t error = fd_table_get_entry(ft, from, 0, 0, &fe_from);
-  if (error != 0) {
+    struct fd_object *fo;
+    fd_table_detach(ft, to, &fo);
+    refcount_acquire(&fe_from->object->refcount);
+    fd_table_attach(ft, to, fe_from->object, fe_from->rights_base,
+                    fe_from->rights_inheriting);
+    fd_object_release(fo);
+
+    // Remove the old fd from the file descriptor table.
+    fd_table_detach(ft, from, &fo);
+    fd_object_release(fo);
+    --ft->used;
+
     rwlock_unlock(&ft->lock);
-    return error;
-  }
-  struct fd_entry *fe_to;
-  error = fd_table_get_entry(ft, to, 0, 0, &fe_to);
-  if (error != 0) {
-    rwlock_unlock(&ft->lock);
-    return error;
-  }
-
-  struct fd_object *fo;
-  fd_table_detach(ft, to, &fo);
-  refcount_acquire(&fe_from->object->refcount);
-  fd_table_attach(ft, to, fe_from->object, fe_from->rights_base,
-                  fe_from->rights_inheriting);
-  fd_object_release(fo);
-
-  // Remove the old fd from the file descriptor table.
-  fd_table_detach(ft, from, &fo);
-  fd_object_release(fo);
-  --ft->used;
-
-  rwlock_unlock(&ft->lock);
-  return 0;
+    return 0;
 }
 
-__wasi_errno_t wasmtime_ssp_fd_seek(
+__wasi_errno_t
+wasmtime_ssp_fd_seek(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t fd,
-    __wasi_filedelta_t offset,
-    __wasi_whence_t whence,
-    __wasi_filesize_t *newoffset
-) {
-  int nwhence;
-  switch (whence) {
-    case __WASI_WHENCE_CUR:
-      nwhence = SEEK_CUR;
-      break;
-    case __WASI_WHENCE_END:
-      nwhence = SEEK_END;
-      break;
-    case __WASI_WHENCE_SET:
-      nwhence = SEEK_SET;
-      break;
-    default:
-      return __WASI_EINVAL;
-  }
+    __wasi_fd_t fd, __wasi_filedelta_t offset, __wasi_whence_t whence,
+    __wasi_filesize_t *newoffset)
+{
+    int nwhence;
+    switch (whence) {
+        case __WASI_WHENCE_CUR:
+            nwhence = SEEK_CUR;
+            break;
+        case __WASI_WHENCE_END:
+            nwhence = SEEK_END;
+            break;
+        case __WASI_WHENCE_SET:
+            nwhence = SEEK_SET;
+            break;
+        default:
+            return __WASI_EINVAL;
+    }
 
-  struct fd_object *fo;
-  __wasi_errno_t error =
-      fd_object_get(curfds, &fo, fd,
-                    offset == 0 && whence == __WASI_WHENCE_CUR
-                        ? __WASI_RIGHT_FD_TELL
-                        : __WASI_RIGHT_FD_SEEK | __WASI_RIGHT_FD_TELL,
-                    0);
-  if (error != 0)
-    return error;
+    struct fd_object *fo;
+    __wasi_errno_t error =
+        fd_object_get(curfds, &fo, fd,
+                      offset == 0 && whence == __WASI_WHENCE_CUR
+                          ? __WASI_RIGHT_FD_TELL
+                          : __WASI_RIGHT_FD_SEEK | __WASI_RIGHT_FD_TELL,
+                      0);
+    if (error != 0)
+        return error;
 
-  off_t ret = lseek(fd_number(fo), offset, nwhence);
-  fd_object_release(fo);
-  if (ret < 0)
-    return convert_errno(errno);
-  *newoffset = (__wasi_filesize_t)ret;
-  return 0;
+    off_t ret = lseek(fd_number(fo), offset, nwhence);
+    fd_object_release(fo);
+    if (ret < 0)
+        return convert_errno(errno);
+    *newoffset = (__wasi_filesize_t)ret;
+    return 0;
 }
 
-__wasi_errno_t wasmtime_ssp_fd_tell(
+__wasi_errno_t
+wasmtime_ssp_fd_tell(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t fd,
-    __wasi_filesize_t *newoffset
-) {
-  struct fd_object *fo;
-  __wasi_errno_t error =
-      fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_TELL, 0);
-  if (error != 0)
-    return error;
+    __wasi_fd_t fd, __wasi_filesize_t *newoffset)
+{
+    struct fd_object *fo;
+    __wasi_errno_t error =
+        fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_TELL, 0);
+    if (error != 0)
+        return error;
 
-  off_t ret = lseek(fd_number(fo), 0, SEEK_CUR);
-  fd_object_release(fo);
-  if (ret < 0)
-    return convert_errno(errno);
-  *newoffset = (__wasi_filesize_t)ret;
-  return 0;
+    off_t ret = lseek(fd_number(fo), 0, SEEK_CUR);
+    fd_object_release(fo);
+    if (ret < 0)
+        return convert_errno(errno);
+    *newoffset = (__wasi_filesize_t)ret;
+    return 0;
 }
 
-__wasi_errno_t wasmtime_ssp_fd_fdstat_get(
+__wasi_errno_t
+wasmtime_ssp_fd_fdstat_get(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t fd,
-    __wasi_fdstat_t *buf
-) {
-  struct fd_table *ft = curfds;
-  rwlock_rdlock(&ft->lock);
-  struct fd_entry *fe;
-  __wasi_errno_t error = fd_table_get_entry(ft, fd, 0, 0, &fe);
-  if (error != 0) {
+    __wasi_fd_t fd, __wasi_fdstat_t *buf)
+{
+    struct fd_table *ft = curfds;
+    rwlock_rdlock(&ft->lock);
+    struct fd_entry *fe;
+    __wasi_errno_t error = fd_table_get_entry(ft, fd, 0, 0, &fe);
+    if (error != 0) {
+        rwlock_unlock(&ft->lock);
+        return error;
+    }
+
+    // Extract file descriptor type and rights.
+    struct fd_object *fo = fe->object;
+    *buf = (__wasi_fdstat_t){
+        .fs_filetype = fo->type,
+        .fs_rights_base = fe->rights_base,
+        .fs_rights_inheriting = fe->rights_inheriting,
+    };
+
+    // Fetch file descriptor flags.
+    int ret;
+    switch (fo->type) {
+        default:
+            ret = fcntl(fd_number(fo), F_GETFL);
+            break;
+    }
     rwlock_unlock(&ft->lock);
-    return error;
-  }
+    if (ret < 0)
+        return convert_errno(errno);
 
-  // Extract file descriptor type and rights.
-  struct fd_object *fo = fe->object;
-  *buf = (__wasi_fdstat_t){
-      .fs_filetype = fo->type,
-      .fs_rights_base = fe->rights_base,
-      .fs_rights_inheriting = fe->rights_inheriting,
-  };
-
-  // Fetch file descriptor flags.
-  int ret;
-  switch (fo->type) {
-    default:
-      ret = fcntl(fd_number(fo), F_GETFL);
-      break;
-  }
-  rwlock_unlock(&ft->lock);
-  if (ret < 0)
-    return convert_errno(errno);
-
-  if ((ret & O_APPEND) != 0)
-    buf->fs_flags |= __WASI_FDFLAG_APPEND;
+    if ((ret & O_APPEND) != 0)
+        buf->fs_flags |= __WASI_FDFLAG_APPEND;
 #ifdef O_DSYNC
-  if ((ret & O_DSYNC) != 0)
-    buf->fs_flags |= __WASI_FDFLAG_DSYNC;
+    if ((ret & O_DSYNC) != 0)
+        buf->fs_flags |= __WASI_FDFLAG_DSYNC;
 #endif
-  if ((ret & O_NONBLOCK) != 0)
-    buf->fs_flags |= __WASI_FDFLAG_NONBLOCK;
+    if ((ret & O_NONBLOCK) != 0)
+        buf->fs_flags |= __WASI_FDFLAG_NONBLOCK;
 #ifdef O_RSYNC
-  if ((ret & O_RSYNC) != 0)
-    buf->fs_flags |= __WASI_FDFLAG_RSYNC;
+    if ((ret & O_RSYNC) != 0)
+        buf->fs_flags |= __WASI_FDFLAG_RSYNC;
 #endif
-  if ((ret & O_SYNC) != 0)
-    buf->fs_flags |= __WASI_FDFLAG_SYNC;
-  return 0;
+    if ((ret & O_SYNC) != 0)
+        buf->fs_flags |= __WASI_FDFLAG_SYNC;
+    return 0;
 }
 
-__wasi_errno_t wasmtime_ssp_fd_fdstat_set_flags(
+__wasi_errno_t
+wasmtime_ssp_fd_fdstat_set_flags(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t fd,
-    __wasi_fdflags_t fs_flags
-) {
-  int noflags = 0;
-  if ((fs_flags & __WASI_FDFLAG_APPEND) != 0)
-    noflags |= O_APPEND;
-  if ((fs_flags & __WASI_FDFLAG_DSYNC) != 0)
+    __wasi_fd_t fd, __wasi_fdflags_t fs_flags)
+{
+    int noflags = 0;
+    if ((fs_flags & __WASI_FDFLAG_APPEND) != 0)
+        noflags |= O_APPEND;
+    if ((fs_flags & __WASI_FDFLAG_DSYNC) != 0)
 #ifdef O_DSYNC
-    noflags |= O_DSYNC;
+        noflags |= O_DSYNC;
 #else
-    noflags |= O_SYNC;
+        noflags |= O_SYNC;
 #endif
-  if ((fs_flags & __WASI_FDFLAG_NONBLOCK) != 0)
-    noflags |= O_NONBLOCK;
-  if ((fs_flags & __WASI_FDFLAG_RSYNC) != 0)
+    if ((fs_flags & __WASI_FDFLAG_NONBLOCK) != 0)
+        noflags |= O_NONBLOCK;
+    if ((fs_flags & __WASI_FDFLAG_RSYNC) != 0)
 #ifdef O_RSYNC
-    noflags |= O_RSYNC;
+        noflags |= O_RSYNC;
 #else
-    noflags |= O_SYNC;
+        noflags |= O_SYNC;
 #endif
-  if ((fs_flags & __WASI_FDFLAG_SYNC) != 0)
-    noflags |= O_SYNC;
+    if ((fs_flags & __WASI_FDFLAG_SYNC) != 0)
+        noflags |= O_SYNC;
 
-  struct fd_object *fo;
-  __wasi_errno_t error =
-      fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_FDSTAT_SET_FLAGS, 0);
-  if (error != 0)
-    return error;
+    struct fd_object *fo;
+    __wasi_errno_t error =
+        fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_FDSTAT_SET_FLAGS, 0);
+    if (error != 0)
+        return error;
 
-  int ret = fcntl(fd_number(fo), F_SETFL, noflags);
-  fd_object_release(fo);
-  if (ret < 0)
-    return convert_errno(errno);
-  return 0;
+    int ret = fcntl(fd_number(fo), F_SETFL, noflags);
+    fd_object_release(fo);
+    if (ret < 0)
+        return convert_errno(errno);
+    return 0;
 }
 
-__wasi_errno_t wasmtime_ssp_fd_fdstat_set_rights(
+__wasi_errno_t
+wasmtime_ssp_fd_fdstat_set_rights(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t fd,
-    __wasi_rights_t fs_rights_base,
-    __wasi_rights_t fs_rights_inheriting
-) {
-  struct fd_table *ft = curfds;
-  rwlock_wrlock(&ft->lock);
-  struct fd_entry *fe;
-  __wasi_errno_t error =
-      fd_table_get_entry(ft, fd, fs_rights_base, fs_rights_inheriting, &fe);
-  if (error != 0) {
+    __wasi_fd_t fd, __wasi_rights_t fs_rights_base,
+    __wasi_rights_t fs_rights_inheriting)
+{
+    struct fd_table *ft = curfds;
+    rwlock_wrlock(&ft->lock);
+    struct fd_entry *fe;
+    __wasi_errno_t error =
+        fd_table_get_entry(ft, fd, fs_rights_base, fs_rights_inheriting, &fe);
+    if (error != 0) {
+        rwlock_unlock(&ft->lock);
+        return error;
+    }
+
+    // Restrict the rights on the file descriptor.
+    fe->rights_base = fs_rights_base;
+    fe->rights_inheriting = fs_rights_inheriting;
     rwlock_unlock(&ft->lock);
-    return error;
-  }
-
-  // Restrict the rights on the file descriptor.
-  fe->rights_base = fs_rights_base;
-  fe->rights_inheriting = fs_rights_inheriting;
-  rwlock_unlock(&ft->lock);
-  return 0;
+    return 0;
 }
 
-__wasi_errno_t wasmtime_ssp_fd_sync(
+__wasi_errno_t
+wasmtime_ssp_fd_sync(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t fd
-) {
-  struct fd_object *fo;
-  __wasi_errno_t error = fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_SYNC, 0);
-  if (error != 0)
-    return error;
+    __wasi_fd_t fd)
+{
+    struct fd_object *fo;
+    __wasi_errno_t error =
+        fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_SYNC, 0);
+    if (error != 0)
+        return error;
 
-  int ret = fsync(fd_number(fo));
-  fd_object_release(fo);
-  if (ret < 0)
-    return convert_errno(errno);
-  return 0;
+    int ret = fsync(fd_number(fo));
+    fd_object_release(fo);
+    if (ret < 0)
+        return convert_errno(errno);
+    return 0;
 }
 
-__wasi_errno_t wasmtime_ssp_fd_write(
+__wasi_errno_t
+wasmtime_ssp_fd_write(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t fd,
-    const __wasi_ciovec_t *iov,
-    size_t iovcnt,
-    size_t *nwritten
-) {
-  struct fd_object *fo;
-  __wasi_errno_t error = fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_WRITE, 0);
-  if (error != 0)
-    return error;
+    __wasi_fd_t fd, const __wasi_ciovec_t *iov, size_t iovcnt, size_t *nwritten)
+{
+    struct fd_object *fo;
+    __wasi_errno_t error =
+        fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_WRITE, 0);
+    if (error != 0)
+        return error;
 
 #ifndef BH_VPRINTF
-  ssize_t len = writev(fd_number(fo), (const struct iovec *)iov, (int)iovcnt);
+    ssize_t len = writev(fd_number(fo), (const struct iovec *)iov, (int)iovcnt);
 #else
-  ssize_t len = 0;
-  /* redirect stdout/stderr output to BH_VPRINTF function */
-  if (fd_number(fo) == 1 || fd_number(fo) == 2) {
-    int i;
-    const struct iovec *iov1 = (const struct iovec *)iov;
+    ssize_t len = 0;
+    /* redirect stdout/stderr output to BH_VPRINTF function */
+    if (fd_number(fo) == 1 || fd_number(fo) == 2) {
+        int i;
+        const struct iovec *iov1 = (const struct iovec *)iov;
 
-    for (i = 0; i < (int)iovcnt; i++, iov1++) {
-      if (iov1->iov_len > 0 && iov1->iov_base) {
-        char format[16];
+        for (i = 0; i < (int)iovcnt; i++, iov1++) {
+            if (iov1->iov_len > 0 && iov1->iov_base) {
+                char format[16];
 
-        /* make up format string "%.ns" */
-        snprintf(format, sizeof(format), "%%.%ds", (int)iov1->iov_len);
-        len += (ssize_t)os_printf(format, iov1->iov_base);
-      }
+                /* make up format string "%.ns" */
+                snprintf(format, sizeof(format), "%%.%ds", (int)iov1->iov_len);
+                len += (ssize_t)os_printf(format, iov1->iov_base);
+            }
+        }
     }
-  }
-  else {
-    len = writev(fd_number(fo), (const struct iovec *)iov, (int)iovcnt);
-  }
+    else {
+        len = writev(fd_number(fo), (const struct iovec *)iov, (int)iovcnt);
+    }
 #endif /* end of BH_VPRINTF */
-  fd_object_release(fo);
-  if (len < 0)
-    return convert_errno(errno);
-  *nwritten = (size_t)len;
-  return 0;
+    fd_object_release(fo);
+    if (len < 0)
+        return convert_errno(errno);
+    *nwritten = (size_t)len;
+    return 0;
 }
 
-__wasi_errno_t wasmtime_ssp_fd_advise(
+__wasi_errno_t
+wasmtime_ssp_fd_advise(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t fd,
-    __wasi_filesize_t offset,
-    __wasi_filesize_t len,
-    __wasi_advice_t advice
-) {
+    __wasi_fd_t fd, __wasi_filesize_t offset, __wasi_filesize_t len,
+    __wasi_advice_t advice)
+{
 #ifdef POSIX_FADV_NORMAL
-  int nadvice;
-  switch (advice) {
-    case __WASI_ADVICE_DONTNEED:
-      nadvice = POSIX_FADV_DONTNEED;
-      break;
-    case __WASI_ADVICE_NOREUSE:
-      nadvice = POSIX_FADV_NOREUSE;
-      break;
-    case __WASI_ADVICE_NORMAL:
-      nadvice = POSIX_FADV_NORMAL;
-      break;
-    case __WASI_ADVICE_RANDOM:
-      nadvice = POSIX_FADV_RANDOM;
-      break;
-    case __WASI_ADVICE_SEQUENTIAL:
-      nadvice = POSIX_FADV_SEQUENTIAL;
-      break;
-    case __WASI_ADVICE_WILLNEED:
-      nadvice = POSIX_FADV_WILLNEED;
-      break;
-    default:
-      return __WASI_EINVAL;
-  }
+    int nadvice;
+    switch (advice) {
+        case __WASI_ADVICE_DONTNEED:
+            nadvice = POSIX_FADV_DONTNEED;
+            break;
+        case __WASI_ADVICE_NOREUSE:
+            nadvice = POSIX_FADV_NOREUSE;
+            break;
+        case __WASI_ADVICE_NORMAL:
+            nadvice = POSIX_FADV_NORMAL;
+            break;
+        case __WASI_ADVICE_RANDOM:
+            nadvice = POSIX_FADV_RANDOM;
+            break;
+        case __WASI_ADVICE_SEQUENTIAL:
+            nadvice = POSIX_FADV_SEQUENTIAL;
+            break;
+        case __WASI_ADVICE_WILLNEED:
+            nadvice = POSIX_FADV_WILLNEED;
+            break;
+        default:
+            return __WASI_EINVAL;
+    }
 
-  struct fd_object *fo;
-  __wasi_errno_t error =
-      fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_ADVISE, 0);
-  if (error != 0)
-    return error;
+    struct fd_object *fo;
+    __wasi_errno_t error =
+        fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_ADVISE, 0);
+    if (error != 0)
+        return error;
 
-  int ret = posix_fadvise(fd_number(fo), (off_t)offset, (off_t)len, nadvice);
-  fd_object_release(fo);
-  if (ret != 0)
-    return convert_errno(ret);
-  return 0;
+    int ret = posix_fadvise(fd_number(fo), (off_t)offset, (off_t)len, nadvice);
+    fd_object_release(fo);
+    if (ret != 0)
+        return convert_errno(ret);
+    return 0;
 #else
-  // Advisory information can safely be ignored if unsupported.
-  switch (advice) {
-    case __WASI_ADVICE_DONTNEED:
-    case __WASI_ADVICE_NOREUSE:
-    case __WASI_ADVICE_NORMAL:
-    case __WASI_ADVICE_RANDOM:
-    case __WASI_ADVICE_SEQUENTIAL:
-    case __WASI_ADVICE_WILLNEED:
-      break;
-    default:
-      return __WASI_EINVAL;
-  }
+    // Advisory information can safely be ignored if unsupported.
+    switch (advice) {
+        case __WASI_ADVICE_DONTNEED:
+        case __WASI_ADVICE_NOREUSE:
+        case __WASI_ADVICE_NORMAL:
+        case __WASI_ADVICE_RANDOM:
+        case __WASI_ADVICE_SEQUENTIAL:
+        case __WASI_ADVICE_WILLNEED:
+            break;
+        default:
+            return __WASI_EINVAL;
+    }
 
-  // At least check for file descriptor existence.
-  struct fd_table *ft = curfds;
-  rwlock_rdlock(&ft->lock);
-  struct fd_entry *fe;
-  __wasi_errno_t error =
-      fd_table_get_entry(ft, fd, __WASI_RIGHT_FD_ADVISE, 0, &fe);
-  rwlock_unlock(&ft->lock);
-  return error;
+    // At least check for file descriptor existence.
+    struct fd_table *ft = curfds;
+    rwlock_rdlock(&ft->lock);
+    struct fd_entry *fe;
+    __wasi_errno_t error =
+        fd_table_get_entry(ft, fd, __WASI_RIGHT_FD_ADVISE, 0, &fe);
+    rwlock_unlock(&ft->lock);
+    return error;
 #endif
 }
 
-__wasi_errno_t wasmtime_ssp_fd_allocate(
+__wasi_errno_t
+wasmtime_ssp_fd_allocate(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t fd,
-    __wasi_filesize_t offset,
-    __wasi_filesize_t len
-) {
-  struct fd_object *fo;
-  __wasi_errno_t error =
-      fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_ALLOCATE, 0);
-  if (error != 0)
-    return error;
+    __wasi_fd_t fd, __wasi_filesize_t offset, __wasi_filesize_t len)
+{
+    struct fd_object *fo;
+    __wasi_errno_t error =
+        fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_ALLOCATE, 0);
+    if (error != 0)
+        return error;
 
 #if CONFIG_HAS_POSIX_FALLOCATE
-  int ret = posix_fallocate(fd_number(fo), (off_t)offset, (off_t)len);
+    int ret = posix_fallocate(fd_number(fo), (off_t)offset, (off_t)len);
 #else
-  // At least ensure that the file is grown to the right size.
-  // TODO(ed): See if this can somehow be implemented without any race
-  // conditions. We may end up shrinking the file right now.
-  struct stat sb;
-  int ret = fstat(fd_number(fo), &sb);
-  if (ret == 0 && sb.st_size < offset + len)
-    ret = ftruncate(fd_number(fo), offset + len);
+    // At least ensure that the file is grown to the right size.
+    // TODO(ed): See if this can somehow be implemented without any race
+    // conditions. We may end up shrinking the file right now.
+    struct stat sb;
+    int ret = fstat(fd_number(fo), &sb);
+    if (ret == 0 && sb.st_size < offset + len)
+        ret = ftruncate(fd_number(fo), offset + len);
 #endif
 
-  fd_object_release(fo);
-  if (ret != 0)
-    return convert_errno(ret);
-  return 0;
+    fd_object_release(fo);
+    if (ret != 0)
+        return convert_errno(ret);
+    return 0;
 }
 
 // Reads the entire contents of a symbolic link, returning the contents
 // in an allocated buffer. The allocated buffer is large enough to fit
 // at least one extra byte, so the caller may append a trailing slash to
 // it. This is needed by path_get().
-static char *readlinkat_dup(
-    int fd,
-    const char *path,
-    size_t *p_len
-) {
-  char *buf = NULL;
-  size_t len = 32;
-  size_t len_org = len;
+static char *
+readlinkat_dup(int fd, const char *path, size_t *p_len)
+{
+    char *buf = NULL;
+    size_t len = 32;
+    size_t len_org = len;
 
-  for (;;) {
-    char *newbuf = wasm_runtime_malloc((uint32)len);
+    for (;;) {
+        char *newbuf = wasm_runtime_malloc((uint32)len);
 
-    if (newbuf == NULL) {
-      if (buf)
-        wasm_runtime_free(buf);
-      return NULL;
-    }
+        if (newbuf == NULL) {
+            if (buf)
+                wasm_runtime_free(buf);
+            return NULL;
+        }
 
-    if (buf != NULL) {
-      bh_memcpy_s(newbuf, (uint32)len, buf, (uint32)len_org);
-      wasm_runtime_free(buf);
-    }
+        if (buf != NULL) {
+            bh_memcpy_s(newbuf, (uint32)len, buf, (uint32)len_org);
+            wasm_runtime_free(buf);
+        }
 
-    buf = newbuf;
-    ssize_t ret = readlinkat(fd, path, buf, len);
-    if (ret < 0) {
-      wasm_runtime_free(buf);
-      return NULL;
+        buf = newbuf;
+        ssize_t ret = readlinkat(fd, path, buf, len);
+        if (ret < 0) {
+            wasm_runtime_free(buf);
+            return NULL;
+        }
+        if ((size_t)ret + 1 < len) {
+            buf[ret] = '\0';
+            *p_len = len;
+            return buf;
+        }
+        len_org = len;
+        len *= 2;
     }
-    if ((size_t)ret + 1 < len) {
-      buf[ret] = '\0';
-      *p_len = len;
-      return buf;
-    }
-    len_org = len;
-    len *= 2;
-  }
 }
 
 // Lease to a directory, so a path underneath it can be accessed.
@@ -1419,288 +1413,286 @@ static char *readlinkat_dup(
 // descriptor representing the directory where the lookup needs to start
 // and the actual pathname string.
 struct path_access {
-  int fd;                       // Directory file descriptor.
-  const char *path;             // Pathname.
-  bool follow;                  // Whether symbolic links should be followed.
-  char *path_start;             // Internal: pathname to free.
-  struct fd_object *fd_object;  // Internal: directory file descriptor object.
+    int fd;                      // Directory file descriptor.
+    const char *path;            // Pathname.
+    bool follow;                 // Whether symbolic links should be followed.
+    char *path_start;            // Internal: pathname to free.
+    struct fd_object *fd_object; // Internal: directory file descriptor object.
 };
 
 // Creates a lease to a file descriptor and pathname pair. If the
 // operating system does not implement Capsicum, it also normalizes the
 // pathname to ensure the target path is placed underneath the
 // directory.
-static __wasi_errno_t path_get(
-    struct fd_table *curfds,
-    struct path_access *pa,
-    __wasi_fd_t fd,
-    __wasi_lookupflags_t flags,
-    const char *upath,
-    size_t upathlen,
-    __wasi_rights_t rights_base,
-    __wasi_rights_t rights_inheriting,
-    bool needs_final_component
-) TRYLOCKS_EXCLUSIVE(0, pa->fd_object->refcount) {
-  char *path = str_nullterminate(upath, upathlen);
-  if (path == NULL)
-    return convert_errno(errno);
+static __wasi_errno_t
+path_get(struct fd_table *curfds, struct path_access *pa, __wasi_fd_t fd,
+         __wasi_lookupflags_t flags, const char *upath, size_t upathlen,
+         __wasi_rights_t rights_base, __wasi_rights_t rights_inheriting,
+         bool needs_final_component)
+    TRYLOCKS_EXCLUSIVE(0, pa->fd_object->refcount)
+{
+    char *path = str_nullterminate(upath, upathlen);
+    if (path == NULL)
+        return convert_errno(errno);
 
-  // Fetch the directory file descriptor.
-  struct fd_object *fo;
-  __wasi_errno_t error =
-      fd_object_get(curfds, &fo, fd, rights_base, rights_inheriting);
-  if (error != 0) {
-    wasm_runtime_free(path);
-    return error;
-  }
+    // Fetch the directory file descriptor.
+    struct fd_object *fo;
+    __wasi_errno_t error =
+        fd_object_get(curfds, &fo, fd, rights_base, rights_inheriting);
+    if (error != 0) {
+        wasm_runtime_free(path);
+        return error;
+    }
 
 #if CONFIG_HAS_CAP_ENTER
-  // Rely on the kernel to constrain access to automatically constrain
-  // access to files stored underneath this directory.
-  pa->fd = fd_number(fo);
-  pa->path = pa->path_start = path;
-  pa->follow = (flags & __WASI_LOOKUP_SYMLINK_FOLLOW) != 0;
-  pa->fd_object = fo;
-  return 0;
+    // Rely on the kernel to constrain access to automatically constrain
+    // access to files stored underneath this directory.
+    pa->fd = fd_number(fo);
+    pa->path = pa->path_start = path;
+    pa->follow = (flags & __WASI_LOOKUP_SYMLINK_FOLLOW) != 0;
+    pa->fd_object = fo;
+    return 0;
 #else
-  // The implementation provides no mechanism to constrain lookups to a
-  // directory automatically. Emulate this logic by resolving the
-  // pathname manually.
+    // The implementation provides no mechanism to constrain lookups to a
+    // directory automatically. Emulate this logic by resolving the
+    // pathname manually.
 
-  // Stack of directory file descriptors. Index 0 always corresponds
-  // with the directory provided to this function. Entering a directory
-  // causes a file descriptor to be pushed, while handling ".." entries
-  // causes an entry to be popped. Index 0 cannot be popped, as this
-  // would imply escaping the base directory.
-  int fds[128];
-  fds[0] = fd_number(fo);
-  size_t curfd = 0;
+    // Stack of directory file descriptors. Index 0 always corresponds
+    // with the directory provided to this function. Entering a directory
+    // causes a file descriptor to be pushed, while handling ".." entries
+    // causes an entry to be popped. Index 0 cannot be popped, as this
+    // would imply escaping the base directory.
+    int fds[128];
+    fds[0] = fd_number(fo);
+    size_t curfd = 0;
 
-  // Stack of pathname strings used for symlink expansion. By using a
-  // stack, there is no need to concatenate any pathname strings while
-  // expanding symlinks.
-  char *paths[32];
-  char *paths_start[32];
-  paths[0] = paths_start[0] = path;
-  size_t curpath = 0;
-  size_t expansions = 0;
-  char *symlink;
-  size_t symlink_len;
+    // Stack of pathname strings used for symlink expansion. By using a
+    // stack, there is no need to concatenate any pathname strings while
+    // expanding symlinks.
+    char *paths[32];
+    char *paths_start[32];
+    paths[0] = paths_start[0] = path;
+    size_t curpath = 0;
+    size_t expansions = 0;
+    char *symlink;
+    size_t symlink_len;
 
-  for (;;) {
-    // Extract the next pathname component from 'paths[curpath]', null
-    // terminate it and store it in 'file'. 'ends_with_slashes' stores
-    // whether the pathname component is followed by one or more
-    // trailing slashes, as this requires it to be a directory.
-    char *file = paths[curpath];
-    char *file_end = file + strcspn(file, "/");
-    paths[curpath] = file_end + strspn(file_end, "/");
-    bool ends_with_slashes = *file_end == '/';
-    *file_end = '\0';
+    for (;;) {
+        // Extract the next pathname component from 'paths[curpath]', null
+        // terminate it and store it in 'file'. 'ends_with_slashes' stores
+        // whether the pathname component is followed by one or more
+        // trailing slashes, as this requires it to be a directory.
+        char *file = paths[curpath];
+        char *file_end = file + strcspn(file, "/");
+        paths[curpath] = file_end + strspn(file_end, "/");
+        bool ends_with_slashes = *file_end == '/';
+        *file_end = '\0';
 
-    // Test for empty pathname strings and absolute paths.
-    if (file == file_end) {
-      error = ends_with_slashes ? __WASI_ENOTCAPABLE : __WASI_ENOENT;
-      goto fail;
-    }
+        // Test for empty pathname strings and absolute paths.
+        if (file == file_end) {
+            error = ends_with_slashes ? __WASI_ENOTCAPABLE : __WASI_ENOENT;
+            goto fail;
+        }
 
-    if (strcmp(file, ".") == 0) {
-      // Skip component.
-    } else if (strcmp(file, "..") == 0) {
-      // Pop a directory off the stack.
-      if (curfd == 0) {
-        // Attempted to go to parent directory of the directory file
-        // descriptor.
-        error = __WASI_ENOTCAPABLE;
-        goto fail;
-      }
-      close(fds[curfd--]);
-    } else if (curpath > 0 || *paths[curpath] != '\0' ||
-               (ends_with_slashes && !needs_final_component)) {
-      // A pathname component whose name we're not interested in that is
-      // followed by a slash or is followed by other pathname
-      // components. In other words, a pathname component that must be a
-      // directory. First attempt to obtain a directory file descriptor
-      // for it.
-      int newdir =
+        if (strcmp(file, ".") == 0) {
+            // Skip component.
+        }
+        else if (strcmp(file, "..") == 0) {
+            // Pop a directory off the stack.
+            if (curfd == 0) {
+                // Attempted to go to parent directory of the directory file
+                // descriptor.
+                error = __WASI_ENOTCAPABLE;
+                goto fail;
+            }
+            close(fds[curfd--]);
+        }
+        else if (curpath > 0 || *paths[curpath] != '\0'
+                 || (ends_with_slashes && !needs_final_component)) {
+            // A pathname component whose name we're not interested in that is
+            // followed by a slash or is followed by other pathname
+            // components. In other words, a pathname component that must be a
+            // directory. First attempt to obtain a directory file descriptor
+            // for it.
+            int newdir =
 #ifdef O_SEARCH
-          openat(fds[curfd], file, O_SEARCH | O_DIRECTORY | O_NOFOLLOW);
+                openat(fds[curfd], file, O_SEARCH | O_DIRECTORY | O_NOFOLLOW);
 #else
-          openat(fds[curfd], file, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+                openat(fds[curfd], file, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
 #endif
-      if (newdir != -1) {
-        // Success. Push it onto the directory stack.
-        if (curfd + 1 == sizeof(fds) / sizeof(fds[0])) {
-          close(newdir);
-          error = __WASI_ENAMETOOLONG;
-          goto fail;
+            if (newdir != -1) {
+                // Success. Push it onto the directory stack.
+                if (curfd + 1 == sizeof(fds) / sizeof(fds[0])) {
+                    close(newdir);
+                    error = __WASI_ENAMETOOLONG;
+                    goto fail;
+                }
+                fds[++curfd] = newdir;
+            }
+            else {
+                // Failed to open it. Attempt symlink expansion.
+                if (errno != ELOOP && errno != EMLINK && errno != ENOTDIR) {
+                    error = convert_errno(errno);
+                    goto fail;
+                }
+                symlink = readlinkat_dup(fds[curfd], file, &symlink_len);
+                if (symlink != NULL)
+                    goto push_symlink;
+
+                // readlink returns EINVAL if the path isn't a symlink. In that
+                // case, it's more informative to return ENOTDIR.
+                if (errno == EINVAL)
+                    errno = ENOTDIR;
+
+                error = convert_errno(errno);
+                goto fail;
+            }
         }
-        fds[++curfd] = newdir;
-      } else {
-        // Failed to open it. Attempt symlink expansion.
-        if (errno != ELOOP && errno != EMLINK && errno != ENOTDIR) {
-          error = convert_errno(errno);
-          goto fail;
+        else {
+            // The final pathname component. Depending on whether it ends with
+            // a slash or the symlink-follow flag is set, perform symlink
+            // expansion.
+            if (ends_with_slashes
+                || (flags & __WASI_LOOKUP_SYMLINK_FOLLOW) != 0) {
+                symlink = readlinkat_dup(fds[curfd], file, &symlink_len);
+                if (symlink != NULL)
+                    goto push_symlink;
+                if (errno != EINVAL && errno != ENOENT) {
+                    error = convert_errno(errno);
+                    goto fail;
+                }
+            }
+
+            // Not a symlink, meaning we're done. Return the filename,
+            // together with the directory containing this file.
+            //
+            // If the file was followed by a trailing slash, we must retain
+            // it, to ensure system calls properly return ENOTDIR.
+            // Unfortunately, this opens up a race condition, because this
+            // means that users of path_get() will perform symlink expansion a
+            // second time. There is nothing we can do to mitigate this, as
+            // far as I know.
+            if (ends_with_slashes)
+                *file_end = '/';
+            pa->path = file;
+            pa->path_start = paths_start[0];
+            goto success;
         }
-        symlink = readlinkat_dup(fds[curfd], file, &symlink_len);
-        if (symlink != NULL)
-          goto push_symlink;
 
-        // readlink returns EINVAL if the path isn't a symlink. In that case,
-        // it's more informative to return ENOTDIR.
-        if (errno == EINVAL)
-          errno = ENOTDIR;
+        if (*paths[curpath] == '\0') {
+            if (curpath == 0) {
+                // No further pathname components to process. We may end up here
+                // when called on paths like ".", "a/..", but also if the path
+                // had trailing slashes and the caller is not interested in the
+                // name of the pathname component.
+                wasm_runtime_free(paths_start[0]);
+                pa->path = ".";
+                pa->path_start = NULL;
+                goto success;
+            }
 
-        error = convert_errno(errno);
-        goto fail;
-      }
-    } else {
-      // The final pathname component. Depending on whether it ends with
-      // a slash or the symlink-follow flag is set, perform symlink
-      // expansion.
-      if (ends_with_slashes ||
-          (flags & __WASI_LOOKUP_SYMLINK_FOLLOW) != 0) {
-        symlink = readlinkat_dup(fds[curfd], file, &symlink_len);
-        if (symlink != NULL)
-          goto push_symlink;
-        if (errno != EINVAL && errno != ENOENT) {
-          error = convert_errno(errno);
-          goto fail;
+            // Finished expanding symlink. Continue processing along the
+            // original path.
+            wasm_runtime_free(paths_start[curpath--]);
         }
-      }
+        continue;
 
-      // Not a symlink, meaning we're done. Return the filename,
-      // together with the directory containing this file.
-      //
-      // If the file was followed by a trailing slash, we must retain
-      // it, to ensure system calls properly return ENOTDIR.
-      // Unfortunately, this opens up a race condition, because this
-      // means that users of path_get() will perform symlink expansion a
-      // second time. There is nothing we can do to mitigate this, as
-      // far as I know.
-      if (ends_with_slashes)
-        *file_end = '/';
-      pa->path = file;
-      pa->path_start = paths_start[0];
-      goto success;
+    push_symlink:
+        // Prevent infinite loops by placing an upper limit on the number of
+        // symlink expansions.
+        if (++expansions == 128) {
+            wasm_runtime_free(symlink);
+            error = __WASI_ELOOP;
+            goto fail;
+        }
+
+        if (*paths[curpath] == '\0') {
+            // The original path already finished processing. Replace it by
+            // this symlink entirely.
+            wasm_runtime_free(paths_start[curpath]);
+        }
+        else if (curpath + 1 == sizeof(paths) / sizeof(paths[0])) {
+            // Too many nested symlinks. Stop processing.
+            wasm_runtime_free(symlink);
+            error = __WASI_ELOOP;
+            goto fail;
+        }
+        else {
+            // The original path still has components left. Retain the
+            // components that remain, so we can process them afterwards.
+            ++curpath;
+        }
+
+        // Append a trailing slash to the symlink if the path leading up to
+        // it also contained one. Otherwise we would not throw ENOTDIR if
+        // the target is not a directory.
+        if (ends_with_slashes)
+            bh_strcat_s(symlink, (uint32)symlink_len, "/");
+        paths[curpath] = paths_start[curpath] = symlink;
     }
-
-    if (*paths[curpath] == '\0') {
-      if (curpath == 0) {
-        // No further pathname components to process. We may end up here
-        // when called on paths like ".", "a/..", but also if the path
-        // had trailing slashes and the caller is not interested in the
-        // name of the pathname component.
-        wasm_runtime_free(paths_start[0]);
-        pa->path = ".";
-        pa->path_start = NULL;
-        goto success;
-      }
-
-      // Finished expanding symlink. Continue processing along the
-      // original path.
-      wasm_runtime_free(paths_start[curpath--]);
-    }
-    continue;
-
-  push_symlink:
-    // Prevent infinite loops by placing an upper limit on the number of
-    // symlink expansions.
-    if (++expansions == 128) {
-      wasm_runtime_free(symlink);
-      error = __WASI_ELOOP;
-      goto fail;
-    }
-
-    if (*paths[curpath] == '\0') {
-      // The original path already finished processing. Replace it by
-      // this symlink entirely.
-      wasm_runtime_free(paths_start[curpath]);
-    } else if (curpath + 1 == sizeof(paths) / sizeof(paths[0])) {
-      // Too many nested symlinks. Stop processing.
-      wasm_runtime_free(symlink);
-      error = __WASI_ELOOP;
-      goto fail;
-    } else {
-      // The original path still has components left. Retain the
-      // components that remain, so we can process them afterwards.
-      ++curpath;
-    }
-
-    // Append a trailing slash to the symlink if the path leading up to
-    // it also contained one. Otherwise we would not throw ENOTDIR if
-    // the target is not a directory.
-    if (ends_with_slashes)
-      bh_strcat_s(symlink, (uint32)symlink_len, "/");
-    paths[curpath] = paths_start[curpath] = symlink;
-  }
 
 success:
-  // Return the lease. Close all directories, except the one the caller
-  // needs to use.
-  for (size_t i = 1; i < curfd; ++i)
-    close(fds[i]);
-  pa->fd = fds[curfd];
-  pa->follow = false;
-  pa->fd_object = fo;
-  return 0;
+    // Return the lease. Close all directories, except the one the caller
+    // needs to use.
+    for (size_t i = 1; i < curfd; ++i)
+        close(fds[i]);
+    pa->fd = fds[curfd];
+    pa->follow = false;
+    pa->fd_object = fo;
+    return 0;
 
 fail:
-  // Failure. Free all resources.
-  for (size_t i = 1; i <= curfd; ++i)
-    close(fds[i]);
-  for (size_t i = 0; i <= curpath; ++i)
-    wasm_runtime_free(paths_start[i]);
-  fd_object_release(fo);
-  return error;
+    // Failure. Free all resources.
+    for (size_t i = 1; i <= curfd; ++i)
+        close(fds[i]);
+    for (size_t i = 0; i <= curpath; ++i)
+        wasm_runtime_free(paths_start[i]);
+    fd_object_release(fo);
+    return error;
 #endif
 }
 
-static __wasi_errno_t path_get_nofollow(
-    struct fd_table *curfds,
-    struct path_access *pa,
-    __wasi_fd_t fd,
-    const char *path,
-    size_t pathlen,
-    __wasi_rights_t rights_base,
-    __wasi_rights_t rights_inheriting,
-    bool needs_final_component
-) TRYLOCKS_EXCLUSIVE(0, pa->fd_object->refcount) {
-  __wasi_lookupflags_t flags = 0;
-  return path_get(curfds, pa, fd, flags, path, pathlen, rights_base, rights_inheriting,
-                  needs_final_component);
+static __wasi_errno_t
+path_get_nofollow(struct fd_table *curfds, struct path_access *pa,
+                  __wasi_fd_t fd, const char *path, size_t pathlen,
+                  __wasi_rights_t rights_base,
+                  __wasi_rights_t rights_inheriting, bool needs_final_component)
+    TRYLOCKS_EXCLUSIVE(0, pa->fd_object->refcount)
+{
+    __wasi_lookupflags_t flags = 0;
+    return path_get(curfds, pa, fd, flags, path, pathlen, rights_base,
+                    rights_inheriting, needs_final_component);
 }
 
-static void path_put(
-    struct path_access *pa
-) UNLOCKS(pa->fd_object->refcount) {
-  if (pa->path_start)
-    wasm_runtime_free(pa->path_start);
-  if (fd_number(pa->fd_object) != pa->fd)
-    close(pa->fd);
-  fd_object_release(pa->fd_object);
+static void
+path_put(struct path_access *pa) UNLOCKS(pa->fd_object->refcount)
+{
+    if (pa->path_start)
+        wasm_runtime_free(pa->path_start);
+    if (fd_number(pa->fd_object) != pa->fd)
+        close(pa->fd);
+    fd_object_release(pa->fd_object);
 }
 
-__wasi_errno_t wasmtime_ssp_path_create_directory(
+__wasi_errno_t
+wasmtime_ssp_path_create_directory(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t fd,
-    const char *path,
-    size_t pathlen
-) {
-  struct path_access pa;
-  __wasi_errno_t error =
-      path_get_nofollow(curfds, &pa, fd, path, pathlen,
-                        __WASI_RIGHT_PATH_CREATE_DIRECTORY, 0, true);
-  if (error != 0)
-    return error;
+    __wasi_fd_t fd, const char *path, size_t pathlen)
+{
+    struct path_access pa;
+    __wasi_errno_t error =
+        path_get_nofollow(curfds, &pa, fd, path, pathlen,
+                          __WASI_RIGHT_PATH_CREATE_DIRECTORY, 0, true);
+    if (error != 0)
+        return error;
 
-  int ret = mkdirat(pa.fd, pa.path, 0777);
-  path_put(&pa);
-  if (ret < 0)
-    return convert_errno(errno);
-  return 0;
+    int ret = mkdirat(pa.fd, pa.path, 0777);
+    path_put(&pa);
+    if (ret < 0)
+        return convert_errno(errno);
+    return 0;
 }
 
 static bool
@@ -1719,8 +1711,8 @@ validate_path(const char *path, struct fd_prestats *pt)
 
     for (i = 0; i < pt->size; i++) {
         if (pt->prestats[i].dir) {
-            if (!(prestat_dir_real = realpath(pt->prestats[i].dir,
-                                              prestat_dir_resolved)))
+            if (!(prestat_dir_real =
+                      realpath(pt->prestats[i].dir, prestat_dir_resolved)))
                 return false;
             if (!strncmp(path_real, prestat_dir_real, strlen(prestat_dir_real)))
                 return true;
@@ -1730,939 +1722,945 @@ validate_path(const char *path, struct fd_prestats *pt)
     return false;
 }
 
-__wasi_errno_t wasmtime_ssp_path_link(
+__wasi_errno_t
+wasmtime_ssp_path_link(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
-    struct fd_table *curfds,
-    struct fd_prestats *prestats,
+    struct fd_table *curfds, struct fd_prestats *prestats,
 #endif
-    __wasi_fd_t old_fd,
-    __wasi_lookupflags_t old_flags,
-    const char *old_path,
-    size_t old_path_len,
-    __wasi_fd_t new_fd,
-    const char *new_path,
-    size_t new_path_len
-) {
-  struct path_access old_pa;
-  __wasi_errno_t error = path_get(curfds, &old_pa, old_fd, old_flags, old_path, old_path_len,
-                                  __WASI_RIGHT_PATH_LINK_SOURCE, 0, false);
-  if (error != 0)
-    return error;
+    __wasi_fd_t old_fd, __wasi_lookupflags_t old_flags, const char *old_path,
+    size_t old_path_len, __wasi_fd_t new_fd, const char *new_path,
+    size_t new_path_len)
+{
+    struct path_access old_pa;
+    __wasi_errno_t error =
+        path_get(curfds, &old_pa, old_fd, old_flags, old_path, old_path_len,
+                 __WASI_RIGHT_PATH_LINK_SOURCE, 0, false);
+    if (error != 0)
+        return error;
 
-  struct path_access new_pa;
-  error = path_get_nofollow(curfds, &new_pa, new_fd, new_path, new_path_len,
-                            __WASI_RIGHT_PATH_LINK_TARGET, 0, true);
-  if (error != 0) {
-    path_put(&old_pa);
-    return error;
-  }
-
-  rwlock_rdlock(&prestats->lock);
-  if (!validate_path(old_pa.path, prestats)
-      || !validate_path(new_pa.path, prestats)) {
-      rwlock_unlock(&prestats->lock);
-      return __WASI_EBADF;
-  }
-  rwlock_unlock(&prestats->lock);
-
-  int ret = linkat(old_pa.fd, old_pa.path, new_pa.fd, new_pa.path,
-                   old_pa.follow ? AT_SYMLINK_FOLLOW : 0);
-  if (ret < 0 && errno == ENOTSUP && !old_pa.follow) {
-    // OS X doesn't allow creating hardlinks to symbolic links.
-    // Duplicate the symbolic link instead.
-    size_t target_len;
-    char *target = readlinkat_dup(old_pa.fd, old_pa.path, &target_len);
-    if (target != NULL) {
-      bh_assert(target[target_len] == '\0');
-      rwlock_rdlock(&prestats->lock);
-      if (!validate_path(target, prestats)) {
-          rwlock_unlock(&prestats->lock);
-          wasm_runtime_free(target);
-          return __WASI_EBADF;
-      }
-      rwlock_unlock(&prestats->lock);
-      ret = symlinkat(target, new_pa.fd, new_pa.path);
-      wasm_runtime_free(target);
+    struct path_access new_pa;
+    error = path_get_nofollow(curfds, &new_pa, new_fd, new_path, new_path_len,
+                              __WASI_RIGHT_PATH_LINK_TARGET, 0, true);
+    if (error != 0) {
+        path_put(&old_pa);
+        return error;
     }
-  }
-  path_put(&old_pa);
-  path_put(&new_pa);
-  if (ret < 0)
-    return convert_errno(errno);
-  return 0;
+
+    rwlock_rdlock(&prestats->lock);
+    if (!validate_path(old_pa.path, prestats)
+        || !validate_path(new_pa.path, prestats)) {
+        rwlock_unlock(&prestats->lock);
+        return __WASI_EBADF;
+    }
+    rwlock_unlock(&prestats->lock);
+
+    int ret = linkat(old_pa.fd, old_pa.path, new_pa.fd, new_pa.path,
+                     old_pa.follow ? AT_SYMLINK_FOLLOW : 0);
+    if (ret < 0 && errno == ENOTSUP && !old_pa.follow) {
+        // OS X doesn't allow creating hardlinks to symbolic links.
+        // Duplicate the symbolic link instead.
+        size_t target_len;
+        char *target = readlinkat_dup(old_pa.fd, old_pa.path, &target_len);
+        if (target != NULL) {
+            bh_assert(target[target_len] == '\0');
+            rwlock_rdlock(&prestats->lock);
+            if (!validate_path(target, prestats)) {
+                rwlock_unlock(&prestats->lock);
+                wasm_runtime_free(target);
+                return __WASI_EBADF;
+            }
+            rwlock_unlock(&prestats->lock);
+            ret = symlinkat(target, new_pa.fd, new_pa.path);
+            wasm_runtime_free(target);
+        }
+    }
+    path_put(&old_pa);
+    path_put(&new_pa);
+    if (ret < 0)
+        return convert_errno(errno);
+    return 0;
 }
 
-__wasi_errno_t wasmtime_ssp_path_open(
+__wasi_errno_t
+wasmtime_ssp_path_open(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t dirfd,
-    __wasi_lookupflags_t dirflags,
-    const char *path,
-    size_t pathlen,
-    __wasi_oflags_t oflags,
-    __wasi_rights_t fs_rights_base,
-    __wasi_rights_t fs_rights_inheriting,
-    __wasi_fdflags_t fs_flags,
-    __wasi_fd_t *fd
-) {
-  // Rights that should be installed on the new file descriptor.
-  __wasi_rights_t rights_base = fs_rights_base;
-  __wasi_rights_t rights_inheriting = fs_rights_inheriting;
+    __wasi_fd_t dirfd, __wasi_lookupflags_t dirflags, const char *path,
+    size_t pathlen, __wasi_oflags_t oflags, __wasi_rights_t fs_rights_base,
+    __wasi_rights_t fs_rights_inheriting, __wasi_fdflags_t fs_flags,
+    __wasi_fd_t *fd)
+{
+    // Rights that should be installed on the new file descriptor.
+    __wasi_rights_t rights_base = fs_rights_base;
+    __wasi_rights_t rights_inheriting = fs_rights_inheriting;
 
-  // Which open() mode should be used to satisfy the needed rights.
-  bool read =
-      (rights_base & (__WASI_RIGHT_FD_READ | __WASI_RIGHT_FD_READDIR)) != 0;
-  bool write =
-      (rights_base & (__WASI_RIGHT_FD_DATASYNC | __WASI_RIGHT_FD_WRITE |
-                      __WASI_RIGHT_FD_ALLOCATE |
-                      __WASI_RIGHT_FD_FILESTAT_SET_SIZE)) != 0;
-  int noflags = write ? read ? O_RDWR : O_WRONLY : O_RDONLY;
+    // Which open() mode should be used to satisfy the needed rights.
+    bool read =
+        (rights_base & (__WASI_RIGHT_FD_READ | __WASI_RIGHT_FD_READDIR)) != 0;
+    bool write =
+        (rights_base
+         & (__WASI_RIGHT_FD_DATASYNC | __WASI_RIGHT_FD_WRITE
+            | __WASI_RIGHT_FD_ALLOCATE | __WASI_RIGHT_FD_FILESTAT_SET_SIZE))
+        != 0;
+    int noflags = write ? read ? O_RDWR : O_WRONLY : O_RDONLY;
 
-  // Which rights are needed on the directory file descriptor.
-  __wasi_rights_t needed_base = __WASI_RIGHT_PATH_OPEN;
-  __wasi_rights_t needed_inheriting = rights_base | rights_inheriting;
+    // Which rights are needed on the directory file descriptor.
+    __wasi_rights_t needed_base = __WASI_RIGHT_PATH_OPEN;
+    __wasi_rights_t needed_inheriting = rights_base | rights_inheriting;
 
-  // Convert open flags.
-  if ((oflags & __WASI_O_CREAT) != 0) {
-    noflags |= O_CREAT;
-    needed_base |= __WASI_RIGHT_PATH_CREATE_FILE;
-  }
-  if ((oflags & __WASI_O_DIRECTORY) != 0)
-    noflags |= O_DIRECTORY;
-  if ((oflags & __WASI_O_EXCL) != 0)
-    noflags |= O_EXCL;
-  if ((oflags & __WASI_O_TRUNC) != 0) {
-    noflags |= O_TRUNC;
-    needed_base |= __WASI_RIGHT_PATH_FILESTAT_SET_SIZE;
-  }
-
-  // Convert file descriptor flags.
-  if ((fs_flags & __WASI_FDFLAG_APPEND) != 0)
-    noflags |= O_APPEND;
-  if ((fs_flags & __WASI_FDFLAG_DSYNC) != 0) {
-#ifdef O_DSYNC
-    noflags |= O_DSYNC;
-#else
-    noflags |= O_SYNC;
-#endif
-    needed_inheriting |= __WASI_RIGHT_FD_DATASYNC;
-  }
-  if ((fs_flags & __WASI_FDFLAG_NONBLOCK) != 0)
-    noflags |= O_NONBLOCK;
-  if ((fs_flags & __WASI_FDFLAG_RSYNC) != 0) {
-#ifdef O_RSYNC
-    noflags |= O_RSYNC;
-#else
-    noflags |= O_SYNC;
-#endif
-    needed_inheriting |= __WASI_RIGHT_FD_SYNC;
-  }
-  if ((fs_flags & __WASI_FDFLAG_SYNC) != 0) {
-    noflags |= O_SYNC;
-    needed_inheriting |= __WASI_RIGHT_FD_SYNC;
-  }
-  if (write && (noflags & (O_APPEND | O_TRUNC)) == 0)
-    needed_inheriting |= __WASI_RIGHT_FD_SEEK;
-
-  struct path_access pa;
-  __wasi_errno_t error =
-      path_get(curfds, &pa, dirfd, dirflags, path, pathlen, needed_base, needed_inheriting,
-               (oflags & __WASI_O_CREAT) != 0);
-  if (error != 0)
-    return error;
-  if (!pa.follow)
-    noflags |= O_NOFOLLOW;
-
-  int nfd = openat(pa.fd, pa.path, noflags, 0666);
-  if (nfd < 0) {
-    int openat_errno = errno;
-    // Linux returns ENXIO instead of EOPNOTSUPP when opening a socket.
-    if (openat_errno == ENXIO) {
-      struct stat sb;
-      int ret =
-          fstatat(pa.fd, pa.path, &sb, pa.follow ? 0 : AT_SYMLINK_NOFOLLOW);
-      path_put(&pa);
-      return ret == 0 && S_ISSOCK(sb.st_mode) ? __WASI_ENOTSUP
-                                              : __WASI_ENXIO;
+    // Convert open flags.
+    if ((oflags & __WASI_O_CREAT) != 0) {
+        noflags |= O_CREAT;
+        needed_base |= __WASI_RIGHT_PATH_CREATE_FILE;
     }
-    // Linux returns ENOTDIR instead of ELOOP when using O_NOFOLLOW|O_DIRECTORY
-    // on a symlink.
-    if (openat_errno == ENOTDIR && (noflags & (O_NOFOLLOW | O_DIRECTORY)) != 0) {
-      struct stat sb;
-      int ret = fstatat(pa.fd, pa.path, &sb, AT_SYMLINK_NOFOLLOW);
-      if (S_ISLNK(sb.st_mode)) {
+    if ((oflags & __WASI_O_DIRECTORY) != 0)
+        noflags |= O_DIRECTORY;
+    if ((oflags & __WASI_O_EXCL) != 0)
+        noflags |= O_EXCL;
+    if ((oflags & __WASI_O_TRUNC) != 0) {
+        noflags |= O_TRUNC;
+        needed_base |= __WASI_RIGHT_PATH_FILESTAT_SET_SIZE;
+    }
+
+    // Convert file descriptor flags.
+    if ((fs_flags & __WASI_FDFLAG_APPEND) != 0)
+        noflags |= O_APPEND;
+    if ((fs_flags & __WASI_FDFLAG_DSYNC) != 0) {
+#ifdef O_DSYNC
+        noflags |= O_DSYNC;
+#else
+        noflags |= O_SYNC;
+#endif
+        needed_inheriting |= __WASI_RIGHT_FD_DATASYNC;
+    }
+    if ((fs_flags & __WASI_FDFLAG_NONBLOCK) != 0)
+        noflags |= O_NONBLOCK;
+    if ((fs_flags & __WASI_FDFLAG_RSYNC) != 0) {
+#ifdef O_RSYNC
+        noflags |= O_RSYNC;
+#else
+        noflags |= O_SYNC;
+#endif
+        needed_inheriting |= __WASI_RIGHT_FD_SYNC;
+    }
+    if ((fs_flags & __WASI_FDFLAG_SYNC) != 0) {
+        noflags |= O_SYNC;
+        needed_inheriting |= __WASI_RIGHT_FD_SYNC;
+    }
+    if (write && (noflags & (O_APPEND | O_TRUNC)) == 0)
+        needed_inheriting |= __WASI_RIGHT_FD_SEEK;
+
+    struct path_access pa;
+    __wasi_errno_t error =
+        path_get(curfds, &pa, dirfd, dirflags, path, pathlen, needed_base,
+                 needed_inheriting, (oflags & __WASI_O_CREAT) != 0);
+    if (error != 0)
+        return error;
+    if (!pa.follow)
+        noflags |= O_NOFOLLOW;
+
+    int nfd = openat(pa.fd, pa.path, noflags, 0666);
+    if (nfd < 0) {
+        int openat_errno = errno;
+        // Linux returns ENXIO instead of EOPNOTSUPP when opening a socket.
+        if (openat_errno == ENXIO) {
+            struct stat sb;
+            int ret = fstatat(pa.fd, pa.path, &sb,
+                              pa.follow ? 0 : AT_SYMLINK_NOFOLLOW);
+            path_put(&pa);
+            return ret == 0 && S_ISSOCK(sb.st_mode) ? __WASI_ENOTSUP
+                                                    : __WASI_ENXIO;
+        }
+        // Linux returns ENOTDIR instead of ELOOP when using
+        // O_NOFOLLOW|O_DIRECTORY on a symlink.
+        if (openat_errno == ENOTDIR
+            && (noflags & (O_NOFOLLOW | O_DIRECTORY)) != 0) {
+            struct stat sb;
+            int ret = fstatat(pa.fd, pa.path, &sb, AT_SYMLINK_NOFOLLOW);
+            if (S_ISLNK(sb.st_mode)) {
+                path_put(&pa);
+                return __WASI_ELOOP;
+            }
+            (void)ret;
+        }
         path_put(&pa);
-        return __WASI_ELOOP;
-      }
-      (void)ret;
+        // FreeBSD returns EMLINK instead of ELOOP when using O_NOFOLLOW on
+        // a symlink.
+        if (!pa.follow && openat_errno == EMLINK)
+            return __WASI_ELOOP;
+        return convert_errno(openat_errno);
     }
     path_put(&pa);
-    // FreeBSD returns EMLINK instead of ELOOP when using O_NOFOLLOW on
-    // a symlink.
-    if (!pa.follow && openat_errno == EMLINK)
-      return __WASI_ELOOP;
-    return convert_errno(openat_errno);
-  }
-  path_put(&pa);
 
-  // Determine the type of the new file descriptor and which rights
-  // contradict with this type.
-  __wasi_filetype_t type;
-  __wasi_rights_t max_base, max_inheriting;
-  error = fd_determine_type_rights(nfd, &type, &max_base, &max_inheriting);
-  if (error != 0) {
-    close(nfd);
-    return error;
-  }
-
-  {
-    struct stat sb;
-
-    if (fstat(nfd, &sb) < 0) {
-      close(nfd);
-      return convert_errno(errno);
+    // Determine the type of the new file descriptor and which rights
+    // contradict with this type.
+    __wasi_filetype_t type;
+    __wasi_rights_t max_base, max_inheriting;
+    error = fd_determine_type_rights(nfd, &type, &max_base, &max_inheriting);
+    if (error != 0) {
+        close(nfd);
+        return error;
     }
 
-    if (S_ISDIR(sb.st_mode))
-      rights_base |= (__wasi_rights_t)RIGHTS_DIRECTORY_BASE;
-    else if (S_ISREG(sb.st_mode))
-      rights_base |= (__wasi_rights_t)RIGHTS_REGULAR_FILE_BASE;
-  }
+    {
+        struct stat sb;
 
-  return fd_table_insert_fd(curfds, nfd, type, rights_base & max_base,
-                            rights_inheriting & max_inheriting, fd);
+        if (fstat(nfd, &sb) < 0) {
+            close(nfd);
+            return convert_errno(errno);
+        }
+
+        if (S_ISDIR(sb.st_mode))
+            rights_base |= (__wasi_rights_t)RIGHTS_DIRECTORY_BASE;
+        else if (S_ISREG(sb.st_mode))
+            rights_base |= (__wasi_rights_t)RIGHTS_REGULAR_FILE_BASE;
+    }
+
+    return fd_table_insert_fd(curfds, nfd, type, rights_base & max_base,
+                              rights_inheriting & max_inheriting, fd);
 }
 
 // Copies out directory entry metadata or filename, potentially
 // truncating it in the process.
-static void fd_readdir_put(
-    void *buf,
-    size_t bufsize,
-    size_t *bufused,
-    const void *elem,
-    size_t elemsize
-) {
-  size_t bufavail = bufsize - *bufused;
-  if (elemsize > bufavail)
-    elemsize = bufavail;
-  bh_memcpy_s((char *)buf + *bufused, (uint32)bufavail, elem, (uint32)elemsize);
-  *bufused += elemsize;
+static void
+fd_readdir_put(void *buf, size_t bufsize, size_t *bufused, const void *elem,
+               size_t elemsize)
+{
+    size_t bufavail = bufsize - *bufused;
+    if (elemsize > bufavail)
+        elemsize = bufavail;
+    bh_memcpy_s((char *)buf + *bufused, (uint32)bufavail, elem,
+                (uint32)elemsize);
+    *bufused += elemsize;
 }
 
-__wasi_errno_t wasmtime_ssp_fd_readdir(
+__wasi_errno_t
+wasmtime_ssp_fd_readdir(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t fd,
-    void *buf,
-    size_t nbyte,
-    __wasi_dircookie_t cookie,
-    size_t *bufused
-) {
-  struct fd_object *fo;
-  __wasi_errno_t error =
-      fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_READDIR, 0);
-  if (error != 0) {
-    return error;
-  }
+    __wasi_fd_t fd, void *buf, size_t nbyte, __wasi_dircookie_t cookie,
+    size_t *bufused)
+{
+    struct fd_object *fo;
+    __wasi_errno_t error =
+        fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_READDIR, 0);
+    if (error != 0) {
+        return error;
+    }
 
-  // Create a directory handle if none has been opened yet.
-  mutex_lock(&fo->directory.lock);
-  DIR *dp = fo->directory.handle;
-  if (dp == NULL) {
-    dp = fdopendir(fd_number(fo));
+    // Create a directory handle if none has been opened yet.
+    mutex_lock(&fo->directory.lock);
+    DIR *dp = fo->directory.handle;
     if (dp == NULL) {
-      mutex_unlock(&fo->directory.lock);
-      fd_object_release(fo);
-      return convert_errno(errno);
+        dp = fdopendir(fd_number(fo));
+        if (dp == NULL) {
+            mutex_unlock(&fo->directory.lock);
+            fd_object_release(fo);
+            return convert_errno(errno);
+        }
+        fo->directory.handle = dp;
+        fo->directory.offset = __WASI_DIRCOOKIE_START;
     }
-    fo->directory.handle = dp;
-    fo->directory.offset = __WASI_DIRCOOKIE_START;
-  }
 
-  // Seek to the right position if the requested offset does not match
-  // the current offset.
-  if (fo->directory.offset != cookie) {
-    if (cookie == __WASI_DIRCOOKIE_START)
-      rewinddir(dp);
-    else
-      seekdir(dp, (long)cookie);
-    fo->directory.offset = cookie;
-  }
-
-  *bufused = 0;
-  while (*bufused < nbyte) {
-    // Read the next directory entry.
-    errno = 0;
-    struct dirent *de = readdir(dp);
-    if (de == NULL) {
-      mutex_unlock(&fo->directory.lock);
-      fd_object_release(fo);
-      return errno == 0 || *bufused > 0 ? 0 : convert_errno(errno);
+    // Seek to the right position if the requested offset does not match
+    // the current offset.
+    if (fo->directory.offset != cookie) {
+        if (cookie == __WASI_DIRCOOKIE_START)
+            rewinddir(dp);
+        else
+            seekdir(dp, (long)cookie);
+        fo->directory.offset = cookie;
     }
-    fo->directory.offset = (__wasi_dircookie_t)telldir(dp);
 
-    // Craft a directory entry and copy that back.
-    size_t namlen = strlen(de->d_name);
-    __wasi_dirent_t cde = {
-        .d_next = fo->directory.offset,
-        .d_ino = de->d_ino,
-        .d_namlen = (uint32)namlen,
-    };
-    switch (de->d_type) {
-      case DT_BLK:
-        cde.d_type = __WASI_FILETYPE_BLOCK_DEVICE;
-        break;
-      case DT_CHR:
-        cde.d_type = __WASI_FILETYPE_CHARACTER_DEVICE;
-        break;
-      case DT_DIR:
-        cde.d_type = __WASI_FILETYPE_DIRECTORY;
-        break;
-      case DT_FIFO:
-        cde.d_type = __WASI_FILETYPE_SOCKET_STREAM;
-        break;
-      case DT_LNK:
-        cde.d_type = __WASI_FILETYPE_SYMBOLIC_LINK;
-        break;
-      case DT_REG:
-        cde.d_type = __WASI_FILETYPE_REGULAR_FILE;
-        break;
+    *bufused = 0;
+    while (*bufused < nbyte) {
+        // Read the next directory entry.
+        errno = 0;
+        struct dirent *de = readdir(dp);
+        if (de == NULL) {
+            mutex_unlock(&fo->directory.lock);
+            fd_object_release(fo);
+            return errno == 0 || *bufused > 0 ? 0 : convert_errno(errno);
+        }
+        fo->directory.offset = (__wasi_dircookie_t)telldir(dp);
+
+        // Craft a directory entry and copy that back.
+        size_t namlen = strlen(de->d_name);
+        __wasi_dirent_t cde = {
+            .d_next = fo->directory.offset,
+            .d_ino = de->d_ino,
+            .d_namlen = (uint32)namlen,
+        };
+        switch (de->d_type) {
+            case DT_BLK:
+                cde.d_type = __WASI_FILETYPE_BLOCK_DEVICE;
+                break;
+            case DT_CHR:
+                cde.d_type = __WASI_FILETYPE_CHARACTER_DEVICE;
+                break;
+            case DT_DIR:
+                cde.d_type = __WASI_FILETYPE_DIRECTORY;
+                break;
+            case DT_FIFO:
+                cde.d_type = __WASI_FILETYPE_SOCKET_STREAM;
+                break;
+            case DT_LNK:
+                cde.d_type = __WASI_FILETYPE_SYMBOLIC_LINK;
+                break;
+            case DT_REG:
+                cde.d_type = __WASI_FILETYPE_REGULAR_FILE;
+                break;
 #ifdef DT_SOCK
-      case DT_SOCK:
-        // Technically not correct, but good enough.
-        cde.d_type = __WASI_FILETYPE_SOCKET_STREAM;
-        break;
+            case DT_SOCK:
+                // Technically not correct, but good enough.
+                cde.d_type = __WASI_FILETYPE_SOCKET_STREAM;
+                break;
 #endif
-      default:
-        cde.d_type = __WASI_FILETYPE_UNKNOWN;
-        break;
+            default:
+                cde.d_type = __WASI_FILETYPE_UNKNOWN;
+                break;
+        }
+        fd_readdir_put(buf, nbyte, bufused, &cde, sizeof(cde));
+        fd_readdir_put(buf, nbyte, bufused, de->d_name, namlen);
     }
-    fd_readdir_put(buf, nbyte, bufused, &cde, sizeof(cde));
-    fd_readdir_put(buf, nbyte, bufused, de->d_name, namlen);
-  }
-  mutex_unlock(&fo->directory.lock);
-  fd_object_release(fo);
-  return 0;
+    mutex_unlock(&fo->directory.lock);
+    fd_object_release(fo);
+    return 0;
 }
 
-__wasi_errno_t wasmtime_ssp_path_readlink(
+__wasi_errno_t
+wasmtime_ssp_path_readlink(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t fd,
-    const char *path,
-    size_t pathlen,
-    char *buf,
-    size_t bufsize,
-    size_t *bufused
-) {
-  struct path_access pa;
-  __wasi_errno_t error = path_get_nofollow(curfds,
-      &pa, fd, path, pathlen, __WASI_RIGHT_PATH_READLINK, 0, false);
-  if (error != 0)
-    return error;
+    __wasi_fd_t fd, const char *path, size_t pathlen, char *buf, size_t bufsize,
+    size_t *bufused)
+{
+    struct path_access pa;
+    __wasi_errno_t error = path_get_nofollow(
+        curfds, &pa, fd, path, pathlen, __WASI_RIGHT_PATH_READLINK, 0, false);
+    if (error != 0)
+        return error;
 
-  // Linux requires that the buffer size is positive. whereas POSIX does
-  // not. Use a fake buffer to store the results if the size is zero.
-  char fakebuf[1];
-  ssize_t len = readlinkat(pa.fd, pa.path, bufsize == 0 ? fakebuf : buf,
-                           bufsize == 0 ? sizeof(fakebuf) : bufsize);
-  path_put(&pa);
-  if (len < 0)
-    return convert_errno(errno);
-  *bufused = (size_t)len < bufsize ? (size_t)len : bufsize;
-  return 0;
+    // Linux requires that the buffer size is positive. whereas POSIX does
+    // not. Use a fake buffer to store the results if the size is zero.
+    char fakebuf[1];
+    ssize_t len = readlinkat(pa.fd, pa.path, bufsize == 0 ? fakebuf : buf,
+                             bufsize == 0 ? sizeof(fakebuf) : bufsize);
+    path_put(&pa);
+    if (len < 0)
+        return convert_errno(errno);
+    *bufused = (size_t)len < bufsize ? (size_t)len : bufsize;
+    return 0;
 }
 
-__wasi_errno_t wasmtime_ssp_path_rename(
+__wasi_errno_t
+wasmtime_ssp_path_rename(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t old_fd,
-    const char *old_path,
-    size_t old_path_len,
-    __wasi_fd_t new_fd,
-    const char *new_path,
-    size_t new_path_len
-) {
-  struct path_access old_pa;
-  __wasi_errno_t error = path_get_nofollow(curfds, &old_pa, old_fd, old_path, old_path_len,
-                                           __WASI_RIGHT_PATH_RENAME_SOURCE, 0, true);
-  if (error != 0)
-    return error;
+    __wasi_fd_t old_fd, const char *old_path, size_t old_path_len,
+    __wasi_fd_t new_fd, const char *new_path, size_t new_path_len)
+{
+    struct path_access old_pa;
+    __wasi_errno_t error =
+        path_get_nofollow(curfds, &old_pa, old_fd, old_path, old_path_len,
+                          __WASI_RIGHT_PATH_RENAME_SOURCE, 0, true);
+    if (error != 0)
+        return error;
 
-  struct path_access new_pa;
-  error = path_get_nofollow(curfds, &new_pa, new_fd, new_path, new_path_len,
-                            __WASI_RIGHT_PATH_RENAME_TARGET, 0, true);
-  if (error != 0) {
+    struct path_access new_pa;
+    error = path_get_nofollow(curfds, &new_pa, new_fd, new_path, new_path_len,
+                              __WASI_RIGHT_PATH_RENAME_TARGET, 0, true);
+    if (error != 0) {
+        path_put(&old_pa);
+        return error;
+    }
+
+    int ret = renameat(old_pa.fd, old_pa.path, new_pa.fd, new_pa.path);
     path_put(&old_pa);
-    return error;
-  }
-
-  int ret = renameat(old_pa.fd, old_pa.path, new_pa.fd, new_pa.path);
-  path_put(&old_pa);
-  path_put(&new_pa);
-  if (ret < 0) {
-    return convert_errno(errno);
-  }
-  return 0;
+    path_put(&new_pa);
+    if (ret < 0) {
+        return convert_errno(errno);
+    }
+    return 0;
 }
 
 // Converts a POSIX stat structure to a CloudABI filestat structure.
-static void convert_stat(
-    const struct stat *in,
-    __wasi_filestat_t *out
-) {
-  *out = (__wasi_filestat_t){
-      .st_dev = in->st_dev,
-      .st_ino = in->st_ino,
-      .st_nlink = (__wasi_linkcount_t)in->st_nlink,
-      .st_size = (__wasi_filesize_t)in->st_size,
-      .st_atim = convert_timespec(&in->st_atim),
-      .st_mtim = convert_timespec(&in->st_mtim),
-      .st_ctim = convert_timespec(&in->st_ctim),
-  };
+static void
+convert_stat(const struct stat *in, __wasi_filestat_t *out)
+{
+    *out = (__wasi_filestat_t){
+        .st_dev = in->st_dev,
+        .st_ino = in->st_ino,
+        .st_nlink = (__wasi_linkcount_t)in->st_nlink,
+        .st_size = (__wasi_filesize_t)in->st_size,
+        .st_atim = convert_timespec(&in->st_atim),
+        .st_mtim = convert_timespec(&in->st_mtim),
+        .st_ctim = convert_timespec(&in->st_ctim),
+    };
 }
 
-__wasi_errno_t wasmtime_ssp_fd_filestat_get(
+__wasi_errno_t
+wasmtime_ssp_fd_filestat_get(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t fd,
-    __wasi_filestat_t *buf
-) {
-  struct fd_object *fo;
-  __wasi_errno_t error =
-      fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_FILESTAT_GET, 0);
-  if (error != 0)
-    return error;
+    __wasi_fd_t fd, __wasi_filestat_t *buf)
+{
+    struct fd_object *fo;
+    __wasi_errno_t error =
+        fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_FILESTAT_GET, 0);
+    if (error != 0)
+        return error;
 
-  int ret;
-  switch (fo->type) {
-    default: {
-      struct stat sb;
-      ret = fstat(fd_number(fo), &sb);
-      convert_stat(&sb, buf);
-      break;
+    int ret;
+    switch (fo->type) {
+        default:
+        {
+            struct stat sb;
+            ret = fstat(fd_number(fo), &sb);
+            convert_stat(&sb, buf);
+            break;
+        }
     }
-  }
-  buf->st_filetype = fo->type;
-  fd_object_release(fo);
-  if (ret < 0)
-    return convert_errno(errno);
-  return 0;
+    buf->st_filetype = fo->type;
+    fd_object_release(fo);
+    if (ret < 0)
+        return convert_errno(errno);
+    return 0;
 }
 
-static void convert_timestamp(
-    __wasi_timestamp_t in,
-    struct timespec *out
-) {
-  // Store sub-second remainder.
+static void
+convert_timestamp(__wasi_timestamp_t in, struct timespec *out)
+{
+    // Store sub-second remainder.
 #if defined(__SYSCALL_SLONG_TYPE)
-  out->tv_nsec = (__SYSCALL_SLONG_TYPE)(in % 1000000000);
+    out->tv_nsec = (__SYSCALL_SLONG_TYPE)(in % 1000000000);
 #else
-  out->tv_nsec = (long)(in % 1000000000);
+    out->tv_nsec = (long)(in % 1000000000);
 #endif
-  in /= 1000000000;
+    in /= 1000000000;
 
-  // Clamp to the maximum in case it would overflow our system's time_t.
-  out->tv_sec = (time_t)in < NUMERIC_MAX(time_t) ? (time_t)in : NUMERIC_MAX(time_t);
+    // Clamp to the maximum in case it would overflow our system's time_t.
+    out->tv_sec =
+        (time_t)in < NUMERIC_MAX(time_t) ? (time_t)in : NUMERIC_MAX(time_t);
 }
 
 // Converts the provided timestamps and flags to a set of arguments for
 // futimens() and utimensat().
-static void convert_utimens_arguments(
-    __wasi_timestamp_t st_atim,
-    __wasi_timestamp_t st_mtim,
-    __wasi_fstflags_t fstflags,
-    struct timespec *ts
-) {
-  if ((fstflags & __WASI_FILESTAT_SET_ATIM_NOW) != 0) {
-    ts[0].tv_nsec = UTIME_NOW;
-  } else if ((fstflags & __WASI_FILESTAT_SET_ATIM) != 0) {
-    convert_timestamp(st_atim, &ts[0]);
-  } else {
-    ts[0].tv_nsec = UTIME_OMIT;
-  }
-
-  if ((fstflags & __WASI_FILESTAT_SET_MTIM_NOW) != 0) {
-    ts[1].tv_nsec = UTIME_NOW;
-  } else if ((fstflags & __WASI_FILESTAT_SET_MTIM) != 0) {
-    convert_timestamp(st_mtim, &ts[1]);
-  } else {
-    ts[1].tv_nsec = UTIME_OMIT;
-  }
-}
-
-__wasi_errno_t wasmtime_ssp_fd_filestat_set_size(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
-    struct fd_table *curfds,
-#endif
-    __wasi_fd_t fd,
-    __wasi_filesize_t st_size
-) {
-  struct fd_object *fo;
-  __wasi_errno_t error =
-      fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_FILESTAT_SET_SIZE, 0);
-  if (error != 0)
-    return error;
-
-  int ret = ftruncate(fd_number(fo), (off_t)st_size);
-  fd_object_release(fo);
-  if (ret < 0)
-    return convert_errno(errno);
-  return 0;
-}
-
-__wasi_errno_t wasmtime_ssp_fd_filestat_set_times(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
-    struct fd_table *curfds,
-#endif
-    __wasi_fd_t fd,
-    __wasi_timestamp_t st_atim,
-    __wasi_timestamp_t st_mtim,
-    __wasi_fstflags_t fstflags
-) {
-  if ((fstflags & ~(__WASI_FILESTAT_SET_ATIM | __WASI_FILESTAT_SET_ATIM_NOW |
-                    __WASI_FILESTAT_SET_MTIM | __WASI_FILESTAT_SET_MTIM_NOW)) != 0)
-    return __WASI_EINVAL;
-
-  struct fd_object *fo;
-  __wasi_errno_t error =
-      fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_FILESTAT_SET_TIMES, 0);
-  if (error != 0)
-    return error;
-
-  struct timespec ts[2];
-  convert_utimens_arguments(st_atim, st_mtim, fstflags, ts);
-  int ret = futimens(fd_number(fo), ts);
-
-  fd_object_release(fo);
-  if (ret < 0)
-    return convert_errno(errno);
-  return 0;
-}
-
-__wasi_errno_t wasmtime_ssp_path_filestat_get(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
-    struct fd_table *curfds,
-#endif
-    __wasi_fd_t fd,
-    __wasi_lookupflags_t flags,
-    const char *path,
-    size_t pathlen,
-    __wasi_filestat_t *buf
-) {
-  struct path_access pa;
-  __wasi_errno_t error =
-      path_get(curfds, &pa, fd, flags, path, pathlen, __WASI_RIGHT_PATH_FILESTAT_GET, 0, false);
-  if (error != 0)
-    return error;
-
-  struct stat sb;
-  int ret = fstatat(pa.fd, pa.path, &sb, pa.follow ? 0 : AT_SYMLINK_NOFOLLOW);
-  path_put(&pa);
-  if (ret < 0)
-    return convert_errno(errno);
-  convert_stat(&sb, buf);
-
-  // Convert the file type. In the case of sockets there is no way we
-  // can easily determine the exact socket type.
-  if (S_ISBLK(sb.st_mode))
-    buf->st_filetype = __WASI_FILETYPE_BLOCK_DEVICE;
-  else if (S_ISCHR(sb.st_mode))
-    buf->st_filetype = __WASI_FILETYPE_CHARACTER_DEVICE;
-  else if (S_ISDIR(sb.st_mode))
-    buf->st_filetype = __WASI_FILETYPE_DIRECTORY;
-  else if (S_ISFIFO(sb.st_mode))
-    buf->st_filetype = __WASI_FILETYPE_SOCKET_STREAM;
-  else if (S_ISLNK(sb.st_mode))
-    buf->st_filetype = __WASI_FILETYPE_SYMBOLIC_LINK;
-  else if (S_ISREG(sb.st_mode))
-    buf->st_filetype = __WASI_FILETYPE_REGULAR_FILE;
-  else if (S_ISSOCK(sb.st_mode))
-    buf->st_filetype = __WASI_FILETYPE_SOCKET_STREAM;
-  return 0;
-}
-
-__wasi_errno_t wasmtime_ssp_path_filestat_set_times(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
-    struct fd_table *curfds,
-#endif
-    __wasi_fd_t fd,
-    __wasi_lookupflags_t flags,
-    const char *path,
-    size_t pathlen,
-    __wasi_timestamp_t st_atim,
-    __wasi_timestamp_t st_mtim,
-    __wasi_fstflags_t fstflags
-) {
-  if (((fstflags & ~(__WASI_FILESTAT_SET_ATIM | __WASI_FILESTAT_SET_ATIM_NOW |
-                     __WASI_FILESTAT_SET_MTIM | __WASI_FILESTAT_SET_MTIM_NOW)) != 0)
-      /* ATIM & ATIM_NOW can't be set at the same time */
-      || ((fstflags & __WASI_FILESTAT_SET_ATIM) != 0
-          && (fstflags & __WASI_FILESTAT_SET_ATIM_NOW) != 0)
-      /* MTIM & MTIM_NOW can't be set at the same time */
-      || ((fstflags & __WASI_FILESTAT_SET_MTIM) != 0
-          && (fstflags & __WASI_FILESTAT_SET_MTIM_NOW) != 0))
-    return __WASI_EINVAL;
-
-  struct path_access pa;
-  __wasi_errno_t error = path_get(curfds,
-      &pa, fd, flags, path, pathlen, __WASI_RIGHT_PATH_FILESTAT_SET_TIMES, 0, false);
-  if (error != 0)
-    return error;
-
-  struct timespec ts[2];
-  convert_utimens_arguments(st_atim, st_mtim, fstflags, ts);
-  int ret = utimensat(pa.fd, pa.path, ts, pa.follow ? 0 : AT_SYMLINK_NOFOLLOW);
-
-  path_put(&pa);
-  if (ret < 0)
-    return convert_errno(errno);
-  return 0;
-}
-
-__wasi_errno_t wasmtime_ssp_path_symlink(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
-    struct fd_table *curfds,
-    struct fd_prestats *prestats,
-#endif
-    const char *old_path,
-    size_t old_path_len,
-    __wasi_fd_t fd,
-    const char *new_path,
-    size_t new_path_len
-) {
-  char *target = str_nullterminate(old_path, old_path_len);
-  if (target == NULL)
-    return convert_errno(errno);
-
-  struct path_access pa;
-  __wasi_errno_t error = path_get_nofollow(curfds,
-      &pa, fd, new_path, new_path_len, __WASI_RIGHT_PATH_SYMLINK, 0, true);
-  if (error != 0) {
-    wasm_runtime_free(target);
-    return error;
-  }
-
-  rwlock_rdlock(&prestats->lock);
-  if (!validate_path(target, prestats)) {
-      rwlock_unlock(&prestats->lock);
-      wasm_runtime_free(target);
-      return __WASI_EBADF;
-  }
-  rwlock_unlock(&prestats->lock);
-
-  int ret = symlinkat(target, pa.fd, pa.path);
-  path_put(&pa);
-  wasm_runtime_free(target);
-  if (ret < 0)
-    return convert_errno(errno);
-  return 0;
-}
-
-__wasi_errno_t wasmtime_ssp_path_unlink_file(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
-    struct fd_table *curfds,
-#endif
-    __wasi_fd_t fd,
-    const char *path,
-    size_t pathlen
-) {
-  struct path_access pa;
-  __wasi_errno_t error = path_get_nofollow(curfds,
-      &pa, fd, path, pathlen, __WASI_RIGHT_PATH_UNLINK_FILE, 0, true);
-  if (error != 0)
-    return error;
-
-  int ret = unlinkat(pa.fd, pa.path, 0);
-#ifndef __linux__
-  // Non-Linux implementations may return EPERM when attempting to remove a
-  // directory without REMOVEDIR. While that's what POSIX specifies, it's
-  // less useful. Adjust this to EISDIR. It doesn't matter that this is not
-  // atomic with the unlinkat, because if the file is removed and a directory
-  // is created before fstatat sees it, we're racing with that change anyway
-  // and unlinkat could have legitimately seen the directory if the race had
-  // turned out differently.
-  if (ret < 0 && errno == EPERM) {
-    struct stat statbuf;
-    if (fstatat(pa.fd, pa.path, &statbuf, AT_SYMLINK_NOFOLLOW) == 0 &&
-        S_ISDIR(statbuf.st_mode)) {
-      errno = EISDIR;
+static void
+convert_utimens_arguments(__wasi_timestamp_t st_atim,
+                          __wasi_timestamp_t st_mtim,
+                          __wasi_fstflags_t fstflags, struct timespec *ts)
+{
+    if ((fstflags & __WASI_FILESTAT_SET_ATIM_NOW) != 0) {
+        ts[0].tv_nsec = UTIME_NOW;
     }
-  }
-#endif
-  path_put(&pa);
-  if (ret < 0) {
-    return convert_errno(errno);
-  }
-  return 0;
+    else if ((fstflags & __WASI_FILESTAT_SET_ATIM) != 0) {
+        convert_timestamp(st_atim, &ts[0]);
+    }
+    else {
+        ts[0].tv_nsec = UTIME_OMIT;
+    }
+
+    if ((fstflags & __WASI_FILESTAT_SET_MTIM_NOW) != 0) {
+        ts[1].tv_nsec = UTIME_NOW;
+    }
+    else if ((fstflags & __WASI_FILESTAT_SET_MTIM) != 0) {
+        convert_timestamp(st_mtim, &ts[1]);
+    }
+    else {
+        ts[1].tv_nsec = UTIME_OMIT;
+    }
 }
 
-__wasi_errno_t wasmtime_ssp_path_remove_directory(
+__wasi_errno_t
+wasmtime_ssp_fd_filestat_set_size(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t fd,
-    const char *path,
-    size_t pathlen
-) {
-  struct path_access pa;
-  __wasi_errno_t error = path_get_nofollow(curfds,
-      &pa, fd, path, pathlen, __WASI_RIGHT_PATH_REMOVE_DIRECTORY, 0, true);
-  if (error != 0)
-    return error;
+    __wasi_fd_t fd, __wasi_filesize_t st_size)
+{
+    struct fd_object *fo;
+    __wasi_errno_t error =
+        fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_FILESTAT_SET_SIZE, 0);
+    if (error != 0)
+        return error;
 
-  int ret = unlinkat(pa.fd, pa.path, AT_REMOVEDIR);
-#ifndef __linux__
-  // POSIX permits either EEXIST or ENOTEMPTY when the directory is not empty.
-  // Map it to ENOTEMPTY.
-  if (ret < 0 && errno == EEXIST) {
-    errno = ENOTEMPTY;
-  }
-#endif
-  path_put(&pa);
-  if (ret < 0) {
-    return convert_errno(errno);
-  }
-  return 0;
-}
-
-__wasi_errno_t wasmtime_ssp_poll_oneoff(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
-    struct fd_table *curfds,
-#endif
-    const __wasi_subscription_t *in,
-    __wasi_event_t *out,
-    size_t nsubscriptions,
-    size_t *nevents
-) NO_LOCK_ANALYSIS {
-  // Sleeping.
-  if (nsubscriptions == 1 && in[0].type == __WASI_EVENTTYPE_CLOCK) {
-    out[0] = (__wasi_event_t){
-        .userdata = in[0].userdata,
-        .type = in[0].type,
-    };
-#if CONFIG_HAS_CLOCK_NANOSLEEP
-    clockid_t clock_id;
-    if (convert_clockid(in[0].u.clock.clock_id, &clock_id)) {
-      struct timespec ts;
-      convert_timestamp(in[0].u.clock.timeout, &ts);
-      int ret = clock_nanosleep(
-          clock_id,
-          (in[0].u.clock.flags & __WASI_SUBSCRIPTION_CLOCK_ABSTIME) != 0
-              ? TIMER_ABSTIME
-              : 0,
-          &ts, NULL);
-      if (ret != 0)
-        out[0].error = convert_errno(ret);
-    } else {
-      out[0].error = __WASI_ENOTSUP;
-    }
-#else
-    switch (in[0].u.clock.clock_id) {
-      case __WASI_CLOCK_MONOTONIC:
-        if ((in[0].u.clock.flags & __WASI_SUBSCRIPTION_CLOCK_ABSTIME) != 0) {
-          // TODO(ed): Implement.
-          fputs("Unimplemented absolute sleep on monotonic clock\n", stderr);
-          out[0].error = __WASI_ENOSYS;
-        } else {
-          // Perform relative sleeps on the monotonic clock also using
-          // nanosleep(). This is incorrect, but good enough for now.
-          struct timespec ts;
-          convert_timestamp(in[0].u.clock.timeout, &ts);
-          nanosleep(&ts, NULL);
-        }
-        break;
-      case __WASI_CLOCK_REALTIME:
-        if ((in[0].u.clock.flags & __WASI_SUBSCRIPTION_CLOCK_ABSTIME) != 0) {
-          // Sleeping to an absolute point in time can only be done
-          // by waiting on a condition variable.
-          struct mutex mutex;
-          struct cond cond;
-
-          if (!mutex_init(&mutex))
-            return -1;
-          if (!cond_init_realtime(&cond)) {
-            mutex_destroy(&mutex);
-            return -1;
-          }
-          mutex_lock(&mutex);
-          cond_timedwait(&cond, &mutex, in[0].u.clock.timeout, true);
-          mutex_unlock(&mutex);
-          mutex_destroy(&mutex);
-          cond_destroy(&cond);
-        } else {
-          // Relative sleeps can be done using nanosleep().
-          struct timespec ts;
-          convert_timestamp(in[0].u.clock.timeout, &ts);
-          nanosleep(&ts, NULL);
-        }
-        break;
-      default:
-        out[0].error = __WASI_ENOTSUP;
-        break;
-    }
-#endif
-    *nevents = 1;
+    int ret = ftruncate(fd_number(fo), (off_t)st_size);
+    fd_object_release(fo);
+    if (ret < 0)
+        return convert_errno(errno);
     return 0;
-  }
+}
 
-  // Last option: call into poll(). This can only be done in case all
-  // subscriptions consist of __WASI_EVENTTYPE_FD_READ and
-  // __WASI_EVENTTYPE_FD_WRITE entries. There may be up to one
-  // __WASI_EVENTTYPE_CLOCK entry to act as a timeout. These are also
-  // the subscriptions generate by cloudlibc's poll() and select().
-  struct fd_object **fos = wasm_runtime_malloc((uint32)(nsubscriptions * sizeof(*fos)));
-  if (fos == NULL)
-    return __WASI_ENOMEM;
-  struct pollfd *pfds = wasm_runtime_malloc((uint32)(nsubscriptions * sizeof(*pfds)));
-  if (pfds == NULL) {
-    wasm_runtime_free(fos);
-    return __WASI_ENOMEM;
-  }
-
-  // Convert subscriptions to pollfd entries. Increase the reference
-  // count on the file descriptors to ensure they remain valid across
-  // the call to poll().
-  struct fd_table *ft = curfds;
-  rwlock_rdlock(&ft->lock);
-  *nevents = 0;
-  const __wasi_subscription_t *clock_subscription = NULL;
-  for (size_t i = 0; i < nsubscriptions; ++i) {
-    const __wasi_subscription_t *s = &in[i];
-    switch (s->type) {
-      case __WASI_EVENTTYPE_FD_READ:
-      case __WASI_EVENTTYPE_FD_WRITE: {
-        __wasi_errno_t error =
-            fd_object_get_locked(&fos[i], ft, s->u.fd_readwrite.fd,
-                                 __WASI_RIGHT_POLL_FD_READWRITE, 0);
-        if (error == 0) {
-          // Proper file descriptor on which we can poll().
-          pfds[i] = (struct pollfd){
-              .fd = fd_number(fos[i]),
-              .events = s->type == __WASI_EVENTTYPE_FD_READ ? POLLRDNORM
-                                                              : POLLWRNORM,
-          };
-        } else {
-          // Invalid file descriptor or rights missing.
-          fos[i] = NULL;
-          pfds[i] = (struct pollfd){.fd = -1};
-          out[(*nevents)++] = (__wasi_event_t){
-              .userdata = s->userdata,
-              .error = error,
-              .type = s->type,
-          };
-        }
-        break;
-      }
-      case __WASI_EVENTTYPE_CLOCK:
-        if (clock_subscription == NULL &&
-            (s->u.clock.flags & __WASI_SUBSCRIPTION_CLOCK_ABSTIME) == 0) {
-          // Relative timeout.
-          fos[i] = NULL;
-          pfds[i] = (struct pollfd){.fd = -1};
-          clock_subscription = s;
-          break;
-        }
-      // Fallthrough.
-      default:
-        // Unsupported event.
-        fos[i] = NULL;
-        pfds[i] = (struct pollfd){.fd = -1};
-        out[(*nevents)++] = (__wasi_event_t){
-            .userdata = s->userdata,
-            .error = __WASI_ENOSYS,
-            .type = s->type,
-        };
-        break;
-    }
-  }
-  rwlock_unlock(&ft->lock);
-
-  // Use a zero-second timeout in case we've already generated events in
-  // the loop above.
-  int timeout;
-  if (*nevents != 0) {
-    timeout = 0;
-  } else if (clock_subscription != NULL) {
-    __wasi_timestamp_t ts = clock_subscription->u.clock.timeout / 1000000;
-    timeout = ts > INT_MAX ? -1 : (int)ts;
-  } else {
-    timeout = -1;
-  }
-  int ret = poll(pfds, nsubscriptions, timeout);
-
-  __wasi_errno_t error = 0;
-  if (ret == -1) {
-    error = convert_errno(errno);
-  } else if (ret == 0 && *nevents == 0 && clock_subscription != NULL) {
-    // No events triggered. Trigger the clock event.
-    out[(*nevents)++] = (__wasi_event_t){
-        .userdata = clock_subscription->userdata,
-        .type = __WASI_EVENTTYPE_CLOCK,
-    };
-  } else {
-    // Events got triggered. Don't trigger the clock event.
-    for (size_t i = 0; i < nsubscriptions; ++i) {
-      if (pfds[i].fd >= 0) {
-        __wasi_filesize_t nbytes = 0;
-        if (in[i].type == __WASI_EVENTTYPE_FD_READ) {
-          int l;
-          if (ioctl(fd_number(fos[i]), FIONREAD, &l) == 0)
-            nbytes = (__wasi_filesize_t)l;
-        }
-        if ((pfds[i].revents & POLLNVAL) != 0) {
-          // Bad file descriptor. This normally cannot occur, as
-          // referencing the file descriptor object will always ensure
-          // the descriptor is valid. Still, macOS may sometimes return
-          // this on FIFOs when reaching end-of-file.
-          out[(*nevents)++] = (__wasi_event_t){
-              .userdata = in[i].userdata,
-#ifdef __APPLE__
-              .u.fd_readwrite.nbytes = nbytes,
-              .u.fd_readwrite.flags = __WASI_EVENT_FD_READWRITE_HANGUP,
-#else
-              .error = __WASI_EBADF,
+__wasi_errno_t
+wasmtime_ssp_fd_filestat_set_times(
+#if !defined(WASMTIME_SSP_STATIC_CURFDS)
+    struct fd_table *curfds,
 #endif
-              .type = in[i].type,
-          };
-        } else if ((pfds[i].revents & POLLERR) != 0) {
-          // File descriptor is in an error state.
-          out[(*nevents)++] = (__wasi_event_t){
-              .userdata = in[i].userdata,
-              .error = __WASI_EIO,
-              .type = in[i].type,
-          };
-        } else if ((pfds[i].revents & POLLHUP) != 0) {
-          // End-of-file.
-          out[(*nevents)++] = (__wasi_event_t){
-              .userdata = in[i].userdata,
-              .type = in[i].type,
-              .u.fd_readwrite.nbytes = nbytes,
-              .u.fd_readwrite.flags = __WASI_EVENT_FD_READWRITE_HANGUP,
-          };
-        } else if ((pfds[i].revents & (POLLRDNORM | POLLWRNORM)) != 0) {
-          // Read or write possible.
-          out[(*nevents)++] = (__wasi_event_t){
-              .userdata = in[i].userdata,
-              .type = in[i].type,
-              .u.fd_readwrite.nbytes = nbytes,
-          };
-        }
-      }
-    }
-  }
+    __wasi_fd_t fd, __wasi_timestamp_t st_atim, __wasi_timestamp_t st_mtim,
+    __wasi_fstflags_t fstflags)
+{
+    if ((fstflags
+         & ~(__WASI_FILESTAT_SET_ATIM | __WASI_FILESTAT_SET_ATIM_NOW
+             | __WASI_FILESTAT_SET_MTIM | __WASI_FILESTAT_SET_MTIM_NOW))
+        != 0)
+        return __WASI_EINVAL;
 
-  for (size_t i = 0; i < nsubscriptions; ++i)
-    if (fos[i] != NULL)
-      fd_object_release(fos[i]);
-  wasm_runtime_free(fos);
-  wasm_runtime_free(pfds);
-  return error;
+    struct fd_object *fo;
+    __wasi_errno_t error =
+        fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_FILESTAT_SET_TIMES, 0);
+    if (error != 0)
+        return error;
+
+    struct timespec ts[2];
+    convert_utimens_arguments(st_atim, st_mtim, fstflags, ts);
+    int ret = futimens(fd_number(fo), ts);
+
+    fd_object_release(fo);
+    if (ret < 0)
+        return convert_errno(errno);
+    return 0;
+}
+
+__wasi_errno_t
+wasmtime_ssp_path_filestat_get(
+#if !defined(WASMTIME_SSP_STATIC_CURFDS)
+    struct fd_table *curfds,
+#endif
+    __wasi_fd_t fd, __wasi_lookupflags_t flags, const char *path,
+    size_t pathlen, __wasi_filestat_t *buf)
+{
+    struct path_access pa;
+    __wasi_errno_t error = path_get(curfds, &pa, fd, flags, path, pathlen,
+                                    __WASI_RIGHT_PATH_FILESTAT_GET, 0, false);
+    if (error != 0)
+        return error;
+
+    struct stat sb;
+    int ret = fstatat(pa.fd, pa.path, &sb, pa.follow ? 0 : AT_SYMLINK_NOFOLLOW);
+    path_put(&pa);
+    if (ret < 0)
+        return convert_errno(errno);
+    convert_stat(&sb, buf);
+
+    // Convert the file type. In the case of sockets there is no way we
+    // can easily determine the exact socket type.
+    if (S_ISBLK(sb.st_mode))
+        buf->st_filetype = __WASI_FILETYPE_BLOCK_DEVICE;
+    else if (S_ISCHR(sb.st_mode))
+        buf->st_filetype = __WASI_FILETYPE_CHARACTER_DEVICE;
+    else if (S_ISDIR(sb.st_mode))
+        buf->st_filetype = __WASI_FILETYPE_DIRECTORY;
+    else if (S_ISFIFO(sb.st_mode))
+        buf->st_filetype = __WASI_FILETYPE_SOCKET_STREAM;
+    else if (S_ISLNK(sb.st_mode))
+        buf->st_filetype = __WASI_FILETYPE_SYMBOLIC_LINK;
+    else if (S_ISREG(sb.st_mode))
+        buf->st_filetype = __WASI_FILETYPE_REGULAR_FILE;
+    else if (S_ISSOCK(sb.st_mode))
+        buf->st_filetype = __WASI_FILETYPE_SOCKET_STREAM;
+    return 0;
+}
+
+__wasi_errno_t
+wasmtime_ssp_path_filestat_set_times(
+#if !defined(WASMTIME_SSP_STATIC_CURFDS)
+    struct fd_table *curfds,
+#endif
+    __wasi_fd_t fd, __wasi_lookupflags_t flags, const char *path,
+    size_t pathlen, __wasi_timestamp_t st_atim, __wasi_timestamp_t st_mtim,
+    __wasi_fstflags_t fstflags)
+{
+    if (((fstflags
+          & ~(__WASI_FILESTAT_SET_ATIM | __WASI_FILESTAT_SET_ATIM_NOW
+              | __WASI_FILESTAT_SET_MTIM | __WASI_FILESTAT_SET_MTIM_NOW))
+         != 0)
+        /* ATIM & ATIM_NOW can't be set at the same time */
+        || ((fstflags & __WASI_FILESTAT_SET_ATIM) != 0
+            && (fstflags & __WASI_FILESTAT_SET_ATIM_NOW) != 0)
+        /* MTIM & MTIM_NOW can't be set at the same time */
+        || ((fstflags & __WASI_FILESTAT_SET_MTIM) != 0
+            && (fstflags & __WASI_FILESTAT_SET_MTIM_NOW) != 0))
+        return __WASI_EINVAL;
+
+    struct path_access pa;
+    __wasi_errno_t error =
+        path_get(curfds, &pa, fd, flags, path, pathlen,
+                 __WASI_RIGHT_PATH_FILESTAT_SET_TIMES, 0, false);
+    if (error != 0)
+        return error;
+
+    struct timespec ts[2];
+    convert_utimens_arguments(st_atim, st_mtim, fstflags, ts);
+    int ret =
+        utimensat(pa.fd, pa.path, ts, pa.follow ? 0 : AT_SYMLINK_NOFOLLOW);
+
+    path_put(&pa);
+    if (ret < 0)
+        return convert_errno(errno);
+    return 0;
+}
+
+__wasi_errno_t
+wasmtime_ssp_path_symlink(
+#if !defined(WASMTIME_SSP_STATIC_CURFDS)
+    struct fd_table *curfds, struct fd_prestats *prestats,
+#endif
+    const char *old_path, size_t old_path_len, __wasi_fd_t fd,
+    const char *new_path, size_t new_path_len)
+{
+    char *target = str_nullterminate(old_path, old_path_len);
+    if (target == NULL)
+        return convert_errno(errno);
+
+    struct path_access pa;
+    __wasi_errno_t error =
+        path_get_nofollow(curfds, &pa, fd, new_path, new_path_len,
+                          __WASI_RIGHT_PATH_SYMLINK, 0, true);
+    if (error != 0) {
+        wasm_runtime_free(target);
+        return error;
+    }
+
+    rwlock_rdlock(&prestats->lock);
+    if (!validate_path(target, prestats)) {
+        rwlock_unlock(&prestats->lock);
+        wasm_runtime_free(target);
+        return __WASI_EBADF;
+    }
+    rwlock_unlock(&prestats->lock);
+
+    int ret = symlinkat(target, pa.fd, pa.path);
+    path_put(&pa);
+    wasm_runtime_free(target);
+    if (ret < 0)
+        return convert_errno(errno);
+    return 0;
+}
+
+__wasi_errno_t
+wasmtime_ssp_path_unlink_file(
+#if !defined(WASMTIME_SSP_STATIC_CURFDS)
+    struct fd_table *curfds,
+#endif
+    __wasi_fd_t fd, const char *path, size_t pathlen)
+{
+    struct path_access pa;
+    __wasi_errno_t error = path_get_nofollow(
+        curfds, &pa, fd, path, pathlen, __WASI_RIGHT_PATH_UNLINK_FILE, 0, true);
+    if (error != 0)
+        return error;
+
+    int ret = unlinkat(pa.fd, pa.path, 0);
+#ifndef __linux__
+    // Non-Linux implementations may return EPERM when attempting to remove a
+    // directory without REMOVEDIR. While that's what POSIX specifies, it's
+    // less useful. Adjust this to EISDIR. It doesn't matter that this is not
+    // atomic with the unlinkat, because if the file is removed and a directory
+    // is created before fstatat sees it, we're racing with that change anyway
+    // and unlinkat could have legitimately seen the directory if the race had
+    // turned out differently.
+    if (ret < 0 && errno == EPERM) {
+        struct stat statbuf;
+        if (fstatat(pa.fd, pa.path, &statbuf, AT_SYMLINK_NOFOLLOW) == 0
+            && S_ISDIR(statbuf.st_mode)) {
+            errno = EISDIR;
+        }
+    }
+#endif
+    path_put(&pa);
+    if (ret < 0) {
+        return convert_errno(errno);
+    }
+    return 0;
+}
+
+__wasi_errno_t
+wasmtime_ssp_path_remove_directory(
+#if !defined(WASMTIME_SSP_STATIC_CURFDS)
+    struct fd_table *curfds,
+#endif
+    __wasi_fd_t fd, const char *path, size_t pathlen)
+{
+    struct path_access pa;
+    __wasi_errno_t error =
+        path_get_nofollow(curfds, &pa, fd, path, pathlen,
+                          __WASI_RIGHT_PATH_REMOVE_DIRECTORY, 0, true);
+    if (error != 0)
+        return error;
+
+    int ret = unlinkat(pa.fd, pa.path, AT_REMOVEDIR);
+#ifndef __linux__
+    // POSIX permits either EEXIST or ENOTEMPTY when the directory is not empty.
+    // Map it to ENOTEMPTY.
+    if (ret < 0 && errno == EEXIST) {
+        errno = ENOTEMPTY;
+    }
+#endif
+    path_put(&pa);
+    if (ret < 0) {
+        return convert_errno(errno);
+    }
+    return 0;
+}
+
+__wasi_errno_t
+wasmtime_ssp_poll_oneoff(
+#if !defined(WASMTIME_SSP_STATIC_CURFDS)
+    struct fd_table *curfds,
+#endif
+    const __wasi_subscription_t *in, __wasi_event_t *out, size_t nsubscriptions,
+    size_t *nevents) NO_LOCK_ANALYSIS
+{
+    // Sleeping.
+    if (nsubscriptions == 1 && in[0].type == __WASI_EVENTTYPE_CLOCK) {
+        out[0] = (__wasi_event_t){
+            .userdata = in[0].userdata,
+            .type = in[0].type,
+        };
+#if CONFIG_HAS_CLOCK_NANOSLEEP
+        clockid_t clock_id;
+        if (convert_clockid(in[0].u.clock.clock_id, &clock_id)) {
+            struct timespec ts;
+            convert_timestamp(in[0].u.clock.timeout, &ts);
+            int ret = clock_nanosleep(
+                clock_id,
+                (in[0].u.clock.flags & __WASI_SUBSCRIPTION_CLOCK_ABSTIME) != 0
+                    ? TIMER_ABSTIME
+                    : 0,
+                &ts, NULL);
+            if (ret != 0)
+                out[0].error = convert_errno(ret);
+        }
+        else {
+            out[0].error = __WASI_ENOTSUP;
+        }
+#else
+        switch (in[0].u.clock.clock_id) {
+            case __WASI_CLOCK_MONOTONIC:
+                if ((in[0].u.clock.flags & __WASI_SUBSCRIPTION_CLOCK_ABSTIME)
+                    != 0) {
+                    // TODO(ed): Implement.
+                    fputs("Unimplemented absolute sleep on monotonic clock\n",
+                          stderr);
+                    out[0].error = __WASI_ENOSYS;
+                }
+                else {
+                    // Perform relative sleeps on the monotonic clock also using
+                    // nanosleep(). This is incorrect, but good enough for now.
+                    struct timespec ts;
+                    convert_timestamp(in[0].u.clock.timeout, &ts);
+                    nanosleep(&ts, NULL);
+                }
+                break;
+            case __WASI_CLOCK_REALTIME:
+                if ((in[0].u.clock.flags & __WASI_SUBSCRIPTION_CLOCK_ABSTIME)
+                    != 0) {
+                    // Sleeping to an absolute point in time can only be done
+                    // by waiting on a condition variable.
+                    struct mutex mutex;
+                    struct cond cond;
+
+                    if (!mutex_init(&mutex))
+                        return -1;
+                    if (!cond_init_realtime(&cond)) {
+                        mutex_destroy(&mutex);
+                        return -1;
+                    }
+                    mutex_lock(&mutex);
+                    cond_timedwait(&cond, &mutex, in[0].u.clock.timeout, true);
+                    mutex_unlock(&mutex);
+                    mutex_destroy(&mutex);
+                    cond_destroy(&cond);
+                }
+                else {
+                    // Relative sleeps can be done using nanosleep().
+                    struct timespec ts;
+                    convert_timestamp(in[0].u.clock.timeout, &ts);
+                    nanosleep(&ts, NULL);
+                }
+                break;
+            default:
+                out[0].error = __WASI_ENOTSUP;
+                break;
+        }
+#endif
+        *nevents = 1;
+        return 0;
+    }
+
+    // Last option: call into poll(). This can only be done in case all
+    // subscriptions consist of __WASI_EVENTTYPE_FD_READ and
+    // __WASI_EVENTTYPE_FD_WRITE entries. There may be up to one
+    // __WASI_EVENTTYPE_CLOCK entry to act as a timeout. These are also
+    // the subscriptions generate by cloudlibc's poll() and select().
+    struct fd_object **fos =
+        wasm_runtime_malloc((uint32)(nsubscriptions * sizeof(*fos)));
+    if (fos == NULL)
+        return __WASI_ENOMEM;
+    struct pollfd *pfds =
+        wasm_runtime_malloc((uint32)(nsubscriptions * sizeof(*pfds)));
+    if (pfds == NULL) {
+        wasm_runtime_free(fos);
+        return __WASI_ENOMEM;
+    }
+
+    // Convert subscriptions to pollfd entries. Increase the reference
+    // count on the file descriptors to ensure they remain valid across
+    // the call to poll().
+    struct fd_table *ft = curfds;
+    rwlock_rdlock(&ft->lock);
+    *nevents = 0;
+    const __wasi_subscription_t *clock_subscription = NULL;
+    for (size_t i = 0; i < nsubscriptions; ++i) {
+        const __wasi_subscription_t *s = &in[i];
+        switch (s->type) {
+            case __WASI_EVENTTYPE_FD_READ:
+            case __WASI_EVENTTYPE_FD_WRITE:
+            {
+                __wasi_errno_t error =
+                    fd_object_get_locked(&fos[i], ft, s->u.fd_readwrite.fd,
+                                         __WASI_RIGHT_POLL_FD_READWRITE, 0);
+                if (error == 0) {
+                    // Proper file descriptor on which we can poll().
+                    pfds[i] = (struct pollfd){
+                        .fd = fd_number(fos[i]),
+                        .events = s->type == __WASI_EVENTTYPE_FD_READ
+                                      ? POLLRDNORM
+                                      : POLLWRNORM,
+                    };
+                }
+                else {
+                    // Invalid file descriptor or rights missing.
+                    fos[i] = NULL;
+                    pfds[i] = (struct pollfd){ .fd = -1 };
+                    out[(*nevents)++] = (__wasi_event_t){
+                        .userdata = s->userdata,
+                        .error = error,
+                        .type = s->type,
+                    };
+                }
+                break;
+            }
+            case __WASI_EVENTTYPE_CLOCK:
+                if (clock_subscription == NULL
+                    && (s->u.clock.flags & __WASI_SUBSCRIPTION_CLOCK_ABSTIME)
+                           == 0) {
+                    // Relative timeout.
+                    fos[i] = NULL;
+                    pfds[i] = (struct pollfd){ .fd = -1 };
+                    clock_subscription = s;
+                    break;
+                }
+            // Fallthrough.
+            default:
+                // Unsupported event.
+                fos[i] = NULL;
+                pfds[i] = (struct pollfd){ .fd = -1 };
+                out[(*nevents)++] = (__wasi_event_t){
+                    .userdata = s->userdata,
+                    .error = __WASI_ENOSYS,
+                    .type = s->type,
+                };
+                break;
+        }
+    }
+    rwlock_unlock(&ft->lock);
+
+    // Use a zero-second timeout in case we've already generated events in
+    // the loop above.
+    int timeout;
+    if (*nevents != 0) {
+        timeout = 0;
+    }
+    else if (clock_subscription != NULL) {
+        __wasi_timestamp_t ts = clock_subscription->u.clock.timeout / 1000000;
+        timeout = ts > INT_MAX ? -1 : (int)ts;
+    }
+    else {
+        timeout = -1;
+    }
+    int ret = poll(pfds, nsubscriptions, timeout);
+
+    __wasi_errno_t error = 0;
+    if (ret == -1) {
+        error = convert_errno(errno);
+    }
+    else if (ret == 0 && *nevents == 0 && clock_subscription != NULL) {
+        // No events triggered. Trigger the clock event.
+        out[(*nevents)++] = (__wasi_event_t){
+            .userdata = clock_subscription->userdata,
+            .type = __WASI_EVENTTYPE_CLOCK,
+        };
+    }
+    else {
+        // Events got triggered. Don't trigger the clock event.
+        for (size_t i = 0; i < nsubscriptions; ++i) {
+            if (pfds[i].fd >= 0) {
+                __wasi_filesize_t nbytes = 0;
+                if (in[i].type == __WASI_EVENTTYPE_FD_READ) {
+                    int l;
+                    if (ioctl(fd_number(fos[i]), FIONREAD, &l) == 0)
+                        nbytes = (__wasi_filesize_t)l;
+                }
+                if ((pfds[i].revents & POLLNVAL) != 0) {
+                    // Bad file descriptor. This normally cannot occur, as
+                    // referencing the file descriptor object will always ensure
+                    // the descriptor is valid. Still, macOS may sometimes
+                    // return this on FIFOs when reaching end-of-file.
+                    out[(*nevents)++] = (__wasi_event_t){
+                        .userdata = in[i].userdata,
+#ifdef __APPLE__
+                        .u.fd_readwrite.nbytes = nbytes,
+                        .u.fd_readwrite.flags =
+                            __WASI_EVENT_FD_READWRITE_HANGUP,
+#else
+                        .error = __WASI_EBADF,
+#endif
+                        .type = in[i].type,
+                    };
+                }
+                else if ((pfds[i].revents & POLLERR) != 0) {
+                    // File descriptor is in an error state.
+                    out[(*nevents)++] = (__wasi_event_t){
+                        .userdata = in[i].userdata,
+                        .error = __WASI_EIO,
+                        .type = in[i].type,
+                    };
+                }
+                else if ((pfds[i].revents & POLLHUP) != 0) {
+                    // End-of-file.
+                    out[(*nevents)++] = (__wasi_event_t){
+                        .userdata = in[i].userdata,
+                        .type = in[i].type,
+                        .u.fd_readwrite.nbytes = nbytes,
+                        .u.fd_readwrite.flags =
+                            __WASI_EVENT_FD_READWRITE_HANGUP,
+                    };
+                }
+                else if ((pfds[i].revents & (POLLRDNORM | POLLWRNORM)) != 0) {
+                    // Read or write possible.
+                    out[(*nevents)++] = (__wasi_event_t){
+                        .userdata = in[i].userdata,
+                        .type = in[i].type,
+                        .u.fd_readwrite.nbytes = nbytes,
+                    };
+                }
+            }
+        }
+    }
+
+    for (size_t i = 0; i < nsubscriptions; ++i)
+        if (fos[i] != NULL)
+            fd_object_release(fos[i]);
+    wasm_runtime_free(fos);
+    wasm_runtime_free(pfds);
+    return error;
 }
 
 #if 0
@@ -2677,227 +2675,228 @@ void wasmtime_ssp_proc_exit(
 }
 #endif
 
-__wasi_errno_t wasmtime_ssp_proc_raise(
-    __wasi_signal_t sig
-) {
-  static const int signals[] = {
+__wasi_errno_t
+wasmtime_ssp_proc_raise(__wasi_signal_t sig)
+{
+    static const int signals[] = {
 #define X(v) [__WASI_##v] = v
-      X(SIGABRT), X(SIGALRM), X(SIGBUS), X(SIGCHLD), X(SIGCONT), X(SIGFPE),
-      X(SIGHUP),  X(SIGILL),  X(SIGINT), X(SIGKILL), X(SIGPIPE), X(SIGQUIT),
-      X(SIGSEGV), X(SIGSTOP), X(SIGSYS), X(SIGTERM), X(SIGTRAP), X(SIGTSTP),
-      X(SIGTTIN), X(SIGTTOU), X(SIGURG), X(SIGUSR1), X(SIGUSR2), X(SIGVTALRM),
-      X(SIGXCPU), X(SIGXFSZ),
+        X(SIGABRT), X(SIGALRM), X(SIGBUS), X(SIGCHLD), X(SIGCONT), X(SIGFPE),
+        X(SIGHUP),  X(SIGILL),  X(SIGINT), X(SIGKILL), X(SIGPIPE), X(SIGQUIT),
+        X(SIGSEGV), X(SIGSTOP), X(SIGSYS), X(SIGTERM), X(SIGTRAP), X(SIGTSTP),
+        X(SIGTTIN), X(SIGTTOU), X(SIGURG), X(SIGUSR1), X(SIGUSR2), X(SIGVTALRM),
+        X(SIGXCPU), X(SIGXFSZ),
 #undef X
-  };
-  if (sig >= sizeof(signals) / sizeof(signals[0]) || signals[sig] == 0)
-    return __WASI_EINVAL;
+    };
+    if (sig >= sizeof(signals) / sizeof(signals[0]) || signals[sig] == 0)
+        return __WASI_EINVAL;
 
 #if CONFIG_TLS_USE_GSBASE
-  // TLS on OS X depends on installing a SIGSEGV handler. Reset SIGSEGV
-  // to the default action before raising.
-  if (sig == __WASI_SIGSEGV) {
-    struct sigaction sa = {
-        .sa_handler = SIG_DFL,
+    // TLS on OS X depends on installing a SIGSEGV handler. Reset SIGSEGV
+    // to the default action before raising.
+    if (sig == __WASI_SIGSEGV) {
+        struct sigaction sa = {
+            .sa_handler = SIG_DFL,
+        };
+        sigemptyset(&sa.sa_mask);
+        sigaction(SIGSEGV, &sa, NULL);
+    }
+#endif
+
+    if (raise(signals[sig]) < 0)
+        return convert_errno(errno);
+    return 0;
+}
+
+__wasi_errno_t
+wasmtime_ssp_random_get(void *buf, size_t nbyte)
+{
+    random_buf(buf, nbyte);
+    return 0;
+}
+
+__wasi_errno_t
+wasmtime_ssp_sock_recv(
+#if !defined(WASMTIME_SSP_STATIC_CURFDS)
+    struct fd_table *curfds,
+#endif
+    __wasi_fd_t sock, const __wasi_iovec_t *ri_data, size_t ri_data_len,
+    __wasi_riflags_t ri_flags, size_t *ro_datalen, __wasi_roflags_t *ro_flags)
+{
+    // Convert input to msghdr.
+    struct msghdr hdr = {
+        .msg_iov = (struct iovec *)ri_data,
+        .msg_iovlen = ri_data_len,
     };
-    sigemptyset(&sa.sa_mask);
-    sigaction(SIGSEGV, &sa, NULL);
-  }
-#endif
+    int nflags = 0;
+    if ((ri_flags & __WASI_SOCK_RECV_PEEK) != 0)
+        nflags |= MSG_PEEK;
+    if ((ri_flags & __WASI_SOCK_RECV_WAITALL) != 0)
+        nflags |= MSG_WAITALL;
 
-  if (raise(signals[sig]) < 0)
-    return convert_errno(errno);
-  return 0;
+    struct fd_object *fo;
+    __wasi_errno_t error =
+        fd_object_get(curfds, &fo, sock, __WASI_RIGHT_FD_READ, 0);
+    if (error != 0) {
+        return error;
+    }
+
+    ssize_t datalen = recvmsg(fd_number(fo), &hdr, nflags);
+    fd_object_release(fo);
+    if (datalen < 0) {
+        return convert_errno(errno);
+    }
+
+    // Convert msghdr to output.
+    *ro_datalen = (size_t)datalen;
+    *ro_flags = 0;
+    if ((hdr.msg_flags & MSG_TRUNC) != 0)
+        *ro_flags |= __WASI_SOCK_RECV_DATA_TRUNCATED;
+    return 0;
 }
 
-__wasi_errno_t wasmtime_ssp_random_get(
-    void *buf,
-    size_t nbyte
-) {
-  random_buf(buf, nbyte);
-  return 0;
-}
-
-__wasi_errno_t wasmtime_ssp_sock_recv(
+__wasi_errno_t
+wasmtime_ssp_sock_send(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t sock,
-    const __wasi_iovec_t *ri_data,
-    size_t ri_data_len,
-    __wasi_riflags_t ri_flags,
-    size_t *ro_datalen,
-    __wasi_roflags_t *ro_flags
-) {
-  // Convert input to msghdr.
-  struct msghdr hdr = {
-      .msg_iov = (struct iovec *)ri_data,
-      .msg_iovlen = ri_data_len,
-  };
-  int nflags = 0;
-  if ((ri_flags & __WASI_SOCK_RECV_PEEK) != 0)
-    nflags |= MSG_PEEK;
-  if ((ri_flags & __WASI_SOCK_RECV_WAITALL) != 0)
-    nflags |= MSG_WAITALL;
+    __wasi_fd_t sock, const __wasi_ciovec_t *si_data, size_t si_data_len,
+    __wasi_siflags_t si_flags, size_t *so_datalen) NO_LOCK_ANALYSIS
+{
+    // Convert input to msghdr.
+    struct msghdr hdr = {
+        .msg_iov = (struct iovec *)si_data,
+        .msg_iovlen = si_data_len,
+    };
 
-  struct fd_object *fo;
-  __wasi_errno_t error = fd_object_get(curfds, &fo, sock, __WASI_RIGHT_FD_READ, 0);
-  if (error != 0) {
-    return error;
-  }
+    // Attach file descriptors if present.
+    __wasi_errno_t error;
 
-  ssize_t datalen = recvmsg(fd_number(fo), &hdr, nflags);
-  fd_object_release(fo);
-  if (datalen < 0) {
-    return convert_errno(errno);
-  }
-
-
-  // Convert msghdr to output.
-  *ro_datalen = (size_t)datalen;
-  *ro_flags = 0;
-  if ((hdr.msg_flags & MSG_TRUNC) != 0)
-    *ro_flags |= __WASI_SOCK_RECV_DATA_TRUNCATED;
-  return 0;
-}
-
-__wasi_errno_t wasmtime_ssp_sock_send(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
-    struct fd_table *curfds,
-#endif
-    __wasi_fd_t sock,
-    const __wasi_ciovec_t *si_data,
-    size_t si_data_len,
-    __wasi_siflags_t si_flags,
-    size_t *so_datalen
-) NO_LOCK_ANALYSIS {
-  // Convert input to msghdr.
-  struct msghdr hdr = {
-      .msg_iov = (struct iovec *)si_data,
-      .msg_iovlen = si_data_len,
-  };
-
-  // Attach file descriptors if present.
-  __wasi_errno_t error;
-
-  // Send message.
-  struct fd_object *fo;
-  error = fd_object_get(curfds, &fo, sock, __WASI_RIGHT_FD_WRITE, 0);
-  if (error != 0)
-    goto out;
-  ssize_t len = sendmsg(fd_number(fo), &hdr, 0);
-  fd_object_release(fo);
-  if (len < 0) {
-    error = convert_errno(errno);
-  } else {
-    *so_datalen = (size_t)len;
-  }
+    // Send message.
+    struct fd_object *fo;
+    error = fd_object_get(curfds, &fo, sock, __WASI_RIGHT_FD_WRITE, 0);
+    if (error != 0)
+        goto out;
+    ssize_t len = sendmsg(fd_number(fo), &hdr, 0);
+    fd_object_release(fo);
+    if (len < 0) {
+        error = convert_errno(errno);
+    }
+    else {
+        *so_datalen = (size_t)len;
+    }
 
 out:
-  return error;
+    return error;
 }
 
-__wasi_errno_t wasmtime_ssp_sock_shutdown(
+__wasi_errno_t
+wasmtime_ssp_sock_shutdown(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t sock,
-    __wasi_sdflags_t how
-) {
-  int nhow;
-  switch (how) {
-    case __WASI_SHUT_RD:
-      nhow = SHUT_RD;
-      break;
-    case __WASI_SHUT_WR:
-      nhow = SHUT_WR;
-      break;
-    case __WASI_SHUT_RD | __WASI_SHUT_WR:
-      nhow = SHUT_RDWR;
-      break;
-    default:
-      return __WASI_EINVAL;
-  }
+    __wasi_fd_t sock, __wasi_sdflags_t how)
+{
+    int nhow;
+    switch (how) {
+        case __WASI_SHUT_RD:
+            nhow = SHUT_RD;
+            break;
+        case __WASI_SHUT_WR:
+            nhow = SHUT_WR;
+            break;
+        case __WASI_SHUT_RD | __WASI_SHUT_WR:
+            nhow = SHUT_RDWR;
+            break;
+        default:
+            return __WASI_EINVAL;
+    }
 
-  struct fd_object *fo;
-  __wasi_errno_t error =
-      fd_object_get(curfds, &fo, sock, __WASI_RIGHT_SOCK_SHUTDOWN, 0);
-  if (error != 0)
-    return error;
+    struct fd_object *fo;
+    __wasi_errno_t error =
+        fd_object_get(curfds, &fo, sock, __WASI_RIGHT_SOCK_SHUTDOWN, 0);
+    if (error != 0)
+        return error;
 
-  int ret = shutdown(fd_number(fo), nhow);
-  fd_object_release(fo);
-  if (ret < 0)
-    return convert_errno(errno);
-  return 0;
+    int ret = shutdown(fd_number(fo), nhow);
+    fd_object_release(fo);
+    if (ret < 0)
+        return convert_errno(errno);
+    return 0;
 }
 
-__wasi_errno_t wasmtime_ssp_sched_yield(void) {
-  if (sched_yield() < 0)
-    return convert_errno(errno);
-  return 0;
+__wasi_errno_t
+wasmtime_ssp_sched_yield(void)
+{
+    if (sched_yield() < 0)
+        return convert_errno(errno);
+    return 0;
 }
 
-__wasi_errno_t wasmtime_ssp_args_get(
+__wasi_errno_t
+wasmtime_ssp_args_get(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
-  struct argv_environ_values *argv_environ,
+    struct argv_environ_values *argv_environ,
 #endif
-  char **argv,
-  char *argv_buf
-) {
-  for (size_t i = 0; i < argv_environ->argc; ++i) {
-    argv[i] = argv_buf + (argv_environ->argv_list[i] - argv_environ->argv_buf);
-  }
-  argv[argv_environ->argc] = NULL;
-  bh_memcpy_s(argv_buf, (uint32)argv_environ->argv_buf_size,
-              argv_environ->argv_buf, (uint32)argv_environ->argv_buf_size);
-  return __WASI_ESUCCESS;
+    char **argv, char *argv_buf)
+{
+    for (size_t i = 0; i < argv_environ->argc; ++i) {
+        argv[i] =
+            argv_buf + (argv_environ->argv_list[i] - argv_environ->argv_buf);
+    }
+    argv[argv_environ->argc] = NULL;
+    bh_memcpy_s(argv_buf, (uint32)argv_environ->argv_buf_size,
+                argv_environ->argv_buf, (uint32)argv_environ->argv_buf_size);
+    return __WASI_ESUCCESS;
 }
 
-__wasi_errno_t wasmtime_ssp_args_sizes_get(
+__wasi_errno_t
+wasmtime_ssp_args_sizes_get(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
-  struct argv_environ_values *argv_environ,
+    struct argv_environ_values *argv_environ,
 #endif
-  size_t *argc,
-  size_t *argv_buf_size
-) {
-  *argc = argv_environ->argc;
-  *argv_buf_size = argv_environ->argv_buf_size;
-  return __WASI_ESUCCESS;
+    size_t *argc, size_t *argv_buf_size)
+{
+    *argc = argv_environ->argc;
+    *argv_buf_size = argv_environ->argv_buf_size;
+    return __WASI_ESUCCESS;
 }
 
-__wasi_errno_t wasmtime_ssp_environ_get(
+__wasi_errno_t
+wasmtime_ssp_environ_get(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
-  struct argv_environ_values *argv_environ,
+    struct argv_environ_values *argv_environ,
 #endif
-  char **environ,
-  char *environ_buf
-) {
-  for (size_t i = 0; i < argv_environ->environ_count; ++i) {
-    environ[i] = environ_buf + (argv_environ->environ_list[i] - argv_environ->environ_buf);
-  }
-  environ[argv_environ->environ_count] = NULL;
-  bh_memcpy_s(environ_buf, (uint32)argv_environ->environ_buf_size,
-              argv_environ->environ_buf, (uint32)argv_environ->environ_buf_size);
-  return __WASI_ESUCCESS;
+    char **environ, char *environ_buf)
+{
+    for (size_t i = 0; i < argv_environ->environ_count; ++i) {
+        environ[i] =
+            environ_buf
+            + (argv_environ->environ_list[i] - argv_environ->environ_buf);
+    }
+    environ[argv_environ->environ_count] = NULL;
+    bh_memcpy_s(environ_buf, (uint32)argv_environ->environ_buf_size,
+                argv_environ->environ_buf,
+                (uint32)argv_environ->environ_buf_size);
+    return __WASI_ESUCCESS;
 }
 
-__wasi_errno_t wasmtime_ssp_environ_sizes_get(
+__wasi_errno_t
+wasmtime_ssp_environ_sizes_get(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
-  struct argv_environ_values *argv_environ,
+    struct argv_environ_values *argv_environ,
 #endif
-  size_t *environ_count,
-  size_t *environ_buf_size
-) {
-  *environ_count = argv_environ->environ_count;
-  *environ_buf_size = argv_environ->environ_buf_size;
-  return __WASI_ESUCCESS;
+    size_t *environ_count, size_t *environ_buf_size)
+{
+    *environ_count = argv_environ->environ_count;
+    *environ_buf_size = argv_environ->environ_buf_size;
+    return __WASI_ESUCCESS;
 }
 
-bool argv_environ_init(struct argv_environ_values *argv_environ,
-                       char *argv_buf, size_t argv_buf_size,
-                       char **argv_list, size_t argc,
-                       char *environ_buf, size_t environ_buf_size,
-                       char **environ_list, size_t environ_count)
+bool
+argv_environ_init(struct argv_environ_values *argv_environ, char *argv_buf,
+                  size_t argv_buf_size, char **argv_list, size_t argc,
+                  char *environ_buf, size_t environ_buf_size,
+                  char **environ_list, size_t environ_count)
 {
     memset(argv_environ, 0, sizeof(struct argv_environ_values));
 
@@ -2912,11 +2911,12 @@ bool argv_environ_init(struct argv_environ_values *argv_environ,
     return true;
 }
 
-void argv_environ_destroy(struct argv_environ_values *argv_environ)
-{
-}
+void
+argv_environ_destroy(struct argv_environ_values *argv_environ)
+{}
 
-void fd_table_destroy(struct fd_table *ft)
+void
+fd_table_destroy(struct fd_table *ft)
 {
     if (ft->entries) {
         for (uint32 i = 0; i < ft->size; i++) {
@@ -2929,12 +2929,13 @@ void fd_table_destroy(struct fd_table *ft)
     }
 }
 
-void fd_prestats_destroy(struct fd_prestats *pt)
+void
+fd_prestats_destroy(struct fd_prestats *pt)
 {
     if (pt->prestats) {
         for (uint32 i = 0; i < pt->size; i++) {
             if (pt->prestats[i].dir != NULL) {
-                wasm_runtime_free((void*)pt->prestats[i].dir);
+                wasm_runtime_free((void *)pt->prestats[i].dir);
             }
         }
         rwlock_destroy(&pt->lock);

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.h
@@ -1,5 +1,7 @@
-// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license information.
+// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM
+// Exceptions. See
+// https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license
+// information.
 //
 // Significant parts of this file are derived from cloudabi-utils. See
 // https://github.com/bytecodealliance/wasmtime/blob/main/lib/wasi/sandboxed-system-primitives/src/LICENSE
@@ -20,41 +22,48 @@ struct fd_prestat;
 struct syscalls;
 
 struct fd_table {
-  struct rwlock lock;
-  struct fd_entry *entries;
-  size_t size;
-  size_t used;
+    struct rwlock lock;
+    struct fd_entry *entries;
+    size_t size;
+    size_t used;
 };
 
 struct fd_prestats {
-  struct rwlock lock;
-  struct fd_prestat *prestats;
-  size_t size;
-  size_t used;
+    struct rwlock lock;
+    struct fd_prestat *prestats;
+    size_t size;
+    size_t used;
 };
 
 struct argv_environ_values {
-  const char *argv_buf;
-  size_t argv_buf_size;
-  char **argv_list;
-  size_t argc;
-  char *environ_buf;
-  size_t environ_buf_size;
-  char **environ_list;
-  size_t environ_count;
+    const char *argv_buf;
+    size_t argv_buf_size;
+    char **argv_list;
+    size_t argc;
+    char *environ_buf;
+    size_t environ_buf_size;
+    char **environ_list;
+    size_t environ_count;
 };
 
-bool fd_table_init(struct fd_table *);
-bool fd_table_insert_existing(struct fd_table *, __wasi_fd_t, int);
-bool fd_prestats_init(struct fd_prestats *);
-bool fd_prestats_insert(struct fd_prestats *, const char *, __wasi_fd_t);
-bool argv_environ_init(struct argv_environ_values *argv_environ,
-                       char *argv_buf, size_t argv_buf_size,
-                       char **argv_list, size_t argc,
-                       char *environ_buf, size_t environ_buf_size,
-                       char **environ_list, size_t environ_count);
-void argv_environ_destroy(struct argv_environ_values *argv_environ);
-void fd_table_destroy(struct fd_table *ft);
-void fd_prestats_destroy(struct fd_prestats *pt);
+bool
+fd_table_init(struct fd_table *);
+bool
+fd_table_insert_existing(struct fd_table *, __wasi_fd_t, int);
+bool
+fd_prestats_init(struct fd_prestats *);
+bool
+fd_prestats_insert(struct fd_prestats *, const char *, __wasi_fd_t);
+bool
+argv_environ_init(struct argv_environ_values *argv_environ, char *argv_buf,
+                  size_t argv_buf_size, char **argv_list, size_t argc,
+                  char *environ_buf, size_t environ_buf_size,
+                  char **environ_list, size_t environ_count);
+void
+argv_environ_destroy(struct argv_environ_values *argv_environ);
+void
+fd_table_destroy(struct fd_table *ft);
+void
+fd_prestats_destroy(struct fd_prestats *pt);
 
 #endif

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/queue.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/queue.h
@@ -1,5 +1,7 @@
-// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license information.
+// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM
+// Exceptions. See
+// https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license
+// information.
 //
 // Significant parts of this file are derived from cloudabi-utils. See
 // https://github.com/bytecodealliance/wasmtime/blob/main/lib/wasi/sandboxed-system-primitives/src/LICENSE
@@ -15,76 +17,82 @@
 // LIST: Double-linked list.
 
 #define LIST_HEAD(name, type) \
-  struct name {               \
-    struct type *l_first;     \
-  }
-#define LIST_HEAD_INITIALIZER(head) \
-  { NULL }
+    struct name {             \
+        struct type *l_first; \
+    }
 
-#define LIST_ENTRY(type)  \
-  struct {                \
-    struct type *l_next;  \
-    struct type **l_prev; \
-  }
+/* clang-format off */
+#define LIST_HEAD_INITIALIZER(head) \
+    { NULL }
+/* clang-format on */
+
+#define LIST_ENTRY(type)      \
+    struct {                  \
+        struct type *l_next;  \
+        struct type **l_prev; \
+    }
 
 #define LIST_FOREACH(var, head, field) \
-  for ((var) = (head)->l_first; (var) != NULL; (var) = (var)->field.l_next)
-#define LIST_INIT(head)     \
-  do {                      \
-    (head)->l_first = NULL; \
-  } while (0)
-#define LIST_INSERT_HEAD(head, element, field)                  \
-  do {                                                          \
-    (element)->field.l_next = (head)->l_first;                  \
-    if ((head)->l_first != NULL)                                \
-      (head)->l_first->field.l_prev = &(element)->field.l_next; \
-    (head)->l_first = (element);                                \
-    (element)->field.l_prev = &(head)->l_first;                 \
-  } while (0)
-#define LIST_REMOVE(element, field)                                    \
-  do {                                                                 \
-    if ((element)->field.l_next != NULL)                               \
-      (element)->field.l_next->field.l_prev = (element)->field.l_prev; \
-    *(element)->field.l_prev = (element)->field.l_next;                \
-  } while (0)
+    for ((var) = (head)->l_first; (var) != NULL; (var) = (var)->field.l_next)
+
+#define LIST_INIT(head)         \
+    do {                        \
+        (head)->l_first = NULL; \
+    } while (0)
+
+#define LIST_INSERT_HEAD(head, element, field)                        \
+    do {                                                              \
+        (element)->field.l_next = (head)->l_first;                    \
+        if ((head)->l_first != NULL)                                  \
+            (head)->l_first->field.l_prev = &(element)->field.l_next; \
+        (head)->l_first = (element);                                  \
+        (element)->field.l_prev = &(head)->l_first;                   \
+    } while (0)
+
+#define LIST_REMOVE(element, field)                                          \
+    do {                                                                     \
+        if ((element)->field.l_next != NULL)                                 \
+            (element)->field.l_next->field.l_prev = (element)->field.l_prev; \
+        *(element)->field.l_prev = (element)->field.l_next;                  \
+    } while (0)
 
 // TAILQ: Double-linked list with tail pointer.
 
 #define TAILQ_HEAD(name, type) \
-  struct name {                \
-    struct type *t_first;      \
-    struct type **t_last;      \
-  }
+    struct name {              \
+        struct type *t_first;  \
+        struct type **t_last;  \
+    }
 
-#define TAILQ_ENTRY(type) \
-  struct {                \
-    struct type *t_next;  \
-    struct type **t_prev; \
-  }
+#define TAILQ_ENTRY(type)     \
+    struct {                  \
+        struct type *t_next;  \
+        struct type **t_prev; \
+    }
 
 #define TAILQ_EMPTY(head) ((head)->t_first == NULL)
 #define TAILQ_FIRST(head) ((head)->t_first)
 #define TAILQ_FOREACH(var, head, field) \
-  for ((var) = (head)->t_first; (var) != NULL; (var) = (var)->field.t_next)
-#define TAILQ_INIT(head)               \
-  do {                                 \
-    (head)->t_first = NULL;            \
-    (head)->t_last = &(head)->t_first; \
-  } while (0)
-#define TAILQ_INSERT_TAIL(head, elm, field) \
-  do {                                      \
-    (elm)->field.t_next = NULL;             \
-    (elm)->field.t_prev = (head)->t_last;   \
-    *(head)->t_last = (elm);                \
-    (head)->t_last = &(elm)->field.t_next;  \
-  } while (0)
-#define TAILQ_REMOVE(head, element, field)                             \
-  do {                                                                 \
-    if ((element)->field.t_next != NULL)                               \
-      (element)->field.t_next->field.t_prev = (element)->field.t_prev; \
-    else                                                               \
-      (head)->t_last = (element)->field.t_prev;                        \
-    *(element)->field.t_prev = (element)->field.t_next;                \
-  } while (0)
+    for ((var) = (head)->t_first; (var) != NULL; (var) = (var)->field.t_next)
+#define TAILQ_INIT(head)                   \
+    do {                                   \
+        (head)->t_first = NULL;            \
+        (head)->t_last = &(head)->t_first; \
+    } while (0)
+#define TAILQ_INSERT_TAIL(head, elm, field)    \
+    do {                                       \
+        (elm)->field.t_next = NULL;            \
+        (elm)->field.t_prev = (head)->t_last;  \
+        *(head)->t_last = (elm);               \
+        (head)->t_last = &(elm)->field.t_next; \
+    } while (0)
+#define TAILQ_REMOVE(head, element, field)                                   \
+    do {                                                                     \
+        if ((element)->field.t_next != NULL)                                 \
+            (element)->field.t_next->field.t_prev = (element)->field.t_prev; \
+        else                                                                 \
+            (head)->t_last = (element)->field.t_prev;                        \
+        *(element)->field.t_prev = (element)->field.t_next;                  \
+    } while (0)
 
 #endif

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/random.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/random.c
@@ -1,5 +1,7 @@
-// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license information.
+// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM
+// Exceptions. See
+// https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license
+// information.
 //
 // Significant parts of this file are derived from cloudabi-utils. See
 // https://github.com/bytecodealliance/wasmtime/blob/main/lib/wasi/sandboxed-system-primitives/src/LICENSE
@@ -15,8 +17,10 @@
 
 #if CONFIG_HAS_ARC4RANDOM_BUF
 
-void random_buf(void *buf, size_t len) {
-  arc4random_buf(buf, len);
+void
+random_buf(void *buf, size_t len)
+{
+    arc4random_buf(buf, len);
 }
 
 #elif CONFIG_HAS_GETRANDOM
@@ -25,42 +29,48 @@ void random_buf(void *buf, size_t len) {
 #include <sys/random.h>
 #endif
 
-void random_buf(void *buf, size_t len) {
-  for (;;) {
-     ssize_t x = getrandom(buf, len, 0);
-     if (x < 0) {
-         if (errno == EINTR)
-             continue;
-         os_printf("getrandom failed: %s", strerror(errno));
-         abort();
-     }
-     if ((size_t)x == len)
-         return;
-     buf = (void *)((unsigned char *)buf + x);
-     len -= (size_t)x;
-  }
+void
+random_buf(void *buf, size_t len)
+{
+    for (;;) {
+        ssize_t x = getrandom(buf, len, 0);
+        if (x < 0) {
+            if (errno == EINTR)
+                continue;
+            os_printf("getrandom failed: %s", strerror(errno));
+            abort();
+        }
+        if ((size_t)x == len)
+            return;
+        buf = (void *)((unsigned char *)buf + x);
+        len -= (size_t)x;
+    }
 }
 
 #else
 
 static int urandom;
 
-static void open_urandom(void) {
-  urandom = open("/dev/urandom", O_RDONLY);
-  if (urandom < 0) {
-    os_printf("Failed to open /dev/urandom\n");
-    abort();
-  }
+static void
+open_urandom(void)
+{
+    urandom = open("/dev/urandom", O_RDONLY);
+    if (urandom < 0) {
+        os_printf("Failed to open /dev/urandom\n");
+        abort();
+    }
 }
 
-void random_buf(void *buf, size_t len) {
-  static pthread_once_t open_once = PTHREAD_ONCE_INIT;
-  pthread_once(&open_once, open_urandom);
+void
+random_buf(void *buf, size_t len)
+{
+    static pthread_once_t open_once = PTHREAD_ONCE_INIT;
+    pthread_once(&open_once, open_urandom);
 
-  if ((size_t)read(urandom, buf, len) != len) {
-    os_printf("Short read on /dev/urandom\n");
-    abort();
-  }
+    if ((size_t)read(urandom, buf, len) != len) {
+        os_printf("Short read on /dev/urandom\n");
+        abort();
+    }
 }
 
 #endif
@@ -72,15 +82,17 @@ void random_buf(void *buf, size_t len) {
 // arc4random() until it lies within the range [2^k % upper, 2^k). As
 // this range has length k * upper, we can safely obtain a number
 // without any modulo bias.
-uintmax_t random_uniform(uintmax_t upper) {
-  // Compute 2^k % upper
-  //      == (2^k - upper) % upper
-  //      == -upper % upper.
-  uintmax_t lower = -upper % upper;
-  for (;;) {
-    uintmax_t value;
-    random_buf(&value, sizeof(value));
-    if (value >= lower)
-      return value % upper;
-  }
+uintmax_t
+random_uniform(uintmax_t upper)
+{
+    // Compute 2^k % upper
+    //      == (2^k - upper) % upper
+    //      == -upper % upper.
+    uintmax_t lower = -upper % upper;
+    for (;;) {
+        uintmax_t value;
+        random_buf(&value, sizeof(value));
+        if (value >= lower)
+            return value % upper;
+    }
 }

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/random.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/random.h
@@ -1,5 +1,7 @@
-// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license information.
+// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM
+// Exceptions. See
+// https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license
+// information.
 //
 // Significant parts of this file are derived from cloudabi-utils. See
 // https://github.com/bytecodealliance/wasmtime/blob/main/lib/wasi/sandboxed-system-primitives/src/LICENSE
@@ -12,7 +14,8 @@
 #ifndef RANDOM_H
 #define RANDOM_H
 
-void random_buf(void *, size_t);
+void
+random_buf(void *, size_t);
 uintmax_t random_uniform(uintmax_t);
 
 #endif

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/refcount.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/refcount.h
@@ -1,5 +1,7 @@
-// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license information.
+// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM
+// Exceptions. See
+// https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license
+// information.
 //
 // Significant parts of this file are derived from cloudabi-utils. See
 // https://github.com/bytecodealliance/wasmtime/blob/main/lib/wasi/sandboxed-system-primitives/src/LICENSE
@@ -46,8 +48,8 @@ refcount_acquire(struct refcount *r) PRODUCES(*r)
 static inline bool
 refcount_release(struct refcount *r) CONSUMES(*r)
 {
-    int old = (int)atomic_fetch_sub_explicit(&r->count, 1,
-                                             memory_order_release);
+    int old =
+        (int)atomic_fetch_sub_explicit(&r->count, 1, memory_order_release);
     bh_assert(old != 0 && "Reference count becoming negative");
     return old == 1;
 }

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/rights.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/rights.h
@@ -1,5 +1,7 @@
-// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license information.
+// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM
+// Exceptions. See
+// https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license
+// information.
 //
 // Significant parts of this file are derived from cloudabi-utils. See
 // https://github.com/bytecodealliance/wasmtime/blob/main/lib/wasi/sandboxed-system-primitives/src/LICENSE
@@ -11,6 +13,8 @@
 
 #ifndef RIGHTS_H
 #define RIGHTS_H
+
+/* clang-format off */
 
 #define RIGHTS_ALL                                                         \
   (__WASI_RIGHT_FD_DATASYNC | __WASI_RIGHT_FD_READ |                       \
@@ -79,5 +83,7 @@
    __WASI_RIGHT_FD_WRITE | __WASI_RIGHT_FD_FILESTAT_GET |      \
    __WASI_RIGHT_POLL_FD_READWRITE)
 #define RIGHTS_TTY_INHERITING 0
+
+/* clang-format on */
 
 #endif

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/signals.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/signals.h
@@ -1,5 +1,7 @@
-// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license information.
+// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM
+// Exceptions. See
+// https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license
+// information.
 //
 // Significant parts of this file are derived from cloudabi-utils. See
 // https://github.com/bytecodealliance/wasmtime/blob/main/lib/wasi/sandboxed-system-primitives/src/LICENSE
@@ -12,6 +14,7 @@
 #ifndef SIGNALS_H
 #define SIGNALS_H
 
-void signals_init(void);
+void
+signals_init(void);
 
 #endif

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
@@ -1,5 +1,7 @@
-// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license information.
+// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM
+// Exceptions. See
+// https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license
+// information.
 //
 // Significant parts of this file are derived from cloudabi-utils. See
 // https://github.com/bytecodealliance/wasmtime/blob/main/lib/wasi/sandboxed-system-primitives/src/LICENSE
@@ -14,7 +16,8 @@
 
 #include <stdlib.h>
 
-#if defined(__FreeBSD__) || defined(__APPLE__) || (defined(ANDROID) && __ANDROID_API__ < 28)
+#if defined(__FreeBSD__) || defined(__APPLE__) \
+    || (defined(ANDROID) && __ANDROID_API__ < 28)
 #define CONFIG_HAS_ARC4RANDOM_BUF 1
 #else
 #define CONFIG_HAS_ARC4RANDOM_BUF 0
@@ -22,10 +25,9 @@
 
 // On Linux, prefer to use getrandom, though it isn't available in
 // GLIBC before 2.25.
-#if defined(__linux__) && \
-    (!defined(__GLIBC__) || \
-     __GLIBC__ > 2 || \
-     (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 25))
+#if defined(__linux__)                       \
+    && (!defined(__GLIBC__) || __GLIBC__ > 2 \
+        || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 25))
 #define CONFIG_HAS_GETRANDOM 1
 #else
 #define CONFIG_HAS_GETRANDOM 0

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/str.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/str.c
@@ -1,5 +1,7 @@
-// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license information.
+// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM
+// Exceptions. See
+// https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license
+// information.
 //
 // Significant parts of this file are derived from cloudabi-utils. See
 // https://github.com/bytecodealliance/wasmtime/blob/main/lib/wasi/sandboxed-system-primitives/src/LICENSE
@@ -27,7 +29,8 @@ bh_strndup(const char *s, size_t n)
 }
 
 char *
-str_nullterminate(const char *s, size_t len) {
+str_nullterminate(const char *s, size_t len)
+{
     /* Copy string */
     char *ret = bh_strndup(s, len);
 
@@ -40,5 +43,5 @@ str_nullterminate(const char *s, size_t len) {
         errno = EILSEQ;
         return NULL;
     }
-  return ret;
+    return ret;
 }

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/str.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/str.h
@@ -1,5 +1,7 @@
-// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license information.
+// Part of the Wasmtime Project, under the Apache License v2.0 with LLVM
+// Exceptions. See
+// https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE for license
+// information.
 //
 // Significant parts of this file are derived from cloudabi-utils. See
 // https://github.com/bytecodealliance/wasmtime/blob/main/lib/wasi/sandboxed-system-primitives/src/LICENSE
@@ -14,6 +16,7 @@
 
 #include "ssp_config.h"
 
-char *str_nullterminate(const char *, size_t);
+char *
+str_nullterminate(const char *, size_t);
 
 #endif

--- a/core/iwasm/libraries/thread-mgr/thread_manager.h
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.h
@@ -16,30 +16,28 @@
 extern "C" {
 #endif
 #if WASM_ENABLE_DEBUG_INTERP != 0
-#define WAMR_SIG_TRAP  (5)
-#define WAMR_SIG_STOP  (19)
-#define WAMR_SIG_TERM  (15)
-#define WAMR_SIG_SINGSTEP  (0x1ff)
+#define WAMR_SIG_TRAP (5)
+#define WAMR_SIG_STOP (19)
+#define WAMR_SIG_TERM (15)
+#define WAMR_SIG_SINGSTEP (0x1ff)
 
 #define STATUS_RUNNING (0)
-#define STATUS_STOP    (1)
-#define STATUS_EXIT   (2)
-#define STATUS_STEP   (3)
+#define STATUS_STOP (1)
+#define STATUS_EXIT (2)
+#define STATUS_STEP (3)
 
-#define IS_WAMR_TERM_SIG(signo) \
-    ((signo) == WAMR_SIG_TERM)
+#define IS_WAMR_TERM_SIG(signo) ((signo) == WAMR_SIG_TERM)
 
 #define IS_WAMR_STOP_SIG(signo) \
     ((signo) == WAMR_SIG_STOP || (signo) == WAMR_SIG_TRAP)
 
-typedef struct WASMCurrentEnvStatus
-{
-    uint64 signal_flag:32;
-    uint64 step_count:16;
-    uint64 running_status:16;
+typedef struct WASMCurrentEnvStatus {
+    uint64 signal_flag : 32;
+    uint64 step_count : 16;
+    uint64 running_status : 16;
     korp_mutex wait_lock;
     korp_cond wait_cond;
-}WASMCurrentEnvStatus;
+} WASMCurrentEnvStatus;
 
 WASMCurrentEnvStatus *
 wasm_cluster_create_exenv_status();
@@ -57,7 +55,7 @@ void
 wasm_cluster_thread_waiting_run(WASMExecEnv *exec_env);
 
 void
-wasm_cluster_wait_thread_status(WASMExecEnv *exec_env, uint32 * status);
+wasm_cluster_wait_thread_status(WASMExecEnv *exec_env, uint32 *status);
 
 void
 wasm_cluster_thread_exited(WASMExecEnv *exec_env);
@@ -72,8 +70,7 @@ void
 wasm_cluster_thread_step(WASMExecEnv *exec_env);
 
 #endif
-typedef struct WASMCluster
-{
+typedef struct WASMCluster {
     struct WASMCluster *next;
 
     korp_mutex lock;
@@ -89,7 +86,8 @@ typedef struct WASMCluster
     bool *stack_segment_occupied;
 } WASMCluster;
 
-void wasm_cluster_set_max_thread_num(uint32 num);
+void
+wasm_cluster_set_max_thread_num(uint32 num);
 
 bool
 thread_manager_init();
@@ -106,14 +104,13 @@ void
 wasm_cluster_destroy(WASMCluster *cluster);
 
 /* Get the cluster of the current exec_env */
-WASMCluster*
+WASMCluster *
 wasm_exec_env_get_cluster(WASMExecEnv *exec_env);
 
 int32
 wasm_cluster_create_thread(WASMExecEnv *exec_env,
                            wasm_module_inst_t module_inst,
-                           void* (*thread_routine)(void *),
-                           void *arg);
+                           void *(*thread_routine)(void *), void *arg);
 
 int32
 wasm_cluster_join_thread(WASMExecEnv *exec_env, void **ret_val);


### PR DESCRIPTION
Apply clang-format for core/iwasm/compilation and core/iwasm/libraries files.
Add wasm-c-api empty_imports sample to workflow test.
And enable triggering workflow when core/config.h changes.