### PR TITLE
correct RIOT os_mmap size type to size_t

### DIFF
--- a/core/shared/platform/riot/riot_platform.c
+++ b/core/shared/platform/riot/riot_platform.c
@@ -44,9 +44,11 @@ os_free(void *ptr)
 }
 
 void *
-os_mmap(void *hint, unsigned int size, int prot, int flags)
+os_mmap(void *hint, size_t size, int prot, int flags)
 {
-    return BH_MALLOC(size);
+    if (size > ((unsigned)~0))
+        return NULL;
+    return BH_MALLOC((unsigned)size);
 }
 
 void


### PR DESCRIPTION
change signature of riot `os_mmap` implementation to match declaration in core/shared/platform/include/platform_api_vmcore.h