### PR TITLE
Auto dump mem/perf profiling in execute_main/execute_func

### DIFF
--- a/core/iwasm/common/wasm_application.c
+++ b/core/iwasm/common/wasm_application.c
@@ -212,6 +212,8 @@ wasm_application_execute_main(WASMModuleInstanceCommon *module_inst, int32 argc,
     bool ret;
 #if WASM_ENABLE_THREAD_MGR != 0
     WASMCluster *cluster;
+#endif
+#if WASM_ENABLE_THREAD_MGR != 0 || WASM_ENABLE_MEMORY_PROFILING != 0
     WASMExecEnv *exec_env;
 #endif
 
@@ -222,6 +224,17 @@ wasm_application_execute_main(WASMModuleInstanceCommon *module_inst, int32 argc,
     if (exec_env && (cluster = wasm_exec_env_get_cluster(exec_env))) {
         wasm_cluster_wait_for_all_except_self(cluster, exec_env);
     }
+#endif
+
+#if WASM_ENABLE_MEMORY_PROFILING != 0
+    exec_env = wasm_runtime_get_exec_env_singleton(module_inst);
+    if (exec_env) {
+        wasm_runtime_dump_mem_consumption(exec_env);
+    }
+#endif
+
+#if WASM_ENABLE_PERF_PROFILING != 0
+    wasm_runtime_dump_perf_profiling(module_inst);
 #endif
 
     return (ret && !wasm_runtime_get_exception(module_inst)) ? true : false;
@@ -721,6 +734,8 @@ wasm_application_execute_func(WASMModuleInstanceCommon *module_inst,
     bool ret;
 #if WASM_ENABLE_THREAD_MGR != 0
     WASMCluster *cluster;
+#endif
+#if WASM_ENABLE_THREAD_MGR != 0 || WASM_ENABLE_MEMORY_PROFILING != 0
     WASMExecEnv *exec_env;
 #endif
 
@@ -731,6 +746,17 @@ wasm_application_execute_func(WASMModuleInstanceCommon *module_inst,
     if (exec_env && (cluster = wasm_exec_env_get_cluster(exec_env))) {
         wasm_cluster_wait_for_all_except_self(cluster, exec_env);
     }
+#endif
+
+#if WASM_ENABLE_MEMORY_PROFILING != 0
+    exec_env = wasm_runtime_get_exec_env_singleton(module_inst);
+    if (exec_env) {
+        wasm_runtime_dump_mem_consumption(exec_env);
+    }
+#endif
+
+#if WAMR_ENABLE_PERF_PROFILING != 0
+    wasm_runtime_dump_perf_profiling(module_inst);
 #endif
 
     return (ret && !wasm_runtime_get_exception(module_inst)) ? true : false;

--- a/core/iwasm/compilation/aot_compiler.h
+++ b/core/iwasm/compilation/aot_compiler.h
@@ -371,11 +371,6 @@ aot_emit_aot_file_buf(AOTCompContext *comp_ctx, AOTCompData *comp_data,
 bool
 aot_emit_object_file(AOTCompContext *comp_ctx, char *file_name);
 
-uint8 *
-aot_compile_wasm_file(const uint8 *wasm_file_buf, uint32 wasm_file_size,
-                      uint32 opt_level, uint32 size_level, char *error_buf,
-                      uint32 error_buf_size, uint32 *p_aot_file_size);
-
 #ifdef __cplusplus
 } /* end of extern "C" */
 #endif


### PR DESCRIPTION
Automatically dump memory/performance profiling data in
wasm_application_execute_main and wasm_application_execute_func when
the related feature is enabled.

And remove unused aot_compile_wasm_file func declaration in aot_compiler.h.