### PR TITLE
Fix aot compiler compilation errors with llvm-14

### DIFF
--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -808,7 +808,6 @@ wait_for_thread_visitor(void *node, void *user_data)
 {
     WASMExecEnv *curr_exec_env = (WASMExecEnv *)node;
     WASMExecEnv *exec_env = (WASMExecEnv *)user_data;
-    korp_tid handle;
 
     if (curr_exec_env == exec_env)
         return;


### PR DESCRIPTION
Fix aot compiler compilation errors when the llvm version is 14.0,
and clear one compilation warning of thread_manager.c.