### PR TITLE
[WIP] 2D graphic library LittlevGL changed its name to LVGL

### DIFF
--- a/doc/wamr_api.md
+++ b/doc/wamr_api.md
@@ -283,7 +283,7 @@ void on_destroy()
 
 ## GUI API
 
-The API's is listed in header file ```core/app-framework/wgl/app/wa-inc/wgl.h``` which is implemented based on open source 2D graphic library [LittlevGL](https://docs.littlevgl.com/en/html/index.html).
+The API's is listed in header file ```core/app-framework/wgl/app/wa-inc/wgl.h``` which is implemented based on open source 2D graphic library [LVGL](https://docs.lvgl.io/master/index.html).
 
 ``` C
 static void btn_event_cb(wgl_obj_t btn, wgl_event_t event);


### PR DESCRIPTION
Hello,

while browsing through the documentation I noticed that the link of `LittlevGL` leads to nowhere. After a little Google search I found out that the library had changed its name and domain to [`LVGL`](https://lvgl.io). My pull request updates the documentation accordingly.

See https://blog.lvgl.io/2020-06-01/announcement

*Edit: I noticed that there are a lot more references to `littlevgl` and its old domain, so this pull request still needs some work.*