### PR TITLE
sandboxed-system-primitives: Use d_ino=0 for NuttX

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -1992,7 +1992,11 @@ wasmtime_ssp_fd_readdir(
         size_t namlen = strlen(de->d_name);
         __wasi_dirent_t cde = {
             .d_next = fo->directory.offset,
+#if CONFIG_HAS_D_INO
             .d_ino = de->d_ino,
+#else
+            .d_ino = 0,
+#endif
             .d_namlen = (uint32)namlen,
         };
         switch (de->d_type) {

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
@@ -105,4 +105,10 @@
 #define CONFIG_HAS_STD_ATOMIC 0
 #endif
 
+#if !defined(__NuttX__)
+#define CONFIG_HAS_D_INO 1
+#else
+#define CONFIG_HAS_D_INO 0
+#endif
+
 #endif


### PR DESCRIPTION
NuttX doesn't have d_ino.