### PR TITLE
core/iwasm/aot/aot_loader.c: Fix a zero-sized malloc warning

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -2063,10 +2063,12 @@ load_relocation_section(const uint8 *buf, const uint8 *buf_end,
         goto fail;
     }
 
-    symbols = loader_malloc((uint64)sizeof(*symbols) * symbol_count, error_buf,
-                            error_buf_size);
-    if (symbols == NULL) {
-        goto fail;
+    if (symbol_count > 0) {
+        symbols = loader_malloc((uint64)sizeof(*symbols) * symbol_count,
+                                error_buf, error_buf_size);
+        if (symbols == NULL) {
+            goto fail;
+        }
     }
 
 #if defined(BH_PLATFORM_WINDOWS)


### PR DESCRIPTION
Fix the following warning when loading an aot file without
relocations.

```
[20:19:00:528 - 1119F1600]: warning: wasm_runtime_malloc with size zero
```

The issue has been introduced by:
```
commit b36931a5897122957ac1d093f5a23aaf718cb730
Author: YAMAMOTO Takashi <yamamoto@midokura.com>
Date:   Tue Apr 19 16:44:30 2022 +0900

    aot_loader.c: Fix issues in "Refine interp/aot string storage" (#1102)

    Fix issues in PR "Refine interp/aot string storage and emitting (#820)",
    which had a few issues:
    - It looks a wrong byte to mark the flag
    - It doesn't work for long strings (>= 0x80 in case of little endian)

    This commit fixes them by maintaining a list of loaded symbols while loading
    relocation section to avoid reading a string repeatedly, and no need to mark
    the flag again.
```