### PR TITLE
the isatty definition on nuttx depends on CONFIG_SERIAL_TERMIOS

### DIFF
--- a/core/shared/platform/nuttx/platform_internal.h
+++ b/core/shared/platform/nuttx/platform_internal.h
@@ -68,6 +68,13 @@ typedef pthread_t korp_thread;
 #define O_NOFOLLOW 0
 #endif
 
+#undef CONFIG_HAS_ISATTY
+#ifdef CONFIG_SERIAL_TERMIOS
+#define CONFIG_HAS_ISATTY 1
+#else
+#define CONFIG_HAS_ISATTY 0
+#endif
+
 /*
  * NuttX doesn't have openat family.
  */


### PR DESCRIPTION
the isatty definition on nuttx depends on CONFIG_SERIAL_TERMIOS