### PR TITLE
Fixed: Error ‘MADV_HUGEPAGE’ undeclared (first use in this function)

### DIFF
--- a/core/shared/platform/common/posix/posix_memmap.c
+++ b/core/shared/platform/common/posix/posix_memmap.c
@@ -16,7 +16,7 @@ static size_t total_size_munmapped = 0;
 
 #define HUGE_PAGE_SIZE (2 * 1024 * 1024)
 
-#if !defined(__APPLE__) && !defined(__NuttX__)
+#if !defined(__APPLE__) && !defined(__NuttX__) && defined(MADV_HUGEPAGE)
 static inline uintptr_t
 round_up(uintptr_t v, uintptr_t b)
 {
@@ -148,7 +148,7 @@ os_mmap(void *hint, size_t size, int prot, int flags)
               addr, request_size, total_size_mmapped, total_size_munmapped);
 #endif
 
-#if !defined(__APPLE__) && !defined(__NuttX__)
+#if !defined(__APPLE__) && !defined(__NuttX__) && defined(MADV_HUGEPAGE)
     /* huge page isn't supported on MacOS and NuttX */
     if (request_size > HUGE_PAGE_SIZE) {
         uintptr_t huge_start, huge_end;
@@ -200,7 +200,7 @@ os_mmap(void *hint, size_t size, int prot, int flags)
             }
         }
     }
-#endif /* end of __APPLE__ || __NuttX__ */
+#endif /* end of __APPLE__ || __NuttX__ || !MADV_HUGEPAGE */
 
     return addr;
 }

--- a/core/shared/platform/common/posix/posix_memmap.c
+++ b/core/shared/platform/common/posix/posix_memmap.c
@@ -9,6 +9,13 @@
 #define BH_ENABLE_TRACE_MMAP 0
 #endif
 
+#ifndef MADV_HUGEPAGE
+#define MADV_HUGEPAGE 14
+#endif
+#ifndef MADV_NOHUGEPAGE
+#define MADV_NOHUGEPAGE 15
+#endif
+
 #if BH_ENABLE_TRACE_MMAP != 0
 static size_t total_size_mmapped = 0;
 static size_t total_size_munmapped = 0;

--- a/core/shared/platform/common/posix/posix_memmap.c
+++ b/core/shared/platform/common/posix/posix_memmap.c
@@ -9,13 +9,6 @@
 #define BH_ENABLE_TRACE_MMAP 0
 #endif
 
-#ifndef MADV_HUGEPAGE
-#define MADV_HUGEPAGE 14
-#endif
-#ifndef MADV_NOHUGEPAGE
-#define MADV_NOHUGEPAGE 15
-#endif
-
 #if BH_ENABLE_TRACE_MMAP != 0
 static size_t total_size_mmapped = 0;
 static size_t total_size_munmapped = 0;
@@ -51,7 +44,7 @@ os_mmap(void *hint, size_t size, int prot, int flags)
     page_size = (uint64)getpagesize();
     request_size = (size + page_size - 1) & ~(page_size - 1);
 
-#if !defined(__APPLE__) && !defined(__NuttX__)
+#if !defined(__APPLE__) && !defined(__NuttX__) && defined(MADV_HUGEPAGE)
     /* huge page isn't supported on MacOS and NuttX */
     if (request_size >= HUGE_PAGE_SIZE)
         /* apply one extra huge page */


### PR DESCRIPTION
Fixed: Error ‘MADV_HUGEPAGE’ undeclared (first use in this function)

## Error log

```bash
[root@centos6 build]# cmake ..
CMake Deprecation Warning at CMakeLists.txt:4 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- The C compiler identification is GNU 4.9.1
-- The CXX compiler identification is GNU 4.9.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /opt/rh/devtoolset-3/root/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /opt/rh/devtoolset-3/root/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Build Configurations:
     Build as target X86_64
     CMAKE_BUILD_TYPE Release
     WAMR Interpreter enabled
     WAMR AOT disabled
     WAMR JIT disabled
     Libc builtin enabled
     Libc WASI enabled
     Fast interpreter enabled
     Multiple modules disabled
     SIMD enabled
     Reference types disabled
-- The ASM compiler identification is GNU
-- Found assembler: /opt/rh/devtoolset-3/root/usr/bin/cc
-- Configuring done
-- Generating done
-- Build files have been written to: /usr/src/wasm-micro-runtime/product-mini/platforms/linux/build
[root@centos6 build]# make
Scanning dependencies of target vmlib
[  1%] Building C object CMakeFiles/vmlib.dir/usr/src/wasm-micro-runtime/core/shared/platform/linux/platform_init.c.o
[  2%] Building C object CMakeFiles/vmlib.dir/usr/src/wasm-micro-runtime/core/shared/platform/common/posix/posix_malloc.c.o
[  4%] Building C object CMakeFiles/vmlib.dir/usr/src/wasm-micro-runtime/core/shared/platform/common/posix/posix_memmap.c.o
/usr/src/wasm-micro-runtime/core/shared/platform/common/posix/posix_memmap.c: In function ‘os_mmap’:
/usr/src/wasm-micro-runtime/core/shared/platform/common/posix/posix_memmap.c:193:31: error: ‘MADV_HUGEPAGE’ undeclared (first use in this function)
                               MADV_HUGEPAGE);
                               ^
/usr/src/wasm-micro-runtime/core/shared/platform/common/posix/posix_memmap.c:193:31: note: each undeclared identifier is reported only once for each function it appears in
make[2]: *** [CMakeFiles/vmlib.dir/usr/src/wasm-micro-runtime/core/shared/platform/common/posix/posix_memmap.c.o] Error 1
make[1]: *** [CMakeFiles/vmlib.dir/all] Error 2
make: *** [all] Error 2
```

## Related articles
  * https://lore.kernel.org/lkml/1362546223-20486-1-git-send-email-vlee@twitter.com/