### PR TITLE
Use LLVM new pass manager

### DIFF
--- a/core/iwasm/compilation/aot_compiler.c
+++ b/core/iwasm/compilation/aot_compiler.c
@@ -2620,8 +2620,7 @@ aot_compile_wasm(AOTCompContext *comp_ctx)
     bh_print_time("Begin to run function optimization passes");
 
 #if 1
-    aot_apply_new_pass_builder(comp_ctx->module, comp_ctx->target_machine,
-                               comp_ctx->opt_level);
+    aot_apply_llvm_new_pass_manager(comp_ctx);
 #else
     /* Run function pass manager */
     if (comp_ctx->optimize) {

--- a/core/iwasm/compilation/aot_compiler.c
+++ b/core/iwasm/compilation/aot_compiler.c
@@ -2619,6 +2619,10 @@ aot_compile_wasm(AOTCompContext *comp_ctx)
 
     bh_print_time("Begin to run function optimization passes");
 
+#if 1
+    aot_apply_new_pass_builder(comp_ctx->module, comp_ctx->target_machine,
+                               comp_ctx->opt_level);
+#else
     /* Run function pass manager */
     if (comp_ctx->optimize) {
         LLVMInitializeFunctionPassManager(comp_ctx->pass_mgr);
@@ -2656,6 +2660,7 @@ aot_compile_wasm(AOTCompContext *comp_ctx)
         LLVMDisposePassManager(common_pass_mgr);
         LLVMPassManagerBuilderDispose(pass_mgr_builder);
     }
+#endif
 
     if (comp_ctx->optimize && comp_ctx->is_indirect_mode) {
         LLVMPassManagerRef common_pass_mgr = NULL;

--- a/core/iwasm/compilation/aot_llvm.h
+++ b/core/iwasm/compilation/aot_llvm.h
@@ -453,9 +453,7 @@ void
 aot_add_expand_memory_op_pass(LLVMPassManagerRef pass);
 
 void
-aot_apply_new_pass_builder(LLVMModuleRef module,
-                           LLVMTargetMachineRef target_machine,
-                           unsigned opt_level);
+aot_apply_llvm_new_pass_manager(AOTCompContext *comp_ctx);
 
 #if WASM_ENABLE_LAZY_JIT != 0
 void

--- a/core/iwasm/compilation/aot_llvm.h
+++ b/core/iwasm/compilation/aot_llvm.h
@@ -452,6 +452,11 @@ aot_check_simd_compatibility(const char *arch_c_str, const char *cpu_c_str);
 void
 aot_add_expand_memory_op_pass(LLVMPassManagerRef pass);
 
+void
+aot_apply_new_pass_builder(LLVMModuleRef module,
+                           LLVMTargetMachineRef target_machine,
+                           unsigned opt_level);
+
 #if WASM_ENABLE_LAZY_JIT != 0
 void
 aot_handle_llvm_errmsg(char *error_buf, uint32 error_buf_size,

--- a/core/iwasm/compilation/aot_llvm_extra.cpp
+++ b/core/iwasm/compilation/aot_llvm_extra.cpp
@@ -356,10 +356,21 @@ aot_apply_new_pass_builder(LLVMModuleRef module,
 
     MPM.run(*M, MAM);
 
+#if 0
     // Set initializer for constant value
     if (auto *IntrinsicsTable = M->getNamedGlobal("intrinsics")) {
         IntrinsicsTable->setInitializer(llvm::ConstantPointerNull::get(
             llvm::cast<llvm::PointerType>(IntrinsicsTable->getValueType())));
         IntrinsicsTable->setConstant(false);
     }
+
+    llvm::legacy::PassManager CodeGenPasses;
+    CodeGenPasses.add(
+        llvm::createTargetTransformInfoWrapperPass(TM->getTargetIRAnalysis()));
+
+    // Add LibraryInfo.
+    CodeGenPasses.add(new llvm::TargetLibraryInfoWrapperPass(*TLII));
+
+    CodeGenPasses.run(*M);
+#endif
 }

--- a/core/iwasm/compilation/aot_llvm_extra.cpp
+++ b/core/iwasm/compilation/aot_llvm_extra.cpp
@@ -352,7 +352,8 @@ aot_apply_new_pass_builder(LLVMModuleRef module,
             break;
     }
 
-    MPM.addPass(PB.buildPerModuleDefaultPipeline(OL));
+    // MPM.addPass(PB.buildPerModuleDefaultPipeline(OL));
+    MPM.addPass(PB.buildPerModuleDefaultPipeline(OL, true));
 
     MPM.run(*M, MAM);
 

--- a/core/iwasm/compilation/aot_llvm_extra.cpp
+++ b/core/iwasm/compilation/aot_llvm_extra.cpp
@@ -358,9 +358,17 @@ aot_apply_llvm_new_pass_manager(AOTCompContext *comp_ctx)
             break;
     }
 
+    if (comp_ctx->disable_llvm_lto) {
+        uint32 i;
+
+        for (i = 0; i < comp_ctx->func_ctx_count; i++) {
+            aot_func_disable_tce(comp_ctx->func_ctxes[i]->func);
+        }
+    }
+
     if (comp_ctx->is_jit_mode) {
         /* Apply normal pipeline for JIT mode, without
-           Vectorize related passes, with LTO */
+           Vectorize related passes, without LTO */
         MPM.addPass(PB.buildPerModuleDefaultPipeline(OL));
     }
     else {
@@ -379,11 +387,11 @@ aot_apply_llvm_new_pass_manager(AOTCompContext *comp_ctx)
 
         MPM.addPass(createModuleToFunctionPassAdaptor(std::move(FPM)));
 
-        /* Apply LTO for AOT mode */
         if (!comp_ctx->disable_llvm_lto)
+            /* Apply LTO for AOT mode */
             MPM.addPass(PB.buildLTODefaultPipeline(OL, NULL));
         else
-            MPM.addPass(PB.buildPerModuleDefaultPipeline(OL, NULL));
+            MPM.addPass(PB.buildPerModuleDefaultPipeline(OL));
     }
 
     MPM.run(*M, MAM);

--- a/core/iwasm/compilation/aot_llvm_extra.cpp
+++ b/core/iwasm/compilation/aot_llvm_extra.cpp
@@ -359,7 +359,6 @@ aot_apply_llvm_new_pass_manager(AOTCompContext *comp_ctx)
             break;
     }
 
-
     if (comp_ctx->disable_llvm_lto) {
         disable_llvm_lto = true;
     }


### PR DESCRIPTION
Use LLVM new pass manager to replace the legacy pass manger to
gain better performance and reduce the compilation time.
Refer links:
https://llvm.org/docs/NewPassManager.html
https://blog.llvm.org/posts/2021-03-26-the-new-pass-manager/