### PR TITLE
Focus on IF block

### DIFF
--- a/core/iwasm/fast-jit/fe/jit_emit_control.c
+++ b/core/iwasm/fast-jit/fe/jit_emit_control.c
@@ -128,8 +128,7 @@ push_jit_block_to_stack_and_pass_params(JitCompContext *cc, JitBlock *block,
     JitReg value;
     uint32 i, param_index, cell_num;
 
-    if (block->label_type == LABEL_TYPE_BLOCK
-        || (block->label_type == LABEL_TYPE_IF && !cond)) {
+    if (cc->cur_basic_block == basic_block) {
         /* Reuse the current basic block and no need to commit values,
            we just move param values from current block's value stack to
            the new block's value stack */
@@ -178,10 +177,11 @@ push_jit_block_to_stack_and_pass_params(JitCompContext *cc, JitBlock *block,
         /* Push the new block to block stack */
         jit_block_stack_push(&cc->block_stack, block);
 
-        if (!cond) { /* LOOP block */
+        if (block->label_type == LABEL_TYPE_LOOP) {
             BUILD_BR(basic_block);
         }
-        else { /* IF block with condition br insn */
+        else {
+            /* IF block with condition br insn */
             if (!GEN_INSN(CMP, cc->cmp_reg, cond, NEW_CONST(I32, 0))
                 || !(insn = GEN_INSN(BNE, cc->cmp_reg,
                                      jit_basic_block_label(basic_block), 0))) {
@@ -192,7 +192,7 @@ push_jit_block_to_stack_and_pass_params(JitCompContext *cc, JitBlock *block,
             /* Don't create else basic block or end basic block now, just
                save its incoming BNE insn, and patch the insn's else label
                when the basic block is lazily created */
-            if (basic_block == block->basic_block_entry) {
+            if (block->wasm_code_else) {
                 block->incoming_insn_for_else_bb = insn;
             }
             else {
@@ -594,7 +594,7 @@ jit_compile_op_block(JitCompContext *cc, uint8 **p_frame_ip,
                    BASIC_BLOCK if cannot be reached, we treat it same as
                    LABEL_TYPE_BLOCK and start to translate if branch */
                 if (!push_jit_block_to_stack_and_pass_params(
-                        cc, block, block->basic_block_entry, 0))
+                        cc, block, cc->cur_basic_block, 0))
                     goto fail;
             }
             else {
@@ -603,7 +603,7 @@ jit_compile_op_block(JitCompContext *cc, uint8 **p_frame_ip,
                        BASIC_BLOCK if cannot be reached, we treat it same as
                        LABEL_TYPE_BLOCK and start to translate else branch */
                     if (!push_jit_block_to_stack_and_pass_params(
-                            cc, block, block->basic_block_else, 0))
+                            cc, block, cc->cur_basic_block, 0))
                         goto fail;
                     *p_frame_ip = else_addr + 1;
                 }

--- a/core/iwasm/fast-jit/fe/jit_emit_control.c
+++ b/core/iwasm/fast-jit/fe/jit_emit_control.c
@@ -584,16 +584,9 @@ jit_compile_op_block(JitCompContext *cc, uint8 **p_frame_ip,
             SET_BB_END_BCIP(cc->cur_basic_block, *p_frame_ip - 1);
             SET_BB_BEGIN_BCIP(block->basic_block_entry, *p_frame_ip);
 
-            if (else_addr) {
-                if (!push_jit_block_to_stack_and_pass_params(
-                        cc, block, block->basic_block_entry, value))
-                    goto fail;
-            }
-            else {
-                if (!push_jit_block_to_stack_and_pass_params(
-                        cc, block, block->basic_block_else, value))
-                    goto fail;
-            }
+            if (!push_jit_block_to_stack_and_pass_params(
+                    cc, block, block->basic_block_entry, value))
+                goto fail;
         }
         else {
             if (jit_cc_get_const_I32(cc, value) != 0) {

--- a/core/iwasm/fast-jit/jit_dump.c
+++ b/core/iwasm/fast-jit/jit_dump.c
@@ -185,8 +185,7 @@ jit_dump_basic_block(JitCompContext *cc, JitBasicBlock *block)
                 : cc->jitted_addr_end);
     else
         /* Dump IR.  */
-        JIT_FOREACH_INSN(block, insn)
-    jit_dump_insn(cc, insn);
+        JIT_FOREACH_INSN(block, insn) jit_dump_insn(cc, insn);
 
     os_printf("    ; SUCCS(");
 


### PR DESCRIPTION
Since `basic_block_else` is NULL, it meets a crash if there is a
IF block without a else branch. Like:

``` wat
(func (export "params-id") (param i32) (result i32)
  (i32.const 1)
  (if (param i32) (result i32) (local.get 0)
    (then)
  )
)
```

Consider the ELSE block will be created lazily, focus on
`basic_block_entry" here.