### PR TITLE
Enable opaque pointer for aot compiler to fit LLVM 14/15

### DIFF
--- a/build-scripts/build_llvm.py
+++ b/build-scripts/build_llvm.py
@@ -35,14 +35,13 @@ def build_llvm(llvm_dir, platform, backends, projects):
         '-DCMAKE_BUILD_TYPE:STRING="Release"',
         "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
         "-DLLVM_APPEND_VC_REV:BOOL=ON",
-        "-DLLVM_BUILD_BENCHMARKS:BOOL=OFF",
-        "-DLLVM_BUILD_DOCS:BOOL=OFF",
         "-DLLVM_BUILD_EXAMPLES:BOOL=OFF",
         "-DLLVM_BUILD_LLVM_DYLIB:BOOL=OFF",
         "-DLLVM_BUILD_TESTS:BOOL=OFF",
         "-DLLVM_CCACHE_BUILD:BOOL=OFF",
         "-DLLVM_ENABLE_BINDINGS:BOOL=OFF",
         "-DLLVM_ENABLE_IDE:BOOL=OFF",
+        "-DLLVM_ENABLE_LIBEDIT=OFF",
         "-DLLVM_ENABLE_TERMINFO:BOOL=OFF",
         "-DLLVM_ENABLE_ZLIB:BOOL=OFF",
         "-DLLVM_INCLUDE_BENCHMARKS:BOOL=OFF",
@@ -133,21 +132,21 @@ def build_llvm(llvm_dir, platform, backends, projects):
 def repackage_llvm(llvm_dir):
     build_dir = llvm_dir.joinpath("./build").resolve()
 
-    packs = [f for f in build_dir.glob("LLVM-13*.tar.gz")]
+    packs = [f for f in build_dir.glob("LLVM-15*.tar.gz")]
     if len(packs) > 1:
-        raise Exception("Find more than one LLVM-13*.tar.gz")
+        raise Exception("Find more than one LLVM-15*.tar.gz")
 
     if not packs:
         return
 
     llvm_package = packs[0].name
-    # mv build/LLVM-13.0.0*.gz .
+    # mv build/LLVM-15.0.0*.gz .
     shutil.move(str(build_dir.joinpath(llvm_package).resolve()), str(llvm_dir))
     # rm -r build
     shutil.rmtree(str(build_dir))
     # mkdir build
     build_dir.mkdir()
-    # tar xf ./LLVM-13.0.0-*.tar.gz --strip-components=1 --directory=build
+    # tar xf ./LLVM-15.0.0-*.tar.gz --strip-components=1 --directory=build
     CMD = f"tar xf {llvm_dir.joinpath(llvm_package).resolve()} --strip-components=1 --directory={build_dir}"
     subprocess.check_call(shlex.split(CMD), cwd=llvm_dir)
 
@@ -204,11 +203,11 @@ def main():
     llvm_repo_and_branch = {
         "arc": {
             "repo": "https://github.com/llvm/llvm-project.git",
-            "branch": "release/13.x",
+            "branch": "main",
         },
         "xtensa": {
             "repo": "https://github.com/espressif/llvm-project.git",
-            "branch": "xtensa_release_13.0.0",
+            "branch": "xtensa_release_14.0.0",
         },
         "default": {
             "repo": "https://github.com/llvm/llvm-project.git",

--- a/build-scripts/build_llvm.py
+++ b/build-scripts/build_llvm.py
@@ -132,21 +132,21 @@ def build_llvm(llvm_dir, platform, backends, projects):
 def repackage_llvm(llvm_dir):
     build_dir = llvm_dir.joinpath("./build").resolve()
 
-    packs = [f for f in build_dir.glob("LLVM-15*.tar.gz")]
+    packs = [f for f in build_dir.glob("LLVM-14*.tar.gz")]
     if len(packs) > 1:
-        raise Exception("Find more than one LLVM-15*.tar.gz")
+        raise Exception("Find more than one LLVM-14*.tar.gz")
 
     if not packs:
         return
 
     llvm_package = packs[0].name
-    # mv build/LLVM-15.0.0*.gz .
+    # mv build/LLVM-14.0.0*.gz .
     shutil.move(str(build_dir.joinpath(llvm_package).resolve()), str(llvm_dir))
     # rm -r build
     shutil.rmtree(str(build_dir))
     # mkdir build
     build_dir.mkdir()
-    # tar xf ./LLVM-15.0.0-*.tar.gz --strip-components=1 --directory=build
+    # tar xf ./LLVM-14.0.0-*.tar.gz --strip-components=1 --directory=build
     CMD = f"tar xf {llvm_dir.joinpath(llvm_package).resolve()} --strip-components=1 --directory={build_dir}"
     subprocess.check_call(shlex.split(CMD), cwd=llvm_dir)
 
@@ -203,7 +203,7 @@ def main():
     llvm_repo_and_branch = {
         "arc": {
             "repo": "https://github.com/llvm/llvm-project.git",
-            "branch": "main",
+            "branch": "release/14.x",
         },
         "xtensa": {
             "repo": "https://github.com/espressif/llvm-project.git",
@@ -211,7 +211,7 @@ def main():
         },
         "default": {
             "repo": "https://github.com/llvm/llvm-project.git",
-            "branch": "main",
+            "branch": "release/14.x",
         },
     }
 

--- a/build-scripts/build_llvm.py
+++ b/build-scripts/build_llvm.py
@@ -212,7 +212,7 @@ def main():
         },
         "default": {
             "repo": "https://github.com/llvm/llvm-project.git",
-            "branch": "release/13.x",
+            "branch": "main",
         },
     }
 

--- a/core/iwasm/compilation/aot_emit_const.c
+++ b/core/iwasm/compilation/aot_emit_const.c
@@ -72,7 +72,8 @@ aot_compile_op_f32_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             aot_set_last_error("llvm build bitcast failed.");
             return false;
         }
-        if (!(value = LLVMBuildLoad(comp_ctx->builder, alloca, ""))) {
+        if (!(value =
+                  LLVMBuildLoad2(comp_ctx->builder, F32_TYPE, alloca, ""))) {
             aot_set_last_error("llvm build load failed.");
             return false;
         }
@@ -127,7 +128,8 @@ aot_compile_op_f64_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             aot_set_last_error("llvm build bitcast failed.");
             return false;
         }
