### PR TITLE
Zephyr update

### DIFF
--- a/doc/build_wamr.md
+++ b/doc/build_wamr.md
@@ -303,15 +303,24 @@ WAMR provides some features which can be easily configured by passing options to
 
 Zephyr
 -------------------------
-You need to download the Zephyr source code first and embed WAMR into it.
+You need to prepare Zephyr first as described here https://docs.zephyrproject.org/latest/getting_started/index.html#get-zephyr-and-install-python-dependencies).
+
+After that you need to point the `ZEPHYR_BASE` variable to e.g. `~/zephyrproject/zephyr`. Also, it is important that you have `west` available for subsequent actions.
+
 ``` Bash
-git clone https://github.com/zephyrproject-rtos/zephyr.git
-source zephyr/zephyr-env.sh
 cd <wamr_root_dir>/product-mini/platforms/zephyr/simple
 # Execute the ./build_and_run.sh script with board name as parameter. Here take x86 as example:
 ./build_and_run.sh x86
-
 ```
+
+If you want to use the Espressif toolchain (esp32 or esp32c3), you can most conveniently install it with `west`:
+
+``` Bash
+cd $ZEPHYR_BASE
+west espressif install
+```
+
+After that set `ESPRESSIF_TOOLCHAIN_PATH` according to the output, for example `~/.espressif/tools/zephyr`.
 
 Note:
 WAMR provides some features which can be easily configured by passing options to cmake, please see [WAMR vmcore cmake building configurations](./build_wamr.md#wamr-vmcore-cmake-building-configurations) for details. Currently in Zephyr, interpreter, AoT and builtin libc are enabled by default.

--- a/product-mini/platforms/zephyr/simple/Dockerfile
+++ b/product-mini/platforms/zephyr/simple/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:20.04
+
+ARG DOCKER_UID=1000
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get -qq update && apt-get -qq dist-upgrade && apt install -qq -y python3-pip git wget ninja-build
+
+WORKDIR /tmp
+
+RUN mkdir /opt/cmake && wget -q https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1-linux-x86_64.sh && sh cmake-3.22.1-linux-x86_64.sh --skip-license --prefix=/opt/cmake && rm cmake-3.22.1-linux-x86_64.sh
+
+ENV PATH="/opt/cmake/bin:$PATH"
+
+RUN useradd -m wamr -u ${DOCKER_UID} -G dialout
+
+USER wamr
+
+ENV PATH="/home/wamr/.local/bin:$PATH"
+
+RUN pip3 install --user west
+
+RUN west init ~/zephyrproject && cd ~/zephyrproject && west update && west zephyr-export
+
+RUN pip3 install --user -r ~/zephyrproject/zephyr/scripts/requirements.txt
+
+WORKDIR /home/wamr/zephyrproject
+
+RUN west espressif install
+
+ENV ZEPHYR_BASE=/home/wamr/zephyrproject/zephyr
+ENV ESPRESSIF_TOOLCHAIN_PATH=/home/wamr/.espressif/tools/zephyr
+
+WORKDIR /home/wamr/source/product-mini/platforms/zephyr/simple

--- a/product-mini/platforms/zephyr/simple/README_docker.md
+++ b/product-mini/platforms/zephyr/simple/README_docker.md
@@ -1,0 +1,25 @@
+# Build with Docker
+
+To have a quicker start, a Docker container of the Zephyr setup can be generated.
+
+## Build Docker container
+
+``` Bash
+docker build --build-arg DOCKER_UID=$(id -u) . -t wamr-zephyr
+```
+
+## Run Docker container to build images
+
+Enter the docker container (maps the toplevel wasm-micro-runtime repo as volume):
+
+``` Bash
+docker run -ti -v $PWD/../../../..:/home/wamr/source --device=/dev/ttyUSB0 wamr-zephyr
+```
+
+Adopt the device or remove if not needed.
+
+And then in the docker container:
+
+``` Bash
+./build_and_run.sh esp32c3
+```

--- a/product-mini/platforms/zephyr/simple/build_and_run.sh
+++ b/product-mini/platforms/zephyr/simple/build_and_run.sh
@@ -6,6 +6,8 @@
 X86_TARGET="x86"
 STM32_TARGET="stm32"
 ESP32_TARGET="esp32"
+ESP32C3_TARGET="esp32c3"
+PARTICLE_ARGON_TARGET="particle_argon"
 QEMU_CORTEX_A53="qemu_cortex_a53"
 QEMU_XTENSA_TARGET="qemu_xtensa"
 QEMU_RISCV64_TARGET="qemu_riscv64"
@@ -15,11 +17,13 @@ QEMU_ARC_TARGET="qemu_arc"
 usage ()
 {
         echo "USAGE:"
-        echo "$0 $X86_TARGET|$STM32_TARGET|$ESP32_TARGET|$QEMU_CORTEX_A53|$QEMU_XTENSA_TARGET|$QEMU_RISCV64_TARGET|$QEMU_RISCV32_TARGET|$QEMU_ARC_TARGET"
+        echo "$0 $X86_TARGET|$STM32_TARGET|$ESP32_TARGET|$ESP32C3_TARGET|$PARTICLE_ARGON_TARGET|$QEMU_CORTEX_A53|$QEMU_XTENSA_TARGET|$QEMU_RISCV64_TARGET|$QEMU_RISCV32_TARGET|$QEMU_ARC_TARGET"
         echo "Example:"
         echo "        $0 $X86_TARGET"
         echo "        $0 $STM32_TARGET"
         echo "        $0 $ESP32_TARGET"
+        echo "        $0 $ESP32C3_TARGET"
+        echo "        $0 $PARTICLE_ARGON_TARGET"
         echo "        $0 $QEMU_CORTEX_A53"
         echo "        $0 $QEMU_XTENSA_TARGET"
         echo "        $0 $QEMU_RISCV64_TARGET"
@@ -55,6 +59,25 @@ case $TARGET in
                 west build -b esp32 \
                            . -p always -- \
                            -DWAMR_BUILD_TARGET=XTENSA                           
+                # west flash will discover the device
+                west flash
+                ;;
+        $ESP32C3_TARGET)
+                export ZEPHYR_TOOLCHAIN_VARIANT="espressif"
+                if [[ -z "${ESPRESSIF_TOOLCHAIN_PATH}" ]]; then
+                        echo "Set ESPRESSIF_TOOLCHAIN_PATH to your espressif toolchain"
+                        exit 1
+                fi
+                west build -b esp32c3_devkitm \
+                           . -p always -- \
+                           -DWAMR_BUILD_TARGET=RISCV32_ILP32
+                # west flash will discover the device
+                west flash
+                ;;
+        $PARTICLE_ARGON_TARGET)
+                west build -b  particle_argon \
+                           . -p always -- \
+                           -DWAMR_BUILD_TARGET=THUMBV7
                 # west flash will discover the device
                 west flash
                 ;;

