### PR TITLE
Fix some issues reported by Coverity

### DIFF
--- a/core/app-mgr/app-manager/module_wasm_app.c
+++ b/core/app-mgr/app-manager/module_wasm_app.c
@@ -491,9 +491,16 @@ wasm_app_routine(void *arg)
 fail2:
     /* Call WASM app onDestroy() method if there is */
     func_onDestroy = app_manager_lookup_function(inst, "_on_destroy", "()");
-    if (func_onDestroy)
-        wasm_runtime_call_wasm(wasm_app_data->exec_env, func_onDestroy, 0,
-                               NULL);
+    if (func_onDestroy) {
+        if (!wasm_runtime_call_wasm(wasm_app_data->exec_env, func_onDestroy, 0,
+                                    NULL)) {
+            const char *exception = wasm_runtime_get_exception(inst);
+            bh_assert(exception);
+            app_manager_printf("Got exception running WASM code: %s\n",
+                               exception);
+            wasm_runtime_clear_exception(inst);
+        }
+    }
 
 fail1:
 

--- a/core/iwasm/common/wasm_exec_env.c
+++ b/core/iwasm/common/wasm_exec_env.c
@@ -54,7 +54,6 @@ wasm_exec_env_create_internal(struct WASMModuleInstanceCommon *module_inst,
     if (!(exec_env->current_status = wasm_cluster_create_exenv_status()))
         goto fail4;
 #endif
-
 #endif
 
     exec_env->module_inst = module_inst;
@@ -84,13 +83,17 @@ fail4:
 fail3:
     os_mutex_destroy(&exec_env->wait_lock);
 fail2:
-#endif
 #if WASM_ENABLE_AOT != 0
     wasm_runtime_free(exec_env->argv_buf);
+#endif
+#endif /* end of WASM_ENABLE_THREAD_MGR != 0 */
+#if WASM_ENABLE_AOT != 0
 fail1:
 #endif
+#if WASM_ENABLE_THREAD_MGR != 0 || WASM_ENABLE_AOT != 0
     wasm_runtime_free(exec_env);
     return NULL;
+#endif
 }
 
 void

--- a/core/iwasm/common/wasm_exec_env.c
+++ b/core/iwasm/common/wasm_exec_env.c
@@ -83,17 +83,13 @@ fail4:
 fail3:
     os_mutex_destroy(&exec_env->wait_lock);
 fail2:
+#endif
 #if WASM_ENABLE_AOT != 0
     wasm_runtime_free(exec_env->argv_buf);
-#endif
-#endif /* end of WASM_ENABLE_THREAD_MGR != 0 */
-#if WASM_ENABLE_AOT != 0
 fail1:
 #endif
-#if WASM_ENABLE_THREAD_MGR != 0 || WASM_ENABLE_AOT != 0
     wasm_runtime_free(exec_env);
     return NULL;
