### PR TITLE
Enlarge max pool size and fix bh_memcpy_s size check

### DIFF
--- a/core/iwasm/common/wasm_memory.c
+++ b/core/iwasm/common/wasm_memory.c
@@ -86,7 +86,7 @@ wasm_runtime_memory_pool_size()
     if (memory_mode == MEMORY_MODE_POOL)
         return global_pool_size;
     else
-        return 1 * BH_GB;
+        return UINT32_MAX;
 }
 
 static inline void *

--- a/core/iwasm/common/wasm_memory.h
+++ b/core/iwasm/common/wasm_memory.h
@@ -20,6 +20,9 @@ wasm_runtime_memory_init(mem_alloc_type_t mem_alloc_type,
 void
 wasm_runtime_memory_destroy();
 
+unsigned
+wasm_runtime_memory_pool_size();
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -10,6 +10,7 @@
 #include "wasm_opcode.h"
 #include "wasm_runtime.h"
 #include "../common/wasm_native.h"
+#include "../common/wasm_memory.h"
 #if WASM_ENABLE_DEBUG_INTERP != 0
 #include "../libraries/debug-engine/debug_engine.h"
 #endif
@@ -1228,9 +1229,6 @@ load_table_import(const uint8 **p_buf, const uint8 *buf_end,
 fail:
     return false;
 }
-
-unsigned
-wasm_runtime_memory_pool_size();
 
 static bool
 check_memory_init_size(uint32 init_size, char *error_buf, uint32 error_buf_size)

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -10,6 +10,7 @@
 #include "wasm_opcode.h"
 #include "wasm_runtime.h"
 #include "../common/wasm_native.h"
+#include "../common/wasm_memory.h"
 
 /* Read a value of given type from the address pointed to by the given
    pointer and increase the pointer to the position just after the
@@ -496,9 +497,6 @@ load_table_import(const uint8 **p_buf, const uint8 *buf_end,
     table->max_size = declare_max_size;
     return true;
 }
-
-unsigned
-wasm_runtime_memory_pool_size();
 
 static bool
 load_memory_import(const uint8 **p_buf, const uint8 *buf_end,

--- a/core/shared/utils/bh_common.c
+++ b/core/shared/utils/bh_common.c
@@ -5,12 +5,6 @@
 
 #include "bh_common.h"
 
-#ifdef RSIZE_MAX
-#undef RSIZE_MAX
-#endif
-
-#define RSIZE_MAX 0x7FFFFFFF
-
 int
 b_memcpy_s(void *s1, unsigned int s1max, const void *s2, unsigned int n)
 {
@@ -20,7 +14,7 @@ b_memcpy_s(void *s1, unsigned int s1max, const void *s2, unsigned int n)
         return 0;
     }
 
-    if (s1 == NULL || s1max > RSIZE_MAX) {
+    if (s1 == NULL) {
         return -1;
     }
     if (s2 == NULL || n > s1max) {
@@ -40,7 +34,7 @@ b_memmove_s(void *s1, unsigned int s1max, const void *s2, unsigned int n)
         return 0;
     }
 
-    if (s1 == NULL || s1max > RSIZE_MAX) {
+    if (s1 == NULL) {
         return -1;
     }
     if (s2 == NULL || n > s1max) {
@@ -54,8 +48,7 @@ b_memmove_s(void *s1, unsigned int s1max, const void *s2, unsigned int n)
 int
 b_strcat_s(char *s1, unsigned int s1max, const char *s2)
 {
-    if (NULL == s1 || NULL == s2 || s1max < (strlen(s1) + strlen(s2) + 1)
-        || s1max > RSIZE_MAX) {
+    if (NULL == s1 || NULL == s2 || s1max < (strlen(s1) + strlen(s2) + 1)) {
         return -1;
     }
 
@@ -66,8 +59,7 @@ b_strcat_s(char *s1, unsigned int s1max, const char *s2)
 int
 b_strcpy_s(char *s1, unsigned int s1max, const char *s2)
 {
-    if (NULL == s1 || NULL == s2 || s1max < (strlen(s2) + 1)
-        || s1max > RSIZE_MAX) {
+    if (NULL == s1 || NULL == s2 || s1max < (strlen(s2) + 1)) {
         return -1;
     }
 


### PR DESCRIPTION
Enlarge max pool size and fix bh_memcpy_s size check to support
large linear memory, e.g. with initial page count 65535.