### PR TITLE
Refine fast jit frontend: merge cmp and if/br_if

### DIFF
--- a/core/iwasm/fast-jit/cg/x86-64/jit_codegen_x86_64.cpp
+++ b/core/iwasm/fast-jit/cg/x86-64/jit_codegen_x86_64.cpp
@@ -381,7 +381,7 @@ cmp_r_and_jmp_label(JitCompContext *cc, x86::Assembler &a,
 
     bool fp_cmp = cc->last_cmp_on_fp;
 
-    bh_assert(!fp_cmp || (fp_cmp && (op == GES)));
+    bh_assert(!fp_cmp || (fp_cmp && (op == GTS || op == GES)));
 
     switch (op) {
         case EQ:
@@ -396,7 +396,10 @@ cmp_r_and_jmp_label(JitCompContext *cc, x86::Assembler &a,
         }
         case GTS:
         {
-            a.jg(imm);
+            if (fp_cmp)
+                a.ja(imm);
+            else
+                a.jg(imm);
             break;
         }
         case LES:
@@ -5149,8 +5152,7 @@ cmp_r_and_jmp_relative(JitCompContext *cc, x86::Assembler &a, COND_OP op,
                        int32 offset)
 {
     Imm target(INT32_MAX);
-    char *stream = (char *)a.code()->sectionById(0)->buffer().data()
-                   + a.code()->sectionById(0)->buffer().size();
+    char *stream;
     bool fp_cmp = cc->last_cmp_on_fp;
 
     bh_assert(!fp_cmp || (fp_cmp && (op == GTS || op == GES)));
@@ -5223,8 +5225,14 @@ cmp_r_and_jmp_relative(JitCompContext *cc, x86::Assembler &a, COND_OP op,
         }
     }
 
-    /* The offset written by asmjit is always 0, we patch it again */
-    *(int32 *)(stream + 2) = offset;
+    JitErrorHandler *err_handler = (JitErrorHandler *)a.code()->errorHandler();
+
+    if (!err_handler->err) {
+        /* The offset written by asmjit is always 0, we patch it again */
+        stream = (char *)a.code()->sectionById(0)->buffer().data()
+                 + a.code()->sectionById(0)->buffer().size() - 6;
+        *(int32 *)(stream + 2) = offset;
+    }
     return true;
 }
 
@@ -5302,24 +5310,30 @@ fail:
 }
 
 /* jmp to dst label */
