### PR TITLE
Fix the bug that destroy_callback_list is not cleared when thread_man…

### DIFF
--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -240,6 +240,7 @@ void
 wasm_cluster_cancel_all_callbacks()
 {
     traverse_list(destroy_callback_list, free_node_visitor, NULL);
+    bh_list_init(destroy_callback_list);
 }
 
 WASMCluster *


### PR DESCRIPTION
The destroy_callback_list variable in thread_manager_destroy is not cleared. When wamr is started as a task, after exiting and restarting, it will loop endlessly in traverse_list