### PR TITLE
Don't throw exception while malloc failed

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -1774,7 +1774,7 @@ aot_module_malloc(AOTModuleInstance *module_inst, uint32 size,
             aot_set_exception(module_inst, "app heap corrupted");
         }
         else {
-            LOG_WARNING("alloc %d bytes memory failed", size);
+            LOG_WARNING("warning: allocate %u bytes memory failed", size);
         }
         return 0;
     }

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -1774,7 +1774,7 @@ aot_module_malloc(AOTModuleInstance *module_inst, uint32 size,
             aot_set_exception(module_inst, "app heap corrupted");
         }
         else {
-            aot_set_exception(module_inst, "out of memory");
+            LOG_ERROR("alloc %d bytes memory failed", size);
         }
         return 0;
     }

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -1774,7 +1774,7 @@ aot_module_malloc(AOTModuleInstance *module_inst, uint32 size,
             aot_set_exception(module_inst, "app heap corrupted");
         }
         else {
-            LOG_ERROR("alloc %d bytes memory failed", size);
+            LOG_WARNING("alloc %d bytes memory failed", size);
         }
         return 0;
     }

--- a/core/iwasm/common/wasm_shared_memory.c
+++ b/core/iwasm/common/wasm_shared_memory.c
@@ -224,7 +224,8 @@ acquire_wait_info(void *address, bool create)
     AtomicWaitInfo *wait_info = NULL;
     bh_list_status ret;
 
-    wait_info = (AtomicWaitInfo *)bh_hash_map_find(wait_map, address);
+    if (address)
+        wait_info = (AtomicWaitInfo *)bh_hash_map_find(wait_map, address);
 
     if (!create)
         return wait_info;

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1830,7 +1830,7 @@ wasm_module_malloc(WASMModuleInstance *module_inst, uint32 size,
             wasm_set_exception(module_inst, "app heap corrupted");
         }
         else {
-            LOG_ERROR("alloc %d bytes memory failed", size);
+            LOG_WARNING("alloc %d bytes memory failed", size);
         }
         return 0;
     }

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1830,7 +1830,7 @@ wasm_module_malloc(WASMModuleInstance *module_inst, uint32 size,
             wasm_set_exception(module_inst, "app heap corrupted");
         }
         else {
-            LOG_WARNING("alloc %d bytes memory failed", size);
+            LOG_WARNING("warning: allocate %u bytes memory failed", size);
         }
         return 0;
     }

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1830,7 +1830,7 @@ wasm_module_malloc(WASMModuleInstance *module_inst, uint32 size,
             wasm_set_exception(module_inst, "app heap corrupted");
         }
         else {
-            wasm_set_exception(module_inst, "out of memory");
+            LOG_ERROR("alloc %d bytes memory failed", size);
         }
         return 0;
     }

--- a/core/shared/utils/bh_hashmap.c
+++ b/core/shared/utils/bh_hashmap.c
@@ -127,13 +127,8 @@ bh_hash_map_find(HashMap *map, void *key)
     HashMapElem *elem;
     void *value;
 
-    if (!map) {
-        LOG_ERROR("HashMap find elem failed: map is NULL.\n");
-        return NULL;
-    }
-
-    if (!key) {
-        LOG_VERBOSE("HashMap find elem failed: key is NULL.\n");
+    if (!map || !key) {
+        LOG_ERROR("HashMap find elem failed: map or key is NULL.\n");
         return NULL;
     }
 

--- a/core/shared/utils/bh_hashmap.c
+++ b/core/shared/utils/bh_hashmap.c
@@ -127,8 +127,13 @@ bh_hash_map_find(HashMap *map, void *key)
     HashMapElem *elem;
     void *value;
 
-    if (!map || !key) {
-        LOG_ERROR("HashMap find elem failed: map or key is NULL.\n");
+    if (!map) {
+        LOG_ERROR("HashMap find elem failed: map is NULL.\n");
+        return NULL;
+    }
+
+    if (!key) {
+        LOG_VERBOSE("HashMap find elem failed: key is NULL.\n");
         return NULL;
     }
 


### PR DESCRIPTION
* Exception will terminate the wasm app, it's not necessary since app should check the result of dynamic allocation, and they can do some cleanup or fallback operation on fail instead of 'crash' directly.
* In acquire_wait_info the key of hasn_map_find can be NULL thus there are
many sesenless error log
