### PR TITLE
Don't suppress prev signal handler in hw bound check

### DIFF
--- a/core/shared/platform/common/posix/posix_thread.c
+++ b/core/shared/platform/common/posix/posix_thread.c
@@ -448,8 +448,8 @@ mask_signals(int how)
     pthread_sigmask(how, &set, NULL);
 }
 
-static struct sigaction prev_sig_act_SIGSEGV;
-static struct sigaction prev_sig_act_SIGBUS;
+static os_thread_local_attribute struct sigaction prev_sig_act_SIGSEGV;
+static os_thread_local_attribute struct sigaction prev_sig_act_SIGBUS;
 
 static void
 signal_callback(int sig_num, siginfo_t *sig_info, void *sig_ucontext)


### PR DESCRIPTION
Enhance the hw bound check reported in #1262:

When registering signal handlers for SIGSEGV & SIGBUS in boundary
check with hardware trap, preserve the previous handlers for signal
SIGSEGV and SIGBUS, and forward the signal to the preserved signal
handlers if it isn't handled by hw bound check.
