### PR TITLE
Correct DPFPU and FPU handling for NuttX

### DIFF
--- a/product-mini/platforms/nuttx/wamr.mk
+++ b/product-mini/platforms/nuttx/wamr.mk
@@ -74,12 +74,12 @@ else ifeq (${WAMR_BUILD_TARGET}, XTENSA)
   AOT_RELOC := aot_reloc_xtensa.c
 else ifeq (${WAMR_BUILD_TARGET}, RISCV64)
 
-ifeq (${CONFIG_ARCH_FPU},y)
-  $(error riscv64 lp64f is unsupported)
-else ifeq (${CONFIG_ARCH_DPFPU}, y)
+ifeq (${CONFIG_ARCH_DPFPU},y)
   CFLAGS += -DBUILD_TARGET_RISCV64_LP64D
-else
+else ifneq (${CONFIG_ARCH_FPU},y)
   CFLAGS += -DBUILD_TARGET_RISCV64_LP64
+else
+  $(error riscv64 lp64f is unsupported)
 endif
   INVOKE_NATIVE += invokeNative_riscv.S
 
@@ -87,12 +87,12 @@ endif
 
 else ifeq (${WAMR_BUILD_TARGET}, RISCV32)
 
-ifeq (${CONFIG_ARCH_FPU}, y)
-  $(error riscv32 ilp32f is unsupported)
-else ifeq (${CONFIG_ARCH_DPFPU}, y)
+ifeq (${CONFIG_ARCH_DPFPU},y)
   CFLAGS += -DBUILD_TARGET_RISCV32_ILP32D
-else
+else ifneq (${CONFIG_ARCH_FPU},y)
   CFLAGS += -DBUILD_TARGET_RISCV32_ILP32
+else
+  $(error riscv32 ilp32f is unsupported)
 endif
 
   INVOKE_NATIVE += invokeNative_riscv.S


### PR DESCRIPTION
Since DPFPU is depend on FPU, if DPFPU enabled we will never enter DPFPU branch since `ifeq (${CONFIG_ARCH_FPU},y)` is always true.