-        if (!(value = LLVMBuildLoad(comp_ctx->builder, alloca, ""))) {
+        if (!(value =
+                  LLVMBuildLoad2(comp_ctx->builder, F64_TYPE, alloca, ""))) {
             aot_set_last_error("llvm build load failed.");
             return false;
         }

--- a/core/iwasm/compilation/aot_emit_control.c
+++ b/core/iwasm/compilation/aot_emit_control.c
@@ -677,9 +677,9 @@ check_suspend_flags(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
     /* Offset of suspend_flags */
     offset = I32_FIVE;
 
-    if (!(terminate_addr =
-              LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->exec_env,
-                                   &offset, 1, "terminate_addr"))) {
+    if (!(terminate_addr = LLVMBuildInBoundsGEP2(
+              comp_ctx->builder, OPQ_PTR_TYPE, func_ctx->exec_env, &offset, 1,
+              "terminate_addr"))) {
         aot_set_last_error("llvm build in bounds gep failed");
         return false;
     }
@@ -690,8 +690,9 @@ check_suspend_flags(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
         return false;
     }
 
-    if (!(terminate_flags = LLVMBuildLoad(comp_ctx->builder, terminate_addr,
-                                          "terminate_flags"))) {
+    if (!(terminate_flags =
+              LLVMBuildLoad2(comp_ctx->builder, I32_TYPE, terminate_addr,
+                             "terminate_flags"))) {
         aot_set_last_error("llvm build bit cast failed");
         return false;
     }

--- a/core/iwasm/compilation/aot_emit_exception.c
+++ b/core/iwasm/compilation/aot_emit_exception.c
@@ -96,7 +96,8 @@ aot_emit_exception(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         /* Call the aot_set_exception_with_id() function */
         param_values[0] = func_ctx->aot_inst;
         param_values[1] = func_ctx->exception_id_phi;
-        if (!LLVMBuildCall(comp_ctx->builder, func, param_values, 2, "")) {
+        if (!LLVMBuildCall2(comp_ctx->builder, func_type, func, param_values, 2,
+                            "")) {
             aot_set_last_error("llvm build call failed.");
             return false;
         }

--- a/core/iwasm/compilation/aot_emit_function.c
+++ b/core/iwasm/compilation/aot_emit_function.c
@@ -881,7 +881,7 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         }
     }
     else {
-#if LLVM_VERSION_MAJOR >= 15
+#if LLVM_VERSION_MAJOR >= 14
         LLVMTypeRef llvm_func_type;
 #endif
         bool recursive_call =
@@ -950,7 +950,7 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             && !check_stack_boundary(comp_ctx, func_ctx, callee_cell_num))
             goto fail;
 
-#if LLVM_VERSION_MAJOR >= 15
+#if LLVM_VERSION_MAJOR >= 14
         llvm_func_type = func_ctxes[func_idx - import_func_count]->func_type;
 #endif
 

--- a/core/iwasm/compilation/aot_emit_function.c
+++ b/core/iwasm/compilation/aot_emit_function.c
@@ -57,8 +57,8 @@ check_exception_thrown(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 
     /* Load the first byte of aot_module_inst->cur_exception, and check
        whether it is '\0'. If yes, no exception was thrown. */
-    if (!(value = LLVMBuildLoad(comp_ctx->builder, func_ctx->cur_exception,
-                                "exce_value"))
+    if (!(value = LLVMBuildLoad2(comp_ctx->builder, INT8_TYPE,
+                                 func_ctx->cur_exception, "exce_value"))
         || !(cmp = LLVMBuildICmp(comp_ctx->builder, LLVMIntEQ, value, I8_ZERO,
                                  "cmp"))) {
         aot_set_last_error("llvm build icmp failed.");
@@ -207,8 +207,9 @@ call_aot_invoke_native_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         }
 
         snprintf(buf, sizeof(buf), "%s%d", "elem", i);
-        if (!(elem_ptr = LLVMBuildInBoundsGEP(
-                  comp_ctx->builder, func_ctx->argv_buf, &elem_idx, 1, buf))
+        if (!(elem_ptr =
+                  LLVMBuildInBoundsGEP2(comp_ctx->builder, I32_TYPE,
+                                        func_ctx->argv_buf, &elem_idx, 1, buf))
             || !(elem_ptr = LLVMBuildBitCast(comp_ctx->builder, elem_ptr,
                                              elem_ptr_type, buf))) {
             aot_set_last_error("llvm build bit cast failed.");
@@ -236,8 +237,8 @@ call_aot_invoke_native_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     }
 
     /* call aot_invoke_native() function */
-    if (!(res = LLVMBuildCall(comp_ctx->builder, func, func_param_values, 4,
-                              "res"))) {
+    if (!(res = LLVMBuildCall2(comp_ctx->builder, func_type, func,
+                               func_param_values, 4, "res"))) {
         aot_set_last_error("llvm build call failed.");
         return false;
     }
@@ -255,8 +256,8 @@ call_aot_invoke_native_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             aot_set_last_error("llvm build bit cast failed.");
             return false;
         }
-        if (!(*p_value_ret =
-                  LLVMBuildLoad(comp_ctx->builder, value_ret, "value_ret"))) {
+        if (!(*p_value_ret = LLVMBuildLoad2(comp_ctx->builder, ret_type,
+                                            value_ret, "value_ret"))) {
             aot_set_last_error("llvm build load failed.");
             return false;
         }
@@ -299,14 +300,15 @@ lookup_orcjit_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     LLVMPositionBuilderAtEnd(comp_ctx->builder, block_curr);
 
     /* Load function pointer */
-    if (!(func_ptr =
-              LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->func_ptrs,
-                                   &func_idx, 1, "func_ptr_tmp"))) {
+    if (!(func_ptr = LLVMBuildInBoundsGEP2(comp_ctx->builder, OPQ_PTR_TYPE,
+                                           func_ctx->func_ptrs, &func_idx, 1,
+                                           "func_ptr_tmp"))) {
         aot_set_last_error("llvm build inbounds gep failed.");
         return false;
     }
 
-    if (!(func = LLVMBuildLoad(comp_ctx->builder, func_ptr, "func_ptr"))) {
+    if (!(func = LLVMBuildLoad2(comp_ctx->builder, OPQ_PTR_TYPE, func_ptr,
+                                "func_ptr"))) {
         aot_set_last_error("llvm build load failed.");
         return false;
     }
@@ -364,8 +366,8 @@ lookup_orcjit_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     }
 
     /* Call the function */
-    if (!(func = LLVMBuildCall(comp_ctx->builder, func, param_values, 3,
-                               "call_orcjit_lookup"))) {
+    if (!(func = LLVMBuildCall2(comp_ctx->builder, func_type, func,
+                                param_values, 3, "call_orcjit_lookup"))) {
         aot_set_last_error("LLVM build call failed.");
         return false;
     }
@@ -410,8 +412,9 @@ call_aot_alloc_frame_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     param_values[0] = func_ctx->exec_env;
     param_values[1] = func_idx;
 
-    if (!(ret_value = LLVMBuildCall(comp_ctx->builder, func, param_values, 2,
-                                    "call_aot_alloc_frame"))) {
+    if (!(ret_value =
+              LLVMBuildCall2(comp_ctx->builder, func_type, func, param_values,
+                             2, "call_aot_alloc_frame"))) {
         aot_set_last_error("llvm build call failed.");
         return false;
     }
@@ -462,8 +465,8 @@ call_aot_free_frame_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 
     param_values[0] = func_ctx->exec_env;
 
-    if (!(ret_value = LLVMBuildCall(comp_ctx->builder, func, param_values, 1,
-                                    "call_aot_free_frame"))) {
+    if (!(ret_value = LLVMBuildCall2(comp_ctx->builder, func_type, func,
+                                     param_values, 1, "call_aot_free_frame"))) {
         aot_set_last_error("llvm build call failed.");
         return false;
     }
@@ -488,8 +491,8 @@ check_stack_boundary(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         return false;
     }
 
-    if (!(stack_bound = LLVMBuildInBoundsGEP(
-              comp_ctx->builder, func_ctx->native_stack_bound,
+    if (!(stack_bound = LLVMBuildInBoundsGEP2(
+              comp_ctx->builder, INT8_TYPE, func_ctx->native_stack_bound,
               &callee_local_size, 1, "stack_bound"))) {
         aot_set_last_error("llvm build inbound gep failed.");
         return false;
@@ -603,8 +606,8 @@ check_app_addr_and_convert(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     }
 
     /* call aot_check_app_addr_and_convert() function */
-    if (!(res = LLVMBuildCall(comp_ctx->builder, func, func_param_values, 5,
-                              "res"))) {
+    if (!(res = LLVMBuildCall2(comp_ctx->builder, func_type, func,
+                               func_param_values, 5, "res"))) {
         aot_set_last_error("llvm build call failed.");
         return false;
     }
@@ -614,8 +617,9 @@ check_app_addr_and_convert(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         return false;
     }
 
-    if (!(*p_native_addr_converted = LLVMBuildLoad(
-              comp_ctx->builder, native_addr_ptr, "native_addr"))) {
+    if (!(*p_native_addr_converted =
+              LLVMBuildLoad2(comp_ctx->builder, OPQ_PTR_TYPE, native_addr_ptr,
+                             "native_addr"))) {
         aot_set_last_error("llvm build load failed.");
         return false;
     }
@@ -734,9 +738,9 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             }
 
             snprintf(buf, sizeof(buf), "ext_ret%d_ptr", i);
-            if (!(ext_ret_ptr = LLVMBuildInBoundsGEP(comp_ctx->builder,
-                                                     func_ctx->argv_buf,
-                                                     &ext_ret_idx, 1, buf))) {
+            if (!(ext_ret_ptr = LLVMBuildInBoundsGEP2(
+                      comp_ctx->builder, I32_TYPE, func_ctx->argv_buf,
+                      &ext_ret_idx, 1, buf))) {
                 aot_set_last_error("llvm build GEP failed.");
                 goto fail;
             }
@@ -841,15 +845,15 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             }
 
             /* Load function pointer */
-            if (!(func_ptr = LLVMBuildInBoundsGEP(
-                      comp_ctx->builder, func_ctx->func_ptrs, &import_func_idx,
-                      1, "native_func_ptr_tmp"))) {
+            if (!(func_ptr = LLVMBuildInBoundsGEP2(
+                      comp_ctx->builder, OPQ_PTR_TYPE, func_ctx->func_ptrs,
+                      &import_func_idx, 1, "native_func_ptr_tmp"))) {
                 aot_set_last_error("llvm build inbounds gep failed.");
                 goto fail;
             }
 
-            if (!(func_ptr = LLVMBuildLoad(comp_ctx->builder, func_ptr,
-                                           "native_func_ptr"))) {
+            if (!(func_ptr = LLVMBuildLoad2(comp_ctx->builder, OPQ_PTR_TYPE,
+                                            func_ptr, "native_func_ptr"))) {
                 aot_set_last_error("llvm build load failed.");
                 goto fail;
             }
@@ -861,8 +865,8 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             }
 
             /* Call the function */
-            if (!(value_ret = LLVMBuildCall(
-                      comp_ctx->builder, func, param_values,
+            if (!(value_ret = LLVMBuildCall2(
+                      comp_ctx->builder, native_func_type, func, param_values,
                       (uint32)param_count + 1 + ext_ret_count,
                       (func_type->result_count > 0 ? "call" : "")))) {
                 aot_set_last_error("LLVM build call failed.");
@@ -877,6 +881,9 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         }
     }
     else {
+#if LLVM_VERSION_MAJOR >= 15
+        LLVMTypeRef llvm_func_type;
+#endif
         bool recursive_call =
             (func_ctx == func_ctxes[func_idx - import_func_count]) ? true
                                                                    : false;
@@ -943,11 +950,15 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             && !check_stack_boundary(comp_ctx, func_ctx, callee_cell_num))
             goto fail;
 
+#if LLVM_VERSION_MAJOR >= 15
+        llvm_func_type = func_ctxes[func_idx - import_func_count]->func_type;
+#endif
+
         /* Call the function */
-        if (!(value_ret =
-                  LLVMBuildCall(comp_ctx->builder, func, param_values,
-                                (uint32)param_count + 1 + ext_ret_count,
-                                (func_type->result_count > 0 ? "call" : "")))) {
+        if (!(value_ret = LLVMBuildCall2(
+                  comp_ctx->builder, llvm_func_type, func, param_values,
+                  (uint32)param_count + 1 + ext_ret_count,
+                  (func_type->result_count > 0 ? "call" : "")))) {
             aot_set_last_error("LLVM build call failed.");
             goto fail;
         }
@@ -972,9 +983,9 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         /* Load extra result from its address and push to stack */
         for (i = 0; i < ext_ret_count; i++) {
             snprintf(buf, sizeof(buf), "func%d_ext_ret%d", func_idx, i);
-            if (!(ext_ret =
-                      LLVMBuildLoad(comp_ctx->builder,
-                                    param_values[1 + param_count + i], buf))) {
+            if (!(ext_ret = LLVMBuildLoad2(
+                      comp_ctx->builder, TO_LLVM_TYPE(ext_ret_types[i]),
+                      param_values[1 + param_count + i], buf))) {
                 aot_set_last_error("llvm build load failed.");
                 goto fail;
             }
@@ -1084,8 +1095,9 @@ call_aot_call_indirect_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         }
 
         snprintf(buf, sizeof(buf), "%s%d", "elem", i);
-        if (!(elem_ptr = LLVMBuildInBoundsGEP(
-                  comp_ctx->builder, func_ctx->argv_buf, &elem_idx, 1, buf))
+        if (!(elem_ptr =
+                  LLVMBuildInBoundsGEP2(comp_ctx->builder, I32_TYPE,
+                                        func_ctx->argv_buf, &elem_idx, 1, buf))
             || !(elem_ptr = LLVMBuildBitCast(comp_ctx->builder, elem_ptr,
                                              elem_ptr_type, buf))) {
             aot_set_last_error("llvm build bit cast failed.");
@@ -1114,8 +1126,8 @@ call_aot_call_indirect_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     }
 
     /* call aot_call_indirect() function */
-    if (!(res = LLVMBuildCall(comp_ctx->builder, func, func_param_values, 5,
-                              "res"))) {
+    if (!(res = LLVMBuildCall2(comp_ctx->builder, func_type, func,
+                               func_param_values, 5, "res"))) {
         aot_set_last_error("llvm build call failed.");
         return false;
     }
@@ -1131,8 +1143,9 @@ call_aot_call_indirect_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         }
 
         snprintf(buf, sizeof(buf), "argv_ret%d", i);
-        if (!(ret_ptr = LLVMBuildInBoundsGEP(
-                  comp_ctx->builder, func_ctx->argv_buf, &ret_idx, 1, buf))
+        if (!(ret_ptr =
+                  LLVMBuildInBoundsGEP2(comp_ctx->builder, I32_TYPE,
+                                        func_ctx->argv_buf, &ret_idx, 1, buf))
             || !(ret_ptr = LLVMBuildBitCast(comp_ctx->builder, ret_ptr,
                                             ret_ptr_type, buf))) {
             aot_set_last_error("llvm build GEP or bit cast failed.");
@@ -1140,7 +1153,8 @@ call_aot_call_indirect_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         }
 
         snprintf(buf, sizeof(buf), "ret%d", i);
-        if (!(value_rets[i] = LLVMBuildLoad(comp_ctx->builder, ret_ptr, buf))) {
+        if (!(value_rets[i] =
+                  LLVMBuildLoad2(comp_ctx->builder, ret_type, ret_ptr, buf))) {
             aot_set_last_error("llvm build load failed.");
             return false;
         }
@@ -1208,8 +1222,9 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         goto fail;
     }
 
-    if (!(table_size_const = LLVMBuildGEP(comp_ctx->builder, func_ctx->aot_inst,
-                                          &offset, 1, "cur_size_i8p"))) {
+    if (!(table_size_const = LLVMBuildInBoundsGEP2(comp_ctx->builder, INT8_TYPE,
+                                                   func_ctx->aot_inst, &offset,
+                                                   1, "cur_size_i8p"))) {
         HANDLE_FAILURE("LLVMBuildGEP");
         goto fail;
     }
@@ -1221,8 +1236,8 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         goto fail;
     }
 
-    if (!(table_size_const =
-              LLVMBuildLoad(comp_ctx->builder, table_size_const, "cur_size"))) {
+    if (!(table_size_const = LLVMBuildLoad2(comp_ctx->builder, I32_TYPE,
+                                            table_size_const, "cur_size"))) {
         HANDLE_FAILURE("LLVMBuildLoad");
         goto fail;
     }
@@ -1255,8 +1270,9 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         goto fail;
     }
 
-    if (!(table_elem = LLVMBuildGEP(comp_ctx->builder, func_ctx->aot_inst,
-                                    &offset, 1, "table_elem_i8p"))) {
+    if (!(table_elem = LLVMBuildInBoundsGEP2(comp_ctx->builder, INT8_TYPE,
+                                             func_ctx->aot_inst, &offset, 1,
+                                             "table_elem_i8p"))) {
         aot_set_last_error("llvm build add failed.");
         goto fail;
     }
@@ -1268,14 +1284,15 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     }
 
     /* Load function index */
-    if (!(table_elem = LLVMBuildGEP(comp_ctx->builder, table_elem, &elem_idx, 1,
-                                    "table_elem"))) {
+    if (!(table_elem =
+              LLVMBuildInBoundsGEP2(comp_ctx->builder, I32_TYPE, table_elem,
+                                    &elem_idx, 1, "table_elem"))) {
         HANDLE_FAILURE("LLVMBuildNUWAdd");
         goto fail;
     }
 
-    if (!(func_idx =
-              LLVMBuildLoad(comp_ctx->builder, table_elem, "func_idx"))) {
+    if (!(func_idx = LLVMBuildLoad2(comp_ctx->builder, I32_TYPE, table_elem,
+                                    "func_idx"))) {
         aot_set_last_error("llvm build load failed.");
         goto fail;
     }
@@ -1302,15 +1319,15 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         goto fail;
 
     /* Load function type index */
-    if (!(ftype_idx_ptr = LLVMBuildInBoundsGEP(
-              comp_ctx->builder, func_ctx->func_type_indexes, &func_idx, 1,
-              "ftype_idx_ptr"))) {
+    if (!(ftype_idx_ptr = LLVMBuildInBoundsGEP2(
+              comp_ctx->builder, I32_TYPE, func_ctx->func_type_indexes,
+              &func_idx, 1, "ftype_idx_ptr"))) {
         aot_set_last_error("llvm build inbounds gep failed.");
         goto fail;
     }
 
-    if (!(ftype_idx =
-              LLVMBuildLoad(comp_ctx->builder, ftype_idx_ptr, "ftype_idx"))) {
+    if (!(ftype_idx = LLVMBuildLoad2(comp_ctx->builder, I32_TYPE, ftype_idx_ptr,
+                                     "ftype_idx"))) {
         aot_set_last_error("llvm build load failed.");
         goto fail;
     }
@@ -1399,9 +1416,9 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         CHECK_LLVM_CONST(ext_ret_offset);
 
         snprintf(buf, sizeof(buf), "ext_ret%d_ptr", i - 1);
-        if (!(ext_ret_ptr =
-                  LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->argv_buf,
-                                       &ext_ret_offset, 1, buf))) {
+        if (!(ext_ret_ptr = LLVMBuildInBoundsGEP2(comp_ctx->builder, I32_TYPE,
+                                                  func_ctx->argv_buf,
+                                                  &ext_ret_offset, 1, buf))) {
             aot_set_last_error("llvm build GEP failed.");
             goto fail;
         }
@@ -1553,14 +1570,15 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
 #if WASM_ENABLE_LAZY_JIT == 0
     /* Load function pointer */
-    if (!(func_ptr =
-              LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->func_ptrs,
-                                   &func_idx, 1, "func_ptr_tmp"))) {
+    if (!(func_ptr = LLVMBuildInBoundsGEP2(comp_ctx->builder, OPQ_PTR_TYPE,
+                                           func_ctx->func_ptrs, &func_idx, 1,
+                                           "func_ptr_tmp"))) {
         aot_set_last_error("llvm build inbounds gep failed.");
         goto fail;
     }
 
-    if (!(func_ptr = LLVMBuildLoad(comp_ctx->builder, func_ptr, "func_ptr"))) {
+    if (!(func_ptr = LLVMBuildLoad2(comp_ctx->builder, OPQ_PTR_TYPE, func_ptr,
+                                    "func_ptr"))) {
         aot_set_last_error("llvm build load failed.");
         goto fail;
     }
@@ -1584,9 +1602,9 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         goto fail;
     }
 
-    if (!(value_ret = LLVMBuildCall(comp_ctx->builder, func, param_values,
-                                    total_param_count,
-                                    func_result_count > 0 ? "ret" : ""))) {
+    if (!(value_ret = LLVMBuildCall2(comp_ctx->builder, llvm_func_type, func,
+                                     param_values, total_param_count,
+                                     func_result_count > 0 ? "ret" : ""))) {
         aot_set_last_error("llvm build call failed.");
         goto fail;
     }
@@ -1603,10 +1621,11 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
         /* Load extra result from its address and push to stack */
         for (i = 1; i < func_result_count; i++) {
+            ret_type = TO_LLVM_TYPE(func_type->types[func_param_count + i]);
             snprintf(buf, sizeof(buf), "ext_ret%d", i - 1);
-            if (!(ext_ret =
-                      LLVMBuildLoad(comp_ctx->builder,
-                                    param_values[func_param_count + i], buf))) {
+            if (!(ext_ret = LLVMBuildLoad2(comp_ctx->builder, ret_type,
+                                           param_values[func_param_count + i],
+                                           buf))) {
                 aot_set_last_error("llvm build load failed.");
                 goto fail;
             }

--- a/core/iwasm/compilation/aot_emit_table.c
+++ b/core/iwasm/compilation/aot_emit_table.c
@@ -58,9 +58,10 @@ aot_compile_get_tbl_inst(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         goto fail;
     }
 
-    if (!(tbl_inst = LLVMBuildGEP(comp_ctx->builder, func_ctx->aot_inst,
-                                  &offset, 1, "tbl_inst"))) {
-        HANDLE_FAILURE("LLVMBuildGEP");
+    if (!(tbl_inst = LLVMBuildInBoundsGEP2(comp_ctx->builder, INT8_TYPE,
+                                           func_ctx->aot_inst, &offset, 1,
+                                           "tbl_inst"))) {
+        HANDLE_FAILURE("LLVMBuildInBoundsGEP");
         goto fail;
     }
 
@@ -90,8 +91,8 @@ aot_compile_op_elem_drop(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     }
 
     /* "" means return void */
-    if (!(ret_value =
-              LLVMBuildCall(comp_ctx->builder, func, param_values, 2, ""))) {
+    if (!(ret_value = LLVMBuildCall2(comp_ctx->builder, func_type, func,
+                                     param_values, 2, ""))) {
         HANDLE_FAILURE("LLVMBuildCall");
         goto fail;
     }
@@ -115,9 +116,10 @@ aot_check_table_access(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         goto fail;
     }
 
-    if (!(tbl_sz = LLVMBuildGEP(comp_ctx->builder, func_ctx->aot_inst, &offset,
-                                1, "cur_size_i8p"))) {
-        HANDLE_FAILURE("LLVMBuildGEP");
+    if (!(tbl_sz = LLVMBuildInBoundsGEP2(comp_ctx->builder, INT8_TYPE,
+                                         func_ctx->aot_inst, &offset, 1,
+                                         "cur_size_i8p"))) {
+        HANDLE_FAILURE("LLVMBuildInBoundsGEP");
         goto fail;
     }
 
@@ -127,7 +129,8 @@ aot_check_table_access(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         goto fail;
     }
 
-    if (!(tbl_sz = LLVMBuildLoad(comp_ctx->builder, tbl_sz, "cur_size"))) {
+    if (!(tbl_sz = LLVMBuildLoad2(comp_ctx->builder, I32_TYPE, tbl_sz,
+                                  "cur_size"))) {
         HANDLE_FAILURE("LLVMBuildLoad");
         goto fail;
     }
@@ -178,8 +181,9 @@ aot_compile_op_table_get(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         goto fail;
     }
 
-    if (!(table_elem = LLVMBuildGEP(comp_ctx->builder, func_ctx->aot_inst,
-                                    &offset, 1, "table_elem_i8p"))) {
+    if (!(table_elem = LLVMBuildInBoundsGEP2(comp_ctx->builder, INT8_TYPE,
+                                             func_ctx->aot_inst, &offset, 1,
+                                             "table_elem_i8p"))) {
         aot_set_last_error("llvm build add failed.");
         goto fail;
     }
@@ -191,14 +195,15 @@ aot_compile_op_table_get(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     }
 
     /* Load function index */
-    if (!(table_elem = LLVMBuildGEP(comp_ctx->builder, table_elem, &elem_idx, 1,
-                                    "table_elem"))) {
+    if (!(table_elem =
+              LLVMBuildInBoundsGEP2(comp_ctx->builder, I32_TYPE, table_elem,
+                                    &elem_idx, 1, "table_elem"))) {
         HANDLE_FAILURE("LLVMBuildNUWAdd");
         goto fail;
     }
 
-    if (!(func_idx =
-              LLVMBuildLoad(comp_ctx->builder, table_elem, "func_idx"))) {
+    if (!(func_idx = LLVMBuildLoad2(comp_ctx->builder, I32_TYPE, table_elem,
+                                    "func_idx"))) {
         HANDLE_FAILURE("LLVMBuildLoad");
         goto fail;
     }
@@ -230,9 +235,10 @@ aot_compile_op_table_set(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         goto fail;
     }
 
-    if (!(table_elem = LLVMBuildGEP(comp_ctx->builder, func_ctx->aot_inst,
-                                    &offset, 1, "table_elem_i8p"))) {
-        HANDLE_FAILURE("LLVMBuildGEP");
+    if (!(table_elem = LLVMBuildInBoundsGEP2(comp_ctx->builder, INT8_TYPE,
+                                             func_ctx->aot_inst, &offset, 1,
+                                             "table_elem_i8p"))) {
+        HANDLE_FAILURE("LLVMBuildInBoundsGEP");
         goto fail;
     }
 
@@ -243,9 +249,10 @@ aot_compile_op_table_set(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     }
 
     /* Load function index */
-    if (!(table_elem = LLVMBuildGEP(comp_ctx->builder, table_elem, &elem_idx, 1,
-                                    "table_elem"))) {
-        HANDLE_FAILURE("LLVMBuildGEP");
+    if (!(table_elem =
+              LLVMBuildInBoundsGEP2(comp_ctx->builder, I32_TYPE, table_elem,
+                                    &elem_idx, 1, "table_elem"))) {
+        HANDLE_FAILURE("LLVMBuildInBoundsGEP");
         goto fail;
     }
 
@@ -297,7 +304,8 @@ aot_compile_op_table_init(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     POP_I32(param_values[5]);
 
     /* "" means return void */
-    if (!(LLVMBuildCall(comp_ctx->builder, func, param_values, 6, ""))) {
+    if (!(LLVMBuildCall2(comp_ctx->builder, func_type, func, param_values, 6,
+                         ""))) {
         HANDLE_FAILURE("LLVMBuildCall");
         goto fail;
     }
@@ -344,7 +352,8 @@ aot_compile_op_table_copy(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     POP_I32(param_values[5]);
 
     /* "" means return void */
-    if (!(LLVMBuildCall(comp_ctx->builder, func, param_values, 6, ""))) {
+    if (!(LLVMBuildCall2(comp_ctx->builder, func_type, func, param_values, 6,
+                         ""))) {
         HANDLE_FAILURE("LLVMBuildCall");
         goto fail;
     }
@@ -366,9 +375,10 @@ aot_compile_op_table_size(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         goto fail;
     }
 
-    if (!(tbl_sz = LLVMBuildGEP(comp_ctx->builder, func_ctx->aot_inst, &offset,
-                                1, "tbl_sz_ptr_i8"))) {
-        HANDLE_FAILURE("LLVMBuildGEP");
+    if (!(tbl_sz = LLVMBuildInBoundsGEP2(comp_ctx->builder, INT8_TYPE,
+                                         func_ctx->aot_inst, &offset, 1,
+                                         "tbl_sz_ptr_i8"))) {
+        HANDLE_FAILURE("LLVMBuildInBoundsGEP");
         goto fail;
     }
 
@@ -378,7 +388,8 @@ aot_compile_op_table_size(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         goto fail;
     }
 
-    if (!(tbl_sz = LLVMBuildLoad(comp_ctx->builder, tbl_sz, "tbl_sz"))) {
+    if (!(tbl_sz =
+              LLVMBuildLoad2(comp_ctx->builder, I32_TYPE, tbl_sz, "tbl_sz"))) {
         HANDLE_FAILURE("LLVMBuildLoad");
         goto fail;
     }
@@ -417,8 +428,8 @@ aot_compile_op_table_grow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     /* v */
     POP_I32(param_values[3]);
 
-    if (!(ret = LLVMBuildCall(comp_ctx->builder, func, param_values, 4,
-                              "table_grow"))) {
+    if (!(ret = LLVMBuildCall2(comp_ctx->builder, func_type, func, param_values,
+                               4, "table_grow"))) {
         HANDLE_FAILURE("LLVMBuildCall");
         goto fail;
     }
@@ -461,7 +472,8 @@ aot_compile_op_table_fill(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     POP_I32(param_values[4]);
 
     /* "" means return void */
-    if (!(LLVMBuildCall(comp_ctx->builder, func, param_values, 5, ""))) {
+    if (!(LLVMBuildCall2(comp_ctx->builder, func_type, func, param_values, 5,
+                         ""))) {
         HANDLE_FAILURE("LLVMBuildCall");
         goto fail;
     }

--- a/core/iwasm/compilation/aot_emit_variable.c
+++ b/core/iwasm/compilation/aot_emit_variable.c
@@ -33,17 +33,20 @@ aot_compile_op_get_local(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     char name[32];
     LLVMValueRef value;
     AOTValue *aot_value_top;
+    uint8 local_type;
 
     CHECK_LOCAL(local_idx);
 
+    local_type = get_local_type(func_ctx, local_idx);
+
     snprintf(name, sizeof(name), "%s%d%s", "local", local_idx, "#");
-    if (!(value = LLVMBuildLoad(comp_ctx->builder, func_ctx->locals[local_idx],
-                                name))) {
+    if (!(value = LLVMBuildLoad2(comp_ctx->builder, TO_LLVM_TYPE(local_type),
+                                 func_ctx->locals[local_idx], name))) {
         aot_set_last_error("llvm build load fail");
         return false;
     }
 
-    PUSH(value, get_local_type(func_ctx, local_idx));
+    PUSH(value, local_type);
 
     aot_value_top =
         func_ctx->block_stack.block_list_end->value_stack.value_list_end;
@@ -134,9 +137,9 @@ compile_global(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     }
 
     offset = I32_CONST(global_offset);
-    if (!(global_ptr =
-              LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->aot_inst,
-                                   &offset, 1, "global_ptr_tmp"))) {
+    if (!(global_ptr = LLVMBuildInBoundsGEP2(comp_ctx->builder, INT8_TYPE,
+                                             func_ctx->aot_inst, &offset, 1,
+                                             "global_ptr_tmp"))) {
         aot_set_last_error("llvm build in bounds gep failed.");
         return false;
     }
@@ -172,7 +175,8 @@ compile_global(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
     if (!is_set) {
         if (!(global =
-                  LLVMBuildLoad(comp_ctx->builder, global_ptr, "global"))) {
+                  LLVMBuildLoad2(comp_ctx->builder, TO_LLVM_TYPE(global_type),
+                                 global_ptr, "global"))) {
             aot_set_last_error("llvm build load failed.");
             return false;
         }

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -556,7 +556,7 @@ create_func_type_indexes(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
     }
 
     func_ctx->func_type_indexes =
-        LLVMBuildLoad2(comp_ctx->builder, OPQ_PTR_TYPE,
+        LLVMBuildLoad2(comp_ctx->builder, INT32_PTR_TYPE,
                        func_ctx->func_type_indexes, "func_type_indexes");
     if (!func_ctx->func_type_indexes) {
         aot_set_last_error("llvm build load failed.");
@@ -702,7 +702,7 @@ aot_create_func_context(AOTCompData *comp_data, AOTCompContext *comp_ctx,
         goto fail;
     }
 
-    if (!(func_ctx->argv_buf = LLVMBuildLoad2(comp_ctx->builder, OPQ_PTR_TYPE,
+    if (!(func_ctx->argv_buf = LLVMBuildLoad2(comp_ctx->builder, INT32_PTR_TYPE,
                                               argv_buf_addr, "argv_buf"))) {
         aot_set_last_error("llvm build load failed");
         goto fail;

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -2557,7 +2557,7 @@ __call_llvm_intrinsic(const AOTCompContext *comp_ctx,
         }
     }
 
-#if LLVM_VERSION_MAJOR >= 15
+#if LLVM_VERSION_MAJOR >= 14
     func_type =
         LLVMFunctionType(ret_type, param_types, (uint32)param_count, false);
 #endif

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -232,9 +232,9 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         }
 
         /* aot_inst->memories */
-        if (!(shared_mem_addr =
-                  LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->aot_inst,
-                                       &offset, 1, "shared_mem_addr_offset"))) {
+        if (!(shared_mem_addr = LLVMBuildInBoundsGEP2(
+                  comp_ctx->builder, INT8_TYPE, func_ctx->aot_inst, &offset, 1,
+                  "shared_mem_addr_offset"))) {
             aot_set_last_error("llvm build in bounds gep failed");
             return false;
         }
@@ -245,8 +245,9 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             return false;
         }
         /* aot_inst->memories[0] */
-        if (!(shared_mem_addr = LLVMBuildLoad(
-                  comp_ctx->builder, shared_mem_addr, "shared_mem_addr"))) {
+        if (!(shared_mem_addr =
+                  LLVMBuildLoad2(comp_ctx->builder, OPQ_PTR_TYPE,
+                                 shared_mem_addr, "shared_mem_addr"))) {
             aot_set_last_error("llvm build load failed");
             return false;
         }
@@ -256,29 +257,34 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             aot_set_last_error("llvm build bit cast failed");
             return false;
         }
-        if (!(shared_mem_addr = LLVMBuildLoad(
-                  comp_ctx->builder, shared_mem_addr, "shared_mem_addr"))) {
+        if (!(shared_mem_addr =
+                  LLVMBuildLoad2(comp_ctx->builder, OPQ_PTR_TYPE,
+                                 shared_mem_addr, "shared_mem_addr"))) {
             aot_set_last_error("llvm build load failed");
             return false;
         }
+        /* memories[0]->memory_data */
         offset = I32_CONST(offsetof(AOTMemoryInstance, memory_data.ptr));
-        if (!(func_ctx->mem_info[0].mem_base_addr =
-                  LLVMBuildInBoundsGEP(comp_ctx->builder, shared_mem_addr,
-                                       &offset, 1, "mem_base_addr_offset"))) {
+        if (!(func_ctx->mem_info[0].mem_base_addr = LLVMBuildInBoundsGEP2(
+                  comp_ctx->builder, INT8_TYPE, shared_mem_addr, &offset, 1,
+                  "mem_base_addr_offset"))) {
             aot_set_last_error("llvm build in bounds gep failed");
             return false;
         }
+        /* memories[0]->cur_page_count */
         offset = I32_CONST(offsetof(AOTMemoryInstance, cur_page_count));
         if (!(func_ctx->mem_info[0].mem_cur_page_count_addr =
-                  LLVMBuildInBoundsGEP(comp_ctx->builder, shared_mem_addr,
-                                       &offset, 1, "mem_cur_page_offset"))) {
+                  LLVMBuildInBoundsGEP2(comp_ctx->builder, INT8_TYPE,
+                                        shared_mem_addr, &offset, 1,
+                                        "mem_cur_page_offset"))) {
             aot_set_last_error("llvm build in bounds gep failed");
             return false;
         }
+        /* memories[0]->memory_data_size */
         offset = I32_CONST(offsetof(AOTMemoryInstance, memory_data_size));
-        if (!(func_ctx->mem_info[0].mem_data_size_addr =
-                  LLVMBuildInBoundsGEP(comp_ctx->builder, shared_mem_addr,
-                                       &offset, 1, "mem_data_size_offset"))) {
+        if (!(func_ctx->mem_info[0].mem_data_size_addr = LLVMBuildInBoundsGEP2(
+                  comp_ctx->builder, INT8_TYPE, shared_mem_addr, &offset, 1,
+                  "mem_data_size_offset"))) {
             aot_set_last_error("llvm build in bounds gep failed");
             return false;
         }
@@ -288,25 +294,26 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     {
         offset = I32_CONST(offsetof(AOTModuleInstance, global_table_data)
                            + offsetof(AOTMemoryInstance, memory_data.ptr));
-        if (!(func_ctx->mem_info[0].mem_base_addr =
-                  LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->aot_inst,
-                                       &offset, 1, "mem_base_addr_offset"))) {
+        if (!(func_ctx->mem_info[0].mem_base_addr = LLVMBuildInBoundsGEP2(
+                  comp_ctx->builder, INT8_TYPE, func_ctx->aot_inst, &offset, 1,
+                  "mem_base_addr_offset"))) {
             aot_set_last_error("llvm build in bounds gep failed");
             return false;
         }
         offset = I32_CONST(offsetof(AOTModuleInstance, global_table_data)
                            + offsetof(AOTMemoryInstance, cur_page_count));
         if (!(func_ctx->mem_info[0].mem_cur_page_count_addr =
-                  LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->aot_inst,
-                                       &offset, 1, "mem_cur_page_offset"))) {
+                  LLVMBuildInBoundsGEP2(comp_ctx->builder, INT8_TYPE,
+                                        func_ctx->aot_inst, &offset, 1,
+                                        "mem_cur_page_offset"))) {
             aot_set_last_error("llvm build in bounds gep failed");
             return false;
         }
         offset = I32_CONST(offsetof(AOTModuleInstance, global_table_data)
                            + offsetof(AOTMemoryInstance, memory_data_size));
-        if (!(func_ctx->mem_info[0].mem_data_size_addr =
-                  LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->aot_inst,
-                                       &offset, 1, "mem_data_size_offset"))) {
+        if (!(func_ctx->mem_info[0].mem_data_size_addr = LLVMBuildInBoundsGEP2(
+                  comp_ctx->builder, INT8_TYPE, func_ctx->aot_inst, &offset, 1,
+                  "mem_data_size_offset"))) {
             aot_set_last_error("llvm build in bounds gep failed");
             return false;
         }
@@ -333,22 +340,22 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         return false;
     }
     if (mem_space_unchanged) {
-        if (!(func_ctx->mem_info[0].mem_base_addr = LLVMBuildLoad(
-                  comp_ctx->builder, func_ctx->mem_info[0].mem_base_addr,
-                  "mem_base_addr"))) {
+        if (!(func_ctx->mem_info[0].mem_base_addr = LLVMBuildLoad2(
+                  comp_ctx->builder, OPQ_PTR_TYPE,
+                  func_ctx->mem_info[0].mem_base_addr, "mem_base_addr"))) {
             aot_set_last_error("llvm build load failed");
             return false;
         }
         if (!(func_ctx->mem_info[0].mem_cur_page_count_addr =
-                  LLVMBuildLoad(comp_ctx->builder,
-                                func_ctx->mem_info[0].mem_cur_page_count_addr,
-                                "mem_cur_page_count"))) {
+                  LLVMBuildLoad2(comp_ctx->builder, I32_TYPE,
+                                 func_ctx->mem_info[0].mem_cur_page_count_addr,
+                                 "mem_cur_page_count"))) {
             aot_set_last_error("llvm build load failed");
             return false;
         }
-        if (!(func_ctx->mem_info[0].mem_data_size_addr = LLVMBuildLoad(
-                  comp_ctx->builder, func_ctx->mem_info[0].mem_data_size_addr,
-                  "mem_data_size"))) {
+        if (!(func_ctx->mem_info[0].mem_data_size_addr = LLVMBuildLoad2(
+                  comp_ctx->builder, I32_TYPE,
+                  func_ctx->mem_info[0].mem_data_size_addr, "mem_data_size"))) {
             aot_set_last_error("llvm build load failed");
             return false;
         }
@@ -357,9 +364,9 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     else if (is_shared_memory) {
         /* The base address for shared memory will never changed,
             we can load the value here */
-        if (!(func_ctx->mem_info[0].mem_base_addr = LLVMBuildLoad(
-                  comp_ctx->builder, func_ctx->mem_info[0].mem_base_addr,
-                  "mem_base_addr"))) {
+        if (!(func_ctx->mem_info[0].mem_base_addr = LLVMBuildLoad2(
+                  comp_ctx->builder, OPQ_PTR_TYPE,
+                  func_ctx->mem_info[0].mem_base_addr, "mem_base_addr"))) {
             aot_set_last_error("llvm build load failed");
             return false;
         }
@@ -374,8 +381,8 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     offset = I32_CONST(offsetof(AOTMemoryInstance, mem_bound_check_1byte)
                        - offsetof(AOTMemoryInstance, memory_data.ptr));
     if (!(func_ctx->mem_info[0].mem_bound_check_1byte =
-              LLVMBuildInBoundsGEP(comp_ctx->builder, mem_info_base, &offset, 1,
-                                   "bound_check_1byte_offset"))) {
+              LLVMBuildInBoundsGEP2(comp_ctx->builder, INT8_TYPE, mem_info_base,
+                                    &offset, 1, "bound_check_1byte_offset"))) {
         aot_set_last_error("llvm build in bounds gep failed");
         return false;
     }
@@ -386,10 +393,12 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         return false;
     }
     if (mem_space_unchanged) {
-        if (!(func_ctx->mem_info[0].mem_bound_check_1byte =
-                  LLVMBuildLoad(comp_ctx->builder,
-                                func_ctx->mem_info[0].mem_bound_check_1byte,
-                                "bound_check_1byte"))) {
+        if (!(func_ctx->mem_info[0].mem_bound_check_1byte = LLVMBuildLoad2(
+                  comp_ctx->builder,
+                  (comp_ctx->pointer_size == sizeof(uint64)) ? I64_TYPE
+                                                             : I32_TYPE,
+                  func_ctx->mem_info[0].mem_bound_check_1byte,
+                  "bound_check_1byte"))) {
             aot_set_last_error("llvm build load failed");
             return false;
         }
@@ -398,8 +407,8 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     offset = I32_CONST(offsetof(AOTMemoryInstance, mem_bound_check_2bytes)
                        - offsetof(AOTMemoryInstance, memory_data.ptr));
     if (!(func_ctx->mem_info[0].mem_bound_check_2bytes =
-              LLVMBuildInBoundsGEP(comp_ctx->builder, mem_info_base, &offset, 1,
-                                   "bound_check_2bytes_offset"))) {
+              LLVMBuildInBoundsGEP2(comp_ctx->builder, INT8_TYPE, mem_info_base,
+                                    &offset, 1, "bound_check_2bytes_offset"))) {
         aot_set_last_error("llvm build in bounds gep failed");
         return false;
     }
@@ -410,10 +419,12 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         return false;
     }
     if (mem_space_unchanged) {
-        if (!(func_ctx->mem_info[0].mem_bound_check_2bytes =
-                  LLVMBuildLoad(comp_ctx->builder,
-                                func_ctx->mem_info[0].mem_bound_check_2bytes,
-                                "bound_check_2bytes"))) {
+        if (!(func_ctx->mem_info[0].mem_bound_check_2bytes = LLVMBuildLoad2(
+                  comp_ctx->builder,
+                  (comp_ctx->pointer_size == sizeof(uint64)) ? I64_TYPE
+                                                             : I32_TYPE,
+                  func_ctx->mem_info[0].mem_bound_check_2bytes,
+                  "bound_check_2bytes"))) {
             aot_set_last_error("llvm build load failed");
             return false;
         }
@@ -422,8 +433,8 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     offset = I32_CONST(offsetof(AOTMemoryInstance, mem_bound_check_4bytes)
                        - offsetof(AOTMemoryInstance, memory_data.ptr));
     if (!(func_ctx->mem_info[0].mem_bound_check_4bytes =
-              LLVMBuildInBoundsGEP(comp_ctx->builder, mem_info_base, &offset, 1,
-                                   "bound_check_4bytes_offset"))) {
+              LLVMBuildInBoundsGEP2(comp_ctx->builder, INT8_TYPE, mem_info_base,
+                                    &offset, 1, "bound_check_4bytes_offset"))) {
         aot_set_last_error("llvm build in bounds gep failed");
         return false;
     }
@@ -434,10 +445,12 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         return false;
     }
     if (mem_space_unchanged) {
-        if (!(func_ctx->mem_info[0].mem_bound_check_4bytes =
-                  LLVMBuildLoad(comp_ctx->builder,
-                                func_ctx->mem_info[0].mem_bound_check_4bytes,
-                                "bound_check_4bytes"))) {
+        if (!(func_ctx->mem_info[0].mem_bound_check_4bytes = LLVMBuildLoad2(
+                  comp_ctx->builder,
+                  (comp_ctx->pointer_size == sizeof(uint64)) ? I64_TYPE
+                                                             : I32_TYPE,
+                  func_ctx->mem_info[0].mem_bound_check_4bytes,
+                  "bound_check_4bytes"))) {
             aot_set_last_error("llvm build load failed");
             return false;
         }
@@ -446,8 +459,8 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     offset = I32_CONST(offsetof(AOTMemoryInstance, mem_bound_check_8bytes)
                        - offsetof(AOTMemoryInstance, memory_data.ptr));
     if (!(func_ctx->mem_info[0].mem_bound_check_8bytes =
-              LLVMBuildInBoundsGEP(comp_ctx->builder, mem_info_base, &offset, 1,
-                                   "bound_check_8bytes_offset"))) {
+              LLVMBuildInBoundsGEP2(comp_ctx->builder, INT8_TYPE, mem_info_base,
+                                    &offset, 1, "bound_check_8bytes_offset"))) {
         aot_set_last_error("llvm build in bounds gep failed");
         return false;
     }
@@ -458,10 +471,12 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         return false;
     }
     if (mem_space_unchanged) {
-        if (!(func_ctx->mem_info[0].mem_bound_check_8bytes =
-                  LLVMBuildLoad(comp_ctx->builder,
-                                func_ctx->mem_info[0].mem_bound_check_8bytes,
-                                "bound_check_8bytes"))) {
+        if (!(func_ctx->mem_info[0].mem_bound_check_8bytes = LLVMBuildLoad2(
+                  comp_ctx->builder,
+                  (comp_ctx->pointer_size == sizeof(uint64)) ? I64_TYPE
+                                                             : I32_TYPE,
+                  func_ctx->mem_info[0].mem_bound_check_8bytes,
+                  "bound_check_8bytes"))) {
             aot_set_last_error("llvm build load failed");
             return false;
         }
@@ -469,9 +484,9 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
     offset = I32_CONST(offsetof(AOTMemoryInstance, mem_bound_check_16bytes)
                        - offsetof(AOTMemoryInstance, memory_data.ptr));
-    if (!(func_ctx->mem_info[0].mem_bound_check_16bytes =
-              LLVMBuildInBoundsGEP(comp_ctx->builder, mem_info_base, &offset, 1,
-                                   "bound_check_16bytes_offset"))) {
+    if (!(func_ctx->mem_info[0].mem_bound_check_16bytes = LLVMBuildInBoundsGEP2(
+              comp_ctx->builder, INT8_TYPE, mem_info_base, &offset, 1,
+              "bound_check_16bytes_offset"))) {
         aot_set_last_error("llvm build in bounds gep failed");
         return false;
     }
@@ -482,10 +497,12 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         return false;
     }
     if (mem_space_unchanged) {
-        if (!(func_ctx->mem_info[0].mem_bound_check_16bytes =
-                  LLVMBuildLoad(comp_ctx->builder,
-                                func_ctx->mem_info[0].mem_bound_check_16bytes,
-                                "bound_check_16bytes"))) {
+        if (!(func_ctx->mem_info[0].mem_bound_check_16bytes = LLVMBuildLoad2(
+                  comp_ctx->builder,
+                  (comp_ctx->pointer_size == sizeof(uint64)) ? I64_TYPE
+                                                             : I32_TYPE,
+                  func_ctx->mem_info[0].mem_bound_check_16bytes,
+                  "bound_check_16bytes"))) {
             aot_set_last_error("llvm build load failed");
             return false;
         }
@@ -500,8 +517,9 @@ create_cur_exception(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
     LLVMValueRef offset;
 
     offset = I32_CONST(offsetof(AOTModuleInstance, cur_exception));
-    func_ctx->cur_exception = LLVMBuildInBoundsGEP(
-        comp_ctx->builder, func_ctx->aot_inst, &offset, 1, "cur_exception");
+    func_ctx->cur_exception =
+        LLVMBuildInBoundsGEP2(comp_ctx->builder, INT8_TYPE, func_ctx->aot_inst,
+                              &offset, 1, "cur_exception");
     if (!func_ctx->cur_exception) {
         aot_set_last_error("llvm build in bounds gep failed.");
         return false;
@@ -517,8 +535,8 @@ create_func_type_indexes(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 
     offset = I32_CONST(offsetof(AOTModuleInstance, func_type_indexes.ptr));
     func_type_indexes_ptr =
-        LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->aot_inst, &offset, 1,
-                             "func_type_indexes_ptr");
+        LLVMBuildInBoundsGEP2(comp_ctx->builder, INT8_TYPE, func_ctx->aot_inst,
+                              &offset, 1, "func_type_indexes_ptr");
     if (!func_type_indexes_ptr) {
         aot_set_last_error("llvm build add failed.");
         return false;
@@ -537,8 +555,9 @@ create_func_type_indexes(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
         return false;
     }
 
-    func_ctx->func_type_indexes = LLVMBuildLoad(
-        comp_ctx->builder, func_ctx->func_type_indexes, "func_type_indexes");
+    func_ctx->func_type_indexes =
+        LLVMBuildLoad2(comp_ctx->builder, OPQ_PTR_TYPE,
+                       func_ctx->func_type_indexes, "func_type_indexes");
     if (!func_ctx->func_type_indexes) {
         aot_set_last_error("llvm build load failed.");
         return false;
@@ -552,8 +571,9 @@ create_func_ptrs(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
     LLVMValueRef offset;
 
     offset = I32_CONST(offsetof(AOTModuleInstance, func_ptrs));
-    func_ctx->func_ptrs = LLVMBuildInBoundsGEP(
-        comp_ctx->builder, func_ctx->aot_inst, &offset, 1, "func_ptrs_offset");
+    func_ctx->func_ptrs =
+        LLVMBuildInBoundsGEP2(comp_ctx->builder, INT8_TYPE, func_ctx->aot_inst,
+                              &offset, 1, "func_ptrs_offset");
     if (!func_ctx->func_ptrs) {
         aot_set_last_error("llvm build in bounds gep failed.");
         return false;
@@ -566,8 +586,8 @@ create_func_ptrs(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
         return false;
     }
 
-    func_ctx->func_ptrs =
-        LLVMBuildLoad(comp_ctx->builder, func_ctx->func_ptrs, "func_ptrs_ptr");
+    func_ctx->func_ptrs = LLVMBuildLoad2(comp_ctx->builder, OPQ_PTR_TYPE,
+                                         func_ctx->func_ptrs, "func_ptrs_ptr");
     if (!func_ctx->func_ptrs) {
         aot_set_last_error("llvm build load failed.");
         return false;
@@ -648,24 +668,24 @@ aot_create_func_context(AOTCompData *comp_data, AOTCompContext *comp_ctx,
 
     /* Get aot inst address, the layout of exec_env is:
        exec_env->next, exec_env->prev, exec_env->module_inst, and argv_buf */
-    if (!(aot_inst_addr =
-              LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->exec_env,
-                                   &aot_inst_offset, 1, "aot_inst_addr"))) {
+    if (!(aot_inst_addr = LLVMBuildInBoundsGEP2(
+              comp_ctx->builder, OPQ_PTR_TYPE, func_ctx->exec_env,
+              &aot_inst_offset, 1, "aot_inst_addr"))) {
         aot_set_last_error("llvm build in bounds gep failed");
         goto fail;
     }
 
     /* Load aot inst */
-    if (!(func_ctx->aot_inst =
-              LLVMBuildLoad(comp_ctx->builder, aot_inst_addr, "aot_inst"))) {
+    if (!(func_ctx->aot_inst = LLVMBuildLoad2(comp_ctx->builder, OPQ_PTR_TYPE,
+                                              aot_inst_addr, "aot_inst"))) {
         aot_set_last_error("llvm build load failed");
         goto fail;
     }
 
     /* Get argv buffer address */
-    if (!(argv_buf_addr =
-              LLVMBuildInBoundsGEP(comp_ctx->builder, func_ctx->exec_env,
-                                   &argv_buf_offset, 1, "argv_buf_addr"))) {
+    if (!(argv_buf_addr = LLVMBuildInBoundsGEP2(
+              comp_ctx->builder, OPQ_PTR_TYPE, func_ctx->exec_env,
+              &argv_buf_offset, 1, "argv_buf_addr"))) {
         aot_set_last_error("llvm build in bounds gep failed");
         goto fail;
     }
@@ -682,30 +702,31 @@ aot_create_func_context(AOTCompData *comp_data, AOTCompContext *comp_ctx,
         goto fail;
     }
 
-    if (!(func_ctx->argv_buf =
-              LLVMBuildLoad(comp_ctx->builder, argv_buf_addr, "argv_buf"))) {
+    if (!(func_ctx->argv_buf = LLVMBuildLoad2(comp_ctx->builder, OPQ_PTR_TYPE,
+                                              argv_buf_addr, "argv_buf"))) {
         aot_set_last_error("llvm build load failed");
         goto fail;
     }
 
     /* Get native stack boundary address */
-    if (!(stack_bound_addr = LLVMBuildInBoundsGEP(
-              comp_ctx->builder, func_ctx->exec_env, &stack_bound_offset, 1,
-              "stack_bound_addr"))) {
+    if (!(stack_bound_addr = LLVMBuildInBoundsGEP2(
+              comp_ctx->builder, OPQ_PTR_TYPE, func_ctx->exec_env,
+              &stack_bound_offset, 1, "stack_bound_addr"))) {
         aot_set_last_error("llvm build in bounds gep failed");
         goto fail;
     }
 
-    if (!(func_ctx->native_stack_bound = LLVMBuildLoad(
-              comp_ctx->builder, stack_bound_addr, "native_stack_bound"))) {
+    if (!(func_ctx->native_stack_bound =
+              LLVMBuildLoad2(comp_ctx->builder, OPQ_PTR_TYPE, stack_bound_addr,
+                             "native_stack_bound"))) {
         aot_set_last_error("llvm build load failed");
         goto fail;
     }
 
     /* Get aux stack boundary address */
-    if (!(aux_stack_bound_addr = LLVMBuildInBoundsGEP(
-              comp_ctx->builder, func_ctx->exec_env, &aux_stack_bound_offset, 1,
-              "aux_stack_bound_addr"))) {
+    if (!(aux_stack_bound_addr = LLVMBuildInBoundsGEP2(
+              comp_ctx->builder, OPQ_PTR_TYPE, func_ctx->exec_env,
+              &aux_stack_bound_offset, 1, "aux_stack_bound_addr"))) {
         aot_set_last_error("llvm build in bounds gep failed");
         goto fail;
     }
@@ -717,16 +738,17 @@ aot_create_func_context(AOTCompData *comp_data, AOTCompContext *comp_ctx,
         goto fail;
     }
 
-    if (!(func_ctx->aux_stack_bound = LLVMBuildLoad(
-              comp_ctx->builder, aux_stack_bound_addr, "aux_stack_bound"))) {
+    if (!(func_ctx->aux_stack_bound =
+              LLVMBuildLoad2(comp_ctx->builder, I32_TYPE, aux_stack_bound_addr,
+                             "aux_stack_bound"))) {
         aot_set_last_error("llvm build load failed");
         goto fail;
     }
 
     /* Get aux stack bottom address */
-    if (!(aux_stack_bottom_addr = LLVMBuildInBoundsGEP(
-              comp_ctx->builder, func_ctx->exec_env, &aux_stack_bottom_offset,
-              1, "aux_stack_bottom_addr"))) {
+    if (!(aux_stack_bottom_addr = LLVMBuildInBoundsGEP2(
+              comp_ctx->builder, OPQ_PTR_TYPE, func_ctx->exec_env,
+              &aux_stack_bottom_offset, 1, "aux_stack_bottom_addr"))) {
         aot_set_last_error("llvm build in bounds gep failed");
         goto fail;
     }
@@ -737,21 +759,23 @@ aot_create_func_context(AOTCompData *comp_data, AOTCompContext *comp_ctx,
         aot_set_last_error("llvm build bit cast failed");
         goto fail;
     }
-    if (!(func_ctx->aux_stack_bottom = LLVMBuildLoad(
-              comp_ctx->builder, aux_stack_bottom_addr, "aux_stack_bottom"))) {
+    if (!(func_ctx->aux_stack_bottom =
+              LLVMBuildLoad2(comp_ctx->builder, I32_TYPE, aux_stack_bottom_addr,
+                             "aux_stack_bottom"))) {
         aot_set_last_error("llvm build load failed");
         goto fail;
     }
 
-    if (!(native_symbol_addr = LLVMBuildInBoundsGEP(
-              comp_ctx->builder, func_ctx->exec_env, &native_symbol_offset, 1,
-              "native_symbol_addr"))) {
+    if (!(native_symbol_addr = LLVMBuildInBoundsGEP2(
+              comp_ctx->builder, OPQ_PTR_TYPE, func_ctx->exec_env,
+              &native_symbol_offset, 1, "native_symbol_addr"))) {
         aot_set_last_error("llvm build in bounds gep failed");
         goto fail;
     }
 
-    if (!(func_ctx->native_symbol = LLVMBuildLoad(
-              comp_ctx->builder, native_symbol_addr, "native_symbol_tmp"))) {
+    if (!(func_ctx->native_symbol =
+              LLVMBuildLoad2(comp_ctx->builder, OPQ_PTR_TYPE,
+                             native_symbol_addr, "native_symbol_tmp"))) {
         aot_set_last_error("llvm build bit cast failed");
         goto fail;
     }
@@ -2533,9 +2557,14 @@ __call_llvm_intrinsic(const AOTCompContext *comp_ctx,
         }
     }
 
+#if LLVM_VERSION_MAJOR >= 15
+    func_type =
+        LLVMFunctionType(ret_type, param_types, (uint32)param_count, false);
+#endif
+
     /* Call the LLVM intrinsic function */
-    if (!(ret = LLVMBuildCall(comp_ctx->builder, func, param_values,
-                              (uint32)param_count, "call"))) {
+    if (!(ret = LLVMBuildCall2(comp_ctx->builder, func_type, func, param_values,
+                               (uint32)param_count, "call"))) {
         aot_set_last_error("llvm build intrinsic call failed.");
         return NULL;
     }
@@ -2618,13 +2647,15 @@ aot_get_func_from_table(const AOTCompContext *comp_ctx, LLVMValueRef base,
         goto fail;
     }
 
-    if (!(func_addr = LLVMBuildInBoundsGEP(comp_ctx->builder, base, &func_addr,
-                                           1, "func_addr"))) {
+    if (!(func_addr =
+              LLVMBuildInBoundsGEP2(comp_ctx->builder, OPQ_PTR_TYPE, base,
+                                    &func_addr, 1, "func_addr"))) {
         aot_set_last_error("get function addr by index failed.");
         goto fail;
     }
 
-    func = LLVMBuildLoad(comp_ctx->builder, func_addr, "func_tmp");
+    func =
+        LLVMBuildLoad2(comp_ctx->builder, OPQ_PTR_TYPE, func_addr, "func_tmp");
 
     if (func == NULL) {
         aot_set_last_error("get function pointer failed.");
@@ -2647,7 +2678,7 @@ aot_load_const_from_table(AOTCompContext *comp_ctx, LLVMValueRef base,
                           const WASMValue *value, uint8 value_type)
 {
     LLVMValueRef const_index, const_addr, const_value;
-    LLVMTypeRef const_ptr_type;
+    LLVMTypeRef const_ptr_type, const_type;
     char buf[128] = { 0 };
     int32 index;
 
@@ -2656,11 +2687,13 @@ aot_load_const_from_table(AOTCompContext *comp_ctx, LLVMValueRef base,
             /* Store the raw int bits of f32 const as a hex string */
             snprintf(buf, sizeof(buf), "f32#%08" PRIX32, value->i32);
             const_ptr_type = F32_PTR_TYPE;
+            const_type = F32_TYPE;
             break;
         case VALUE_TYPE_F64:
             /* Store the raw int bits of f64 const as a hex string */
             snprintf(buf, sizeof(buf), "f64#%016" PRIX64, value->i64);
             const_ptr_type = F64_PTR_TYPE;
+            const_type = F64_TYPE;
             break;
         default:
             bh_assert(0);
@@ -2679,8 +2712,9 @@ aot_load_const_from_table(AOTCompContext *comp_ctx, LLVMValueRef base,
         return NULL;
     }
 
-    if (!(const_addr = LLVMBuildInBoundsGEP(
-              comp_ctx->builder, base, &const_index, 1, "const_addr_tmp"))) {
+    if (!(const_addr =
+              LLVMBuildInBoundsGEP2(comp_ctx->builder, OPQ_PTR_TYPE, base,
+                                    &const_index, 1, "const_addr_tmp"))) {
         aot_set_last_error("get const addr by index failed.");
         return NULL;
     }
@@ -2691,11 +2725,12 @@ aot_load_const_from_table(AOTCompContext *comp_ctx, LLVMValueRef base,
         return NULL;
     }
 
-    if (!(const_value =
-              LLVMBuildLoad(comp_ctx->builder, const_addr, "const_value"))) {
+    if (!(const_value = LLVMBuildLoad2(comp_ctx->builder, const_type,
+                                       const_addr, "const_value"))) {
         aot_set_last_error("load const failed.");
         return NULL;
     }
 
+    (void)const_type;
     return const_value;
 }

--- a/core/iwasm/compilation/aot_llvm.h
+++ b/core/iwasm/compilation/aot_llvm.h
@@ -37,7 +37,7 @@
 extern "C" {
 #endif
 
-#if LLVM_VERSION_MAJOR < 15
+#if LLVM_VERSION_MAJOR < 14
 #define LLVMBuildLoad2(builder, type, value, name) \
     LLVMBuildLoad(builder, value, name)
 

--- a/core/iwasm/compilation/aot_llvm.h
+++ b/core/iwasm/compilation/aot_llvm.h
@@ -37,6 +37,20 @@
 extern "C" {
 #endif
 
+#if LLVM_VERSION_MAJOR < 15
+#define LLVMBuildLoad2(builder, type, value, name) \
+    LLVMBuildLoad(builder, value, name)
+
+#define LLVMBuildCall2(builder, type, func, args, num_args, name) \
+    LLVMBuildCall(builder, func, args, num_args, name)
+
+#define LLVMBuildInBoundsGEP2(builder, type, ptr, indices, num_indices, name) \
+    LLVMBuildInBoundsGEP(builder, ptr, indices, num_indices, name)
+#else
+/* Opaque pointer type */
+#define OPQ_PTR_TYPE INT8_PTR_TYPE
+#endif
+
 /**
  * Value in the WASM operation stack, each stack element
  * is an LLVM value

--- a/core/iwasm/compilation/aot_llvm_extra.cpp
+++ b/core/iwasm/compilation/aot_llvm_extra.cpp
@@ -492,7 +492,11 @@ aot_apply_llvm_new_pass_manager(AOTCompContext *comp_ctx)
 
         if (!disable_llvm_lto) {
             /* Apply LTO for AOT mode */
+#if LLVM_VERSION_MAJOR < 14
             MPM.addPass(PB.buildLTODefaultPipeline(OL, NULL));
+#else
+            MPM.addPass(PB.buildLTOPreLinkDefaultPipeline(OL));
+#endif
         }
         else {
             MPM.addPass(PB.buildPerModuleDefaultPipeline(OL));

--- a/core/iwasm/compilation/simd/simd_load_store.c
+++ b/core/iwasm/compilation/simd/simd_load_store.c
@@ -16,6 +16,9 @@ simd_load(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx, uint32 align,
           uint32 offset, uint32 data_length, LLVMTypeRef ptr_type)
 {
     LLVMValueRef maddr, data;
+#if LLVM_VERSION_MAJOR >= 15
+    LLVMTypeRef data_type = LLVMGetElementType(ptr_type);
+#endif
 
     if (!(maddr = aot_check_memory_overflow(comp_ctx, func_ctx, offset,
                                             data_length))) {
@@ -29,7 +32,7 @@ simd_load(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx, uint32 align,
         return NULL;
     }
 
-    if (!(data = LLVMBuildLoad(comp_ctx->builder, maddr, "data"))) {
+    if (!(data = LLVMBuildLoad2(comp_ctx->builder, data_type, maddr, "data"))) {
         HANDLE_FAILURE("LLVMBuildLoad");
         return NULL;
     }


### PR DESCRIPTION
Enable opaque pointer for aot compiler to meet the requirements
of LLVM 15, modify LLVMBuildLoad/LLVMBuildCall/LLVMInBoundsGEP
to LLVMBuildLoad2/LLVMBuildCall2/LLVMInBoundsGEP2, and pass
the related type.
And update the build script to build LLVM 15 by default.