### PR TITLE
Only handle one const case in `DEF_UNI_INT_CONST_OPS`

### DIFF
--- a/core/iwasm/fast-jit/fe/jit_emit_numberic.c
+++ b/core/iwasm/fast-jit/fe/jit_emit_numberic.c
@@ -713,15 +713,6 @@ DEF_UNI_INT_CONST_OPS(xor)
     if (IS_CONST_ZERO(right))
         return left;
 
-    if (is_i32) {
-        if (jit_cc_get_const_I32(cc, left) == jit_cc_get_const_I32(cc, right))
-            return NEW_CONST(I32, 0);
-    }
-    else {
-        if (jit_cc_get_const_I64(cc, left) == jit_cc_get_const_I64(cc, right))
-            return NEW_CONST(I64, 0);
-    }
-
     return 0;
 }
 


### PR DESCRIPTION
`DEF_UNI_INT_CONST_OPS` handle the case of both consts