### PR TITLE
Reset members of `value_stack` and allow to reuse

### DIFF
--- a/core/iwasm/fast-jit/jit_ir.c
+++ b/core/iwasm/fast-jit/jit_ir.c
@@ -1330,6 +1330,9 @@ jit_value_stack_destroy(JitValueStack *stack)
         jit_free(value);
         value = p;
     }
+
+    stack->value_list_head = NULL;
+    stack->value_list_end = NULL;
 }
 
 void
@@ -1373,6 +1376,9 @@ jit_block_stack_destroy(JitBlockStack *stack)
         jit_block_destroy(block);
         block = p;
     }
+
+    stack->block_list_head = NULL;
+    stack->block_list_end = NULL;
 }
 
 bool


### PR DESCRIPTION
After `jit_value_stack_destory()`, the `JitValue` pointed
by `value_list_head` and `value_list_end` are freed and
still keep the value.

So, when `jit_value_stack_push()` is called, for example,
`load_block_params()` after `jit_value_stack_destroy()` in
`handle_op_else()`, `value_stack` will not be treated like
an empty one, and new `JitValue` will be appended to `value_list_end`,
which is a dangling pointer(pointer to the freed `JitValue`).

In my case, the crash will occur if `value_stack` be destroyed
again.

P.S.
Test with 
``` wat
(module
  (func (export "main") (param i32 i32) (result i32)
    (block (result i32)
      (if (result i32) (local.get 1)
        (then (i32.const 16))
        (else (i32.const 32))
      )
    )
  )
)
```