### PR TITLE
aot_loader.c: Fix crashing issues in "Refine interp/aot string storage"

### DIFF
--- a/core/iwasm/aot/aot_runtime.h
+++ b/core/iwasm/aot/aot_runtime.h
@@ -222,6 +222,7 @@ typedef struct AOTModule {
 
     /* constant string set */
     HashMap *const_str_set;
+    HashMap *const_inline_str_set;
 
     /* the index of auxiliary __data_end global,
        -1 means unexported */

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -986,6 +986,8 @@ wasm_runtime_dump_module_mem_consumption(const WASMModuleCommon *module)
     os_printf("    table segs size: %u\n", mem_conspn.table_segs_size);
     os_printf("    data segs size: %u\n", mem_conspn.data_segs_size);
     os_printf("    const strings size: %u\n", mem_conspn.const_strs_size);
+    os_printf("    const inline strings size: %u\n",
+              mem_conspn.const_inline_strs_size);
 #if WASM_ENABLE_AOT != 0
     os_printf("    aot code size: %u\n", mem_conspn.aot_code_size);
 #endif

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -330,6 +330,7 @@ typedef struct WASMModuleMemConsumption {
     uint32 table_segs_size;
     uint32 data_segs_size;
     uint32 const_strs_size;
+    uint32 const_inline_strs_size;
 #if WASM_ENABLE_AOT != 0
     uint32 aot_code_size;
 #endif

--- a/core/iwasm/interpreter/wasm.h
+++ b/core/iwasm/interpreter/wasm.h
@@ -502,6 +502,25 @@ wasm_string_equal(const char *s1, const char *s2)
 }
 
 /**
+ * Return the hash value of pointer.
+ */
+inline static uint32
+wasm_ptr_hash(const void *p)
+{
+    uintptr_t v = (uintptr_t)p;
+    return (v >> 32) ^ v;
+}
+
+/**
+ * Whether two pointers are equal.
+ */
+inline static bool
+wasm_ptr_equal(const void *p1, const void *p2)
+{
+    return p1 == p2;
+}
+
+/**
  * Return the byte size of value type.
  *
  */


### PR DESCRIPTION
The following commit [1] had a few issues.

* it looks a wrong byte for the mark
* it didn't work for long strings (>= 0x80 in case of little endian)

This commit fixes it by maintaining another hash instead of
the "0x80" marking.  (The idea from Wenyong Huang)

[1]
```
commit 403a7d3f4fe3eec3092f9fb7b8a71dc93e4589b1
Author: Wenyong Huang <wenyong.huang@intel.com>
Date:   Mon Nov 8 11:27:26 2021 +0800

    Refine interp/aot string storage and emitting (#820)

    Currently the string in the wasm/aot file will be duplicated and stored
    into const string list/set in interpreter/aot loader, which leads to extra
    unnecessary memory consumption if the file buffer can be referred to
    after loading. We refine the string storage by:
    - if the file buffer can be referred to after loading and it is writable, we
      reuse the file buffer to store the string but not store it into the const
      string set: move string backward and append '\0'
    - emit string with '\0' only for XIP mode in which the AOT file is readonly
    - if the file buffer cannot be referred to, e.g. in app manager, keep the
      same behavior as before

    Signed-off-by: Wenyong Huang <wenyong.huang@intel.com>
```