### PR TITLE
Add __umoddi3 to target symbol map in aot_reloc_arm.c

### DIFF
--- a/core/iwasm/aot/arch/aot_reloc_arm.c
+++ b/core/iwasm/aot/arch/aot_reloc_arm.c
@@ -65,6 +65,7 @@ static SymbolMap target_sym_map[] = {
     REG_SYM(__divdi3),
     /* clang-format on */
     REG_SYM(__udivdi3),
+    REG_SYM(__moddi3),
     REG_SYM(__umoddi3),
     REG_SYM(__divsi3),
     REG_SYM(__udivsi3),


### PR DESCRIPTION
I found it used by one of my AOT modules built with clang+wamrc.