### PR TITLE
Refine codes and fix several issues

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -1850,7 +1850,9 @@ do_text_relocation(AOTModule *module, AOTRelocationGroup *group,
                  || !strcmp(symbol, ".rdata")
                  || !strcmp(symbol, ".rodata")
                  /* ".rodata.cst4/8/16/.." */
-                 || !strncmp(symbol, ".rodata.cst", strlen(".rodata.cst"))) {
+                 || !strncmp(symbol, ".rodata.cst", strlen(".rodata.cst"))
+                 /* ".rodata.strn.m" */
+                 || !strncmp(symbol, ".rodata.str", strlen(".rodata.str"))) {
             symbol_addr = get_data_section_addr(module, symbol, NULL);
             if (!symbol_addr) {
                 set_error_buf_v(error_buf, error_buf_size,
@@ -2314,7 +2316,10 @@ load_relocation_section(const uint8 *buf, const uint8 *buf_end,
             || !strcmp(data_section->name, ".rodata")
             /* ".rodata.cst4/8/16/.." */
             || !strncmp(data_section->name, ".rodata.cst",
-                        strlen(".rodata.cst"))) {
+                        strlen(".rodata.cst"))
+            /* ".rodata.strn.m" */
+            || !strncmp(data_section->name, ".rodata.str",
+                        strlen(".rodata.str"))) {
             os_mprotect(data_section->data, data_section->size, map_prot);
         }
     }

--- a/core/iwasm/compilation/aot_emit_aot_file.c
+++ b/core/iwasm/compilation/aot_emit_aot_file.c
@@ -2180,6 +2180,8 @@ is_data_section(LLVMSectionIteratorRef sec_itr, char *section_name)
             || !strcmp(section_name, ".rodata")
             /* ".rodata.cst4/8/16/.." */
             || !strncmp(section_name, ".rodata.cst", strlen(".rodata.cst"))
+            /* ".rodata.strn.m" */
+            || !strncmp(section_name, ".rodata.str", strlen(".rodata.str"))
             || (!strcmp(section_name, ".rdata")
                 && get_relocations_count(sec_itr, &relocation_count)
                 && relocation_count > 0));

--- a/core/iwasm/compilation/aot_emit_numberic.c
+++ b/core/iwasm/compilation/aot_emit_numberic.c
@@ -529,7 +529,6 @@ compile_int_div(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             default:
                 bh_assert(0);
                 return false;
-                ;
         }
     }
 

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -2276,6 +2276,9 @@ aot_value_stack_destroy(AOTValueStack *stack)
         wasm_runtime_free(value);
         value = p;
     }
+
+    stack->value_list_head = NULL;
+    stack->value_list_end = NULL;
 }
 
 void
@@ -2319,6 +2322,9 @@ aot_block_stack_destroy(AOTBlockStack *stack)
         aot_block_destroy(block);
         block = p;
     }
+
+    stack->block_list_head = NULL;
+    stack->block_list_end = NULL;
 }
 
 void

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -694,7 +694,7 @@ static inline int64
 sign_ext_8_64(int8 val)
 {
     if (val & 0x80)
-        return (int64)val | (int64)0xffffffffffffff00;
+        return (int64)val | (int64)0xffffffffffffff00LL;
     return val;
 }
 
@@ -702,7 +702,7 @@ static inline int64
 sign_ext_16_64(int16 val)
 {
     if (val & 0x8000)
-        return (int64)val | (int64)0xffffffffffff0000;
+        return (int64)val | (int64)0xffffffffffff0000LL;
     return val;
 }
 
@@ -710,15 +710,19 @@ static inline int64
 sign_ext_32_64(int32 val)
 {
     if (val & (int32)0x80000000)
-        return (int64)val | (int64)0xffffffff00000000;
+        return (int64)val | (int64)0xffffffff00000000LL;
     return val;
 }
 
 static inline void
 word_copy(uint32 *dest, uint32 *src, unsigned num)
 {
-    for (; num > 0; num--)
-        *dest++ = *src++;
+    if (dest != src) {
+        /* No overlap buffer */
+        bh_assert(!((src < dest) && (dest < src + num)));
+        for (; num > 0; num--)
+            *dest++ = *src++;
+    }
 }
 
 static inline WASMInterpFrame *
