### PR TITLE
Fix execute_main not wait for other threads

### DIFF
--- a/core/iwasm/common/wasm_application.c
+++ b/core/iwasm/common/wasm_application.c
@@ -376,8 +376,8 @@ union ieee754_double {
 };
 
 static bool
-execute_func(WASMModuleInstanceCommon *module_inst,
-             const char *name, int32 argc, char *argv[])
+execute_func(WASMModuleInstanceCommon *module_inst, const char *name,
+             int32 argc, char *argv[])
 {
     WASMFunctionInstanceCommon *target_func;
     WASMModuleInstanceCommon *target_inst;

--- a/core/iwasm/common/wasm_exec_env.h
+++ b/core/iwasm/common/wasm_exec_env.h
@@ -100,6 +100,9 @@ typedef struct WASMExecEnv {
     korp_cond wait_cond;
     /* the count of threads which are joining current thread */
     uint32 wait_count;
+
+    /* whether current thread is detached */
+    bool thread_is_detached;
 #endif
 
 #if WASM_ENABLE_DEBUG_INTERP != 0

--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -710,6 +710,7 @@ wasm_cluster_detach_thread(WASMExecEnv *exec_env)
            joining it, otherwise let the system resources for the
            thread be released after joining */
         ret = os_thread_detach(exec_env->handle);
+        exec_env->thread_is_detached = true;
     }
     os_mutex_unlock(&cluster_list_lock);
     return ret;
@@ -799,6 +800,45 @@ wasm_cluster_terminate_all_except_self(WASMCluster *cluster,
                                        WASMExecEnv *exec_env)
 {
     traverse_list(&cluster->exec_env_list, terminate_thread_visitor,
+                  (void *)exec_env);
+}
+
+static void
+wait_for_thread_visitor(void *node, void *user_data)
+{
+    WASMExecEnv *curr_exec_env = (WASMExecEnv *)node;
+    WASMExecEnv *exec_env = (WASMExecEnv *)user_data;
+    korp_tid handle;
+    int ret;
+
+    if (curr_exec_env == exec_env)
+        return;
+
+    wasm_cluster_join_thread(curr_exec_env, NULL);
+
+    os_mutex_lock(&cluster_list_lock);
+    if (!clusters_have_exec_env(exec_env) || exec_env->thread_is_detached) {
+        os_mutex_unlock(&cluster_list_lock);
+        return;
+    }
+    exec_env->wait_count++;
+    handle = exec_env->handle;
+    os_mutex_unlock(&cluster_list_lock);
+    ret = os_thread_join(handle, NULL);
+    (void)ret;
+}
+
+void
+wams_cluster_wait_for_all(WASMCluster *cluster)
+{
+    traverse_list(&cluster->exec_env_list, wait_for_thread_visitor, NULL);
+}
+
+void
+wasm_cluster_wait_for_all_except_self(WASMCluster *cluster,
+                                      WASMExecEnv *exec_env)
+{
+    traverse_list(&cluster->exec_env_list, wait_for_thread_visitor,
                   (void *)exec_env);
 }
 

--- a/core/iwasm/libraries/thread-mgr/thread_manager.h
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.h
@@ -106,6 +106,13 @@ void
 wasm_cluster_terminate_all_except_self(WASMCluster *cluster,
                                        WASMExecEnv *exec_env);
 
+void
+wams_cluster_wait_for_all(WASMCluster *cluster);
+
+void
+wasm_cluster_wait_for_all_except_self(WASMCluster *cluster,
+                                      WASMExecEnv *exec_env);
+
 bool
 wasm_cluster_add_exec_env(WASMCluster *cluster, WASMExecEnv *exec_env);
 
@@ -148,8 +155,6 @@ typedef struct WASMCurrentEnvStatus {
     uint64 signal_flag : 32;
     uint64 step_count : 16;
     uint64 running_status : 16;
-    korp_mutex wait_lock;
-    korp_cond wait_cond;
 } WASMCurrentEnvStatus;
 
 WASMCurrentEnvStatus *


### PR DESCRIPTION
Fix wasm_application_execute_main/wasm_application_execute_func not waiting for
other threads to terminate in multi-thread mode, which causes that the exception
thrown by other threads may haven't been not spread the current main thread, and
cannot be detected by the caller, as reported in #1131.