### PR TITLE
Ignore .cache used by clangd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+.cache
 .vs
 .vscode
 /.idea


### PR DESCRIPTION
And another question, I got many warnings while compiling wamr by clang like:
```
[10/67] Building C object CMakeFiles/vmlib.dir/home/huang/Work/wasm-micro-runtime/core/iwasm/common/wasm_exec_env.c.o
In file included from /home/huang/Work/wasm-micro-runtime/core/iwasm/common/wasm_exec_env.c:6:
In file included from /home/huang/Work/wasm-micro-runtime/core/iwasm/common/wasm_exec_env.h:11:
/home/huang/Work/wasm-micro-runtime/core/iwasm/common/../interpreter/wasm.h:573:53: warning: unused parameter 'type_count' [-Wunused-parameter]
wasm_get_smallest_type_idx(WASMType **types, uint32 type_count,
                                                    ^
1 warning generated.
[15/67] Building C object CMakeFiles/vmlib.dir/home/huang/Work/wasm-micro-runtime/core/iwasm/common/wasm_application.c.o
In file included from /home/huang/Work/wasm-micro-runtime/core/iwasm/common/wasm_application.c:8:
In file included from /home/huang/Work/wasm-micro-runtime/core/iwasm/common/../interpreter/wasm_runtime.h:9:
/home/huang/Work/wasm-micro-runtime/core/iwasm/interpreter/wasm.h:573:53: warning: unused parameter 'type_count' [-Wunused-parameter]
wasm_get_smallest_type_idx(WASMType **types, uint32 type_count,
                                                    ^
1 warning generated.
```
It can be fixed simply by -Wno-unused-parameter, but should we fix it by `UNUSED(xxx)` manually ?