### PR TITLE
Fix a few signedness warnings

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -877,7 +877,7 @@ wasmtime_ssp_fd_pread(
         // Copy data back to vectors.
         size_t bufoff = 0;
         for (size_t i = 0; i < iovcnt; ++i) {
-            if (bufoff + iov[i].buf_len < len) {
+            if (bufoff + iov[i].buf_len < (size_t)len) {
                 bh_memcpy_s(iov[i].buf, iov[i].buf_len, buf + bufoff,
                             iov[i].buf_len);
                 bufoff += iov[i].buf_len;
@@ -1356,8 +1356,9 @@ wasmtime_ssp_fd_allocate(
     // conditions. We may end up shrinking the file right now.
     struct stat sb;
     int ret = fstat(fd_number(fo), &sb);
-    if (ret == 0 && sb.st_size < offset + len)
-        ret = ftruncate(fd_number(fo), offset + len);
+    off_t newsize = (off_t)(offset + len);
+    if (ret == 0 && sb.st_size < newsize)
+        ret = ftruncate(fd_number(fo), newsize);
 #endif
 
     fd_object_release(fo);


### PR DESCRIPTION
```
/Users/yamamoto/git/wasm-micro-runtime/core/iwasm/libraries/libc-wasi/sandboxed-
system-primitives/src/posix.c:880:41: warning: comparison of integers of differe
nt signs: 'unsigned long' and 'ssize_t' (aka 'long') [-Wsign-compare]
            if (bufoff + iov[i].buf_len < len) {
                ~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~
/Users/yamamoto/git/wasm-micro-runtime/core/iwasm/libraries/libc-wasi/sandboxed-
system-primitives/src/posix.c:1359:32: warning: comparison of integers of differ
ent signs: 'off_t' (aka 'long long') and 'unsigned long long' [-Wsign-compare]
    if (ret == 0 && sb.st_size < offset + len)
                    ~~~~~~~~~~ ^ ~~~~~~~~~~~~
2 warnings generated.
```