--- a/product-mini/platforms/zephyr/simple/build_and_run.sh
+++ b/product-mini/platforms/zephyr/simple/build_and_run.sh
@@ -47,14 +47,16 @@ case $TARGET in
                 west flash
                 ;;
         $ESP32_TARGET)
-                # suppose you have set environment variable ESP_IDF_PATH
+                export ZEPHYR_TOOLCHAIN_VARIANT="espressif"
+                if [[ -z "${ESPRESSIF_TOOLCHAIN_PATH}" ]]; then
+                        echo "Set ESPRESSIF_TOOLCHAIN_PATH to your espressif toolchain"
+                        exit 1
+                fi
                 west build -b esp32 \
                            . -p always -- \
-                           -DESP_IDF_PATH=$ESP_IDF_PATH \
-                           -DWAMR_BUILD_TARGET=XTENSA
-                # suppose the serial port is /dev/ttyUSB1 and you should change to
-                # the real name accordingly
-                west flash --esp-device /dev/ttyUSB1
+                           -DWAMR_BUILD_TARGET=XTENSA                           
+                # west flash will discover the device
+                west flash
                 ;;
         $QEMU_XTENSA_TARGET)
                 west build -b qemu_xtensa \


### PR DESCRIPTION
I think the Zephyr instructions were not fully up-to-date anymore. Add info about espressif toolchain too.
Add ESP32C3 (RISC-V) and Particle Argon, more boards are possible, but the script doesn't scale well, can be improved in future.
Add Dockerfile to kickstart a Zephyr development environment as it can be rather confusing for new users..