### PR TITLE
Fix C API mistake leading to double-free / use-after-free in `wasm_module_imports`

### DIFF
--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -1947,6 +1947,10 @@ wasm_module_imports(const wasm_module_t *module, own wasm_importtype_vec_t *out)
     for (i = 0; i != import_count; ++i) {
         char *module_name_rt = NULL, *field_name_rt = NULL;
 
+        memset(&module_name, 0, sizeof(module_name));
+        memset(&name, 0, sizeof(name));
+        extern_type = NULL;
+
         if (i < import_func_count) {
             wasm_functype_t *type = NULL;
             WASMType *type_rt = NULL;

--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -1974,16 +1974,6 @@ wasm_module_imports(const wasm_module_t *module, own wasm_importtype_vec_t *out)
                 continue;
             }
 
-            wasm_name_new_from_string(&module_name, module_name_rt);
-            if (strlen(module_name_rt) && !module_name.data) {
-                goto failed;
-            }
-
-            wasm_name_new_from_string(&name, field_name_rt);
-            if (strlen(field_name_rt) && !name.data) {
-                goto failed;
-            }
-
             if (!(type = wasm_functype_new_internal(type_rt))) {
                 goto failed;
             }
@@ -2019,16 +2009,6 @@ wasm_module_imports(const wasm_module_t *module, own wasm_importtype_vec_t *out)
 
             if (!module_name_rt || !field_name_rt) {
                 continue;
-            }
-
-            wasm_name_new_from_string(&module_name, module_name_rt);
-            if (strlen(module_name_rt) && !module_name.data) {
-                goto failed;
-            }
-
-            wasm_name_new_from_string(&name, field_name_rt);
-            if (strlen(field_name_rt) && !name.data) {
-                goto failed;
             }
 
             if (!(type = wasm_globaltype_new_internal(val_type_rt,
@@ -2069,16 +2049,6 @@ wasm_module_imports(const wasm_module_t *module, own wasm_importtype_vec_t *out)
 
             if (!module_name_rt || !field_name_rt) {
                 continue;
-            }
-
-            wasm_name_new_from_string(&module_name, module_name_rt);
-            if (strlen(module_name_rt) && !module_name.data) {
-                goto failed;
-            }
-
-            wasm_name_new_from_string(&name, field_name_rt);
-            if (strlen(field_name_rt) && !name.data) {
-                goto failed;
             }
 
             if (!(type = wasm_memorytype_new_internal(min_page, max_page))) {
@@ -2124,16 +2094,6 @@ wasm_module_imports(const wasm_module_t *module, own wasm_importtype_vec_t *out)
                 continue;
             }
 
-            wasm_name_new_from_string(&module_name, module_name_rt);
-            if (strlen(module_name_rt) && !module_name.data) {
-                goto failed;
-            }
-
-            wasm_name_new_from_string(&name, field_name_rt);
-            if (strlen(field_name_rt) && !name.data) {
-                goto failed;
-            }
-
             if (!(type = wasm_tabletype_new_internal(elem_type_rt, min_size,
                                                      max_size))) {
                 goto failed;
@@ -2144,6 +2104,16 @@ wasm_module_imports(const wasm_module_t *module, own wasm_importtype_vec_t *out)
 
         if (!extern_type) {
             continue;
+        }
+
+        wasm_name_new_from_string(&module_name, module_name_rt);
+        if (strlen(module_name_rt) && !module_name.data) {
+            goto failed;
+        }
+
+        wasm_name_new_from_string(&name, field_name_rt);
+        if (strlen(field_name_rt) && !name.data) {
+            goto failed;
         }
 
         if (!(import_type =

--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -2021,6 +2021,16 @@ wasm_module_imports(const wasm_module_t *module, own wasm_importtype_vec_t *out)
                 continue;
             }
 
+            wasm_name_new_from_string(&module_name, module_name_rt);
+            if (strlen(module_name_rt) && !module_name.data) {
+                goto failed;
+            }
+
+            wasm_name_new_from_string(&name, field_name_rt);
+            if (strlen(field_name_rt) && !name.data) {
+                goto failed;
+            }
+
             if (!(type = wasm_globaltype_new_internal(val_type_rt,
                                                       mutability_rt))) {
                 goto failed;
@@ -2112,6 +2122,16 @@ wasm_module_imports(const wasm_module_t *module, own wasm_importtype_vec_t *out)
 
             if (!module_name_rt || !field_name_rt) {
                 continue;
+            }
+
+            wasm_name_new_from_string(&module_name, module_name_rt);
+            if (strlen(module_name_rt) && !module_name.data) {
+                goto failed;
+            }
+
+            wasm_name_new_from_string(&name, field_name_rt);
+            if (strlen(field_name_rt) && !name.data) {
+                goto failed;
             }
 
             if (!(type = wasm_tabletype_new_internal(elem_type_rt, min_size,


### PR DESCRIPTION
Two of the `if` branches when iterating imports in `wasm_module_imports` never set the `module_name` and `name` fields that are later passed as arguments to `wasm_importtype_new`.

This leads to reusing the same pointers for multiple imports, eventually causing double-free and/or use-after-free. It also leads to imports that hit either of those two branches to be returned with incorrect name fields, but compared to the UB caused that's a "minor" issue.