### PR TITLE
Reorganize externref related public APIs.

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -820,6 +820,7 @@ load_import_table_list(const uint8 **p_buf, const uint8 *buf_end,
 
     /* keep sync with aot_emit_table_info() aot_emit_aot_file */
     for (i = 0; i < module->import_table_count; i++, import_table++) {
+        read_uint32(buf, buf_end, import_table->elem_type);
         read_uint32(buf, buf_end, import_table->table_init_size);
         read_uint32(buf, buf_end, import_table->table_max_size);
         read_uint32(buf, buf_end, possible_grow);

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -2235,9 +2235,9 @@ aot_invoke_native(WASMExecEnv *exec_env, uint32 func_idx, uint32 argc,
     }
     else {
         signature = import_func->signature;
-        return wasm_runtime_invoke_native_raw(exec_env, func_ptr, func_type,
-                                              signature, attachment, argv, argc,
-                                              argv);
+        return wasm_runtime_invoke_native_raw(exec_env, func_ptr, false,
+                                              func_type, signature, attachment,
+                                              argv, argc, argv);
     }
 }
 
@@ -2301,9 +2301,9 @@ aot_call_indirect(WASMExecEnv *exec_env, uint32 tbl_idx, uint32 table_elem_idx,
         signature = import_func->signature;
         if (import_func->call_conv_raw) {
             attachment = import_func->attachment;
-            return wasm_runtime_invoke_native_raw(exec_env, func_ptr, func_type,
-                                                  signature, attachment, argv,
-                                                  argc, argv);
+            return wasm_runtime_invoke_native_raw(exec_env, func_ptr, true,
+                                                  func_type, signature,
+                                                  attachment, argv, argc, argv);
         }
     }
 

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -2301,7 +2301,7 @@ aot_call_indirect(WASMExecEnv *exec_env, uint32 tbl_idx, uint32 table_elem_idx,
         signature = import_func->signature;
         if (import_func->call_conv_raw) {
             attachment = import_func->attachment;
-            return wasm_runtime_invoke_native_raw(exec_env, func_ptr, true,
+            return wasm_runtime_invoke_native_raw(exec_env, func_ptr, false,
                                                   func_type, signature,
                                                   attachment, argv, argc, argv);
         }
@@ -2389,7 +2389,7 @@ aot_call_indirect(WASMExecEnv *exec_env, uint32 tbl_idx, uint32 table_elem_idx,
     }
     else {
         ret = invoke_native_internal(
-            exec_env, func_ptr, func_idx < aot_module->import_func_count,
+            exec_env, func_ptr, func_idx >= aot_module->import_func_count,
             func_type, signature, attachment, argv, argc, argv);
         if (clear_wasi_proc_exit_exception(module_inst))
             return true;

--- a/core/iwasm/common/wasm_application.c
+++ b/core/iwasm/common/wasm_application.c
@@ -656,7 +656,7 @@ wasm_application_execute_func(WASMModuleInstanceCommon *module_inst,
 #if WASM_ENABLE_REF_TYPES != 0
             case VALUE_TYPE_FUNCREF:
             {
-                if (argv1[k] != NULL_REF && argv1[k] != (uint32)-1)
+                if (argv1[k] != NULL_REF)
                     os_printf("%u:ref.func", argv1[k]);
                 else
                     os_printf("func:ref.null");
@@ -666,11 +666,11 @@ wasm_application_execute_func(WASMModuleInstanceCommon *module_inst,
             case VALUE_TYPE_EXTERNREF:
             {
 #if UINTPTR_MAX == UINT32_MAX
-                if (argv1[k] != 0 && NULL_REF != argv1[k]
-                    && argv1[k] != (uint32)-1) {
-                    os_printf("%p:ref.extern", argv1[k]);
-                    k++;
-                }
+                if (argv1[k] != 0 && argv1[k] != (uint32)-1)
+                    os_printf("%p:ref.extern", (void *)argv1[k]);
+                else
+                    os_printf("extern:ref.null");
+                k++;
 #else
                 union {
                     uintptr_t val;
@@ -679,12 +679,11 @@ wasm_application_execute_func(WASMModuleInstanceCommon *module_inst,
                 u.parts[0] = argv1[k];
                 u.parts[1] = argv1[k + 1];
                 k += 2;
-                if (u.val && u.val != NULL_REF && u.val != (uintptr_t)-1LL) {
+                if (u.val && u.val != (uintptr_t)-1LL)
                     os_printf("%p:ref.extern", (void *)u.val);
-                }
-#endif
                 else
                     os_printf("extern:ref.null");
+#endif
                 break;
             }
 #endif

--- a/core/iwasm/common/wasm_application.c
+++ b/core/iwasm/common/wasm_application.c
@@ -566,7 +566,7 @@ wasm_application_execute_func(WASMModuleInstanceCommon *module_inst,
                     uint32 parts[2];
                 } u;
                 if (strncasecmp(argv[i], "null", 4) == 0) {
-                    u.val = (uintptr_t)-1;
+                    u.val = (uintptr_t)-1LL;
                 }
                 else {
                     u.val = strtoull(argv[i], &endptr, 0);
@@ -679,7 +679,7 @@ wasm_application_execute_func(WASMModuleInstanceCommon *module_inst,
                 u.parts[0] = argv1[k];
                 u.parts[1] = argv1[k + 1];
                 k += 2;
-                if (u.val && u.val != NULL_REF && u.val != (uintptr_t)-1) {
+                if (u.val && u.val != NULL_REF && u.val != (uintptr_t)-1LL) {
                     os_printf("%p:ref.extern", (void *)u.val);
                 }
 #endif

--- a/core/iwasm/common/wasm_c_api_internal.h
+++ b/core/iwasm/common/wasm_c_api_internal.h
@@ -56,7 +56,6 @@ struct wasm_globaltype_t {
 
 struct wasm_tabletype_t {
     uint32 extern_kind;
-    /* always be WASM_FUNCREF */
     wasm_valtype_t *val_type;
     wasm_limits_t limits;
 };

--- a/core/iwasm/common/wasm_exec_env.h
+++ b/core/iwasm/common/wasm_exec_env.h
@@ -123,10 +123,6 @@ typedef struct WASMExecEnv {
     WASMJmpBuf *jmpbuf_stack_top;
 #endif
 
-#if WASM_ENABLE_REF_TYPES != 0
-    uint16 nested_calling_depth;
-#endif
-
 #if WASM_ENABLE_MEMORY_PROFILING != 0
     uint32 max_wasm_stack_used;
 #endif

--- a/core/iwasm/common/wasm_native.c
+++ b/core/iwasm/common/wasm_native.c
@@ -74,15 +74,18 @@ check_symbol_signature(const WASMType *type, const char *signature)
 
     for (i = 0; i < type->param_count; i++) {
         sig = *p++;
-        if ((type->types[i] >= VALUE_TYPE_F64
-             && type->types[i] <= VALUE_TYPE_I32
-             && sig == sig_map[type->types[i] - VALUE_TYPE_F64])
-#if WASM_ENABLE_REF_TYPES != 0
-            || (sig == 'I' && type->types[i] == VALUE_TYPE_EXTERNREF)
-#endif
-        )
-            /* normal parameter */
+        /* an i32, i64, f32, f64 parameter */
+        if (type->types[i] >= VALUE_TYPE_F64 && type->types[i] <= VALUE_TYPE_I32
+            && sig == sig_map[type->types[i] - VALUE_TYPE_F64])
             continue;
+
+#if WASM_ENABLE_REF_TYPES != 0
+        /* an externref parameter */
+        if (('r' == sig && type->types[i] == VALUE_TYPE_EXTERNREF))
+            continue;
+#endif
+
+        /* TODO: a v128 parameter */
 
         if (type->types[i] != VALUE_TYPE_I32)
             /* pointer and string must be i32 type */
@@ -112,8 +115,15 @@ check_symbol_signature(const WASMType *type, const char *signature)
     if (type->result_count) {
         if (p >= p_end)
             return false;
-        if (*p++ != sig_map[type->types[i] - VALUE_TYPE_F64])
+        if (*p != sig_map[type->types[i] - VALUE_TYPE_F64]
+#if WASM_ENABLE_REF_TYPES != 0
+            && *p != 'r'
+#endif
+            /* TODO: a v128 result */
+        )
             return false;
+
+        p++;
     }
 
     if (*p != '\0')

--- a/core/iwasm/common/wasm_native.c
+++ b/core/iwasm/common/wasm_native.c
@@ -78,7 +78,7 @@ check_symbol_signature(const WASMType *type, const char *signature)
              && type->types[i] <= VALUE_TYPE_I32
              && sig == sig_map[type->types[i] - VALUE_TYPE_F64])
 #if WASM_ENABLE_REF_TYPES != 0
-            || (sig == 'i' && type->types[i] == VALUE_TYPE_EXTERNREF)
+            || (sig == 'I' && type->types[i] == VALUE_TYPE_EXTERNREF)
 #endif
         )
             /* normal parameter */

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -785,9 +785,9 @@ wasm_runtime_register_natives_raw(const char *module_name,
 
 bool
 wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
-                           const WASMType *func_type, const char *signature,
-                           void *attachment, bool aot_call_native, uint32 *argv,
-                           uint32 argc, uint32 *ret);
+                           bool is_aot_func, const WASMType *func_type,
+                           const char *signature, void *attachment,
+                           uint32 *argv, uint32 argc, uint32 *ret);
 
 bool
 wasm_runtime_invoke_native_raw(WASMExecEnv *exec_env, void *func_ptr,

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -526,11 +526,6 @@ wasm_runtime_call_indirect(WASMExecEnv *exec_env, uint32 element_indices,
                            uint32 argc, uint32 argv[]);
 
 bool
-wasm_runtime_create_exec_env_and_call_wasm(
-    WASMModuleInstanceCommon *module_inst, WASMFunctionInstanceCommon *function,
-    uint32 argc, uint32 argv[]);
-
-bool
 wasm_runtime_create_exec_env_singleton(WASMModuleInstanceCommon *module_inst);
 
 WASMExecEnv *
@@ -791,8 +786,8 @@ wasm_runtime_register_natives_raw(const char *module_name,
 bool
 wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
                            const WASMType *func_type, const char *signature,
-                           void *attachment, uint32 *argv, uint32 argc,
-                           uint32 *ret);
+                           void *attachment, bool aot_call_native, uint32 *argv,
+                           uint32 argc, uint32 *ret);
 
 bool
 wasm_runtime_invoke_native_raw(WASMExecEnv *exec_env, void *func_ptr,
@@ -812,16 +807,6 @@ wasm_runtime_dump_module_inst_mem_consumption(
 
 void
 wasm_runtime_dump_exec_env_mem_consumption(const WASMExecEnv *exec_env);
-
-#if WASM_ENABLE_REF_TYPES != 0
-void
-wasm_runtime_prepare_call_function(WASMExecEnv *exec_env,
-                                   WASMFunctionInstanceCommon *function);
-void
-wasm_runtime_finalize_call_function(WASMExecEnv *exec_env,
-                                    WASMFunctionInstanceCommon *function,
-                                    bool ret, uint32 *argv);
-#endif
 
 bool
 wasm_runtime_get_export_func_type(const WASMModuleCommon *module_comm,

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -791,9 +791,9 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
 
 bool
 wasm_runtime_invoke_native_raw(WASMExecEnv *exec_env, void *func_ptr,
-                               const WASMType *func_type, const char *signature,
-                               void *attachment, uint32 *argv, uint32 argc,
-                               uint32 *ret);
+                               bool is_aot_func, const WASMType *func_type,
+                               const char *signature, void *attachment,
+                               uint32 *argv, uint32 argc, uint32 *ret);
 
 void
 wasm_runtime_read_v128(const uint8 *bytes, uint64 *ret1, uint64 *ret2);

--- a/core/iwasm/compilation/aot.h
+++ b/core/iwasm/compilation/aot.h
@@ -96,6 +96,7 @@ typedef struct AOTMemInitData {
 typedef struct AOTImportTable {
     char *module_name;
     char *table_name;
+    uint32 elem_type;
     uint32 table_flags;
     uint32 table_init_size;
     uint32 table_max_size;

--- a/core/iwasm/compilation/aot_emit_aot_file.c
+++ b/core/iwasm/compilation/aot_emit_aot_file.c
@@ -1398,6 +1398,7 @@ aot_emit_table_info(uint8 *buf, uint8 *buf_end, uint32 *p_offset,
          * EMIT_STR(comp_data->import_tables[i].module_name );
          * EMIT_STR(comp_data->import_tables[i].table_name);
          */
+        EMIT_U32(comp_data->import_tables[i].elem_type);
         EMIT_U32(comp_data->import_tables[i].table_init_size);
         EMIT_U32(comp_data->import_tables[i].table_max_size);
         EMIT_U32(comp_data->import_tables[i].possible_grow & 0x000000FF);

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -788,6 +788,7 @@ wasm_runtime_get_native_addr_range(wasm_module_inst_t module_inst,
  *          'I': the parameter is i64 type
  *          'f': the parameter is f32 type
  *          'F': the parameter is f64 type
+ *          'r': the parameter is externref type, it should be a uintptr_t in host
  *          '*': the parameter is a pointer (i32 in WASM), and runtime will
  *               auto check its boundary before calling the native function.
  *               If it is followed by '~', the checked length of the pointer

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -155,16 +155,17 @@ enum wasm_valkind_enum {
 
 #ifndef WASM_VAL_T_DEFINED
 #define WASM_VAL_T_DEFINED
-struct wasm_ref_t;
 
 typedef struct wasm_val_t {
     wasm_valkind_t kind;
     union {
+        /* also represent a function index */
         int32_t i32;
         int64_t i64;
         float f32;
         double f64;
-        struct wasm_ref_t *ref;
+        /* represent a foreign object, aka externref in .wat */
+        uintptr_t foreign;
     } of;
 } wasm_val_t;
 #endif

--- a/core/iwasm/interpreter/wasm.h
+++ b/core/iwasm/interpreter/wasm.h
@@ -560,6 +560,19 @@ wasm_get_cell_num(const uint8 *types, uint32 type_count)
     return cell_num;
 }
 
+#if WASM_ENABLE_REF_TYPES != 0
+inline static uint16
+wasm_value_type_cell_num_outside(uint8 value_type)
+{
+    if (VALUE_TYPE_EXTERNREF == value_type) {
+        return sizeof(uintptr_t) / sizeof(uint32);
+    }
+    else {
+        return wasm_value_type_cell_num(value_type);
+    }
+}
+#endif
+
 inline static bool
 wasm_type_equal(const WASMType *type1, const WASMType *type2)
 {

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -798,7 +798,7 @@ wasm_interp_call_func_native(WASMModuleInstance *module_inst,
     else if (!func_import->call_conv_raw) {
         ret = wasm_runtime_invoke_native(
             exec_env, func_import->func_ptr_linked, func_import->func_type,
-            func_import->signature, func_import->attachment, frame->lp,
+            func_import->signature, func_import->attachment, false, frame->lp,
             cur_func->param_cell_num, argv_ret);
     }
     else {

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -804,9 +804,10 @@ wasm_interp_call_func_native(WASMModuleInstance *module_inst,
     }
     else {
         ret = wasm_runtime_invoke_native_raw(
-            exec_env, func_import->func_ptr_linked, func_import->func_type,
-            func_import->signature, func_import->attachment, frame->lp,
-            cur_func->param_cell_num, argv_ret);
+            exec_env, func_import->func_ptr_linked, false,
+            func_import->func_type, func_import->signature,
+            func_import->attachment, frame->lp, cur_func->param_cell_num,
+            argv_ret);
     }
 
     if (!ret)

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -796,10 +796,11 @@ wasm_interp_call_func_native(WASMModuleInstance *module_inst,
         }
     }
     else if (!func_import->call_conv_raw) {
-        ret = wasm_runtime_invoke_native(
-            exec_env, func_import->func_ptr_linked, func_import->func_type,
-            func_import->signature, func_import->attachment, false, frame->lp,
-            cur_func->param_cell_num, argv_ret);
+        ret = wasm_runtime_invoke_native(exec_env, func_import->func_ptr_linked,
+                                         false, func_import->func_type,
+                                         func_import->signature,
+                                         func_import->attachment, frame->lp,
+                                         cur_func->param_cell_num, argv_ret);
     }
     else {
         ret = wasm_runtime_invoke_native_raw(

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -875,9 +875,10 @@ wasm_interp_call_func_native(WASMModuleInstance *module_inst,
     }
     else {
         ret = wasm_runtime_invoke_native_raw(
-            exec_env, func_import->func_ptr_linked, func_import->func_type,
-            func_import->signature, func_import->attachment, frame->lp,
-            cur_func->param_cell_num, argv_ret);
+            exec_env, func_import->func_ptr_linked, false,
+            func_import->func_type, func_import->signature,
+            func_import->attachment, frame->lp, cur_func->param_cell_num,
+            argv_ret);
     }
 
     if (!ret)

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -867,10 +867,11 @@ wasm_interp_call_func_native(WASMModuleInstance *module_inst,
         }
     }
     else if (!func_import->call_conv_raw) {
-        ret = wasm_runtime_invoke_native(
-            exec_env, func_import->func_ptr_linked, func_import->func_type,
-            func_import->signature, func_import->attachment, false, frame->lp,
-            cur_func->param_cell_num, argv_ret);
+        ret = wasm_runtime_invoke_native(exec_env, func_import->func_ptr_linked,
+                                         false, func_import->func_type,
+                                         func_import->signature,
+                                         func_import->attachment, frame->lp,
+                                         cur_func->param_cell_num, argv_ret);
     }
     else {
         ret = wasm_runtime_invoke_native_raw(

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -869,7 +869,7 @@ wasm_interp_call_func_native(WASMModuleInstance *module_inst,
     else if (!func_import->call_conv_raw) {
         ret = wasm_runtime_invoke_native(
             exec_env, func_import->func_ptr_linked, func_import->func_type,
-            func_import->signature, func_import->attachment, frame->lp,
+            func_import->signature, func_import->attachment, false, frame->lp,
             cur_func->param_cell_num, argv_ret);
     }
     else {

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1720,15 +1720,7 @@ wasm_create_exec_env_and_call_function(WASMModuleInstance *module_inst,
     }
 #endif
 
-#if WASM_ENABLE_REF_TYPES != 0
-    wasm_runtime_prepare_call_function(exec_env, func);
-#endif
-
     ret = wasm_call_function(exec_env, func, argc, argv);
-
-#if WASM_ENABLE_REF_TYPES != 0
-    wasm_runtime_finalize_call_function(exec_env, func, ret, argv);
-#endif
 
 #if WASM_ENABLE_THREAD_MGR != 0
     /* don't destroy the exec_env if it's searched from the cluster */
@@ -1742,9 +1734,14 @@ wasm_create_exec_env_and_call_function(WASMModuleInstance *module_inst,
 bool
 wasm_create_exec_env_singleton(WASMModuleInstance *module_inst)
 {
-    WASMExecEnv *exec_env =
-        wasm_exec_env_create((WASMModuleInstanceCommon *)module_inst,
-                             module_inst->default_wasm_stack_size);
+    WASMExecEnv *exec_env = NULL;
+
+    if (module_inst->exec_env_singleton) {
+        return true;
+    }
+
+    exec_env = wasm_exec_env_create((WASMModuleInstanceCommon *)module_inst,
+                                    module_inst->default_wasm_stack_size);
     if (exec_env)
         module_inst->exec_env_singleton = exec_env;
 

--- a/core/shared/platform/windows/platform_internal.h
+++ b/core/shared/platform/windows/platform_internal.h
@@ -62,6 +62,9 @@ os_mem_decommit(void *ptr, size_t size);
 
 #define os_thread_local_attribute __declspec(thread)
 
+#define strncasecmp _strnicmp
+#define strcasecmp _stricmp
+
 #if WASM_DISABLE_HW_BOUND_CHECK == 0
 #if defined(BUILD_TARGET_X86_64) || defined(BUILD_TARGET_AMD_64)
 

--- a/doc/export_native_api.md
+++ b/doc/export_native_api.md
@@ -85,10 +85,11 @@ The function signature field in **NativeSymbol** structure is a string for descr
 
 Each letter in the "()" represents a parameter type, and the one following after ")" represents the return value type. The meaning of each letter:
 
-- '**i**': i32 or externref (for externref, developer should use `wasm_externref_obj2ref()` to map host object to externref index firstly)
+- '**i**': i32
 - '**I**': i64 
 - '**f**': f32
 - '**F**': f64
+- '**r**': externref (has to be the value of a `uintptr_t` variable)
 - '**\***': the parameter is a buffer address in WASM application
 - '**~**': the parameter is the byte length of WASM buffer as referred by preceding argument "\*". It must follow after '*', otherwise, registration will fail
 - '**$**': the parameter is a string in WASM application

--- a/doc/ref_types.md
+++ b/doc/ref_types.md
@@ -1,22 +1,9 @@
 # WAMR reference-types introduction
 
-WebAssembly [reference-types](https://github.com/WebAssembly/reference-types) proposal introduces the new type `externref` and makes it easier and more efficient to interoperate with host environment, allowing host references to be represented directly by type externref. And WASM modules can talk about host references directly, rather than requiring external glue code running in the host.
+WebAssembly [reference-types](https://github.com/WebAssembly/reference-types) proposal introduces two new types `funcref` and `externref`. With `externref`, It is easier and more efficient to interoperate with host environment. Host references are able to be represented directly by type `externref`.
 
-WAMR implements the reference-types proposal, allowing developer to pass the host object to WASM application and then restore and access the host object in native lib. In WAMR internal, the external host object is represented as externref index with `uint32` type, developer must firstly map the host object of `void *` type to the externref index, and then pass the index to the function to called as the function's externref argument.
+WAMR has implemented the reference-types proposal. WAMR allows a native method to pass a host object to a WASM application as an `externref` parameter or receives a host object from a WASM application as an `externref` result. Internally, WAMR won't try to parse or dereference `externref`. It is an opaque type.
 
-Currently WAMR provides APIs as below:
-```C
-bool
-wasm_externref_obj2ref(wasm_module_inst_t module_inst,
-                       void *extern_obj, uint32_t *p_externref_idx);
-
-WASM_RUNTIME_API_EXTERN bool
-wasm_externref_ref2obj(uint32_t externref_idx, void **p_extern_obj);
-
-WASM_RUNTIME_API_EXTERN bool
-wasm_externref_retain(uint32 externref_idx);
-```
-
-The `wasm_externref_obj2ref()` API is used to map the host object to the externref index, and the `wasm_externref_ref2obj()` API is used to retrieve the original host object mapped. The `wasm_externref_retain()` API is to retain the host object if we don't want the object to be cleaned when it isn't used during externref object reclaim.
+The restriction of using `externref` in a native method is the host object has to be the value of a `unintptr_t` variable. In other words, it takes **8 bytes** on 64-bit machine and **4 bytes** on 32-bit machines. Please keep that in mind especially when calling `wasm_runtime_call_wasm`.
 
 Please ref to the [sample](../samples/ref-types) for more details.

--- a/samples/ref-types/CMakeLists.txt
+++ b/samples/ref-types/CMakeLists.txt
@@ -116,7 +116,7 @@ endif()
 # wat to wasm
 file(GLOB WAT_FILE src/hello.wat)
 add_custom_target(hello_wasm ALL
-  COMMAND ${WAT2WASM} ${WAT_FILE} -o ${PROJECT_BINARY_DIR}/hello.wasm
+  COMMAND ${WAT2WASM} ${WAT_FILE} --enable-reference-types -o ${PROJECT_BINARY_DIR}/hello.wasm
   DEPENDS ${WAT_FILE}
   BYPRODUCTS ${PROJECT_BINARY_DIR}/hello.wasm
   VERBATIM

--- a/samples/ref-types/src/hello.c
+++ b/samples/ref-types/src/hello.c
@@ -13,52 +13,170 @@
 static char global_heap_buf[10 * 1024 * 1024] = { 0 };
 #endif
 
-static int
-test_write_wrapper(wasm_exec_env_t exec_env, uint32 externref_idx_of_file,
-                   const char *str, int len)
+static uintptr_t global_objects[10] = { 0 };
+
+int32
+local_cmp_externref(wasm_exec_env_t exec_env, uintptr_t externref_a,
+                    uintptr_t externref_b)
 {
-    FILE *file;
-    char buf[16];
+    return externref_a == externref_b;
+}
 
-    printf("## retrieve file handle from externref index\n");
-    if (!wasm_externref_ref2obj(externref_idx_of_file, (void **)&file)) {
-        printf("failed to get host object from externref index!\n");
-        return -1;
-    }
-
-    snprintf(buf, sizeof(buf), "%%%ds", len);
-
-    printf("## write string to file: ");
-    printf(buf, str);
-
-    return fprintf(file, buf, str);
+int32
+local_chk_externref(wasm_exec_env_t exec_env, int32 index, uintptr_t externref)
+{
+    return externref == global_objects[index];
 }
 
 /* clang-format off */
 static NativeSymbol native_symbols[] = {
-    { "test_write", test_write_wrapper, "(i*~)i", NULL }
+    { "native-cmp-externref", local_cmp_externref, "(II)i", NULL },
+    { "native-chk-externref", local_chk_externref, "(iI)i", NULL },
 };
 /* clang-format on */
+
+static inline void
+local_set_externref(int32 index, uintptr_t externref)
+{
+    global_objects[index] = externref;
+}
+
+static WASMFunctionInstanceCommon *wasm_set_externref_ptr;
+static WASMFunctionInstanceCommon *wasm_get_externref_ptr;
+static WASMFunctionInstanceCommon *wasm_cmp_externref_ptr;
+
+static bool
+wasm_set_externref(wasm_exec_env_t exec_env, wasm_module_inst_t inst,
+                   int32 index, uintptr_t externref)
+{
+    union {
+        uintptr_t val;
+        uint32 parts[2];
+    } u;
+    uint32 argv[3] = { 0 };
+
+    if (!exec_env || !wasm_set_externref_ptr) {
+        return false;
+    }
+
+    u.val = externref;
+    argv[0] = index;
+    argv[1] = u.parts[0];
+    argv[2] = u.parts[1];
+    if (!wasm_runtime_call_wasm(exec_env, wasm_set_externref_ptr, 2, argv)) {
+        const char *exception;
+        if ((exception = wasm_runtime_get_exception(inst))) {
+            printf("Exception: %s\n", exception);
+        }
+        return false;
+    }
+
+    return true;
+}
+
+static bool
+wasm_get_externref(wasm_exec_env_t exec_env, wasm_module_inst_t inst,
+                   int32 index, uintptr_t *ret_externref)
+{
+    wasm_val_t results[1] = { 0 };
+
+    if (!exec_env || !wasm_get_externref_ptr || !ret_externref) {
+        return false;
+    }
+
+    if (!wasm_runtime_call_wasm_v(exec_env, wasm_get_externref_ptr, 1, results,
+                                  1, index)) {
+        const char *exception;
+        if ((exception = wasm_runtime_get_exception(inst))) {
+            printf("Exception: %s\n", exception);
+        }
+        return false;
+    }
+
+    if (WASM_ANYREF != results[0].kind) {
+        return false;
+    }
+
+    *ret_externref = results[0].of.foreign;
+    return true;
+}
+
+static bool
+wasm_cmp_externref(wasm_exec_env_t exec_env, wasm_module_inst_t inst,
+                   int32 index, uintptr_t externref, int32 *ret_result)
+{
+    wasm_val_t results[1] = { 0 };
+    wasm_val_t arguments[2] = {
+        { .kind = WASM_I32, .of.i32 = index },
+        { .kind = WASM_ANYREF, .of.foreign = externref },
+    };
+
+    if (!exec_env || !wasm_cmp_externref_ptr || !ret_result) {
+        return false;
+    }
+
+    if (!wasm_runtime_call_wasm_a(exec_env, wasm_cmp_externref_ptr, 1, results,
+                                  2, arguments)) {
+        const char *exception;
+        if ((exception = wasm_runtime_get_exception(inst))) {
+            printf("Exception: %s\n", exception);
+        }
+        return false;
+    }
+
+    if (results[0].kind != WASM_I32) {
+        return false;
+    }
+
+    *ret_result = results[0].of.i32;
+    return true;
+}
+
+static bool
+set_and_cmp(wasm_exec_env_t exec_env, wasm_module_inst_t inst, int32 i,
+            uintptr_t externref)
+{
+    int32 cmp_result = 0;
+    uintptr_t wasm_externref = 0;
+
+    wasm_set_externref(exec_env, inst, i, externref);
+    local_set_externref(i, externref);
+
+    wasm_get_externref(exec_env, inst, 0, &wasm_externref);
+    if (!local_chk_externref(exec_env, 0, wasm_externref)) {
+        printf("#%d, In host language world Wasm Externref 0x%lx Vs. Native "
+               "Externref 0x%lx FAILED\n",
+               i, wasm_externref, externref);
+        return false;
+    }
+
+    if (!wasm_cmp_externref(exec_env, inst, i, global_objects[i], &cmp_result)
+        || !cmp_result) {
+        printf("#%d, In Wasm world Native Externref 0x%lx Vs, Wasm Externref "
+               "FAILED\n",
+               i, global_objects[i]);
+        return false;
+    }
+
+    return true;
+}
 
 int
 main(int argc, char *argv[])
 {
     char *wasm_file = "hello.wasm";
     uint8 *wasm_file_buf = NULL;
-    uint32 wasm_file_size, externref_idx;
+    uint32 wasm_file_size;
     uint32 stack_size = 16 * 1024, heap_size = 16 * 1024;
     wasm_module_t wasm_module = NULL;
     wasm_module_inst_t wasm_module_inst = NULL;
-    wasm_function_inst_t func_inst = NULL;
     wasm_exec_env_t exec_env = NULL;
     RuntimeInitArgs init_args;
     char error_buf[128] = { 0 };
-    const char *exce;
-    unsigned argv1[8];
 #if WASM_ENABLE_LOG != 0
     int log_verbose_level = 2;
 #endif
-    FILE *file;
+    const uint64 big_number = 0x123456789abc;
 
     memset(&init_args, 0, sizeof(RuntimeInitArgs));
 
@@ -90,13 +208,13 @@ main(int argc, char *argv[])
     /* load WASM byte buffer from WASM bin file */
     if (!(wasm_file_buf =
               (uint8 *)bh_read_file_to_buffer(wasm_file, &wasm_file_size)))
-        goto fail1;
+        goto fail;
 
     /* load WASM module */
     if (!(wasm_module = wasm_runtime_load(wasm_file_buf, wasm_file_size,
                                           error_buf, sizeof(error_buf)))) {
         printf("%s\n", error_buf);
-        goto fail2;
+        goto fail;
     }
 
     /* instantiate the module */
@@ -104,62 +222,66 @@ main(int argc, char *argv[])
               wasm_runtime_instantiate(wasm_module, stack_size, heap_size,
                                        error_buf, sizeof(error_buf)))) {
         printf("%s\n", error_buf);
-        goto fail3;
+        goto fail;
     }
 
-    /* lookup function instance */
-    if (!(func_inst =
-              wasm_runtime_lookup_function(wasm_module_inst, "test", NULL))) {
-        printf("%s\n", "lookup function test failed");
-        goto fail4;
-    }
-
+    /* create an execution env */
     if (!(exec_env =
               wasm_runtime_create_exec_env(wasm_module_inst, stack_size))) {
         printf("%s\n", "create exec env failed");
-        goto fail4;
+        goto fail;
     }
 
-    printf("## open file test.txt\n");
-    if (!(file = fopen("test.txt", "wb+"))) {
-        printf("%s\n", "open file text.txt failed");
-        goto fail5;
+    /* lookup function instance */
+    if (!(wasm_cmp_externref_ptr = wasm_runtime_lookup_function(
+              wasm_module_inst, "cmp-externref", NULL))) {
+        printf("%s\n", "lookup function cmp-externref failed");
+        goto fail;
     }
 
-    printf("## map file handle to externref index\n");
-    if (!wasm_externref_obj2ref(wasm_module_inst, file, &externref_idx)) {
-        printf("%s\n", "map host object to externref index failed");
-        goto fail6;
+    if (!(wasm_get_externref_ptr = wasm_runtime_lookup_function(
+              wasm_module_inst, "get-externref", NULL))) {
+        printf("%s\n", "lookup function get-externref failed");
+        goto fail;
     }
 
-    printf("## call wasm function with externref index\n");
-    argv1[0] = externref_idx;
-    wasm_runtime_call_wasm(exec_env, func_inst, 1, argv1);
-
-    if ((exce = wasm_runtime_get_exception(wasm_module_inst))) {
-        printf("Exception: %s\n", exce);
+    if (!(wasm_set_externref_ptr = wasm_runtime_lookup_function(
+              wasm_module_inst, "set-externref", NULL))) {
+        printf("%s\n", "lookup function set-externref failed");
+        goto fail;
     }
 
-fail6:
-    fclose(file);
+    /* test with NULL */
+    if (!set_and_cmp(exec_env, wasm_module_inst, 0, 0)
+        || !set_and_cmp(exec_env, wasm_module_inst, 1, big_number + 1)
+        || !set_and_cmp(exec_env, wasm_module_inst, 2, big_number + 2)
+        || !set_and_cmp(exec_env, wasm_module_inst, 3, big_number + 3)) {
+        goto fail;
+    }
 
-fail5:
+    printf("GREAT! PASS ALL CHKs\n");
+
+fail:
     /* destroy exec env */
-    wasm_runtime_destroy_exec_env(exec_env);
+    if (exec_env) {
+        wasm_runtime_destroy_exec_env(exec_env);
+    }
 
-fail4:
     /* destroy the module instance */
-    wasm_runtime_deinstantiate(wasm_module_inst);
+    if (wasm_module_inst) {
+        wasm_runtime_deinstantiate(wasm_module_inst);
+    }
 
-fail3:
     /* unload the module */
-    wasm_runtime_unload(wasm_module);
+    if (wasm_module) {
+        wasm_runtime_unload(wasm_module);
+    }
 
-fail2:
     /* free the file buffer */
-    wasm_runtime_free(wasm_file_buf);
+    if (wasm_file_buf) {
+        wasm_runtime_free(wasm_file_buf);
+    }
 
-fail1:
     /* destroy runtime environment */
     wasm_runtime_destroy();
     return 0;

--- a/samples/wasm-c-api/src/callback.c
+++ b/samples/wasm-c-api/src/callback.c
@@ -35,7 +35,7 @@ void wasm_val_print(wasm_val_t val) {
 
 // A function to be called from Wasm code.
 own wasm_trap_t* print_callback(
-  const wasm_val_vec_t *args, wasm_val_vec_t *results
+  const wasm_val_vec_t* args, wasm_val_vec_t* results
 ) {
   printf("Calling back...\n> ");
   wasm_val_print(args->data[0]);
@@ -48,7 +48,7 @@ own wasm_trap_t* print_callback(
 
 // A function closure.
 own wasm_trap_t* closure_callback(
-  void* env, const wasm_val_vec_t *args, wasm_val_vec_t *results
+  void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results
 ) {
   int i = *(int*)env;
   printf("Calling back closure...\n");
@@ -113,11 +113,10 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-
-  wasm_extern_vec_t imports;
-  wasm_extern_vec_new(&imports, 2, (wasm_extern_t *[]) {
+  wasm_extern_t* externs[] = {
     wasm_func_as_extern(print_func), wasm_func_as_extern(closure_func)
-  });
+  };
+  wasm_extern_vec_t imports = WASM_ARRAY_VEC(externs);
   own wasm_instance_t* instance =
     wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {
@@ -147,9 +146,10 @@ int main(int argc, const char* argv[]) {
 
   // Call.
   printf("Calling export...\n");
-  wasm_val_vec_t args, results;
-  wasm_val_vec_new(&args, 2, (wasm_val_t[]){ WASM_I32_VAL(3), WASM_I32_VAL(4) });
-  wasm_val_vec_new(&results, 1, (wasm_val_t[]) { WASM_INIT_VAL });
+  wasm_val_t as[2] = { WASM_I32_VAL(3), WASM_I32_VAL(4) };
+  wasm_val_t rs[1] = { WASM_INIT_VAL };
+  wasm_val_vec_t args = WASM_ARRAY_VEC(as);
+  wasm_val_vec_t results = WASM_ARRAY_VEC(rs);
   if (wasm_func_call(run_func, &args, &results)) {
     printf("> Error calling function!\n");
     return 1;
@@ -159,7 +159,7 @@ int main(int argc, const char* argv[]) {
 
   // Print result.
   printf("Printing result...\n");
-  printf("> %u\n", results.data[0].of.i32);
+  printf("> %u\n", rs[0].of.i32);
 
   // Shut down.
   printf("Shutting down...\n");

--- a/samples/wasm-c-api/src/callback_chain.c
+++ b/samples/wasm-c-api/src/callback_chain.c
@@ -61,10 +61,7 @@ enum EXPORT_ITEM_NAME {
 
 DEFINE_FUNCTION(get_pairs)
 {
-    wasm_val_vec_t arg, ret;
-    wasm_val_vec_new(&ret, 1, (wasm_val_t []){ WASM_INIT_VAL });
-    wasm_val_vec_new(&arg, 1, (wasm_val_t []){ WASM_I32_VAL(24) });
-    call_wasm_function(e_malloc, &arg, &ret, "malloc");
+    call_wasm_function(e_malloc, args, results, "malloc");
     return NULL;
 }
 
@@ -204,9 +201,6 @@ main(int argc, const char *argv[])
     IMPORT_FUNCTION_LIST(IMPORT_FUNCTION_VARIABLE_NAME)
 #undef IMPORT_FUNCTION_VARIABLE_NAME
 
-    wasm_extern_vec_t imports;
-    wasm_extern_vec_new_uninitialized(&imports, 10);
-
 #define CREATE_WASM_FUNCTION(name, index, CREATE_FUNC_TYPE)                   \
     {                                                                         \
         own wasm_functype_t *type = CREATE_FUNC_TYPE;                         \
@@ -219,13 +213,13 @@ main(int argc, const char *argv[])
     IMPORT_FUNCTION_LIST(CREATE_WASM_FUNCTION)
 #undef CREATE_WASM_FUNCTION
 
+    wasm_extern_t *fs[10] = {0};
 #define ADD_TO_FUNCTION_LIST(name, index, ...)                                \
-    imports.data[index] = wasm_func_as_extern(function_##name);               \
-    imports.num_elems += 1;
+    fs[index] = wasm_func_as_extern(function_##name);
     IMPORT_FUNCTION_LIST(ADD_TO_FUNCTION_LIST)
-#undef CREATE_IMPORT_FUNCTION
+#undef ADD_TO_FUNCTION_LIST
 
-
+    wasm_extern_vec_t imports = WASM_ARRAY_VEC(fs);
     own wasm_instance_t *instance =
       wasm_instance_new(store, module, &imports, NULL);
     if (!instance) {

--- a/samples/wasm-c-api/src/global.c
+++ b/samples/wasm-c-api/src/global.c
@@ -39,10 +39,11 @@ wasm_func_t* get_export_func(const wasm_extern_vec_t* exports, size_t i) {
 
 #define check_call(func, type, expected) \
   { \
-    wasm_val_vec_t results; \
-    wasm_val_vec_new_uninitialized(&results, 1); \
-    wasm_func_call(func, NULL, &results); \
-    check(results.data[0], type, expected); \
+    wasm_val_t vs[1]; \
+    wasm_val_vec_t args = WASM_EMPTY_VEC; \
+    wasm_val_vec_t results = WASM_ARRAY_VEC(vs); \
+    wasm_func_call(func, &args, &results); \
+    check(vs[0], type, expected); \
   }
 
 
@@ -116,19 +117,13 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  /*const wasm_extern_t* imports1[] = {
+  wasm_extern_t* externs[] = {
     wasm_global_as_extern(const_f32_import),
     wasm_global_as_extern(const_i64_import),
     wasm_global_as_extern(var_f32_import),
     wasm_global_as_extern(var_i64_import)
-    };*/
-  wasm_extern_vec_t imports;
-  wasm_extern_vec_new(&imports, 4, (wasm_extern_t* []) {
-      wasm_global_as_extern(const_f32_import),
-      wasm_global_as_extern(const_i64_import),
-      wasm_global_as_extern(var_f32_import),
-      wasm_global_as_extern(var_i64_import)
-    });
+  };
+  wasm_extern_vec_t imports = WASM_ARRAY_VEC(externs);
   own wasm_instance_t* instance =
     wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {
@@ -208,18 +203,19 @@ int main(int argc, const char* argv[]) {
   check_call(get_var_i64_export, i64, 38);
 
   // Modify variables through calls and check again.
-  wasm_val_vec_t args73;
-  wasm_val_vec_new(&args73, 1, (wasm_val_t []){ WASM_F32_VAL(73) });
-  wasm_func_call(set_var_f32_import, &args73, NULL);
-  wasm_val_vec_t args74;
-  wasm_val_vec_new(&args74, 1, (wasm_val_t []){ WASM_I64_VAL(74) });
-  wasm_func_call(set_var_i64_import, &args74, NULL);
-  wasm_val_vec_t args77;
-  wasm_val_vec_new(&args77, 1, (wasm_val_t []){ WASM_F32_VAL(77) });
-  wasm_func_call(set_var_f32_export, &args77, NULL);
-  wasm_val_vec_t args78;
-  wasm_val_vec_new(&args78, 1, (wasm_val_t []){ WASM_I64_VAL(78) });
-  wasm_func_call(set_var_i64_export, &args78, NULL);
+  wasm_val_vec_t res = WASM_EMPTY_VEC;
+  wasm_val_t vs73[] = { WASM_F32_VAL(73) };
+  wasm_val_vec_t args73 = WASM_ARRAY_VEC(vs73);
+  wasm_func_call(set_var_f32_import, &args73, &res);
+  wasm_val_t vs74[] = { WASM_I64_VAL(74) };
+  wasm_val_vec_t args74 = WASM_ARRAY_VEC(vs74);
+  wasm_func_call(set_var_i64_import, &args74, &res);
+  wasm_val_t vs77[] = { WASM_F32_VAL(77) };
+  wasm_val_vec_t args77 = WASM_ARRAY_VEC(vs77);
+  wasm_func_call(set_var_f32_export, &args77, &res);
+  wasm_val_t vs78[] = { WASM_I64_VAL(78) };
+  wasm_val_vec_t args78 = WASM_ARRAY_VEC(vs78);
+  wasm_func_call(set_var_i64_export, &args78, &res);
 
   check_global(var_f32_import, f32, 73);
   check_global(var_i64_import, i64, 74);

--- a/samples/wasm-c-api/src/hello.c
+++ b/samples/wasm-c-api/src/hello.c
@@ -66,9 +66,8 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  wasm_extern_vec_t imports;
-  wasm_extern_vec_new(&imports, 1, (wasm_extern_t* []) { wasm_func_as_extern(hello_func) });
-
+  wasm_extern_t* externs[] = { wasm_func_as_extern(hello_func) };
+  wasm_extern_vec_t imports = WASM_ARRAY_VEC(externs);
   own wasm_instance_t* instance =
     wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {
@@ -98,7 +97,9 @@ int main(int argc, const char* argv[]) {
 
   // Call.
   printf("Calling export...\n");
-  if (wasm_func_call(run_func, NULL, NULL)) {
+  wasm_val_vec_t args = WASM_EMPTY_VEC;
+  wasm_val_vec_t results = WASM_EMPTY_VEC;
+  if (wasm_func_call(run_func, &args, &results)) {
     printf("> Error calling function!\n");
     return 1;
   }
@@ -114,4 +115,3 @@ int main(int argc, const char* argv[]) {
   printf("Done.\n");
   return 0;
 }
-

--- a/samples/wasm-c-api/src/reflect.c
+++ b/samples/wasm-c-api/src/reflect.c
@@ -32,12 +32,6 @@ void print_valtype(const wasm_valtype_t* type) {
 
 void print_valtypes(const wasm_valtype_vec_t* types) {
   bool first = true;
-
-  if (!types) {
-    printf("> Error print a NULL valtype\n");
-    return;
-  }
-
   for (size_t i = 0; i < types->size; ++i) {
     if (first) {
       first = false;
@@ -49,11 +43,6 @@ void print_valtypes(const wasm_valtype_vec_t* types) {
 }
 
 void print_externtype(const wasm_externtype_t* type) {
-  if (!type) {
-    printf("> Error print a NULL externtype\n");
-    return;
-  }
-
   switch (wasm_externtype_kind(type)) {
     case WASM_EXTERN_FUNC: {
       const wasm_functype_t* functype =
@@ -89,11 +78,6 @@ void print_externtype(const wasm_externtype_t* type) {
 }
 
 void print_name(const wasm_name_t* name) {
-  if (!name) {
-    printf("> Error print a NULL name\n");
-    return;
-  }
-
   printf("\"%.*s\"", (int)name->size, name->data);
 }
 
@@ -139,8 +123,9 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
+  wasm_extern_vec_t imports = WASM_EMPTY_VEC;
   own wasm_instance_t* instance =
-    wasm_instance_new(store, module, NULL, NULL);
+    wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;

--- a/samples/wasm-c-api/src/table.c
+++ b/samples/wasm-c-api/src/table.c
@@ -49,19 +49,21 @@ void check_table(wasm_table_t* table, int32_t i, bool expect_set) {
 }
 
 void check_call(wasm_func_t* func, int32_t arg1, int32_t arg2, int32_t expected) {
-  wasm_val_vec_t args, results;
-  wasm_val_vec_new(&args, 2, (wasm_val_t []){ WASM_I32_VAL(arg1), WASM_I32_VAL(arg2) });
-  wasm_val_vec_new(&results, 1, (wasm_val_t []){ WASM_INIT_VAL });
-  if (wasm_func_call(func, &args, &results) || results.data[0].of.i32 != expected) {
+  wasm_val_t vs[2] = { WASM_I32_VAL(arg1), WASM_I32_VAL(arg2) };
+  wasm_val_t r[1] = { WASM_INIT_VAL };
+  wasm_val_vec_t args = WASM_ARRAY_VEC(vs);
+  wasm_val_vec_t results = WASM_ARRAY_VEC(r);
+  if (wasm_func_call(func, &args, &results) || r[0].of.i32 != expected) {
     printf("> Error on result\n");
     exit(1);
   }
 }
 
 void check_trap(wasm_func_t* func, int32_t arg1, int32_t arg2) {
-  wasm_val_vec_t args, results;
-  wasm_val_vec_new(&args, 2, (wasm_val_t []){ WASM_I32_VAL(arg1), WASM_I32_VAL(arg2) });
-  wasm_val_vec_new(&results, 1, (wasm_val_t []){ WASM_INIT_VAL });
+  wasm_val_t vs[2] = { WASM_I32_VAL(arg1), WASM_I32_VAL(arg2) };
+  wasm_val_t r[1] = { WASM_INIT_VAL };
+  wasm_val_vec_t args = WASM_ARRAY_VEC(vs);
+  wasm_val_vec_t results = WASM_ARRAY_VEC(r);
   own wasm_trap_t* trap = wasm_func_call(func, &args, &results);
   if (! trap) {
     printf("> Error on result, expected trap\n");
@@ -112,8 +114,9 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  own wasm_instance_t *instance =
-    wasm_instance_new(store, module, NULL, NULL);
+  wasm_extern_vec_t imports = WASM_EMPTY_VEC;
+  own wasm_instance_t* instance =
+    wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -134,6 +137,7 @@ int main(int argc, const char* argv[]) {
   // Create external function.
   printf("Creating callback...\n");
   own wasm_functype_t* neg_type = wasm_functype_new_1_1(wasm_valtype_new_i32(), wasm_valtype_new_i32());
+  own wasm_func_t* h = wasm_func_new(store, neg_type, neg_callback);
 
   wasm_functype_delete(neg_type);
 
@@ -155,7 +159,9 @@ int main(int argc, const char* argv[]) {
   printf("Mutating table...\n");
   check(wasm_table_set(table, 0, wasm_func_as_ref(g)));
   check(wasm_table_set(table, 1, NULL));
-  check(! wasm_table_set(table, 2, wasm_func_as_ref(f)));
+  wasm_ref_t *ref_f = wasm_func_as_ref(f);
+  check(! wasm_table_set(table, 2, ref_f));
+  wasm_ref_delete(ref_f);
   check_table(table, 0, true);
   check_table(table, 1, false);
   check_call(call_indirect, 7, 0, 666);
@@ -165,6 +171,8 @@ int main(int argc, const char* argv[]) {
   // Grow table.
   // DO NOT SUPPORT
   printf("Bypass Growing table...\n");
+
+  wasm_func_delete(h);
   wasm_extern_vec_delete(&exports);
   wasm_instance_delete(instance);
 

--- a/samples/wasm-c-api/src/trap.c
+++ b/samples/wasm-c-api/src/trap.c
@@ -80,8 +80,8 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  wasm_extern_vec_t imports;
-  wasm_extern_vec_new(&imports, 1, (wasm_extern_t* []) { wasm_func_as_extern(fail_func) });
+  wasm_extern_t* externs[] = { wasm_func_as_extern(fail_func) };
+  wasm_extern_vec_t imports = WASM_ARRAY_VEC(externs);
   own wasm_instance_t* instance =
     wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {
@@ -112,10 +112,9 @@ int main(int argc, const char* argv[]) {
     }
 
     printf("Calling export %d...\n", i);
-
-    wasm_val_vec_t results;
-    wasm_val_vec_new_uninitialized(&results, 1);
-    own wasm_trap_t* trap = wasm_func_call(func, NULL, &results);
+    wasm_val_vec_t args = WASM_EMPTY_VEC;
+    wasm_val_vec_t results = WASM_EMPTY_VEC;
+    own wasm_trap_t* trap = wasm_func_call(func, &args, &results);
     if (!trap) {
       printf("> Error calling function, expected trap!\n");
       return 1;


### PR DESCRIPTION
Basically, users don't need to use `wasm_externref_obj2ref` before
calling `wasm_runtime_call_wasm_XXX`. User can pass object pointers
directlly as externref parameters.