### PR TITLE
Sync up with wabt latest modification (#296)

### DIFF
--- a/.github/workflows/spec_test.yml
+++ b/.github/workflows/spec_test.yml
@@ -11,6 +11,8 @@ on:
       - "core/shared/**"
       - "wamr-compiler/**"
       - "product-mini/**"
+      - "tests/wamr-test-suites/spec-test-script/**"
+      - "tests/wamr-test-suites/test_wamr.sh"
   # will be triggered on push events
   push:
     paths:
@@ -19,6 +21,8 @@ on:
       - "core/shared/**"
       - "wamr-compiler/**"
       - "product-mini/**"
+      - "tests/wamr-test-suites/spec-test-script/**"
+      - "tests/wamr-test-suites/test_wamr.sh"
   # allow to be triggered manually
   workflow_dispatch:
 

--- a/tests/wamr-test-suites/spec-test-script/runtest.py
+++ b/tests/wamr-test-suites/spec-test-script/runtest.py
@@ -901,10 +901,9 @@ def compile_wast_to_wasm(form, wast_tempfile, wasm_tempfile, opts):
             "--no-check",
             wast_tempfile, "-o", wasm_tempfile ]
 
-    # optional arguments
-    if opts.ref_types:
-        cmd.append("--enable-reference-types")
-        cmd.append("--enable-bulk-memory")
+    # remove reference-type and bulk-memory enabling options since a WABT
+    # commit 30c1e983d30b33a8004b39fd60cbd64477a7956c
+    # Enable reference types by default (#1729)
 
     log("Running: %s" % " ".join(cmd))
     try:

--- a/tests/wamr-test-suites/spec-test-script/thread_proposal_ignore_cases.patch
+++ b/tests/wamr-test-suites/spec-test-script/thread_proposal_ignore_cases.patch
@@ -163,9 +163,24 @@ index b9fa438c..a5711dd3 100644
  ;; 1 elem segment declared, 2 given
  (assert_malformed
 diff --git a/test/core/elem.wast b/test/core/elem.wast
-index 1ea2b061..f5440e07 100644
+index 1ea2b061..8eded377 100644
 --- a/test/core/elem.wast
 +++ b/test/core/elem.wast
+@@ -12,10 +12,10 @@
+   (elem 0x0 (i32.const 0) $f $f)
+   (elem 0x000 (offset (i32.const 0)))
+   (elem 0 (offset (i32.const 0)) $f $f)
+-  (elem $t (i32.const 0))
+-  (elem $t (i32.const 0) $f $f)
+-  (elem $t (offset (i32.const 0)))
+-  (elem $t (offset (i32.const 0)) $f $f)
++  (elem (i32.const 0))
++  (elem (i32.const 0) $f $f)
++  (elem (offset (i32.const 0)))
++  (elem (offset (i32.const 0)) $f $f)
+ )
+ 
+ ;; Basic use
 @@ -354,6 +354,7 @@
  (assert_return (invoke $module1 "call-8") (i32.const 65))
  (assert_return (invoke $module1 "call-9") (i32.const 66))

--- a/tests/wamr-test-suites/test_wamr.sh
+++ b/tests/wamr-test-suites/test_wamr.sh
@@ -290,7 +290,8 @@ function spec_test()
 
         # fetch spec for threads proposal
         git fetch threads
-        git reset --hard HEAD
+        # [interpreter] Threading (#179) Fri Aug 6 18:02:59 2021 +0200
+        git reset --hard 0d115b494d640eb0c1c352941fd14ca0bad926d3
         git checkout threads/main
 
         git apply ../../spec-test-script/thread_proposal_ignore_cases.patch


### PR DESCRIPTION
- Remove "--enable-reference-types" and "--enable-bulk-memory" for wat2wasm
to support finished proposals.

- Ignore invalid module in the thread spec repo

``` wast
;; my_elem.wast
(module
  (table $t 10 funcref)
  (func $f)
  (elem $t (i32.const 0) 0)
  (elem $t (i32.const 0) $f $f)
  (elem $t (offset (i32.const 0)) $f $f)
)
```

run with reference interpreter under spec/interpreter

``` shell
$ ./wasm ../../../my_elem.wast
../../../my_elem.wast:5.9-5.11: syntax error: duplicate elem segment $t
```

- use a specific commit instead of the latest commit on the thread spec repo