### PR TITLE
Fix win_thread.c timed wait always return 0 issue

### DIFF
--- a/core/shared/platform/windows/win_thread.c
+++ b/core/shared/platform/windows/win_thread.c
@@ -516,10 +516,11 @@ os_cond_wait_internal(korp_cond *cond, korp_mutex *mutex, bool timed,
 
     /* Unlock mutex, wait sem and lock mutex again */
     os_mutex_unlock(mutex);
+    int wait_result;
     if (timed)
-        os_sem_reltimed_wait(&node->sem, useconds);
+        wait_result = os_sem_reltimed_wait(&node->sem, useconds);
     else
-        os_sem_wait(&node->sem);
+        wait_result = os_sem_wait(&node->sem);
     os_mutex_lock(mutex);
 
     /* Remove wait node from wait list */
@@ -535,7 +536,7 @@ os_cond_wait_internal(korp_cond *cond, korp_mutex *mutex, bool timed,
     }
     os_mutex_unlock(&cond->wait_list_lock);
 
-    return BHT_OK;
+    return wait_result;
 }
 
 int


### PR DESCRIPTION
win_thread.c os_cond_wait_internal returns os_sem_reltimed_wait or os_sem_wait result instead of always return BHT_OK before