### PR TITLE
support random debug port by assigning port = 0

### DIFF
--- a/core/iwasm/libraries/debug-engine/gdbserver.c
+++ b/core/iwasm/libraries/debug-engine/gdbserver.c
@@ -104,7 +104,7 @@ wasm_launch_gdbserver(char *host, int port)
         goto fail;
     }
 
-    LOG_VERBOSE("Listening on %s:%d\n", host, ntohs(addr.sin_port));
+    LOG_WARNING("Listening on %s:%d\n", host, ntohs(addr.sin_port));
 
     ret = listen(listen_fd, 1);
     if (ret < 0) {

--- a/core/iwasm/libraries/debug-engine/gdbserver.c
+++ b/core/iwasm/libraries/debug-engine/gdbserver.c
@@ -56,6 +56,7 @@ wasm_launch_gdbserver(char *host, int port)
     int listen_fd = -1;
     const int one = 1;
     struct sockaddr_in addr;
+    socklen_t socklen;
     int ret;
     int sockt_fd = 0;
 
@@ -87,7 +88,6 @@ wasm_launch_gdbserver(char *host, int port)
         goto fail;
     }
 
-    LOG_VERBOSE("Listening on %s:%d\n", host, port);
     addr.sin_family = AF_INET;
     addr.sin_addr.s_addr = inet_addr(host);
     addr.sin_port = htons(port);
@@ -97,6 +97,14 @@ wasm_launch_gdbserver(char *host, int port)
         LOG_ERROR("wasm gdb server error: bind() failed");
         goto fail;
     }
+
+    socklen = sizeof(addr);
+    if (getsockname(listen_fd, (void *)&addr, &socklen) == -1) {
+        LOG_ERROR("%s", strerror(errno));
+        goto fail;
+    }
+
+    LOG_VERBOSE("Listening on %s:%d\n", host, ntohs(addr.sin_port));
 
     ret = listen(listen_fd, 1);
     if (ret < 0) {

--- a/doc/source_debugging.md
+++ b/doc/source_debugging.md
@@ -30,6 +30,7 @@ make
 3. Execute iwasm with debug engine enabled
 ``` bash
 iwasm -g=127.0.0.1:1234 test.wasm
+# Use port = 0 to allow a random assigned debug port
 ```
 
 4. Build customized lldb (assume you have already cloned llvm)

--- a/product-mini/platforms/posix/main.c
+++ b/product-mini/platforms/posix/main.c
@@ -53,6 +53,7 @@ print_help()
 #endif
 #if WASM_ENABLE_DEBUG_INTERP != 0
     printf("  -g=ip:port             Set the debug sever address, default is debug disabled\n");
+    printf("                           if port is 0, then a random port will be used\n");
 #endif
     return 1;
 }


### PR DESCRIPTION
If we don't want to specify a debug port, then we can use `-g=127.0.0.1:0` to get a random port