### PR TITLE
Fix macro redifinition warning for NuttX

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
@@ -51,10 +51,16 @@
 #define CONFIG_HAS_FDATASYNC 0
 #endif
 
+/*
+ * For NuttX, CONFIG_HAS_ISATTY is provided by its platform header.
+ * (platform_internal.h)
+ */
+#ifndef __NuttX__
 #ifndef __CloudABI__
 #define CONFIG_HAS_ISATTY 1
 #else
 #define CONFIG_HAS_ISATTY 0
+#endif
 #endif
 
 #ifndef __APPLE__


### PR DESCRIPTION
Fix the following warning introduced by the recent change.

```
In file included from wamr/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/locking.h:17,
                 from wamr/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.h:18,
                 from wamr/core/iwasm/aot/../common/wasm_runtime_common.h:18,
                 from wamr/core/iwasm/aot/aot_runtime.h:10,
                 from wamr/core/iwasm/aot/aot_loader.c:6:
wamr/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h:55: error: "CONFIG_HAS_ISATTY" redefined [-Werror]
 #define CONFIG_HAS_ISATTY 1

In file included from wamr/core/shared/utils/../platform/include/platform_common.h:13,
                 from wamr/core/shared/utils/bh_platform.h:9,
                 from wamr/core/iwasm/aot/aot_runtime.h:9,
                 from wamr/core/iwasm/aot/aot_loader.c:6:
wamr/core/shared/platform/nuttx/platform_internal.h:75: note: this is the location of the previous definition
 #define CONFIG_HAS_ISATTY 0
```