### PR TITLE
Fix the unrecoverable SIGSEGV when checking hardware boundary

### DIFF
--- a/core/shared/platform/common/posix/posix_thread.c
+++ b/core/shared/platform/common/posix/posix_thread.c
@@ -387,10 +387,6 @@ static uint32
 touch_pages(uint8 *stack_min_addr, uint32 page_size)
 {
     uint8 sum = 0;
-
-    if (stack_min_addr == 0)
-        return sum;
-
     while (1) {
         volatile uint8 *touch_addr = (volatile uint8 *)os_alloca(page_size / 2);
         if (touch_addr < stack_min_addr + page_size) {
@@ -415,7 +411,7 @@ init_stack_guard_pages()
     uint32 guard_page_count = STACK_OVERFLOW_CHECK_GUARD_PAGE_COUNT;
     uint8 *stack_min_addr = os_thread_get_stack_boundary();
 
-    if (stack_min_addr == 0)
+    if (stack_min_addr == NULL)
         return false;
 
     /* Touch each stack page to ensure that it has been mapped: the OS

--- a/core/shared/platform/common/posix/posix_thread.c
+++ b/core/shared/platform/common/posix/posix_thread.c
@@ -387,6 +387,10 @@ static uint32
 touch_pages(uint8 *stack_min_addr, uint32 page_size)
 {
     uint8 sum = 0;
+
+    if (stack_min_addr == 0)
+        return sum;
+
     while (1) {
         volatile uint8 *touch_addr = (volatile uint8 *)os_alloca(page_size / 2);
         if (touch_addr < stack_min_addr + page_size) {
@@ -410,6 +414,9 @@ init_stack_guard_pages()
     uint32 page_size = os_getpagesize();
     uint32 guard_page_count = STACK_OVERFLOW_CHECK_GUARD_PAGE_COUNT;
     uint8 *stack_min_addr = os_thread_get_stack_boundary();
+
+    if (stack_min_addr == 0)
+        return false;
 
     /* Touch each stack page to ensure that it has been mapped: the OS
        may lazily grow the stack mapping as a guard page is hit. */


### PR DESCRIPTION
## Expected behavior

If the minimum stack address (`stack_min_addr`) is **incorrect**, an error should occur as shown below.

```bash
[utilhome1@h25 ~]$ ./iwasm test.wasm
page_size (f: stack_guard_pages): 4096
stack_min_addr (f: stack_guard_pages): 0x0
Failed to init stack guard pages
Init runtime environment failed.
```

If the minimum stack address (`stack_min_addr`) is **correct**, it appears as follows:

```
[root@centos6 build]# ./iwasm test.wasm 
page_size (f: stack_guard_pages): 4096
stack_min_addr (f: stack_guard_pages): 0x924b1000
stack_min_addr (f: touch_pages): 0x924b1000
sum (f: touch_pages): 0
Hello world!
buf ptr: 0x11500
buf: 123
```

## Actual behavior

If the minimum stack address (`stack_min_addr`) is **incorrect**, an unrecoverable SIGSEGV will occur.

```
[utilhome1@h25 ~]$ ./iwasm test.wasm
page_size (f: stack_guard_pages): 4096
stack_min_addr (f: stack_guard_pages): 0x0
stack_min_addr (f: touch_pages): 0x0
Segmentation Fault   <--- unrecoverable SIGSEGV
```

## Related issues
  * #1058
  * #802
