### PR TITLE
Fixed libc_wasi not working in spawned exec_env

### DIFF
--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -393,6 +393,11 @@ wasm_cluster_spawn_exec_env(WASMExecEnv *exec_env)
     wasm_runtime_set_custom_data_internal(
         new_module_inst, wasm_runtime_get_custom_data(module_inst));
 
+#if WASM_ENABLE_LIBC_WASI != 0
+    WASIContext* wasi_ctx = wasm_runtime_get_wasi_ctx(module_inst);
+    wasm_runtime_set_wasi_ctx(new_module_inst, wasi_ctx);
+#endif
+
     new_exec_env = wasm_exec_env_create_internal(new_module_inst,
                                                  exec_env->wasm_stack_size);
     if (!new_exec_env)

--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -362,6 +362,9 @@ wasm_cluster_spawn_exec_env(WASMExecEnv *exec_env)
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasm_module_t module;
     wasm_module_inst_t new_module_inst;
+#if WASM_ENABLE_LIBC_WASI != 0
+    WASIContext* wasi_ctx;
+#endif
     WASMExecEnv *new_exec_env;
     uint32 aux_stack_start, aux_stack_size;
     uint32 stack_size = 8192;
@@ -394,7 +397,7 @@ wasm_cluster_spawn_exec_env(WASMExecEnv *exec_env)
         new_module_inst, wasm_runtime_get_custom_data(module_inst));
 
 #if WASM_ENABLE_LIBC_WASI != 0
-    WASIContext* wasi_ctx = wasm_runtime_get_wasi_ctx(module_inst);
+    wasi_ctx = wasm_runtime_get_wasi_ctx(module_inst);
     wasm_runtime_set_wasi_ctx(new_module_inst, wasi_ctx);
 #endif
 

--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -363,7 +363,7 @@ wasm_cluster_spawn_exec_env(WASMExecEnv *exec_env)
     wasm_module_t module;
     wasm_module_inst_t new_module_inst;
 #if WASM_ENABLE_LIBC_WASI != 0
-    WASIContext* wasi_ctx;
+    WASIContext *wasi_ctx;
 #endif
     WASMExecEnv *new_exec_env;
     uint32 aux_stack_start, aux_stack_size;


### PR DESCRIPTION
In `thread_manager.c:wasm_cluster_spawn_exec_env`, create a new module instance but not set wasi_ctx, so when the new exec_env call WebAssembly function that used WASI API, and the WASI API functions which in `libc_wasi_wrapper.c` call `get_wasi_ctx` will get null result and then return `wasi_errno`.