### PR TITLE
store import function pointer in module instance

### DIFF
--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -771,7 +771,8 @@ wasm_interp_call_func_native(WASMModuleInstance *module_inst,
     WASMFunctionImport *func_import = cur_func->u.func_import;
     unsigned local_cell_num = 2;
     WASMInterpFrame *frame;
-    uint32 argv_ret[2];
+    uint32 argv_ret[2], cur_func_index;
+    void *native_func_pointer = NULL;
     char buf[128];
     bool ret;
 
@@ -786,7 +787,11 @@ wasm_interp_call_func_native(WASMModuleInstance *module_inst,
 
     wasm_exec_env_set_cur_frame(exec_env, frame);
 
-    if (!func_import->func_ptr_linked) {
+    cur_func_index = cur_func - module_inst->functions;
+    bh_assert(cur_func_index < module_inst->module->import_function_count);
+    native_func_pointer = module_inst->import_func_ptrs[cur_func_index];
+
+    if (!native_func_pointer) {
         snprintf(buf, sizeof(buf),
                  "failed to call unlinked import function (%s, %s)",
                  func_import->module_name, func_import->field_name);
@@ -796,9 +801,8 @@ wasm_interp_call_func_native(WASMModuleInstance *module_inst,
 
     if (func_import->call_conv_wasm_c_api) {
         ret = wasm_runtime_invoke_c_api_native(
-            (WASMModuleInstanceCommon *)module_inst,
-            func_import->func_ptr_linked, func_import->func_type,
-            cur_func->param_cell_num, frame->lp,
+            (WASMModuleInstanceCommon *)module_inst, native_func_pointer,
+            func_import->func_type, cur_func->param_cell_num, frame->lp,
             func_import->wasm_c_api_with_env, func_import->attachment);
         if (ret) {
             argv_ret[0] = frame->lp[0];
@@ -807,13 +811,13 @@ wasm_interp_call_func_native(WASMModuleInstance *module_inst,
     }
     else if (!func_import->call_conv_raw) {
         ret = wasm_runtime_invoke_native(
-            exec_env, func_import->func_ptr_linked, func_import->func_type,
+            exec_env, native_func_pointer, func_import->func_type,
             func_import->signature, func_import->attachment, frame->lp,
             cur_func->param_cell_num, argv_ret);
     }
     else {
         ret = wasm_runtime_invoke_native_raw(
-            exec_env, func_import->func_ptr_linked, func_import->func_type,
+            exec_env, native_func_pointer, func_import->func_type,
             func_import->signature, func_import->attachment, frame->lp,
             cur_func->param_cell_num, argv_ret);
     }

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -580,6 +580,13 @@ functions_instantiate(const WASMModule *module, WASMModuleInstance *module_inst,
         return NULL;
     }
 
+    total_size = module->import_function_count * sizeof(void *);
+    if (!(module_inst->import_func_ptrs =
+              runtime_malloc(total_size, error_buf, error_buf_size))) {
+        wasm_runtime_free(functions);
+        return NULL;
+    }
+
     /* instantiate functions from import section */
     function = functions;
     import = module->import_functions;
@@ -607,6 +614,10 @@ functions_instantiate(const WASMModule *module, WASMModuleInstance *module_inst,
         function->local_cell_num = 0;
         function->local_count = 0;
         function->local_types = NULL;
+
+        /* Copy the function pointer to current instance */
+        module_inst->import_func_ptrs[i] =
+            function->u.func_import->func_ptr_linked;
 
         function++;
     }
@@ -1596,6 +1607,10 @@ wasm_deinstantiate(WASMModuleInstance *module_inst, bool is_sub_inst)
     if (module_inst->memory_count > 0)
         memories_deinstantiate(module_inst, module_inst->memories,
                                module_inst->memory_count);
+
+    if (module_inst->import_func_ptrs) {
+        wasm_runtime_free(module_inst->import_func_ptrs);
+    }
 
     tables_deinstantiate(module_inst->tables, module_inst->table_count);
     functions_deinstantiate(module_inst->functions,

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -580,7 +580,7 @@ functions_instantiate(const WASMModule *module, WASMModuleInstance *module_inst,
         return NULL;
     }
 
-    total_size = module->import_function_count * sizeof(void *);
+    total_size = sizeof(void *) * (uint64)module->import_function_count;
     if (!(module_inst->import_func_ptrs =
               runtime_malloc(total_size, error_buf, error_buf_size))) {
         wasm_runtime_free(functions);

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -165,6 +165,9 @@ struct WASMModuleInstance {
     uint32 export_tab_count;
 #endif
 
+    /* Array of function pointers to import functions */
+    void **import_func_ptrs;
+
     WASMMemoryInstance **memories;
     WASMTableInstance **tables;
     WASMGlobalInstance *globals;


### PR DESCRIPTION
Thanks @YoungWenMing for reporting the issue that import functions will be overwrite by further instance in PR #1118 

After some discussions, we decide to use this approach since it avoid copying unnecessary static information into instance.

