### PR TITLE
Automatically detect the host platform.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required (VERSION 2.8...3.16)
 project (iwasm)
 # set (CMAKE_VERBOSE_MAKEFILE 1)
 
-set (WAMR_BUILD_PLATFORM "linux")
+string (TOLOWER ${CMAKE_HOST_SYSTEM_NAME} WAMR_BUILD_PLATFORM)
 
 # Reset default linker flags
 set (CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")


### PR DESCRIPTION
Previously, "linux" was hardcoded, so it was impossible to build
on anything but Linux, even when specifying WAMR_BUILD_PLATFORM.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>