### PR TITLE
Fix issues found by GC and Fast JIT, refine some codes

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -2819,8 +2819,8 @@ aot_table_copy(AOTModuleInstance *module_inst, uint32 src_tbl_idx,
     dst_tbl_inst = aot_get_table_inst(module_inst, dst_tbl_idx);
     bh_assert(dst_tbl_inst);
 
-    if ((uint64)src_offset + length > dst_tbl_inst->cur_size
-        || (uint64)dst_offset + length > src_tbl_inst->cur_size) {
+    if ((uint64)dst_offset + length > dst_tbl_inst->cur_size
+        || (uint64)src_offset + length > src_tbl_inst->cur_size) {
         aot_set_exception_with_id(module_inst, EXCE_OUT_OF_BOUNDS_TABLE_ACCESS);
         return;
     }

--- a/core/iwasm/compilation/aot_compiler.c
+++ b/core/iwasm/compilation/aot_compiler.c
@@ -489,6 +489,7 @@ aot_compile_func(AOTCompContext *comp_ctx, uint32 func_index)
                 break;
 
             case WASM_OP_GET_GLOBAL:
+            case WASM_OP_GET_GLOBAL_64:
                 read_leb_uint32(frame_ip, frame_ip_end, global_idx);
                 if (!aot_compile_op_get_global(comp_ctx, func_ctx, global_idx))
                     return false;

--- a/core/iwasm/interpreter/wasm_interp.h
+++ b/core/iwasm/interpreter/wasm_interp.h
@@ -68,7 +68,7 @@ typedef struct WASMInterpFrame {
 static inline unsigned
 wasm_interp_interp_frame_size(unsigned all_cell_num)
 {
-    return align_uint((uint32)offsetof(WASMInterpFrame, lp) + all_cell_num * 5,
+    return align_uint((uint32)offsetof(WASMInterpFrame, lp) + all_cell_num * 4,
                       4);
 }
 

--- a/core/iwasm/interpreter/wasm_interp.h
+++ b/core/iwasm/interpreter/wasm_interp.h
@@ -68,8 +68,14 @@ typedef struct WASMInterpFrame {
 static inline unsigned
 wasm_interp_interp_frame_size(unsigned all_cell_num)
 {
-    return align_uint((uint32)offsetof(WASMInterpFrame, lp) + all_cell_num * 4,
-                      4);
+    unsigned frame_size;
+
+#if WASM_ENABLE_FAST_INTERP == 0
+    frame_size = (uint32)offsetof(WASMInterpFrame, lp) + all_cell_num * 4;
+#else
+    frame_size = (uint32)offsetof(WASMInterpFrame, operand) + all_cell_num * 4;
+#endif
+    return align_uint(frame_size, 4);
 }
 
 void

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -3067,8 +3067,8 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         s = (uint32)POP_I32();
                         d = (uint32)POP_I32();
 
-                        if (s + n > dst_tbl_inst->cur_size
-                            || d + n > src_tbl_inst->cur_size) {
+                        if (d + n > dst_tbl_inst->cur_size
+                            || s + n > src_tbl_inst->cur_size) {
                             wasm_set_exception(module,
                                                "out of bounds table access");
                             goto got_exception;

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -2984,8 +2984,8 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         s = (uint32)POP_I32();
                         d = (uint32)POP_I32();
 
-                        if (s + n > dst_tbl_inst->cur_size
-                            || d + n > src_tbl_inst->cur_size) {
+                        if (d + n > dst_tbl_inst->cur_size
+                            || s + n > src_tbl_inst->cur_size) {
                             wasm_set_exception(module,
                                                "out of bounds table access");
                             goto got_exception;

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -6414,6 +6414,7 @@ re_scan:
                 uint8 value_type;
                 BlockType block_type;
 
+                p_org = p - 1;
                 value_type = read_uint8(p);
                 if (is_byte_a_type(value_type)) {
                     /* If the first byte is one of these special values:
@@ -6441,9 +6442,9 @@ re_scan:
                      * the block quickly.
                      */
 #if WASM_ENABLE_DEBUG_INTERP != 0
-                    record_fast_op(module, p - 2, *(p - 2));
+                    record_fast_op(module, p_org, *p_org);
 #endif
-                    *(p - 2) = EXT_OP_BLOCK + (opcode - WASM_OP_BLOCK);
+                    *p_org = EXT_OP_BLOCK + (opcode - WASM_OP_BLOCK);
 #endif
                 }
 
@@ -7309,33 +7310,22 @@ re_scan:
                 operand_offset = local_offset;
                 PUSH_OFFSET_TYPE(local_type);
 #else
-#if (WASM_ENABLE_WAMR_COMPILER == 0) && (WASM_ENABLE_JIT == 0)
+#if (WASM_ENABLE_WAMR_COMPILER == 0) && (WASM_ENABLE_JIT == 0) \
+    && (WASM_ENABLE_DEBUG_INTERP == 0)
                 if (local_offset < 0x80) {
-#if WASM_ENABLE_DEBUG_INTERP != 0
-                    record_fast_op(module, p_org, *p_org);
-#endif
                     *p_org++ = EXT_OP_GET_LOCAL_FAST;
                     if (is_32bit_type(local_type)) {
-#if WASM_ENABLE_DEBUG_INTERP != 0
-                        record_fast_op(module, p_org, *p_org);
-#endif
                         *p_org++ = (uint8)local_offset;
                     }
                     else {
-#if WASM_ENABLE_DEBUG_INTERP != 0
-                        record_fast_op(module, p_org, *p_org);
-#endif
                         *p_org++ = (uint8)(local_offset | 0x80);
                     }
                     while (p_org < p) {
-#if WASM_ENABLE_DEBUG_INTERP != 0
-                        record_fast_op(module, p_org, *p_org);
-#endif
                         *p_org++ = WASM_OP_NOP;
                     }
                 }
 #endif
-#endif
+#endif /* end of WASM_ENABLE_FAST_INTERP != 0 */
                 break;
             }
 
@@ -7384,33 +7374,22 @@ re_scan:
                     POP_OFFSET_TYPE(local_type);
                 }
 #else
-#if (WASM_ENABLE_WAMR_COMPILER == 0) && (WASM_ENABLE_JIT == 0)
+#if (WASM_ENABLE_WAMR_COMPILER == 0) && (WASM_ENABLE_JIT == 0) \
+    && (WASM_ENABLE_DEBUG_INTERP == 0)
                 if (local_offset < 0x80) {
-#if WASM_ENABLE_DEBUG_INTERP != 0
-                    record_fast_op(module, p_org, *p_org);
-#endif
                     *p_org++ = EXT_OP_SET_LOCAL_FAST;
                     if (is_32bit_type(local_type)) {
-#if WASM_ENABLE_DEBUG_INTERP != 0
-                        record_fast_op(module, p_org, *p_org);
-#endif
                         *p_org++ = (uint8)local_offset;
                     }
                     else {
-#if WASM_ENABLE_DEBUG_INTERP != 0
-                        record_fast_op(module, p_org, *p_org);
-#endif
                         *p_org++ = (uint8)(local_offset | 0x80);
                     }
                     while (p_org < p) {
-#if WASM_ENABLE_DEBUG_INTERP != 0
-                        record_fast_op(module, p_org, *p_org);
-#endif
                         *p_org++ = WASM_OP_NOP;
                     }
                 }
 #endif
-#endif
+#endif /* end of WASM_ENABLE_FAST_INTERP != 0 */
                 break;
             }
 
@@ -7455,33 +7434,22 @@ re_scan:
                              *(loader_ctx->frame_offset
                                - wasm_value_type_cell_num(local_type)));
 #else
-#if (WASM_ENABLE_WAMR_COMPILER == 0) && (WASM_ENABLE_JIT == 0)
+#if (WASM_ENABLE_WAMR_COMPILER == 0) && (WASM_ENABLE_JIT == 0) \
+    && (WASM_ENABLE_DEBUG_INTERP == 0)
                 if (local_offset < 0x80) {
-#if WASM_ENABLE_DEBUG_INTERP != 0
-                    record_fast_op(module, p_org, *p_org);
-#endif
                     *p_org++ = EXT_OP_TEE_LOCAL_FAST;
                     if (is_32bit_type(local_type)) {
-#if WASM_ENABLE_DEBUG_INTERP != 0
-                        record_fast_op(module, p_org, *p_org);
-#endif
                         *p_org++ = (uint8)local_offset;
                     }
                     else {
-#if WASM_ENABLE_DEBUG_INTERP != 0
-                        record_fast_op(module, p_org, *p_org);
-#endif
                         *p_org++ = (uint8)(local_offset | 0x80);
                     }
                     while (p_org < p) {
-#if WASM_ENABLE_DEBUG_INTERP != 0
-                        record_fast_op(module, p_org, *p_org);
-#endif
                         *p_org++ = WASM_OP_NOP;
                     }
                 }
 #endif
-#endif
+#endif /* end of WASM_ENABLE_FAST_INTERP != 0 */
                 break;
             }
 

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -7505,7 +7505,6 @@ re_scan:
                 PUSH_TYPE(global_type);
 
 #if WASM_ENABLE_FAST_INTERP == 0
-#if (WASM_ENABLE_WAMR_COMPILER == 0) && (WASM_ENABLE_JIT == 0)
                 if (global_type == VALUE_TYPE_I64
                     || global_type == VALUE_TYPE_F64) {
 #if WASM_ENABLE_DEBUG_INTERP != 0
@@ -7513,7 +7512,6 @@ re_scan:
 #endif
                     *p_org = WASM_OP_GET_GLOBAL_64;
                 }
-#endif
 #else  /* else of WASM_ENABLE_FAST_INTERP */
                 if (global_type == VALUE_TYPE_I64
                     || global_type == VALUE_TYPE_F64) {

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -4813,6 +4813,7 @@ re_scan:
                 uint8 value_type;
                 BlockType block_type;
 
+                p_org = p - 1;
                 value_type = read_uint8(p);
                 if (is_byte_a_type(value_type)) {
                     /* If the first byte is one of these special values:
@@ -4835,7 +4836,7 @@ re_scan:
                      * to new extended opcode so that interpreter can resolve
                      * the block quickly.
                      */
-                    *(p - 2) = EXT_OP_BLOCK + (opcode - WASM_OP_BLOCK);
+                    *p_org = EXT_OP_BLOCK + (opcode - WASM_OP_BLOCK);
 #endif
                 }
 
@@ -5787,7 +5788,6 @@ re_scan:
                 POP_TYPE(global_type);
 
 #if WASM_ENABLE_FAST_INTERP == 0
-#if (WASM_ENABLE_WAMR_COMPILER == 0) && (WASM_ENABLE_JIT == 0)
                 if (is_64bit_type(global_type)) {
                     *p_org = WASM_OP_SET_GLOBAL_64;
                 }
@@ -5795,7 +5795,6 @@ re_scan:
                          && global_idx == module->aux_stack_top_global_index) {
                     *p_org = WASM_OP_SET_GLOBAL_AUX_STACK;
                 }
-#endif
 #else  /* else of WASM_ENABLE_FAST_INTERP */
                 if (is_64bit_type(global_type)) {
                     skip_label();

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -5744,12 +5744,10 @@ re_scan:
                 PUSH_TYPE(global_type);
 
 #if WASM_ENABLE_FAST_INTERP == 0
-#if (WASM_ENABLE_WAMR_COMPILER == 0) && (WASM_ENABLE_JIT == 0)
                 if (global_type == VALUE_TYPE_I64
                     || global_type == VALUE_TYPE_F64) {
                     *p_org = WASM_OP_GET_GLOBAL_64;
                 }
-#endif
 #else  /* else of WASM_ENABLE_FAST_INTERP */
                 if (is_64bit_type(global_type)) {
                     skip_label();


### PR DESCRIPTION
Fix handle OP_TABLE_COPY issue
Fix loader handle OP_BLOCK/IF/LOOP issue if type_index is larger than 256
Fix loader handle OP_GET_GLOBAL, allow to change to GET_GLOBAL_64 for
aot compiler similiar to handling OP_SET_GLOBAL
Refine loader handle OP_GET/SET/TEE_LOCAL, disable changing opcode when
source debugging is enabled, so as no need to record the change of opcode
Refine wasm_interp_interp_frame_size to reduce the wasm operand stack usage