### PR TITLE
Refine call native function from AOT code

### DIFF
--- a/core/iwasm/aot/aot_reloc.h
+++ b/core/iwasm/aot/aot_reloc.h
@@ -113,6 +113,7 @@ typedef struct {
     REG_SYM(aot_call_indirect),           \
     REG_SYM(aot_enlarge_memory),          \
     REG_SYM(aot_set_exception),           \
+    REG_SYM(aot_check_app_addr_and_convert),\
     { "memset", (void*)aot_memset },      \
     { "memmove", (void*)aot_memmove },    \
     { "memcpy", (void*)aot_memmove },     \

--- a/core/iwasm/aot/aot_reloc.h
+++ b/core/iwasm/aot/aot_reloc.h
@@ -113,7 +113,7 @@ typedef struct {
     REG_SYM(aot_call_indirect),           \
     REG_SYM(aot_enlarge_memory),          \
     REG_SYM(aot_set_exception),           \
-    REG_SYM(aot_check_app_str),           \
+    REG_SYM(aot_check_app_addr_and_convert),\
     { "memset", (void*)aot_memset },      \
     { "memmove", (void*)aot_memmove },    \
     { "memcpy", (void*)aot_memmove },     \

--- a/core/iwasm/aot/aot_reloc.h
+++ b/core/iwasm/aot/aot_reloc.h
@@ -113,7 +113,7 @@ typedef struct {
     REG_SYM(aot_call_indirect),           \
     REG_SYM(aot_enlarge_memory),          \
     REG_SYM(aot_set_exception),           \
-    REG_SYM(aot_check_app_addr_and_convert),\
+    REG_SYM(aot_check_app_str),           \
     { "memset", (void*)aot_memset },      \
     { "memmove", (void*)aot_memmove },    \
     { "memcpy", (void*)aot_memmove },     \

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -2464,6 +2464,7 @@ aot_check_app_addr_and_convert(AOTModuleInstance *module_inst, bool is_str,
     else {
         const char *str, *str_end;
 
+        /* The whole string must be in the linear memory */
         str = (const char *)native_addr;
         str_end = (const char *)memory_inst->memory_data_end.ptr;
         while (str < str_end && *str != '\0')

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -2436,8 +2436,8 @@ aot_call_indirect(WASMExecEnv *exec_env, uint32 tbl_idx, uint32 table_elem_idx,
  * and convert the app address into native address
  */
 bool
-aot_check_app_addr_and_convert(AOTModuleInstance *module_inst, bool is_str_arg,
-                               uint32 app_offset, uint32 buf_size,
+aot_check_app_addr_and_convert(AOTModuleInstance *module_inst, bool is_str,
+                               uint32 app_buf_addr, uint32 app_buf_size,
                                void **p_native_addr)
 {
     AOTMemoryInstance *memory_inst = aot_get_default_memory(module_inst);
@@ -2447,17 +2447,17 @@ aot_check_app_addr_and_convert(AOTModuleInstance *module_inst, bool is_str_arg,
         goto fail;
     }
 
-    native_addr = (uint8 *)memory_inst->memory_data.ptr + app_offset;
+    native_addr = (uint8 *)memory_inst->memory_data.ptr + app_buf_addr;
 
     /* No need to check the app_offset and buf_size if memory access
        boundary check with hardware trap is enabled */
 #ifndef OS_ENABLE_HW_BOUND_CHECK
-    if (app_offset >= memory_inst->memory_data_size) {
+    if (app_buf_addr >= memory_inst->memory_data_size) {
         goto fail;
     }
 
-    if (!is_str_arg) {
-        if (buf_size > memory_inst->memory_data_size - app_offset) {
+    if (!is_str) {
+        if (app_buf_size > memory_inst->memory_data_size - app_buf_addr) {
             goto fail;
         }
     }

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -2431,46 +2431,29 @@ aot_call_indirect(WASMExecEnv *exec_env, uint32 tbl_idx, uint32 table_elem_idx,
     }
 }
 
+/**
+ * Check whether the whole app string is inside linear memory,
+ * note that the begin address has been checked in AOT code, or,
+ * app_str_offset must be smaller than mem_data_size
+ */
 bool
-aot_check_app_addr_and_convert(AOTModuleInstance *module_inst, bool is_str_arg,
-                               uint32 app_offset, uint32 size,
-                               void **p_native_addr)
+aot_check_app_str(uint8 *mem_base_addr, uint32 mem_data_size,
+                  uint32 app_str_offset)
 {
-    AOTMemoryInstance *memory_inst = aot_get_default_memory(module_inst);
-    uint8 *native_addr;
+    const char *p, *p_end;
 
-    if (!memory_inst || app_offset >= memory_inst->memory_data_size) {
-        goto fail;
+    if (app_str_offset >= mem_data_size) {
+        return false;
     }
 
-    native_addr = memory_inst->memory_data.ptr + app_offset;
-
-    if (!is_str_arg) {
-        /* integer overflow check */
-        if (app_offset > UINT32_MAX - size) {
-            goto fail;
-        }
-
-        if (app_offset + size > memory_inst->memory_data_size) {
-            goto fail;
-        }
+    p = (const char *)mem_base_addr + app_str_offset;
+    p_end = (const char *)mem_base_addr + mem_data_size;
+    while (p < p_end && *p != '\0')
+        p++;
+    if (p == p_end) {
+        return false;
     }
-    else {
-        const char *str, *str_end;
-
-        str = (const char *)native_addr;
-        str_end = (const char *)memory_inst->memory_data_end.ptr;
-        while (str < str_end && *str != '\0')
-            str++;
-        if (str == str_end)
-            goto fail;
-    }
-
-    *p_native_addr = (void *)native_addr;
     return true;
-fail:
-    aot_set_exception(module_inst, "out of bounds memory access");
-    return false;
 }
 
 void *

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -2447,7 +2447,7 @@ aot_check_app_addr_and_convert(AOTModuleInstance *module_inst, bool is_str_arg,
         goto fail;
     }
 
-    native_addr = memory_inst->memory_data.ptr + app_offset;
+    native_addr = (uint8 *)memory_inst->memory_data.ptr + app_offset;
 
     /* No need to check the app_offset and buf_size if memory access
        boundary check with hardware trap is enabled */

--- a/core/iwasm/aot/aot_runtime.h
+++ b/core/iwasm/aot/aot_runtime.h
@@ -647,6 +647,11 @@ bool
 aot_call_indirect(WASMExecEnv *exec_env, uint32 tbl_idx, uint32 table_elem_idx,
                   uint32 argc, uint32 *argv);
 
+bool
+aot_check_app_addr_and_convert(AOTModuleInstance *module_inst, bool is_str_arg,
+                               uint32 app_offset, uint32 size,
+                               void **p_native_addr);
+
 uint32
 aot_get_plt_table_size();
 

--- a/core/iwasm/aot/aot_runtime.h
+++ b/core/iwasm/aot/aot_runtime.h
@@ -648,9 +648,8 @@ aot_call_indirect(WASMExecEnv *exec_env, uint32 tbl_idx, uint32 table_elem_idx,
                   uint32 argc, uint32 *argv);
 
 bool
-aot_check_app_addr_and_convert(AOTModuleInstance *module_inst, bool is_str_arg,
-                               uint32 app_offset, uint32 size,
-                               void **p_native_addr);
+aot_check_app_str(uint8 *mem_base_addr, uint32 mem_data_size,
+                  uint32 app_str_offset);
 
 uint32
 aot_get_plt_table_size();

--- a/core/iwasm/aot/aot_runtime.h
+++ b/core/iwasm/aot/aot_runtime.h
@@ -648,8 +648,9 @@ aot_call_indirect(WASMExecEnv *exec_env, uint32 tbl_idx, uint32 table_elem_idx,
                   uint32 argc, uint32 *argv);
 
 bool
-aot_check_app_str(uint8 *mem_base_addr, uint32 mem_data_size,
-                  uint32 app_str_offset);
+aot_check_app_addr_and_convert(AOTModuleInstance *module_inst, bool is_str_arg,
+                               uint32 app_offset, uint32 buf_size,
+                               void **p_native_addr);
 
 uint32
 aot_get_plt_table_size();

--- a/core/iwasm/aot/aot_runtime.h
+++ b/core/iwasm/aot/aot_runtime.h
@@ -648,8 +648,8 @@ aot_call_indirect(WASMExecEnv *exec_env, uint32 tbl_idx, uint32 table_elem_idx,
                   uint32 argc, uint32 *argv);
 
 bool
-aot_check_app_addr_and_convert(AOTModuleInstance *module_inst, bool is_str_arg,
-                               uint32 app_offset, uint32 buf_size,
+aot_check_app_addr_and_convert(AOTModuleInstance *module_inst, bool is_str,
+                               uint32 app_buf_addr, uint32 app_buf_size,
                                void **p_native_addr);
 
 uint32

--- a/core/iwasm/compilation/aot_emit_function.c
+++ b/core/iwasm/compilation/aot_emit_function.c
@@ -518,6 +518,107 @@ check_stack_boundary(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     return true;
 }
 
+static bool
+check_app_addr_and_convert(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                           bool is_str_arg, LLVMValueRef app_addr,
+                           LLVMValueRef size,
+                           LLVMValueRef *p_native_addr_converted)
+{
+    LLVMTypeRef func_type, func_ptr_type, func_param_types[5];
+    LLVMValueRef func, func_param_values[5], res, native_addr_ptr;
+    char *func_name = "aot_check_app_addr_and_convert";
+
+    /* prepare function type of aot_invoke_native */
+    func_param_types[0] = comp_ctx->aot_inst_type; /* module_inst */
+    func_param_types[1] = INT8_TYPE;               /* is_str_arg */
+    func_param_types[2] = I32_TYPE;                /* app_offset */
+    func_param_types[3] = I32_TYPE;                /* size */
+    func_param_types[4] =
+        comp_ctx->basic_types.int8_pptr_type; /* p_native_addr */
+    if (!(func_type =
+              LLVMFunctionType(INT8_TYPE, func_param_types, 5, false))) {
+        aot_set_last_error("llvm add function type failed.");
+        return false;
+    }
+
+    /* prepare function pointer */
+    if (comp_ctx->is_jit_mode) {
+        if (!(func_ptr_type = LLVMPointerType(func_type, 0))) {
+            aot_set_last_error("create LLVM function type failed.");
+            return false;
+        }
+
+        /* JIT mode, call the function directly */
+        if (!(func =
+                  I64_CONST((uint64)(uintptr_t)aot_check_app_addr_and_convert))
+            || !(func = LLVMConstIntToPtr(func, func_ptr_type))) {
+            aot_set_last_error("create LLVM value failed.");
+            return false;
+        }
+    }
+    else if (comp_ctx->is_indirect_mode) {
+        int32 func_index;
+        if (!(func_ptr_type = LLVMPointerType(func_type, 0))) {
+            aot_set_last_error("create LLVM function type failed.");
+            return false;
+        }
+        func_index = aot_get_native_symbol_index(comp_ctx, func_name);
+        if (func_index < 0) {
+            return false;
+        }
+        if (!(func = aot_get_func_from_table(comp_ctx, func_ctx->native_symbol,
+                                             func_ptr_type, func_index))) {
+            return false;
+        }
+    }
+    else {
+        if (!(func = LLVMGetNamedFunction(func_ctx->module, func_name))
+            && !(func =
+                     LLVMAddFunction(func_ctx->module, func_name, func_type))) {
+            aot_set_last_error("add LLVM function failed.");
+            return false;
+        }
+    }
+
+    if (!(native_addr_ptr = LLVMBuildBitCast(
+              comp_ctx->builder, func_ctx->argv_buf,
+              comp_ctx->basic_types.int8_pptr_type, "p_native_addr"))) {
+        aot_set_last_error("llvm build bit cast failed.");
+        return false;
+    }
+
+    func_param_values[0] = func_ctx->aot_inst;
+    func_param_values[1] = I8_CONST(is_str_arg);
+    func_param_values[2] = app_addr;
+    func_param_values[3] = size;
+    func_param_values[4] = native_addr_ptr;
+
+    if (!func_param_values[1]) {
+        aot_set_last_error("llvm create const failed.");
+        return false;
+    }
+
+    /* call aot_check_app_addr_and_convert() function */
+    if (!(res = LLVMBuildCall(comp_ctx->builder, func, func_param_values, 5,
+                              "res"))) {
+        aot_set_last_error("llvm build call failed.");
+        return false;
+    }
+
+    /* Check whether exception was thrown when executing the function */
+    if (!check_call_return(comp_ctx, func_ctx, res)) {
+        return false;
+    }
+
+    if (!(*p_native_addr_converted = LLVMBuildLoad(
+              comp_ctx->builder, native_addr_ptr, "native_addr"))) {
+        aot_set_last_error("llvm build load failed.");
+        return false;
+    }
+
+    return true;
+}
+
 bool
 aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                     uint32 func_idx, bool tail_call)
@@ -539,6 +640,7 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     uint32 callee_cell_num;
     uint8 wasm_ret_type;
     uint8 *ext_ret_types = NULL;
+    const char *signature = NULL;
     bool ret = false;
     char buf[32];
 
@@ -557,11 +659,14 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     }
 
     /* Get function type */
-    if (func_idx < import_func_count)
+    if (func_idx < import_func_count) {
         func_type = import_funcs[func_idx].func_type;
-    else
+        signature = import_funcs[func_idx].signature;
+    }
+    else {
         func_type =
             func_ctxes[func_idx - import_func_count]->aot_func->func_type;
+    }
 
     /* Get param cell number */
     param_cell_num = func_type->param_cell_num;
@@ -659,8 +764,37 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         j = 0;
         param_types[j++] = comp_ctx->exec_env_type;
 
-        for (i = 0; i < param_count; i++)
-            param_types[j++] = TO_LLVM_TYPE(func_type->types[i]);
+        for (i = 0; i < param_count; i++, j++) {
+            param_types[j] = TO_LLVM_TYPE(func_type->types[i]);
+
+            if (signature) {
+                LLVMValueRef native_addr, native_addr_size;
+                if (signature[i + 1] == '*' || signature[i + 1] == '$') {
+                    param_types[j] = INT8_PTR_TYPE;
+                }
+                if (signature[i + 1] == '*') {
+                    if (signature[i + 2] == '~')
+                        native_addr_size = param_values[i + 2];
+                    else
+                        native_addr_size = I32_ONE;
+                    if (!check_app_addr_and_convert(
+                            comp_ctx, func_ctx, false, param_values[j],
+                            native_addr_size, &native_addr)) {
+                        goto fail;
+                    }
+                    param_values[j] = native_addr;
+                }
+                else if (signature[i + 1] == '$') {
+                    native_addr_size = I32_ZERO;
+                    if (!check_app_addr_and_convert(
+                            comp_ctx, func_ctx, true, param_values[j],
+                            native_addr_size, &native_addr)) {
+                        goto fail;
+                    }
+                    param_values[j] = native_addr;
+                }
+            }
+        }
 
         if (func_type->result_count) {
             wasm_ret_type = func_type->types[func_type->param_count];
@@ -671,17 +805,67 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             ret_type = VOID_TYPE;
         }
 
-        /* call aot_invoke_native() */
-        if (!call_aot_invoke_native_func(
-                comp_ctx, func_ctx, import_func_idx, func_type, param_types + 1,
-                param_values + 1, param_count, param_cell_num, ret_type,
-                wasm_ret_type, &value_ret, &res))
-            goto fail;
+        if (!signature) {
+            /* call aot_invoke_native() */
+            if (!call_aot_invoke_native_func(
+                    comp_ctx, func_ctx, import_func_idx, func_type,
+                    param_types + 1, param_values + 1, param_count,
+                    param_cell_num, ret_type, wasm_ret_type, &value_ret, &res))
+                goto fail;
+            /* Check whether there was exception thrown when executing
+               the function */
+            if (!check_call_return(comp_ctx, func_ctx, res))
+                goto fail;
+        }
+        else {
+            LLVMTypeRef native_func_type, func_ptr_type;
+            LLVMValueRef func_ptr;
 
-        /* Check whether there was exception thrown when executing
-           the function */
-        if (!check_call_return(comp_ctx, func_ctx, res))
-            goto fail;
+            if (!(native_func_type = LLVMFunctionType(
+                      ret_type, param_types, param_count + 1, false))) {
+                aot_set_last_error("llvm add function type failed.");
+                goto fail;
+            }
+
+            if (!(func_ptr_type = LLVMPointerType(native_func_type, 0))) {
+                aot_set_last_error("create LLVM function type failed.");
+                goto fail;
+            }
+
+            /* Load function pointer */
+            if (!(func_ptr = LLVMBuildInBoundsGEP(
+                      comp_ctx->builder, func_ctx->func_ptrs, &import_func_idx,
+                      1, "native_func_ptr_tmp"))) {
+                aot_set_last_error("llvm build inbounds gep failed.");
+                goto fail;
+            }
+
+            if (!(func_ptr = LLVMBuildLoad(comp_ctx->builder, func_ptr,
+                                           "native_func_ptr"))) {
+                aot_set_last_error("llvm build load failed.");
+                goto fail;
+            }
+
+            if (!(func = LLVMBuildBitCast(comp_ctx->builder, func_ptr,
+                                          func_ptr_type, "native_func"))) {
+                aot_set_last_error("llvm bit cast failed.");
+                goto fail;
+            }
+
+            /* Call the function */
+            if (!(value_ret = LLVMBuildCall(
+                      comp_ctx->builder, func, param_values,
+                      (uint32)param_count + 1 + ext_ret_count,
+                      (func_type->result_count > 0 ? "call" : "")))) {
+                aot_set_last_error("LLVM build call failed.");
+                goto fail;
+            }
+
+            /* Check */
+            if (!check_exception_thrown(comp_ctx, func_ctx)) {
+                goto fail;
+            }
+        }
     }
     else {
         bool recursive_call =

--- a/core/iwasm/compilation/aot_emit_function.c
+++ b/core/iwasm/compilation/aot_emit_function.c
@@ -520,7 +520,7 @@ check_stack_boundary(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
 /**
  * Check whether the app address and its buffer are inside the linear memory,
- * if yes, throw exception
+ * if no, throw exception
  */
 static bool
 check_app_addr_and_convert(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
@@ -771,7 +771,7 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         for (i = 0; i < param_count; i++, j++) {
             param_types[j] = TO_LLVM_TYPE(func_type->types[i]);
 
-            /* If the signature can be get, e.g. the signature of the builtin
+            /* If the signature can be gotten, e.g. the signature of the builtin
                native libraries, just check the app offset and buf size, and
                then convert app offset to native addr and call the native func
                directly, no need to call aot_invoke_native to call it */

--- a/core/iwasm/compilation/aot_emit_function.c
+++ b/core/iwasm/compilation/aot_emit_function.c
@@ -518,101 +518,204 @@ check_stack_boundary(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     return true;
 }
 
+/**
+ * Check whether the app address and its buffer are inside the linear memory,
+ * if yes, throw exception
+ */
 static bool
 check_app_addr_and_convert(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                           bool is_str_arg, LLVMValueRef app_addr,
-                           LLVMValueRef size,
+                           bool is_str_arg, LLVMValueRef app_offset,
+                           LLVMValueRef buf_size,
                            LLVMValueRef *p_native_addr_converted)
 {
-    LLVMTypeRef func_type, func_ptr_type, func_param_types[5];
-    LLVMValueRef func, func_param_values[5], res, native_addr_ptr;
-    char *func_name = "aot_check_app_addr_and_convert";
+    LLVMValueRef mem_base_addr, mem_size, mem_size_left, cmp;
+    LLVMBasicBlockRef block_check_succ;
 
-    /* prepare function type of aot_invoke_native */
-    func_param_types[0] = comp_ctx->aot_inst_type; /* module_inst */
-    func_param_types[1] = INT8_TYPE;               /* is_str_arg */
-    func_param_types[2] = I32_TYPE;                /* app_offset */
-    func_param_types[3] = I32_TYPE;                /* size */
-    func_param_types[4] =
-        comp_ctx->basic_types.int8_pptr_type; /* p_native_addr */
-    if (!(func_type =
-              LLVMFunctionType(INT8_TYPE, func_param_types, 5, false))) {
-        aot_set_last_error("llvm add function type failed.");
-        return false;
-    }
-
-    /* prepare function pointer */
-    if (comp_ctx->is_jit_mode) {
-        if (!(func_ptr_type = LLVMPointerType(func_type, 0))) {
-            aot_set_last_error("create LLVM function type failed.");
-            return false;
-        }
-
-        /* JIT mode, call the function directly */
-        if (!(func =
-                  I64_CONST((uint64)(uintptr_t)aot_check_app_addr_and_convert))
-            || !(func = LLVMConstIntToPtr(func, func_ptr_type))) {
-            aot_set_last_error("create LLVM value failed.");
-            return false;
-        }
-    }
-    else if (comp_ctx->is_indirect_mode) {
-        int32 func_index;
-        if (!(func_ptr_type = LLVMPointerType(func_type, 0))) {
-            aot_set_last_error("create LLVM function type failed.");
-            return false;
-        }
-        func_index = aot_get_native_symbol_index(comp_ctx, func_name);
-        if (func_index < 0) {
-            return false;
-        }
-        if (!(func = aot_get_func_from_table(comp_ctx, func_ctx->native_symbol,
-                                             func_ptr_type, func_index))) {
-            return false;
-        }
+    /* get memory base address and memory data size */
+    if (func_ctx->mem_space_unchanged
+#if WASM_ENABLE_SHARED_MEMORY != 0
+        /* memory is shared, the base address won't be changed */
+        || (comp_ctx->comp_data->memories[0].memory_flags & 0x02)
+#endif
+    ) {
+        mem_base_addr = func_ctx->mem_info[0].mem_base_addr;
     }
     else {
-        if (!(func = LLVMGetNamedFunction(func_ctx->module, func_name))
-            && !(func =
-                     LLVMAddFunction(func_ctx->module, func_name, func_type))) {
-            aot_set_last_error("add LLVM function failed.");
+        if (!(mem_base_addr = LLVMBuildLoad(comp_ctx->builder,
+                                            func_ctx->mem_info[0].mem_base_addr,
+                                            "mem_base"))) {
+            aot_set_last_error("llvm build load failed.");
             return false;
         }
     }
 
-    if (!(native_addr_ptr = LLVMBuildBitCast(
-              comp_ctx->builder, func_ctx->argv_buf,
-              comp_ctx->basic_types.int8_pptr_type, "p_native_addr"))) {
-        aot_set_last_error("llvm build bit cast failed.");
+    if (func_ctx->mem_space_unchanged) {
+        mem_size = func_ctx->mem_info[0].mem_data_size_addr;
+    }
+    else {
+        if (!(mem_size = LLVMBuildLoad(comp_ctx->builder,
+                                       func_ctx->mem_info[0].mem_data_size_addr,
+                                       "mem_size"))) {
+            aot_set_last_error("llvm build load failed.");
+            return false;
+        }
+    }
+
+    /* throw exception if app_offset >= mem_data_size */
+    if (!(cmp = LLVMBuildICmp(comp_ctx->builder, LLVMIntUGE, app_offset,
+                              mem_size, "cmp_app_off"))) {
+        aot_set_last_error("llvm build icmp failed.");
         return false;
     }
 
-    func_param_values[0] = func_ctx->aot_inst;
-    func_param_values[1] = I8_CONST(is_str_arg);
-    func_param_values[2] = app_addr;
-    func_param_values[3] = size;
-    func_param_values[4] = native_addr_ptr;
-
-    if (!func_param_values[1]) {
-        aot_set_last_error("llvm create const failed.");
+    if (!(block_check_succ = LLVMAppendBasicBlockInContext(
+              comp_ctx->context, func_ctx->func, "check_app_off_succ"))) {
+        aot_set_last_error("llvm add basic block failed.");
         return false;
     }
 
-    /* call aot_check_app_addr_and_convert() function */
-    if (!(res = LLVMBuildCall(comp_ctx->builder, func, func_param_values, 5,
-                              "res"))) {
-        aot_set_last_error("llvm build call failed.");
+    LLVMMoveBasicBlockAfter(block_check_succ,
+                            LLVMGetInsertBlock(comp_ctx->builder));
+
+    if (!(aot_emit_exception(comp_ctx, func_ctx,
+                             EXCE_OUT_OF_BOUNDS_MEMORY_ACCESS, true, cmp,
+                             block_check_succ))) {
         return false;
     }
 
-    /* Check whether exception was thrown when executing the function */
-    if (!check_call_return(comp_ctx, func_ctx, res)) {
-        return false;
+    /**
+     * check buf size if it is a pointer argument and the buf size isn't 1,
+     * note that if it is string argument or if the buf size is 1, we don't
+     * need to check the size again
+     */
+    if (!is_str_arg
+        && !(LLVMIsConstant(buf_size)
+             && (uint32)LLVMConstIntGetZExtValue(buf_size) == 1)) {
+        /* mem_size_left = mem_size - app_offset */
+        if (!(mem_size_left = LLVMBuildSub(comp_ctx->builder, mem_size,
+                                           app_offset, "mem_size_left"))) {
+            aot_set_last_error("llvm build add failed.");
+            return false;
+        }
+
+        /* throw exception if buf_size > mem_size_left */
+        if (!(cmp = LLVMBuildICmp(comp_ctx->builder, LLVMIntUGT, buf_size,
+                                  mem_size_left, "cmp_buf_size"))) {
+            aot_set_last_error("llvm build icmp failed.");
+            return false;
+        }
+
+        if (!(block_check_succ = LLVMAppendBasicBlockInContext(
+                  comp_ctx->context, func_ctx->func, "check_buf_size_succ"))) {
+            aot_set_last_error("llvm add basic block failed.");
+            return false;
+        }
+
+        LLVMMoveBasicBlockAfter(block_check_succ,
+                                LLVMGetInsertBlock(comp_ctx->builder));
+
+        if (!(aot_emit_exception(comp_ctx, func_ctx,
+                                 EXCE_OUT_OF_BOUNDS_MEMORY_ACCESS, true, cmp,
+                                 block_check_succ))) {
+            return false;
+        }
     }
 
-    if (!(*p_native_addr_converted = LLVMBuildLoad(
-              comp_ctx->builder, native_addr_ptr, "native_addr"))) {
-        aot_set_last_error("llvm build load failed.");
+    /* call aot_check_app_str to check whether the whole string is
+       inside the linear memory */
+    if (is_str_arg) {
+        LLVMTypeRef func_type, func_ptr_type, func_param_types[3];
+        LLVMValueRef func, func_param_values[3], res;
+        char *func_name = "aot_check_app_str";
+
+        /* prepare function type of aot_check_app_str */
+        func_param_types[0] = INT8_PTR_TYPE; /* mem_base_addr */
+        func_param_types[1] = I32_TYPE;      /* mem_size */
+        func_param_types[2] = I32_TYPE;      /* app_offset */
+
+        if (!(func_type =
+                  LLVMFunctionType(INT8_TYPE, func_param_types, 3, false))) {
+            aot_set_last_error("llvm add function type failed.");
+            return false;
+        }
+
+        /* prepare function pointer */
+        if (comp_ctx->is_jit_mode) {
+            if (!(func_ptr_type = LLVMPointerType(func_type, 0))) {
+                aot_set_last_error("create LLVM function type failed.");
+                return false;
+            }
+
+            /* JIT mode, call the function directly */
+            if (!(func = I64_CONST((uint64)(uintptr_t)aot_check_app_str))
+                || !(func = LLVMConstIntToPtr(func, func_ptr_type))) {
+                aot_set_last_error("create LLVM value failed.");
+                return false;
+            }
+        }
+        else if (comp_ctx->is_indirect_mode) {
+            int32 func_index;
+            if (!(func_ptr_type = LLVMPointerType(func_type, 0))) {
+                aot_set_last_error("create LLVM function type failed.");
+                return false;
+            }
+            func_index = aot_get_native_symbol_index(comp_ctx, func_name);
+            if (func_index < 0) {
+                return false;
+            }
+            if (!(func =
+                      aot_get_func_from_table(comp_ctx, func_ctx->native_symbol,
+                                              func_ptr_type, func_index))) {
+                return false;
+            }
+        }
+        else {
+            if (!(func = LLVMGetNamedFunction(func_ctx->module, func_name))
+                && !(func = LLVMAddFunction(func_ctx->module, func_name,
+                                            func_type))) {
+                aot_set_last_error("add LLVM function failed.");
+                return false;
+            }
+        }
+
+        func_param_values[0] = mem_base_addr;
+        func_param_values[1] = mem_size;
+        func_param_values[2] = app_offset;
+
+        /* call aot_check_app_str function */
+        if (!(res = LLVMBuildCall(comp_ctx->builder, func, func_param_values, 3,
+                                  "res"))) {
+            aot_set_last_error("llvm build call failed.");
+            return false;
+        }
+
+        /* throw exception if aot_check_app_str returns false */
+        if (!(cmp = LLVMBuildICmp(comp_ctx->builder, LLVMIntEQ, res, I8_ZERO,
+                                  "cmp_res"))) {
+            aot_set_last_error("llvm build icmp failed.");
+            return false;
+        }
+
+        if (!(block_check_succ = LLVMAppendBasicBlockInContext(
+                  comp_ctx->context, func_ctx->func, "check_app_str_succ"))) {
+            aot_set_last_error("llvm add basic block failed.");
+            return false;
+        }
+
+        LLVMMoveBasicBlockAfter(block_check_succ,
+                                LLVMGetInsertBlock(comp_ctx->builder));
+
+        if (!(aot_emit_exception(comp_ctx, func_ctx,
+                                 EXCE_OUT_OF_BOUNDS_MEMORY_ACCESS, true, cmp,
+                                 block_check_succ))) {
+            return false;
+        }
+    }
+
+    if (!(*p_native_addr_converted =
+              LLVMBuildInBoundsGEP(comp_ctx->builder, mem_base_addr,
+                                   &app_offset, 1, "native_addr"))) {
+        aot_set_last_error("llvm build add failed.");
         return false;
     }
 
@@ -767,6 +870,10 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         for (i = 0; i < param_count; i++, j++) {
             param_types[j] = TO_LLVM_TYPE(func_type->types[i]);
 
+            /* If the signature can be get, e.g. the signature of the builtin
+               native libraries, just check the app offset and buf size, and
+               then convert app offset to native addr and call the native func
+               directly, no need to call aot_invoke_native to call it */
             if (signature) {
                 LLVMValueRef native_addr, native_addr_size;
                 if (signature[i + 1] == '*' || signature[i + 1] == '$') {
@@ -817,7 +924,7 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             if (!check_call_return(comp_ctx, func_ctx, res))
                 goto fail;
         }
-        else {
+        else { /* call native func directly */
             LLVMTypeRef native_func_type, func_ptr_type;
             LLVMValueRef func_ptr;
 
@@ -861,7 +968,7 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                 goto fail;
             }
 
-            /* Check */
+            /* Check whether there is exception thrown */
             if (!check_exception_thrown(comp_ctx, func_ctx)) {
                 goto fail;
             }

--- a/wamr-compiler/CMakeLists.txt
+++ b/wamr-compiler/CMakeLists.txt
@@ -181,6 +181,8 @@ include (${SHARED_DIR}/utils/shared_utils.cmake)
 include (${SHARED_DIR}/utils/uncommon/shared_uncommon.cmake)
 include (${IWASM_DIR}/libraries/thread-mgr/thread_mgr.cmake)
 include (${IWASM_DIR}/libraries/libc-builtin/libc_builtin.cmake)
+include (${IWASM_DIR}/libraries/libc-wasi/libc_wasi.cmake)
+include (${IWASM_DIR}/libraries/lib-pthread/lib_pthread.cmake)
 include (${IWASM_DIR}/common/iwasm_common.cmake)
 include (${IWASM_DIR}/interpreter/iwasm_interp.cmake)
 include (${IWASM_DIR}/aot/iwasm_aot.cmake)
@@ -239,6 +241,8 @@ add_library (vmlib
              ${UNCOMMON_SHARED_SOURCE}
              ${THREAD_MGR_SOURCE}
              ${LIBC_BUILTIN_SOURCE}
+             ${LIBC_WASI_SOURCE}
+             ${LIB_PTHREAD_SOURCE}
              ${IWASM_COMMON_SOURCE}
              ${IWASM_INTERP_SOURCE}
              ${IWASM_AOT_SOURCE})


### PR DESCRIPTION
When calling native function from AOT code, current implementation is to return
back to runtime to call aot_invoke_native, which calls wasm_runtime_invoke_native
and the latter calls assembly code. We did it before as there may be pointer and
string arguments to check and convert if the native function's registered signature
has character '*' and '$'.
As the built-in native function's signatures can be gotten in compilation time, we
check the pointer/string arguments and convert them into native address in AOT
code, and then invoke the native function directly, so as to improve performance.