### PR TITLE
posix os_socket_inet_network: Use inet_addr instead of inet_network

### DIFF
--- a/core/shared/platform/common/posix/posix_socket.c
+++ b/core/shared/platform/common/posix/posix_socket.c
@@ -172,6 +172,7 @@ os_socket_inet_network(const char *cp, uint32 *out)
     if (!cp)
         return BHT_ERROR;
 
-    *out = inet_network(cp);
+    /* Note: ntohl(INADDR_NONE) == INADDR_NONE */
+    *out = ntohl(inet_addr(cp));
     return BHT_OK;
 }


### PR DESCRIPTION
* inet_addr is in posix. inet_network is not.

* NuttX doesn't have inet_network.