-#define JMP_TO_LABEL(label_dst, label_src)                                   \
-    do {                                                                     \
-        if (label_is_ahead(cc, label_dst, label_src)) {                      \
-            char *stream = (char *)a.code()->sectionById(0)->buffer().data() \
-                           + a.code()->sectionById(0)->buffer().size();      \
-            int32 _offset = label_offsets[label_dst]                         \
-                            - a.code()->sectionById(0)->buffer().size();     \
-            Imm imm(INT32_MAX);                                              \
-            a.jmp(imm);                                                      \
-            /* The offset written by asmjit is always 0, we patch it again,  \
-               6 is the size of jmp instruciton */                           \
-            *(int32 *)(stream + 2) = _offset - 6;                            \
-        }                                                                    \
-        else {                                                               \
-            if (!jmp_from_label_to_label(a, jmp_info_list, label_dst,        \
-                                         label_src))                         \
-                GOTO_FAIL;                                                   \
-        }                                                                    \
+#define JMP_TO_LABEL(label_dst, label_src)                                 \
+    do {                                                                   \
+        if (label_is_ahead(cc, label_dst, label_src)) {                    \
+            JitErrorHandler *err_handler =                                 \
+                (JitErrorHandler *)a.code()->errorHandler();               \
+            int32 _offset;                                                 \
+            char *stream;                                                  \
+            Imm imm(INT32_MAX);                                            \
+            a.jmp(imm);                                                    \
+            if (!err_handler->err) {                                       \
+                /* The offset written by asmjit is always 0, we patch it   \
+                   again, 6 is the size of jmp instruciton */              \
+                stream = (char *)a.code()->sectionById(0)->buffer().data() \
+                         + a.code()->sectionById(0)->buffer().size() - 6;  \
+                _offset = label_offsets[label_dst]                         \
+                          - a.code()->sectionById(0)->buffer().size();     \
+                *(int32 *)(stream + 2) = _offset;                          \
+            }                                                              \
+        }                                                                  \
+        else {                                                             \
+            if (!jmp_from_label_to_label(a, jmp_info_list, label_dst,      \
+                                         label_src))                       \
+                GOTO_FAIL;                                                 \
+        }                                                                  \
     } while (0)
 
 /**

--- a/core/iwasm/fast-jit/fe/jit_emit_control.h
+++ b/core/iwasm/fast-jit/fe/jit_emit_control.h
@@ -16,7 +16,7 @@ bool
 jit_compile_op_block(JitCompContext *cc, uint8 **p_frame_ip,
                      uint8 *frame_ip_end, uint32 label_type, uint32 param_count,
                      uint8 *param_types, uint32 result_count,
-                     uint8 *result_types);
+                     uint8 *result_types, bool merge_cmp_and_if);
 
 bool
 jit_compile_op_else(JitCompContext *cc, uint8 **p_frame_ip);
@@ -28,7 +28,8 @@ bool
 jit_compile_op_br(JitCompContext *cc, uint32 br_depth, uint8 **p_frame_ip);
 
 bool
-jit_compile_op_br_if(JitCompContext *cc, uint32 br_depth, uint8 **p_frame_ip);
+jit_compile_op_br_if(JitCompContext *cc, uint32 br_depth,
+                     bool merge_cmp_and_br_if, uint8 **p_frame_ip);
 
 bool
 jit_compile_op_br_table(JitCompContext *cc, uint32 *br_depths, uint32 br_count,

--- a/core/iwasm/fast-jit/jit_regalloc.c
+++ b/core/iwasm/fast-jit/jit_regalloc.c
@@ -339,7 +339,7 @@ fail:
 }
 
 /**
- * Check whether the gien register is an allocation candidate, which
+ * Check whether the given register is an allocation candidate, which
  * must be a variable register that is not fixed hard register.
  *
  * @param cc the compilation context
@@ -359,10 +359,8 @@ static void
 check_vreg_definition(RegallocContext *rc, JitInsn *insn)
 {
     JitRegVec regvec = jit_insn_opnd_regs(insn);
-    unsigned i;
-    JitReg *regp;
-    unsigned first_use = jit_insn_opnd_first_use(insn);
-    JitReg reg_defined;
+    JitReg *regp, reg_defined = 0;
+    unsigned i, first_use = jit_insn_opnd_first_use(insn);
 
     /* check if there is the definition of an vr before its references */
     JIT_REG_VEC_FOREACH(regvec, i, regp)
@@ -372,7 +370,7 @@ check_vreg_definition(RegallocContext *rc, JitInsn *insn)
         if (!is_alloc_candidate(rc->cc, *regp))
             continue;
 
-        /*a strong assumption that there is only on defined reg*/
+        /* a strong assumption that there is only one defined reg */
         if (i < first_use) {
             reg_defined = *regp;
             continue;
@@ -380,8 +378,8 @@ check_vreg_definition(RegallocContext *rc, JitInsn *insn)
 
         /**
          * both definition and references are in one instruction,
-         * like MOV i3,i3
-         **/
+         * like MOV i3, i3
+         */
         if (reg_defined == *regp)
             continue;
 


### PR DESCRIPTION
Merge below INSNs translated by wasm opcodes `cmp + if` or `cmp + br_if`:
    CMP, SELECTcc, CMP, Bcc
into
    CMP, Bcc
So as to reduce the instructions