-#endif
 }
 
 void

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -827,22 +827,22 @@ wasm_runtime_load_from_sections(WASMSection *section_list, bool is_aot,
 {
     WASMModuleCommon *module_common;
 
-#if WASM_ENABLE_INTERP != 0
     if (!is_aot) {
+#if WASM_ENABLE_INTERP != 0
         module_common = (WASMModuleCommon *)wasm_load_from_sections(
             section_list, error_buf, error_buf_size);
         return register_module_with_null_name(module_common, error_buf,
                                               error_buf_size);
-    }
 #endif
+    }
+    else {
 #if WASM_ENABLE_AOT != 0
-    if (is_aot) {
         module_common = (WASMModuleCommon *)aot_load_from_sections(
             section_list, error_buf, error_buf_size);
         return register_module_with_null_name(module_common, error_buf,
                                               error_buf_size);
-    }
 #endif
+    }
 
 #if WASM_ENABLE_INTERP == 0 || WASM_ENABLE_AOT == 0
     set_error_buf(error_buf, error_buf_size,

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -844,9 +844,11 @@ wasm_runtime_load_from_sections(WASMSection *section_list, bool is_aot,
     }
 #endif
 
+#if WASM_ENABLE_INTERP == 0 || WASM_ENABLE_AOT == 0
     set_error_buf(error_buf, error_buf_size,
                   "WASM module load failed: invalid section list type");
     return NULL;
+#endif
 }
 
 void

--- a/core/iwasm/compilation/aot_emit_memory.c
+++ b/core/iwasm/compilation/aot_emit_memory.c
@@ -141,7 +141,7 @@ aot_check_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             comp_ctx->comp_data->memories[0].num_bytes_per_page;
         uint32 init_page_count =
             comp_ctx->comp_data->memories[0].mem_init_page_count;
-        uint64 mem_data_size = num_bytes_per_page * init_page_count;
+        uint64 mem_data_size = (uint64)num_bytes_per_page * init_page_count;
 
         if (mem_offset + bytes <= mem_data_size) {
             /* inside memory space */

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -222,6 +222,8 @@ memory_instantiate(WASMModuleInstance *module_inst, uint32 num_bytes_per_page,
 
             /* Adjust __heap_base global value */
             global_idx = module->aux_heap_base_global_index;
+            bh_assert(module_inst->globals
+                      && global_idx < module_inst->global_count);
             global_addr = module_inst->global_data
                           + module_inst->globals[global_idx].data_offset;
             *(uint32 *)global_addr = aux_heap_base;
@@ -398,19 +400,6 @@ memories_instantiate(const WASMModule *module, WASMModuleInstance *module_inst,
                   module->memories[i].init_page_count,
                   module->memories[i].max_page_count, heap_size,
                   module->memories[i].flags, error_buf, error_buf_size))) {
-            memories_deinstantiate(module_inst, memories, memory_count);
-            return NULL;
-        }
-    }
-
-    if (mem_index == 0) {
-        /**
-         * no import memory and define memory, but still need heap
-         * for wasm code
-         */
-        if (!(memory = memories[mem_index++] =
-                  memory_instantiate(module_inst, 0, 0, 0, heap_size, 0,
-                                     error_buf, error_buf_size))) {
             memories_deinstantiate(module_inst, memories, memory_count);
             return NULL;
         }

--- a/samples/gui/wasm-runtime-wgl/src/platform/linux/iwasm_main.c
+++ b/samples/gui/wasm-runtime-wgl/src/platform/linux/iwasm_main.c
@@ -175,8 +175,8 @@ func_server_mode(void *arg)
     struct sockaddr_in serv_addr, cli_addr;
     int n;
     char buff[MAX];
-
     struct sigaction sa;
+
     sa.sa_handler = SIG_IGN;
     sa.sa_flags = 0;
     sigemptyset(&sa.sa_mask);

--- a/samples/gui/wasm-runtime-wgl/src/platform/linux/iwasm_main.c
+++ b/samples/gui/wasm-runtime-wgl/src/platform/linux/iwasm_main.c
@@ -178,6 +178,8 @@ func_server_mode(void *arg)
 
     struct sigaction sa;
     sa.sa_handler = SIG_IGN;
+    sa.sa_flags = 0;
+    sigemptyset(&sa.sa_mask);
     sigaction(SIGPIPE, &sa, 0);
 
     /* First call to socket() function */

--- a/samples/littlevgl/vgl-wasm-runtime/src/platform/linux/iwasm_main.c
+++ b/samples/littlevgl/vgl-wasm-runtime/src/platform/linux/iwasm_main.c
@@ -169,9 +169,11 @@ func_server_mode(void *arg)
     struct sockaddr_in serv_addr, cli_addr;
     int n;
     char buff[MAX];
-
     struct sigaction sa;
+
     sa.sa_handler = SIG_IGN;
+    sa.sa_flags = 0;
+    sigemptyset(&sa.sa_mask);
     sigaction(SIGPIPE, &sa, 0);
 
     /* First call to socket() function */

--- a/samples/simple/src/iwasm_main.c
+++ b/samples/simple/src/iwasm_main.c
@@ -178,9 +178,11 @@ func_server_mode(void *arg)
     struct sockaddr_in serv_addr, cli_addr;
     int n;
     char buff[MAX];
-
     struct sigaction sa;
+
     sa.sa_handler = SIG_IGN;
+    sa.sa_flags = 0;
+    sigemptyset(&sa.sa_mask);
     sigaction(SIGPIPE, &sa, 0);
 
     /* First call to socket() function */

--- a/test-tools/host-tool/src/transport.c
+++ b/test-tools/host-tool/src/transport.c
@@ -125,6 +125,7 @@ bool
 udp_send(const char *address, int port, const char *buf, int len)
 {
     int sockfd;
+    ssize_t size_sent;
     struct sockaddr_in servaddr;
 
     if ((sockfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0)
@@ -136,11 +137,11 @@ udp_send(const char *address, int port, const char *buf, int len)
     servaddr.sin_port = htons(port);
     servaddr.sin_addr.s_addr = INADDR_ANY;
 
-    sendto(sockfd, buf, len, MSG_CONFIRM, (const struct sockaddr *)&servaddr,
-           sizeof(servaddr));
+    size_sent = sendto(sockfd, buf, len, MSG_CONFIRM,
+                       (const struct sockaddr *)&servaddr, sizeof(servaddr));
 
     close(sockfd);
-    return true;
+    return (size_sent != -1) ? true : false;
 }
 
 bool


### PR DESCRIPTION
module_wasm_app.c: add return value check for wasm_runtime_call_wasm
aot_runtime.c: add return value check for aot_get_default_memory
aot_runtime.c: add return value  check before calling wasm app malloc/free func
wasm_runtime_common.c: fix dead code warning in wasm_runtime_load_from_sections
aot_emit_memory.c: fix potential integer overflow issue
wasm_runtime.c: remove dead code in memory_instantiate, add assertion for globals
samples simple/gui/littlevgl: fix fields of struct sigaction initialization issue
host-tool: add return value check for sendto
