### PR TITLE
Disable source debugging by default

### DIFF
--- a/core/config.h
+++ b/core/config.h
@@ -138,6 +138,15 @@
 #define WASM_ENABLE_THREAD_MGR 0
 #endif
 
+/* Source debugging */
+#ifndef WASM_ENABLE_DEBUG_INTERP
+#define WASM_ENABLE_DEBUG_INTERP 0
+#endif
+
+#ifndef WASM_ENABLE_DEBUG_AOT
+#define WASM_ENABLE_DEBUG_AOT 0
+#endif
+
 /* WASM log system */
 #ifndef WASM_ENABLE_LOG
 #define WASM_ENABLE_LOG 1


### PR DESCRIPTION
For cmake based project, there are default values in .cmake,
but for other build system, may these symbols were not defined in their
build system and warnings (XXX is not defined) generated while buiding.

Signed-off-by: Huang Qi <huangqi3@xiaomi.com>