### PR TITLE
aot_emit_aot_file.c: Convert switch lookup table relocation

### DIFF
--- a/core/iwasm/compilation/aot_emit_aot_file.c
+++ b/core/iwasm/compilation/aot_emit_aot_file.c
@@ -2401,13 +2401,15 @@ aot_resolve_object_relocation_group(AOTObjectData *obj_data,
         relocation->relocation_type = (uint32)type;
         relocation->symbol_name = (char *)LLVMGetSymbolName(rel_sym);
 
-        /* for ".LCPIxxx", ".LJTIxxx" and ".LBBxxx" relocation,
-         * transform the symbol name to real section name and set
+        /* for ".LCPIxxx", ".LJTIxxx", ".LBBxxx" and switch lookup table
+         * relocation, transform the symbol name to real section name and set
          * addend to the offset of the symbol in the real section */
         if (relocation->symbol_name
             && (str_starts_with(relocation->symbol_name, ".LCPI")
                 || str_starts_with(relocation->symbol_name, ".LJTI")
-                || str_starts_with(relocation->symbol_name, ".LBB"))) {
+                || str_starts_with(relocation->symbol_name, ".LBB")
+                || str_starts_with(relocation->symbol_name,
+                                   ".Lswitch.table."))) {
             /* change relocation->relocation_addend and
                relocation->symbol_name */
             LLVMSectionIteratorRef contain_section;


### PR DESCRIPTION
With recent version of wamrc, one of my wasm modules is coverted to
an unloadable aot binary for armv7.
(I guess it's a side effect of the pass manager changes.)

```
AOT module load failed: resolve symbol .Lswitch.table.aot _func#82.2 failed
```

This commit replaces the relocations for such symbols with
.rodata section.