@@ -1067,7 +1071,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
             {
                 value_type = *frame_ip++;
                 param_cell_num = 0;
-                cell_num = wasm_value_type_cell_num(value_type);
+                cell_num = 0;
             handle_op_loop:
                 PUSH_CSP(LABEL_TYPE_LOOP, param_cell_num, cell_num, frame_ip);
                 HANDLE_OP_END();

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -764,7 +764,7 @@ static inline int64
 sign_ext_8_64(int8 val)
 {
     if (val & 0x80)
-        return (int64)val | (int64)0xffffffffffffff00;
+        return (int64)val | (int64)0xffffffffffffff00LL;
     return val;
 }
 
@@ -772,7 +772,7 @@ static inline int64
 sign_ext_16_64(int16 val)
 {
     if (val & 0x8000)
-        return (int64)val | (int64)0xffffffffffff0000;
+        return (int64)val | (int64)0xffffffffffff0000LL;
     return val;
 }
 
@@ -780,15 +780,19 @@ static inline int64
 sign_ext_32_64(int32 val)
 {
     if (val & (int32)0x80000000)
-        return (int64)val | (int64)0xffffffff00000000;
+        return (int64)val | (int64)0xffffffff00000000LL;
     return val;
 }
 
 static inline void
 word_copy(uint32 *dest, uint32 *src, unsigned num)
 {
-    for (; num > 0; num--)
-        *dest++ = *src++;
+    if (dest != src) {
+        /* No overlap buffer */
+        bh_assert(!((src < dest) && (dest < src + num)));
+        for (; num > 0; num--)
+            *dest++ = *src++;
+    }
 }
 
 static inline WASMInterpFrame *

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1099,18 +1099,12 @@ check_linked_symbol(WASMModuleInstance *module_inst, char *error_buf,
             && !func->import_func_linked
 #endif
         ) {
-#if WASM_ENABLE_SPEC_TEST != 0
-            set_error_buf(error_buf, error_buf_size,
-                          "unknown import or incompatible import type");
-            return false;
-#else
 #if WASM_ENABLE_WAMR_COMPILER == 0
             LOG_WARNING("warning: failed to link import function (%s, %s)",
                         func->module_name, func->field_name);
 #else
             /* do nothing to avoid confused message */
 #endif /* WASM_ENABLE_WAMR_COMPILER == 0 */
-#endif /* WASM_ENABLE_SPEC_TEST != 0 */
         }
     }
 

--- a/core/iwasm/libraries/libc-builtin/libc_builtin_wrapper.c
+++ b/core/iwasm/libraries/libc-builtin/libc_builtin_wrapper.c
@@ -81,9 +81,10 @@ typedef char *_va_list;
     int32 n;                                                 \
                                                              \
     /* additional 2 bytes: one is the format char,           \
-     * the other is `\0` */                                  \
-    if (fmt - fmt_start_addr + 2 >= fmt_buf_len) {           \
-        bh_assert(fmt - fmt_start_addr <= UINT32_MAX - 2);   \
+       the other is `\0` */                                  \
+    if ((uint32)(fmt - fmt_start_addr + 2) >= fmt_buf_len) { \
+        bh_assert((uint32)(fmt - fmt_start_addr) <=          \
+                  UINT32_MAX - 2);                           \
         fmt_buf_len = fmt - fmt_start_addr + 2;              \
         if (!(fmt_buf = wasm_runtime_malloc(fmt_buf_len))) { \
             print_err(out, ctx);                             \

--- a/core/shared/platform/linux-sgx/sgx_platform.c
+++ b/core/shared/platform/linux-sgx/sgx_platform.c
@@ -90,8 +90,8 @@ strcpy(char *dest, const char *src)
     const unsigned char *s = src;
     unsigned char *d = dest;
 
-    while ((*d++ = *s++))
-        ;
+    while ((*d++ = *s++)) {
+    }
     return dest;
 }
 


### PR DESCRIPTION
Add aot relocation for ".rodata.str" symbol to support more cases
Fix some coding style issues
Fix aot block/value stack destroy issue
Refine classic/fast interpreter codes
Clear compile warning of libc_builtin_wrapper.c in 32-bit platform