### PR TITLE
Remove `const` flag for wasm_runtime_load argument buf

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -753,7 +753,7 @@ register_module_with_null_name(WASMModuleCommon *module_common, char *error_buf,
 }
 
 WASMModuleCommon *
-wasm_runtime_load(const uint8 *buf, uint32 size, char *error_buf,
+wasm_runtime_load(uint8 *buf, uint32 size, char *error_buf,
                   uint32 error_buf_size)
 {
     WASMModuleCommon *module_common = NULL;

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -413,7 +413,7 @@ wasm_runtime_is_xip_file(const uint8 *buf, uint32 size);
 
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN WASMModuleCommon *
-wasm_runtime_load(const uint8 *buf, uint32 size, char *error_buf,
+wasm_runtime_load(uint8 *buf, uint32 size, char *error_buf,
                   uint32 error_buf_size);
 
 /* See wasm_export.h for description */

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -300,7 +300,10 @@ wasm_runtime_find_module_registered(const char *module_name);
  * WASM binary data when interpreter or JIT is enabled, or AOT binary data
  * when AOT is enabled. If it is AOT binary data, it must be 4-byte aligned.
  *
- * @param buf the byte buffer which contains the WASM binary data
+ * @param buf the byte buffer which contains the WASM/AOT binary data,
+ *        note that the byte buffer must be writable since runtime may
+ *        change its content for footprint and performance purpose, and
+ *        it must be referencable until wasm_runtime_unload is called
  * @param size the size of the buffer
  * @param error_buf output of the exception info
  * @param error_buf_size the size of the exception string
@@ -308,7 +311,7 @@ wasm_runtime_find_module_registered(const char *module_name);
  * @return return WASM module loaded, NULL if failed
  */
 WASM_RUNTIME_API_EXTERN wasm_module_t
-wasm_runtime_load(const uint8_t *buf, uint32_t size,
+wasm_runtime_load(uint8_t *buf, uint32_t size,
                   char *error_buf, uint32_t error_buf_size);
 
 /**

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -3578,7 +3578,7 @@ check_wasi_abi_compatibility(const WASMModule *module, bool main_module,
 #endif
 
 WASMModule *
-wasm_loader_load(const uint8 *buf, uint32 size,
+wasm_loader_load(uint8 *buf, uint32 size,
 #if WASM_ENABLE_MULTI_MODULE != 0
                  bool main_module,
 #endif

--- a/core/iwasm/interpreter/wasm_loader.h
+++ b/core/iwasm/interpreter/wasm_loader.h
@@ -24,7 +24,7 @@ extern "C" {
  * @return return module loaded, NULL if failed
  */
 WASMModule *
-wasm_loader_load(const uint8 *buf, uint32 size,
+wasm_loader_load(uint8 *buf, uint32 size,
 #if WASM_ENABLE_MULTI_MODULE != 0
                  bool main_module,
 #endif

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -2336,7 +2336,7 @@ load(const uint8 *buf, uint32 size, WASMModule *module, char *error_buf,
 }
 
 WASMModule *
-wasm_loader_load(const uint8 *buf, uint32 size, char *error_buf,
+wasm_loader_load(uint8 *buf, uint32 size, char *error_buf,
                  uint32 error_buf_size)
 {
     WASMModule *module = create_module(error_buf, error_buf_size);

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -45,7 +45,7 @@ set_error_buf_v(char *error_buf, uint32 error_buf_size, const char *format, ...)
 }
 
 WASMModule *
-wasm_load(const uint8 *buf, uint32 size, char *error_buf, uint32 error_buf_size)
+wasm_load(uint8 *buf, uint32 size, char *error_buf, uint32 error_buf_size)
 {
     return wasm_loader_load(buf, size,
 #if WASM_ENABLE_MULTI_MODULE != 0

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -273,8 +273,7 @@ wasm_get_func_code_end(WASMFunctionInstance *func)
 }
 
 WASMModule *
-wasm_load(const uint8 *buf, uint32 size, char *error_buf,
-          uint32 error_buf_size);
+wasm_load(uint8 *buf, uint32 size, char *error_buf, uint32 error_buf_size);
 
 WASMModule *
 wasm_load_from_sections(WASMSection *section_list, char *error_buf,


### PR DESCRIPTION
Remove the `const` flag for the first argument `buf` of wasm_runtime_load as
it might be modified by runtime for footprint and performance purpose, and
update the related functions and document.