### PR TITLE
Add missing wasm_export.h include in a few places

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -21,6 +21,7 @@
 #include "refcount.h"
 #include "rights.h"
 #include "str.h"
+#include "wasm_export.h"
 
 #if 0 /* TODO: -std=gnu99 causes compile error, comment them first */
 // struct iovec must have the same layout as __wasi_iovec_t.

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/str.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/str.c
@@ -14,6 +14,7 @@
 #include "ssp_config.h"
 #include "bh_platform.h"
 #include "str.h"
+#include "wasm_export.h"
 
 static char *
 bh_strndup(const char *s, size_t n)

--- a/core/shared/utils/bh_platform.h
+++ b/core/shared/utils/bh_platform.h
@@ -17,6 +17,9 @@
 #include "bh_queue.h"
 #include "bh_vector.h"
 #include "runtime_timer.h"
+#if !defined(WA_MALLOC) || !defined(WA_FREE)
+#include "wasm_export.h"
+#endif
 
 /**
  * WA_MALLOC/WA_FREE need to be redefined for both


### PR DESCRIPTION
This fixes a few pointer truncation crashes I've seen with WASI.