### PR TITLE
Specify a commit ID for XNNPACK workload (#966)

### DIFF
--- a/samples/workload/XNNPACK/CMakeLists.txt
+++ b/samples/workload/XNNPACK/CMakeLists.txt
@@ -15,6 +15,7 @@ ExternalProject_Add(xnnpack
     GIT_PROGRESS   ON
     SOURCE_DIR     ${CMAKE_CURRENT_SOURCE_DIR}/xnnpack
     UPDATE_COMMAND git checkout .
+                   && git reset --hard 4d738aef36872669e4bba05a4b259149ba8e62e1
                    && cmake -E copy ${CMAKE_CURRENT_SOURCE_DIR}/benchmark.patch ${CMAKE_CURRENT_SOURCE_DIR}/xnnpack/third_party
                    && git apply ${CMAKE_CURRENT_SOURCE_DIR}/xnnpack.patch
     CONFIGURE_COMMAND ""


### PR DESCRIPTION
XNNPACK code base is updating quickly, we specify a commit ID
for it so as to build XNNPACK workload successfully.