### PR TITLE
Allow compilation on MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,10 @@ add_library (iwasm_shared SHARED ${WAMR_RUNTIME_LIB_SOURCE})
 set_target_properties (iwasm_shared PROPERTIES OUTPUT_NAME iwasm)
 target_link_libraries (iwasm_shared ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl -lpthread)
 
+if (MINGW)
+target_link_libraries (iwasm_shared -lWs2_32)
+endif ()
+
 install (TARGETS iwasm_shared LIBRARY DESTINATION lib)
 
 # HEADERS

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The iwasm supports the following architectures:
 
 The following platforms are supported, click each link below for how to build iwasm on that platform. Refer to [WAMR porting guide](./doc/port_wamr.md) for how to port WAMR to a new platform.
 
-- [Linux](./doc/build_wamr.md#linux),  [Linux SGX (Intel Software Guard Extension)](./doc/linux_sgx.md),  [MacOS](./doc/build_wamr.md#macos),  [Android](./doc/build_wamr.md#android), [Windows](./doc/build_wamr.md#windows)
+- [Linux](./doc/build_wamr.md#linux),  [Linux SGX (Intel Software Guard Extension)](./doc/linux_sgx.md),  [MacOS](./doc/build_wamr.md#macos),  [Android](./doc/build_wamr.md#android), [Windows](./doc/build_wamr.md#windows), [Windows (MinGW)](./doc/build_wamr.md#mingw)
 - [Zephyr](./doc/build_wamr.md#zephyr),  [AliOS-Things](./doc/build_wamr.md#alios-things),  [VxWorks](./doc/build_wamr.md#vxworks), [NuttX](./doc/build_wamr.md#nuttx), [RT-Thread](./doc/build_wamr.md#RT-Thread), [ESP-IDF](./doc/build_wamr.md#esp-idf)
 
 ### Build iwasm VM core (mini product)

--- a/core/shared/platform/windows/win_time.c
+++ b/core/shared/platform/windows/win_time.c
@@ -9,7 +9,12 @@ uint64
 os_time_get_boot_microsecond()
 {
     struct timespec ts;
+#if defined(__MINGW32__)
+    // https://www.mail-archive.com/mingw-w64-public@lists.sourceforge.net/msg18361.html
+    clock_gettime(CLOCK_REALTIME, &ts);
+#else
     timespec_get(&ts, TIME_UTC);
+#endif
 
     return ((uint64)ts.tv_sec) * 1000 * 1000 + ((uint64)ts.tv_nsec) / 1000;
 }

--- a/core/shared/utils/uncommon/bh_read_file.c
+++ b/core/shared/utils/uncommon/bh_read_file.c
@@ -9,6 +9,11 @@
 #endif
 
 #if defined(_WIN32) || defined(_WIN32_)
+
+#if defined(__MINGW32__) && !defined(_SH_DENYNO)
+#define _SH_DENYNO 0x40
+#endif
+
 char *
 bh_read_file_to_buffer(const char *filename, uint32 *ret_size)
 {

--- a/doc/build_wamr.md
+++ b/doc/build_wamr.md
@@ -324,6 +324,28 @@ For how to build the `JIT` mode and `classic interpreter` mode, please refer to 
 
 WAMR provides some features which can be easily configured by passing options to cmake, please see [WAMR vmcore cmake building configurations](./build_wamr.md#wamr-vmcore-cmake-building-configurations) for details. Currently in Windows, interpreter, AOT, and builtin libc are enabled by default.
 
+MinGW
+-------------------------
+
+Follow build instructions for Windows minus cloning uvwasi and adding the
+following arguments for cmake:
+
+```Bash
+cmake .. -G"Unix Makefiles" \
+         -DWAMR_BUILD_LIBC_UVWASI=0 \
+         -DWAMR_BUILD_INVOKE_NATIVE_GENERAL=1 \
+         -DWAMR_DISABLE_HW_BOUND_CHECK=1
+````
+
+Note that WASI will be disabled until further work is done towards MinGW support.
+
+- uvwasi not building out of the box, though it reportedly supports MinGW.
+- Failing compilation of assembler files, the C version of `invokeNative()` will
+be used instead.
+- Compiler complaining about missing `UnwindInfoAddress` field in `RUNTIME_FUNCTION`
+struct (winnt.h).
+
+
 VxWorks
 -------------------------
 VxWorks 7 SR0620 release is validated.

--- a/doc/build_wamr.md
+++ b/doc/build_wamr.md
@@ -327,8 +327,16 @@ WAMR provides some features which can be easily configured by passing options to
 MinGW
 -------------------------
 
-Follow build instructions for Windows minus cloning uvwasi and adding the
-following arguments for cmake:
+First make sure the correct CMake package is installed; the following commands
+are valid for the MSYS2 build environment:
+
+```Bash
+pacman -R cmake
+pacman -S mingw-w64-x86_64-cmake
+```
+
+Then follow the build instructions for Windows above, minus cloning uvwasi and
+adding the following arguments for cmake:
 
 ```Bash
 cmake .. -G"Unix Makefiles" \
@@ -337,7 +345,7 @@ cmake .. -G"Unix Makefiles" \
          -DWAMR_DISABLE_HW_BOUND_CHECK=1
 ````
 
-Note that WASI will be disabled until further work is done towards MinGW support.
+Note that WASI will be disabled until further work is done towards full MinGW support.
 
 - uvwasi not building out of the box, though it reportedly supports MinGW.
 - Failing compilation of assembler files, the C version of `invokeNative()` will

--- a/product-mini/platforms/windows/CMakeLists.txt
+++ b/product-mini/platforms/windows/CMakeLists.txt
@@ -103,9 +103,11 @@ set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 include (${WAMR_ROOT_DIR}/build-scripts/runtime_lib.cmake)
 add_library(vmlib ${WAMR_RUNTIME_LIB_SOURCE})
 
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWIN32_LEAN_AND_MEAN -D_WINSOCK_DEPRECATED_NO_WARNINGS")
-set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SAFESEH:NO")
-set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /SAFESEH:NO")
+#set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWIN32_LEAN_AND_MEAN -D_WINSOCK_DEPRECATED_NO_WARNINGS")
+if (NOT MINGW)
+  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SAFESEH:NO")
+  set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /SAFESEH:NO")
+endif ()
 
 # set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security")
 # set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wconversion -Wsign-conversion")
@@ -132,6 +134,10 @@ install (TARGETS iwasm DESTINATION bin)
 
 target_link_libraries (iwasm vmlib ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS})
 
+if (MINGW)
+  target_link_libraries (iwasm ws2_32)
+endif ()
+
 add_library (libiwasm SHARED ${WAMR_RUNTIME_LIB_SOURCE})
 
 install (TARGETS libiwasm DESTINATION lib)
@@ -140,3 +146,6 @@ set_target_properties (libiwasm PROPERTIES OUTPUT_NAME libiwasm)
 
 target_link_libraries (libiwasm ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS})
 
+if (MINGW)
+  target_link_libraries (libiwasm ws2_32)
+endif ()


### PR DESCRIPTION
This is the least invasive patch I could came up with. Note that WASI and some other smallish details are still not supported, yet we have a starting point.

Further discussion at https://github.com/bytecodealliance/wasm-micro-runtime/issues/993
