### PR TITLE
Add more wasm operand stack overflow checks for fast-interp

### DIFF
--- a/core/iwasm/common/wasm_exec_env.h
+++ b/core/iwasm/common/wasm_exec_env.h
@@ -179,8 +179,12 @@ wasm_exec_env_alloc_wasm_frame(WASMExecEnv *exec_env, unsigned size)
 
     bh_assert(!(size & 3));
 
-    /* The outs area size cannot be larger than the frame size, so
-       multiplying by 2 is enough. */
+    /* For classic interpreter, the outs area doesn't contain the const cells,
+       its size cannot be larger than the frame size, so here checking stack
+       overflow with multiplying by 2 is enough. For fast interpreter, since
+       the outs area contains const cells, its size may be larger than current
+       frame size, we should check again before putting the function arguments
+       into the outs area. */
     if (addr + size * 2 > exec_env->wasm_stack.s.top_boundary) {
         /* WASM stack overflow. */
         return NULL;

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -3603,7 +3603,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
             outs_area->lp = outs_area->operand + cur_func->const_cell_num;
         }
 
-        if ((uint8*)(outs_area->lp + cur_func->param_cell_num)
+        if ((uint8 *)(outs_area->lp + cur_func->param_cell_num)
             > exec_env->wasm_stack.s.top_boundary) {
             wasm_set_exception(module, "wasm operand stack overflow");
             goto got_exception;
@@ -3799,8 +3799,8 @@ wasm_interp_call_wasm(WASMModuleInstance *module_inst, WASMExecEnv *exec_env,
 
     if ((uint8 *)(outs_area->operand + function->const_cell_num + argc)
         > exec_env->wasm_stack.s.top_boundary) {
-        wasm_set_exception((WASMModuleInstance*)exec_env->module_inst,
-                            "wasm operand stack overflow");
+        wasm_set_exception((WASMModuleInstance *)exec_env->module_inst,
+                           "wasm operand stack overflow");
         return;
     }
 

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -3602,6 +3602,13 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
         {
             outs_area->lp = outs_area->operand + cur_func->const_cell_num;
         }
+
+        if ((uint8*)(outs_area->lp + cur_func->param_cell_num)
+            > exec_env->wasm_stack.s.top_boundary) {
+            wasm_set_exception(module, "wasm operand stack overflow");
+            goto got_exception;
+        }
+
         for (i = 0; i < cur_func->param_count; i++) {
             if (cur_func->param_types[i] == VALUE_TYPE_I64
                 || cur_func->param_types[i] == VALUE_TYPE_F64) {
@@ -3789,6 +3796,13 @@ wasm_interp_call_wasm(WASMModuleInstance *module_inst, WASMExecEnv *exec_env,
     /* There is no local variable. */
     frame->lp = frame->operand + 0;
     frame->ret_offset = 0;
+
+    if ((uint8 *)(outs_area->operand + function->const_cell_num + argc)
+        > exec_env->wasm_stack.s.top_boundary) {
+        wasm_set_exception((WASMModuleInstance*)exec_env->module_inst,
+                            "wasm operand stack overflow");
+        return;
+    }
 
     if (argc > 0)
         word_copy(outs_area->operand + function->const_cell_num, argv, argc);

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -4976,8 +4976,8 @@ wasm_loader_emit_const(WASMLoaderContext *ctx, void *value, bool is_32_bit)
         bh_assert(((uintptr_t)ctx->p_code_compiled & 1) == 0);
 #endif
         bh_memcpy_s(ctx->p_code_compiled,
-                    ctx->p_code_compiled_end - ctx->p_code_compiled, value,
-                    size);
+                    (uint32)(ctx->p_code_compiled_end - ctx->p_code_compiled),
+                    value, size);
         ctx->p_code_compiled += size;
     }
     else {

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -3501,8 +3501,8 @@ wasm_loader_emit_const(WASMLoaderContext *ctx, void *value, bool is_32_bit)
         bh_assert(((uintptr_t)ctx->p_code_compiled & 1) == 0);
 #endif
         bh_memcpy_s(ctx->p_code_compiled,
-                    ctx->p_code_compiled_end - ctx->p_code_compiled, value,
-                    size);
+                    (uint32)(ctx->p_code_compiled_end - ctx->p_code_compiled),
+                    value, size);
         ctx->p_code_compiled += size;
     }
     else {

--- a/core/iwasm/libraries/libc-builtin/libc_builtin_wrapper.c
+++ b/core/iwasm/libraries/libc-builtin/libc_builtin_wrapper.c
@@ -85,7 +85,7 @@ typedef char *_va_list;
     if ((uint32)(fmt - fmt_start_addr + 2) >= fmt_buf_len) { \
         bh_assert((uint32)(fmt - fmt_start_addr) <=          \
                   UINT32_MAX - 2);                           \
-        fmt_buf_len = fmt - fmt_start_addr + 2;              \
+        fmt_buf_len = (uint32)(fmt - fmt_start_addr + 2);    \
         if (!(fmt_buf = wasm_runtime_malloc(fmt_buf_len))) { \
             print_err(out, ctx);                             \
             break;                                           \
@@ -93,8 +93,8 @@ typedef char *_va_list;
     }                                                        \
                                                              \
     memset(fmt_buf, 0, fmt_buf_len);                         \
-    bh_memcpy_s(fmt_buf, fmt_buf_len,                        \
-                fmt_start_addr, fmt - fmt_start_addr + 1);
+    bh_memcpy_s(fmt_buf, fmt_buf_len, fmt_start_addr,        \
+                (uint32)(fmt - fmt_start_addr + 1));
 /* clang-format on */
 
 #define OUTPUT_TEMP_FORMAT()            \
@@ -199,7 +199,7 @@ _vprintf_wa(out_func_t out, void *ctx, const char *fmt, _va_list ap,
                         d = _va_arg(ap, int32);
 
                         if (long_ctr == 1) {
-                            uint32 fmt_end_idx = fmt - fmt_start_addr;
+                            uint32 fmt_end_idx = (uint32)(fmt - fmt_start_addr);
 
                             if (fmt_buf[fmt_end_idx - 1] == 'l'
                                 || fmt_buf[fmt_end_idx - 1] == 'z'
@@ -247,7 +247,7 @@ _vprintf_wa(out_func_t out, void *ctx, const char *fmt, _va_list ap,
 
                     s = start = addr_app_to_native(s_offset);
 
-                    str_len = strlen(start);
+                    str_len = (uint32)strlen(start);
                     if (str_len >= UINT32_MAX - 64) {
                         print_err(out, ctx);
                         if (fmt_buf != temp_fmt) {


### PR DESCRIPTION
And clear compile warnings on Windows