### PR TITLE
xip: Lookup float constants from table to reduce relocations

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -493,23 +493,26 @@ load_native_symbol_section(const uint8 *buf, const uint8 *buf_end,
 
         for (i = cnt - 1; i >= 0; i--) {
             read_string(p, p_end, symbol);
-            if (!strncmp(symbol, "i32_const#", strlen("i32_const#"))) {
+            if (!strncmp(symbol, "i32#", 4)) {
                 uint32 u32;
-                if (!str2uint32(symbol + strlen("i32_const#"), &u32)) {
+                if (!str2uint32(symbol + 4, &u32)) {
                     set_error_buf_v(error_buf, error_buf_size,
                                     "resolve symbol %s failed", symbol);
                     goto fail;
                 }
                 *(uint32 *)(&module->native_symbol_list[i]) = u32;
             }
-            else if (!strncmp(symbol, "i64_const#", strlen("i64_const#"))) {
+            else if (!strncmp(symbol, "i64#", 4)) {
                 uint64 u64;
-                if (!str2uint64(symbol + strlen("i64_const#"), &u64)) {
+                if (!str2uint64(symbol + 4, &u64)) {
                     set_error_buf_v(error_buf, error_buf_size,
                                     "resolve symbol %s failed", symbol);
                     goto fail;
                 }
                 *(uint64 *)(&module->native_symbol_list[i]) = u64;
+            }
+            else if (!strncmp(symbol, "__ignore", 8)) {
+                continue;
             }
             else {
                 module->native_symbol_list[i] =

--- a/core/iwasm/compilation/aot.h
+++ b/core/iwasm/compilation/aot.h
@@ -268,7 +268,7 @@ typedef struct AOTCompData {
 
 typedef struct AOTNativeSymbol {
     bh_list_link link;
-    const char *symbol;
+    char symbol[32];
     int32 index;
 } AOTNativeSymbol;
 

--- a/core/iwasm/compilation/aot_emit_const.c
+++ b/core/iwasm/compilation/aot_emit_const.c
@@ -5,13 +5,85 @@
 
 #include "aot_emit_const.h"
 
+static LLVMValueRef
+get_const_from_table(const AOTCompContext *comp_ctx, LLVMValueRef base,
+                     int32 index, uint8 value_type)
+{
+    LLVMTypeRef const_ptr_type;
+    LLVMValueRef const_index, const_addr, const_value;
+
+    if (!(const_index = I32_CONST(index))) {
+        aot_set_last_error("construct const index failed.");
+        goto fail;
+    }
+
+    if (!(const_addr = LLVMBuildInBoundsGEP(
+              comp_ctx->builder, base, &const_index, 1, "const_addr_tmp"))) {
+        aot_set_last_error("get const addr by index failed.");
+        goto fail;
+    }
+
+    switch (value_type) {
+        case VALUE_TYPE_I32:
+            const_ptr_type = INT32_PTR_TYPE;
+            break;
+        case VALUE_TYPE_I64:
+            const_ptr_type = INT64_PTR_TYPE;
+            break;
+        case VALUE_TYPE_F32:
+            const_ptr_type = F32_PTR_TYPE;
+            break;
+        case VALUE_TYPE_F64:
+            const_ptr_type = F64_PTR_TYPE;
+            break;
+        default:
+            bh_assert(0);
+            goto fail;
+    }
+
+    if (!(const_addr = LLVMBuildBitCast(comp_ctx->builder, const_addr,
+                                        const_ptr_type, "const_addr"))) {
+        aot_set_last_error("cast const fialed.");
+        goto fail;
+    }
+
+    if (!(const_value =
+              LLVMBuildLoad(comp_ctx->builder, const_addr, "const_value"))) {
+        aot_set_last_error("load const failed.");
+        goto fail;
+    }
+
+    return const_value;
+fail:
+    return NULL;
+}
+
 bool
 aot_compile_op_i32_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                          int32 i32_const)
 {
-    LLVMValueRef value = I32_CONST((uint32)i32_const);
-    CHECK_LLVM_CONST(value);
-    PUSH_I32(value);
+    LLVMValueRef value;
+    char buf[128];
+    int32 const_index;
+
+    if (!comp_ctx->is_indirect_mode) {
+        value = I32_CONST((uint32)i32_const);
+        CHECK_LLVM_CONST(value);
+        PUSH_I32(value);
+    }
+    else {
+        snprintf(buf, sizeof(buf), "i32_const#%08X", i32_const);
+        const_index = aot_get_native_symbol_index(comp_ctx, buf);
+        if (const_index < 0) {
+            return false;
+        }
+        value = get_const_from_table(comp_ctx, func_ctx->native_symbol,
+                                     const_index, VALUE_TYPE_I32);
+        if (!value) {
+            return false;
+        }
+        PUSH_I32(value);
+    }
     return true;
 fail:
     return false;
@@ -21,9 +93,28 @@ bool
 aot_compile_op_i64_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                          int64 i64_const)
 {
-    LLVMValueRef value = I64_CONST((uint64)i64_const);
-    CHECK_LLVM_CONST(value);
-    PUSH_I64(value);
+    LLVMValueRef value;
+    char buf[128];
+    int32 const_index;
+
+    if (!comp_ctx->is_indirect_mode) {
+        value = I64_CONST((uint64)i64_const);
+        CHECK_LLVM_CONST(value);
+        PUSH_I64(value);
+    }
+    else {
+        snprintf(buf, sizeof(buf), "i64_const#%016" PRIx64, i64_const);
+        const_index = aot_get_native_symbol_index(comp_ctx, buf);
+        if (const_index < 0) {
+            return false;
+        }
+        value = get_const_from_table(comp_ctx, func_ctx->native_symbol,
+                                     const_index, VALUE_TYPE_I64);
+        if (!value) {
+            return false;
+        }
+        PUSH_I64(value);
+    }
     return true;
 fail:
     return false;
@@ -34,32 +125,51 @@ aot_compile_op_f32_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                          float32 f32_const)
 {
     LLVMValueRef alloca, value;
+    char buf[128];
+    int32 i32_const;
+    int32 const_index;
 
-    if (!isnan(f32_const)) {
-        value = F32_CONST(f32_const);
-        CHECK_LLVM_CONST(value);
-        PUSH_F32(value);
+    if (!comp_ctx->is_indirect_mode) {
+        if (!isnan(f32_const)) {
+            value = F32_CONST(f32_const);
+            CHECK_LLVM_CONST(value);
+            PUSH_F32(value);
+        }
+        else {
+            int32 i32_const;
+            memcpy(&i32_const, &f32_const, sizeof(int32));
+            if (!(alloca = LLVMBuildAlloca(comp_ctx->builder, I32_TYPE,
+                                           "i32_ptr"))) {
+                aot_set_last_error("llvm build alloca failed.");
+                return false;
+            }
+            if (!LLVMBuildStore(comp_ctx->builder, I32_CONST((uint32)i32_const),
+                                alloca)) {
+                aot_set_last_error("llvm build store failed.");
+                return false;
+            }
+            if (!(alloca = LLVMBuildBitCast(comp_ctx->builder, alloca,
+                                            F32_PTR_TYPE, "f32_ptr"))) {
+                aot_set_last_error("llvm build bitcast failed.");
+                return false;
+            }
+            if (!(value = LLVMBuildLoad(comp_ctx->builder, alloca, ""))) {
+                aot_set_last_error("llvm build load failed.");
+                return false;
+            }
+            PUSH_F32(value);
+        }
     }
     else {
-        int32 i32_const;
-        memcpy(&i32_const, &f32_const, sizeof(int32));
-        if (!(alloca =
-                  LLVMBuildAlloca(comp_ctx->builder, I32_TYPE, "i32_ptr"))) {
-            aot_set_last_error("llvm build alloca failed.");
+        bh_memcpy_s(&i32_const, sizeof(int32), &f32_const, sizeof(float32));
+        snprintf(buf, sizeof(buf), "i32_const#%08X", i32_const);
+        const_index = aot_get_native_symbol_index(comp_ctx, buf);
+        if (const_index < 0) {
             return false;
         }
-        if (!LLVMBuildStore(comp_ctx->builder, I32_CONST((uint32)i32_const),
-                            alloca)) {
-            aot_set_last_error("llvm build store failed.");
-            return false;
-        }
-        if (!(alloca = LLVMBuildBitCast(comp_ctx->builder, alloca, F32_PTR_TYPE,
-                                        "f32_ptr"))) {
-            aot_set_last_error("llvm build bitcast failed.");
-            return false;
-        }
-        if (!(value = LLVMBuildLoad(comp_ctx->builder, alloca, ""))) {
-            aot_set_last_error("llvm build load failed.");
+        value = get_const_from_table(comp_ctx, func_ctx->native_symbol,
+                                     const_index, VALUE_TYPE_F32);
+        if (!value) {
             return false;
         }
         PUSH_F32(value);
@@ -75,33 +185,52 @@ aot_compile_op_f64_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                          float64 f64_const)
 {
     LLVMValueRef alloca, value;
+    char buf[128];
+    int64 i64_const;
+    int32 const_index;
 
-    if (!isnan(f64_const)) {
-        value = F64_CONST(f64_const);
-        CHECK_LLVM_CONST(value);
-        PUSH_F64(value);
+    if (!comp_ctx->is_indirect_mode) {
+        if (!isnan(f64_const)) {
+            value = F64_CONST(f64_const);
+            CHECK_LLVM_CONST(value);
+            PUSH_F64(value);
+        }
+        else {
+            int64 i64_const;
+            memcpy(&i64_const, &f64_const, sizeof(int64));
+            if (!(alloca = LLVMBuildAlloca(comp_ctx->builder, I64_TYPE,
+                                           "i64_ptr"))) {
+                aot_set_last_error("llvm build alloca failed.");
+                return false;
+            }
+            value = I64_CONST((uint64)i64_const);
+            CHECK_LLVM_CONST(value);
+            if (!LLVMBuildStore(comp_ctx->builder, value, alloca)) {
+                aot_set_last_error("llvm build store failed.");
+                return false;
+            }
+            if (!(alloca = LLVMBuildBitCast(comp_ctx->builder, alloca,
+                                            F64_PTR_TYPE, "f64_ptr"))) {
+                aot_set_last_error("llvm build bitcast failed.");
+                return false;
+            }
+            if (!(value = LLVMBuildLoad(comp_ctx->builder, alloca, ""))) {
+                aot_set_last_error("llvm build load failed.");
+                return false;
+            }
+            PUSH_F64(value);
+        }
     }
     else {
-        int64 i64_const;
-        memcpy(&i64_const, &f64_const, sizeof(int64));
-        if (!(alloca =
-                  LLVMBuildAlloca(comp_ctx->builder, I64_TYPE, "i64_ptr"))) {
-            aot_set_last_error("llvm build alloca failed.");
+        bh_memcpy_s(&i64_const, sizeof(int64), &f64_const, sizeof(float64));
+        snprintf(buf, sizeof(buf), "i64_const#%016" PRIx64, i64_const);
+        const_index = aot_get_native_symbol_index(comp_ctx, buf);
+        if (const_index < 0) {
             return false;
         }
-        value = I64_CONST((uint64)i64_const);
-        CHECK_LLVM_CONST(value);
-        if (!LLVMBuildStore(comp_ctx->builder, value, alloca)) {
-            aot_set_last_error("llvm build store failed.");
-            return false;
-        }
-        if (!(alloca = LLVMBuildBitCast(comp_ctx->builder, alloca, F64_PTR_TYPE,
-                                        "f64_ptr"))) {
-            aot_set_last_error("llvm build bitcast failed.");
-            return false;
-        }
-        if (!(value = LLVMBuildLoad(comp_ctx->builder, alloca, ""))) {
-            aot_set_last_error("llvm build load failed.");
+        value = get_const_from_table(comp_ctx, func_ctx->native_symbol,
+                                     const_index, VALUE_TYPE_F64);
+        if (!value) {
             return false;
         }
         PUSH_F64(value);

--- a/core/iwasm/compilation/aot_emit_const.c
+++ b/core/iwasm/compilation/aot_emit_const.c
@@ -5,85 +5,13 @@
 
 #include "aot_emit_const.h"
 
-static LLVMValueRef
-get_const_from_table(const AOTCompContext *comp_ctx, LLVMValueRef base,
-                     int32 index, uint8 value_type)
-{
-    LLVMTypeRef const_ptr_type;
-    LLVMValueRef const_index, const_addr, const_value;
-
-    if (!(const_index = I32_CONST(index))) {
-        aot_set_last_error("construct const index failed.");
-        goto fail;
-    }
-
-    if (!(const_addr = LLVMBuildInBoundsGEP(
-              comp_ctx->builder, base, &const_index, 1, "const_addr_tmp"))) {
-        aot_set_last_error("get const addr by index failed.");
-        goto fail;
-    }
-
-    switch (value_type) {
-        case VALUE_TYPE_I32:
-            const_ptr_type = INT32_PTR_TYPE;
-            break;
-        case VALUE_TYPE_I64:
-            const_ptr_type = INT64_PTR_TYPE;
-            break;
-        case VALUE_TYPE_F32:
-            const_ptr_type = F32_PTR_TYPE;
-            break;
-        case VALUE_TYPE_F64:
-            const_ptr_type = F64_PTR_TYPE;
-            break;
-        default:
-            bh_assert(0);
-            goto fail;
-    }
-
-    if (!(const_addr = LLVMBuildBitCast(comp_ctx->builder, const_addr,
-                                        const_ptr_type, "const_addr"))) {
-        aot_set_last_error("cast const fialed.");
-        goto fail;
-    }
-
-    if (!(const_value =
-              LLVMBuildLoad(comp_ctx->builder, const_addr, "const_value"))) {
-        aot_set_last_error("load const failed.");
-        goto fail;
-    }
-
-    return const_value;
-fail:
-    return NULL;
-}
-
 bool
 aot_compile_op_i32_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                          int32 i32_const)
 {
-    LLVMValueRef value;
-    char buf[128];
-    int32 const_index;
-
-    if (!comp_ctx->is_indirect_mode) {
-        value = I32_CONST((uint32)i32_const);
-        CHECK_LLVM_CONST(value);
-        PUSH_I32(value);
-    }
-    else {
-        snprintf(buf, sizeof(buf), "i32_const#%08X", i32_const);
-        const_index = aot_get_native_symbol_index(comp_ctx, buf);
-        if (const_index < 0) {
-            return false;
-        }
-        value = get_const_from_table(comp_ctx, func_ctx->native_symbol,
-                                     const_index, VALUE_TYPE_I32);
-        if (!value) {
-            return false;
-        }
-        PUSH_I32(value);
-    }
+    LLVMValueRef value = I32_CONST((uint32)i32_const);
+    CHECK_LLVM_CONST(value);
+    PUSH_I32(value);
     return true;
 fail:
     return false;
@@ -93,28 +21,9 @@ bool
 aot_compile_op_i64_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                          int64 i64_const)
 {
-    LLVMValueRef value;
-    char buf[128];
-    int32 const_index;
-
-    if (!comp_ctx->is_indirect_mode) {
-        value = I64_CONST((uint64)i64_const);
-        CHECK_LLVM_CONST(value);
-        PUSH_I64(value);
-    }
-    else {
-        snprintf(buf, sizeof(buf), "i64_const#%016" PRIx64, i64_const);
-        const_index = aot_get_native_symbol_index(comp_ctx, buf);
-        if (const_index < 0) {
-            return false;
-        }
-        value = get_const_from_table(comp_ctx, func_ctx->native_symbol,
-                                     const_index, VALUE_TYPE_I64);
-        if (!value) {
-            return false;
-        }
-        PUSH_I64(value);
-    }
+    LLVMValueRef value = I64_CONST((uint64)i64_const);
+    CHECK_LLVM_CONST(value);
+    PUSH_I64(value);
     return true;
 fail:
     return false;
@@ -125,51 +34,44 @@ aot_compile_op_f32_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                          float32 f32_const)
 {
     LLVMValueRef alloca, value;
-    char buf[128];
-    int32 i32_const;
-    int32 const_index;
 
-    if (!comp_ctx->is_indirect_mode) {
-        if (!isnan(f32_const)) {
+    if (!isnan(f32_const)) {
+        if (!comp_ctx->is_indirect_mode) {
             value = F32_CONST(f32_const);
             CHECK_LLVM_CONST(value);
             PUSH_F32(value);
         }
         else {
-            int32 i32_const;
-            memcpy(&i32_const, &f32_const, sizeof(int32));
-            if (!(alloca = LLVMBuildAlloca(comp_ctx->builder, I32_TYPE,
-                                           "i32_ptr"))) {
-                aot_set_last_error("llvm build alloca failed.");
-                return false;
-            }
-            if (!LLVMBuildStore(comp_ctx->builder, I32_CONST((uint32)i32_const),
-                                alloca)) {
-                aot_set_last_error("llvm build store failed.");
-                return false;
-            }
-            if (!(alloca = LLVMBuildBitCast(comp_ctx->builder, alloca,
-                                            F32_PTR_TYPE, "f32_ptr"))) {
-                aot_set_last_error("llvm build bitcast failed.");
-                return false;
-            }
-            if (!(value = LLVMBuildLoad(comp_ctx->builder, alloca, ""))) {
-                aot_set_last_error("llvm build load failed.");
+            WASMValue wasm_value;
+            memcpy(&wasm_value.f32, &f32_const, sizeof(float32));
+            value = aot_load_const_from_table(comp_ctx, func_ctx->native_symbol,
+                                              &wasm_value, VALUE_TYPE_F32);
+            if (!value) {
                 return false;
             }
             PUSH_F32(value);
         }
     }
     else {
-        bh_memcpy_s(&i32_const, sizeof(int32), &f32_const, sizeof(float32));
-        snprintf(buf, sizeof(buf), "i32_const#%08X", i32_const);
-        const_index = aot_get_native_symbol_index(comp_ctx, buf);
-        if (const_index < 0) {
+        int32 i32_const;
+        memcpy(&i32_const, &f32_const, sizeof(int32));
+        if (!(alloca =
+                  LLVMBuildAlloca(comp_ctx->builder, I32_TYPE, "i32_ptr"))) {
+            aot_set_last_error("llvm build alloca failed.");
             return false;
         }
-        value = get_const_from_table(comp_ctx, func_ctx->native_symbol,
-                                     const_index, VALUE_TYPE_F32);
-        if (!value) {
+        if (!LLVMBuildStore(comp_ctx->builder, I32_CONST((uint32)i32_const),
+                            alloca)) {
+            aot_set_last_error("llvm build store failed.");
+            return false;
+        }
+        if (!(alloca = LLVMBuildBitCast(comp_ctx->builder, alloca, F32_PTR_TYPE,
+                                        "f32_ptr"))) {
+            aot_set_last_error("llvm build bitcast failed.");
+            return false;
+        }
+        if (!(value = LLVMBuildLoad(comp_ctx->builder, alloca, ""))) {
+            aot_set_last_error("llvm build load failed.");
             return false;
         }
         PUSH_F32(value);
@@ -185,52 +87,45 @@ aot_compile_op_f64_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                          float64 f64_const)
 {
     LLVMValueRef alloca, value;
-    char buf[128];
-    int64 i64_const;
-    int32 const_index;
 
-    if (!comp_ctx->is_indirect_mode) {
-        if (!isnan(f64_const)) {
+    if (!isnan(f64_const)) {
+        if (!comp_ctx->is_indirect_mode) {
             value = F64_CONST(f64_const);
             CHECK_LLVM_CONST(value);
             PUSH_F64(value);
         }
         else {
-            int64 i64_const;
-            memcpy(&i64_const, &f64_const, sizeof(int64));
-            if (!(alloca = LLVMBuildAlloca(comp_ctx->builder, I64_TYPE,
-                                           "i64_ptr"))) {
-                aot_set_last_error("llvm build alloca failed.");
-                return false;
-            }
-            value = I64_CONST((uint64)i64_const);
-            CHECK_LLVM_CONST(value);
-            if (!LLVMBuildStore(comp_ctx->builder, value, alloca)) {
-                aot_set_last_error("llvm build store failed.");
-                return false;
-            }
-            if (!(alloca = LLVMBuildBitCast(comp_ctx->builder, alloca,
-                                            F64_PTR_TYPE, "f64_ptr"))) {
-                aot_set_last_error("llvm build bitcast failed.");
-                return false;
-            }
-            if (!(value = LLVMBuildLoad(comp_ctx->builder, alloca, ""))) {
-                aot_set_last_error("llvm build load failed.");
+            WASMValue wasm_value;
+            memcpy(&wasm_value.f64, &f64_const, sizeof(float64));
+            value = aot_load_const_from_table(comp_ctx, func_ctx->native_symbol,
+                                              &wasm_value, VALUE_TYPE_F64);
+            if (!value) {
                 return false;
             }
             PUSH_F64(value);
         }
     }
     else {
-        bh_memcpy_s(&i64_const, sizeof(int64), &f64_const, sizeof(float64));
-        snprintf(buf, sizeof(buf), "i64_const#%016" PRIx64, i64_const);
-        const_index = aot_get_native_symbol_index(comp_ctx, buf);
-        if (const_index < 0) {
+        int64 i64_const;
+        memcpy(&i64_const, &f64_const, sizeof(int64));
+        if (!(alloca =
+                  LLVMBuildAlloca(comp_ctx->builder, I64_TYPE, "i64_ptr"))) {
+            aot_set_last_error("llvm build alloca failed.");
             return false;
         }
-        value = get_const_from_table(comp_ctx, func_ctx->native_symbol,
-                                     const_index, VALUE_TYPE_F64);
-        if (!value) {
+        value = I64_CONST((uint64)i64_const);
+        CHECK_LLVM_CONST(value);
+        if (!LLVMBuildStore(comp_ctx->builder, value, alloca)) {
+            aot_set_last_error("llvm build store failed.");
+            return false;
+        }
+        if (!(alloca = LLVMBuildBitCast(comp_ctx->builder, alloca, F64_PTR_TYPE,
+                                        "f64_ptr"))) {
+            aot_set_last_error("llvm build bitcast failed.");
+            return false;
+        }
+        if (!(value = LLVMBuildLoad(comp_ctx->builder, alloca, ""))) {
+            aot_set_last_error("llvm build load failed.");
             return false;
         }
         PUSH_F64(value);

--- a/core/iwasm/compilation/aot_emit_conversion.c
+++ b/core/iwasm/compilation/aot_emit_conversion.c
@@ -348,14 +348,37 @@ aot_compile_op_i32_trunc_f32(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
     POP_F32(value);
 
-    if (sign) {
-        min_value = F32_CONST(-2147483904.0f);
-        max_value = F32_CONST(2147483648.0f);
+    if (!comp_ctx->is_indirect_mode) {
+        if (sign) {
+            min_value = F32_CONST(-2147483904.0f);
+            max_value = F32_CONST(2147483648.0f);
+        }
+        else {
+            min_value = F32_CONST(-1.0f);
+            max_value = F32_CONST(4294967296.0f);
+        }
     }
     else {
-        min_value = F32_CONST(-1.0f);
-        max_value = F32_CONST(4294967296.0f);
+        WASMValue wasm_value;
+        if (sign) {
+            wasm_value.f32 = -2147483904.0f;
+            min_value = aot_load_const_from_table(
+                comp_ctx, func_ctx->native_symbol, &wasm_value, VALUE_TYPE_F32);
+            wasm_value.f32 = 2147483648.0f;
+            max_value = aot_load_const_from_table(
+                comp_ctx, func_ctx->native_symbol, &wasm_value, VALUE_TYPE_F32);
+        }
+        else {
+            wasm_value.f32 = -1.0f;
+            min_value = aot_load_const_from_table(
+                comp_ctx, func_ctx->native_symbol, &wasm_value, VALUE_TYPE_F32);
+            wasm_value.f32 = 4294967296.0f;
+            max_value = aot_load_const_from_table(
+                comp_ctx, func_ctx->native_symbol, &wasm_value, VALUE_TYPE_F32);
+        }
     }
+    CHECK_LLVM_CONST(min_value);
+    CHECK_LLVM_CONST(max_value);
 
     if (!saturating)
         return trunc_float_to_int(
@@ -378,14 +401,37 @@ aot_compile_op_i32_trunc_f64(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
     POP_F64(value);
 
-    if (sign) {
-        min_value = F64_CONST(-2147483649.0);
-        max_value = F64_CONST(2147483648.0);
+    if (!comp_ctx->is_indirect_mode) {
+        if (sign) {
+            min_value = F64_CONST(-2147483649.0);
+            max_value = F64_CONST(2147483648.0);
+        }
+        else {
+            min_value = F64_CONST(-1.0);
+            max_value = F64_CONST(4294967296.0);
+        }
     }
     else {
-        min_value = F64_CONST(-1.0);
-        max_value = F64_CONST(4294967296.0);
+        WASMValue wasm_value;
+        if (sign) {
+            wasm_value.f64 = -2147483649.0;
+            min_value = aot_load_const_from_table(
+                comp_ctx, func_ctx->native_symbol, &wasm_value, VALUE_TYPE_F64);
+            wasm_value.f64 = 2147483648.0;
+            max_value = aot_load_const_from_table(
+                comp_ctx, func_ctx->native_symbol, &wasm_value, VALUE_TYPE_F64);
+        }
+        else {
+            wasm_value.f64 = -1.0;
+            min_value = aot_load_const_from_table(
+                comp_ctx, func_ctx->native_symbol, &wasm_value, VALUE_TYPE_F64);
+            wasm_value.f64 = 4294967296.0;
+            max_value = aot_load_const_from_table(
+                comp_ctx, func_ctx->native_symbol, &wasm_value, VALUE_TYPE_F64);
+        }
     }
+    CHECK_LLVM_CONST(min_value);
+    CHECK_LLVM_CONST(max_value);
 
     if (!saturating)
         return trunc_float_to_int(
@@ -509,14 +555,37 @@ aot_compile_op_i64_trunc_f32(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
     POP_F32(value);
 
-    if (sign) {
-        min_value = F32_CONST(-9223373136366403584.0f);
-        max_value = F32_CONST(9223372036854775808.0f);
+    if (!comp_ctx->is_indirect_mode) {
+        if (sign) {
+            min_value = F32_CONST(-9223373136366403584.0f);
+            max_value = F32_CONST(9223372036854775808.0f);
+        }
+        else {
+            min_value = F32_CONST(-1.0f);
+            max_value = F32_CONST(18446744073709551616.0f);
+        }
     }
     else {
-        min_value = F32_CONST(-1.0f);
-        max_value = F32_CONST(18446744073709551616.0f);
+        WASMValue wasm_value;
+        if (sign) {
+            wasm_value.f32 = -9223373136366403584.0f;
+            min_value = aot_load_const_from_table(
+                comp_ctx, func_ctx->native_symbol, &wasm_value, VALUE_TYPE_F32);
+            wasm_value.f32 = 9223372036854775808.0f;
+            max_value = aot_load_const_from_table(
+                comp_ctx, func_ctx->native_symbol, &wasm_value, VALUE_TYPE_F32);
+        }
+        else {
+            wasm_value.f32 = -1.0f;
+            min_value = aot_load_const_from_table(
+                comp_ctx, func_ctx->native_symbol, &wasm_value, VALUE_TYPE_F32);
+            wasm_value.f32 = 18446744073709551616.0f;
+            max_value = aot_load_const_from_table(
+                comp_ctx, func_ctx->native_symbol, &wasm_value, VALUE_TYPE_F32);
+        }
     }
+    CHECK_LLVM_CONST(min_value);
+    CHECK_LLVM_CONST(max_value);
 
     if (!saturating)
         return trunc_float_to_int(
@@ -539,14 +608,37 @@ aot_compile_op_i64_trunc_f64(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
     POP_F64(value);
 
-    if (sign) {
-        min_value = F64_CONST(-9223372036854777856.0);
-        max_value = F64_CONST(9223372036854775808.0);
+    if (!comp_ctx->is_indirect_mode) {
+        if (sign) {
+            min_value = F64_CONST(-9223372036854777856.0);
+            max_value = F64_CONST(9223372036854775808.0);
+        }
+        else {
+            min_value = F64_CONST(-1.0);
+            max_value = F64_CONST(18446744073709551616.0);
+        }
     }
     else {
-        min_value = F64_CONST(-1.0);
-        max_value = F64_CONST(18446744073709551616.0);
+        WASMValue wasm_value;
+        if (sign) {
+            wasm_value.f64 = -9223372036854777856.0;
+            min_value = aot_load_const_from_table(
+                comp_ctx, func_ctx->native_symbol, &wasm_value, VALUE_TYPE_F64);
+            wasm_value.f64 = 9223372036854775808.0;
+            max_value = aot_load_const_from_table(
+                comp_ctx, func_ctx->native_symbol, &wasm_value, VALUE_TYPE_F64);
+        }
+        else {
+            wasm_value.f64 = -1.0;
+            min_value = aot_load_const_from_table(
+                comp_ctx, func_ctx->native_symbol, &wasm_value, VALUE_TYPE_F64);
+            wasm_value.f64 = 18446744073709551616.0;
+            max_value = aot_load_const_from_table(
+                comp_ctx, func_ctx->native_symbol, &wasm_value, VALUE_TYPE_F64);
+        }
     }
+    CHECK_LLVM_CONST(min_value);
+    CHECK_LLVM_CONST(max_value);
 
     if (!saturating)
         return trunc_float_to_int(

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -2031,7 +2031,7 @@ aot_get_native_symbol_index(AOTCompContext *comp_ctx, const char *symbol)
         }
 
         idx = bh_list_length(&comp_ctx->native_symbols);
-        sym->symbol = symbol;
+        snprintf(sym->symbol, sizeof(sym->symbol), "%s", symbol);
         sym->index = idx;
 
         if (BH_LIST_ERROR == bh_list_insert(&comp_ctx->native_symbols, sym)) {

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -2002,6 +2002,29 @@ aot_destroy_comp_context(AOTCompContext *comp_ctx)
     wasm_runtime_free(comp_ctx);
 }
 
+static bool
+insert_native_symbol(AOTCompContext *comp_ctx, const char *symbol, int32 idx)
+{
+    AOTNativeSymbol *sym = wasm_runtime_malloc(sizeof(AOTNativeSymbol));
+
+    if (!sym) {
+        aot_set_last_error("alloc native symbol failed.");
+        return false;
+    }
+
+    memset(sym, 0, sizeof(AOTNativeSymbol));
+    snprintf(sym->symbol, sizeof(sym->symbol), "%s", symbol);
+    sym->index = idx;
+
+    if (BH_LIST_ERROR == bh_list_insert(&comp_ctx->native_symbols, sym)) {
+        wasm_runtime_free(sym);
+        aot_set_last_error("insert native symbol to list failed.");
+        return false;
+    }
+
+    return true;
+}
+
 int32
 aot_get_native_symbol_index(AOTCompContext *comp_ctx, const char *symbol)
 {
@@ -2023,21 +2046,29 @@ aot_get_native_symbol_index(AOTCompContext *comp_ctx, const char *symbol)
     /* Given symbol is not exist in list, then we alloc a new index for it */
 
     if (idx < 0) {
-        sym = wasm_runtime_malloc(sizeof(AOTNativeSymbol));
-
-        if (!sym) {
-            aot_set_last_error("alloc native symbol failed.");
-            return idx;
+        if (comp_ctx->pointer_size == sizeof(uint32)
+            && !strncmp(symbol, "i64#", 4)) {
+            idx = bh_list_length(&comp_ctx->native_symbols);
+            /* Add 4 bytes padding on 32-bit target to make sure that
+               the i64 const is stored on 8-byte aligned address */
+            if ((idx & 1) && !strncmp(comp_ctx->target_arch, "i386", 4)) {
+                if (!insert_native_symbol(comp_ctx, "__ignore", idx)) {
+                    return -1;
+                }
+            }
         }
 
         idx = bh_list_length(&comp_ctx->native_symbols);
-        snprintf(sym->symbol, sizeof(sym->symbol), "%s", symbol);
-        sym->index = idx;
-
-        if (BH_LIST_ERROR == bh_list_insert(&comp_ctx->native_symbols, sym)) {
-            wasm_runtime_free(sym);
-            aot_set_last_error("alloc index for native symbol failed.");
+        if (!insert_native_symbol(comp_ctx, symbol, idx)) {
             return -1;
+        }
+
+        if (comp_ctx->pointer_size == sizeof(uint32)
+            && !strncmp(symbol, "i64#", 4)) {
+            /* i64 const occupies 2 pointer slots on 32-bit target */
+            if (!insert_native_symbol(comp_ctx, "__ignore", idx + 1)) {
+                return -1;
+            }
         }
     }
 
@@ -2442,4 +2473,66 @@ aot_get_func_from_table(const AOTCompContext *comp_ctx, LLVMValueRef base,
     return func;
 fail:
     return NULL;
+}
+
+LLVMValueRef
+aot_load_const_from_table(AOTCompContext *comp_ctx, LLVMValueRef base,
+                          const WASMValue *value, uint8 value_type)
+{
+    LLVMValueRef const_index, const_addr, const_value;
+    LLVMTypeRef const_ptr_type;
+    char buf[128] = { 0 };
+    int32 index;
+
+    switch (value_type) {
+        case VALUE_TYPE_I32:
+            snprintf(buf, sizeof(buf), "i32#%08X", value->i32);
+            const_ptr_type = INT32_PTR_TYPE;
+            break;
+        case VALUE_TYPE_I64:
+            snprintf(buf, sizeof(buf), "i64#%016" PRIx64, value->i64);
+            const_ptr_type = INT64_PTR_TYPE;
+            break;
+        case VALUE_TYPE_F32:
+            snprintf(buf, sizeof(buf), "i32#%08X", value->i32);
+            const_ptr_type = F32_PTR_TYPE;
+            break;
+        case VALUE_TYPE_F64:
+            snprintf(buf, sizeof(buf), "i64#%016" PRIx64, value->i64);
+            const_ptr_type = F64_PTR_TYPE;
+            break;
+        default:
+            bh_assert(0);
+            return NULL;
+    }
+
+    index = aot_get_native_symbol_index(comp_ctx, buf);
+    if (index < 0) {
+        return NULL;
+    }
+
+    if (!(const_index = I32_CONST(index))) {
+        aot_set_last_error("construct const index failed.");
+        return NULL;
+    }
+
+    if (!(const_addr = LLVMBuildInBoundsGEP(
+              comp_ctx->builder, base, &const_index, 1, "const_addr_tmp"))) {
+        aot_set_last_error("get const addr by index failed.");
+        return NULL;
+    }
+
+    if (!(const_addr = LLVMBuildBitCast(comp_ctx->builder, const_addr,
+                                        const_ptr_type, "const_addr"))) {
+        aot_set_last_error("cast const fialed.");
+        return NULL;
+    }
+
+    if (!(const_value =
+              LLVMBuildLoad(comp_ctx->builder, const_addr, "const_value"))) {
+        aot_set_last_error("load const failed.");
+        return NULL;
+    }
+
+    return const_value;
 }

--- a/core/iwasm/compilation/aot_llvm.h
+++ b/core/iwasm/compilation/aot_llvm.h
@@ -442,6 +442,10 @@ LLVMValueRef
 aot_get_func_from_table(const AOTCompContext *comp_ctx, LLVMValueRef base,
                         LLVMTypeRef func_type, int32 index);
 
+LLVMValueRef
+aot_load_const_from_table(AOTCompContext *comp_ctx, LLVMValueRef base,
+                          const WASMValue *value, uint8 value_type);
+
 bool
 aot_check_simd_compatibility(const char *arch_c_str, const char *cpu_c_str);
 


### PR DESCRIPTION
Lookup float/double constants from exec_env->native_symbol table
but not construct them with LLVMBuildConst if XIP mode is enabled,
these constants are introduced by f32/f64.const opcodes and some
float/double conversion opcodes, and make wamrc generate some
relocations in text section of AOT XIP file. This patch eliminates such
relocations when "--enable-indirect-mode" is added to wamrc.