### PR TITLE
Add spec tests on OSX

### DIFF
--- a/.github/workflows/compilation_on_macos.yml
+++ b/.github/workflows/compilation_on_macos.yml
@@ -30,12 +30,18 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # For building
   AOT_BUILD_OPTIONS: "-DWAMR_BUILD_AOT=1 -DWAMR_BUILD_FAST_INTERP=0 -DWAMR_BUILD_INTERP=0 -DWAMR_BUILD_JIT=0 -DWAMR_BUILD_LAZY_JIT=0"
   CLASSIC_INTERP_BUILD_OPTIONS: "-DWAMR_BUILD_AOT=0 -DWAMR_BUILD_FAST_INTERP=0 -DWAMR_BUILD_INTERP=1 -DWAMR_BUILD_JIT=0 -DWAMR_BUILD_LAZY_JIT=0"
   FAST_INTERP_BUILD_OPTIONS: "-DWAMR_BUILD_AOT=0 -DWAMR_BUILD_FAST_INTERP=1 -DWAMR_BUILD_INTERP=1 -DWAMR_BUILD_JIT=0 -DWAMR_BUILD_LAZY_JIT=0"
   LAZY_JIT_BUILD_OPTIONS: "-DWAMR_BUILD_AOT=1 -DWAMR_BUILD_FAST_INTERP=0 -DWAMR_BUILD_INTERP=0 -DWAMR_BUILD_JIT=1 -DWAMR_BUILD_LAZY_JIT=1"
   MC_JIT_BUILD_OPTIONS: "-DWAMR_BUILD_AOT=1 -DWAMR_BUILD_FAST_INTERP=0 -DWAMR_BUILD_INTERP=0 -DWAMR_BUILD_JIT=1 -DWAMR_BUILD_LAZY_JIT=0"
   LLVM_CACHE_SUFFIX: "build-llvm_libraries_ex"
+  # For spec Test
+  DEFAULT_TEST_OPTIONS: "-s spec"
+  MULTI_MODULES_TEST_OPTIONS: "-s spec -M"
+  SIMD_TEST_OPTIONS: "-s spec -S"
+  THREADS_TEST_OPTIONS: "-s spec -p"
 
 jobs:
   # Cancel any in-flight jobs for the same PR/branch so there's only one active
@@ -391,3 +397,28 @@ jobs:
           cmake ..
           cmake --build . --config Release --parallel 4
           ./hello
+
+  spec_test_default:
+    if: ${{ endsWith(github.repository, 'wasm-micro-runtime') }}
+    needs: [build_iwasm, check_repo]
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        running_mode: ["classic-interp", "fast-interp"]
+        test_option:
+          [
+            $DEFAULT_TEST_OPTIONS,
+            $MULTI_MODULES_TEST_OPTIONS,
+            $SIMD_TEST_OPTIONS,
+            $THREADS_TEST_OPTIONS,
+          ]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: install Ninja
+        run: brew install ninja
+
+      - name: run spec tests
+        run: ./test_wamr.sh ${{ matrix.test_option }} -t ${{ matrix.running_mode }}
+        working-directory: ./tests/wamr-test-suites

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ tests/wamr-test-suites/workspace
 !/test-tools/wamr-ide/VSCode-Extension/.vscode
 
 samples/socket-api/wasm-src/inc/pthread.h
+
+**/__pycache__
+**/*.pyc

--- a/tests/wamr-test-suites/spec-test-script/all.py
+++ b/tests/wamr-test-suites/spec-test-script/all.py
@@ -121,7 +121,7 @@ def test_case(
     ):
         return True
 
-    CMD = ["python2.7", "runtest.py"]
+    CMD = ["python3", "runtest.py"]
     CMD.append("--wast2wasm")
     CMD.append(WAST2WASM_CMD)
     CMD.append("--interpreter")

--- a/tests/wamr-test-suites/spec-test-script/runtest.py
+++ b/tests/wamr-test-suites/spec-test-script/runtest.py
@@ -58,8 +58,7 @@ else:
 rundir = None
 
 def create_a_runner(cmd, no_pty=False):
-    # return TTYRunner(cmd) if sys.platform == "darwin" else Runner(cmd, no_pty)
-    return TTYRunner(cmd)
+    return TTYRunner(cmd) if sys.platform == "darwin" else Runner(cmd, no_pty)
 
 class Runner():
     def __init__(self, args, no_pty=False):
@@ -322,7 +321,7 @@ def get_module_exp_from_assert(string):
 
 def string_to_unsigned(number_in_string, lane_type):
     if not lane_type in ['i8x16', 'i16x8', 'i32x4', 'i64x2']:
-        raise Exception("invalid value {} and type {} and lane_type {}".format(numbers, type, lane_type))
+        raise Exception("invalid value {} and type {} and lane_type {}".format(number_in_string, type, lane_type))
 
     number = int(number_in_string, 16) if '0x' in number_in_string else int(number_in_string)
 
@@ -472,7 +471,7 @@ def int2int64(i):
 
 
 def num_repr(i):
-    if isinstance(i, int) or isinstance(i, long):
+    if isinstance(i, int):
         return re.sub("L$", "", hex(i))
     else:
         return "%.16g" % i
@@ -645,7 +644,6 @@ def test_assert(r, opts, mode, cmd, expected):
     log("Testing(%s) %s = %s" % (mode, cmd, expected))
 
     out = invoke(r, opts, cmd)
-    print("==> {}".format(out.encode("utf-8")))
     if '\n' in out:
         outs = [''] + out.split('\n')[1:]
         out = outs[-1]
@@ -1138,21 +1136,17 @@ if __name__ == "__main__":
                     f = open(wasm_tempfile, 'wb' if IS_PY_3 else "w")
                     # f = open(wasm_tempfile, 'w')
                     s = m.group(1)
-                    print("==>s: {}".format(s))
                     while s:
                         res = re.match("[^\"]*\"([^\"]*)\"(.*)", s, re.DOTALL)
                         binary_module = res.group(1)
 
-                        print("==>1. SZ:{} binary_module: \"{}\"".format(len(binary_module), binary_module))
                         if IS_PY_3:
                             binary_module = binary_module.replace("\\", "\\x").encode("raw_unicode_escape").decode("unicode_escape")
                             binary_module = binary_module.encode("latin-1")
                         else:
                             binary_module = binary_module.replace("\\", "\\x").decode("string_escape")
-                        print("==>2. SZ:{} binary_module: \"{}\"".format(len(binary_module), repr(binary_module)))
 
                         sz = f.write(binary_module)
-                        print("==>3. SZ:{} ".format(sz))
                         s = res.group(2)
                     f.close()
 

--- a/tests/wamr-test-suites/spec-test-script/tty_runner.py
+++ b/tests/wamr-test-suites/spec-test-script/tty_runner.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+
+import os
+import pty
+import re
+import select
+import shlex
+import subprocess
+import sys
+import time
+
+class TTYRunner:
+    def __init__(self, cmd):
+        self.process = None
+
+        # Use tty to setup an interactive environment
+        self.master_in, self.slave_in = pty.openpty()
+        self.master_out, self.slave_out = pty.openpty()
+
+        self.process = subprocess.Popen(
+            cmd,
+            bufsize=1,
+            universal_newlines=True,
+            stdin=self.slave_in,
+            stdout=self.slave_out,
+            stderr=subprocess.STDOUT,
+        )
+        self.buf = ""
+
+    def read_to_prompt(self, prompts, timeout=5):
+        begin = time.time()
+        res = b""
+
+        select_timeout = 2
+        while time.time() - begin < timeout :
+            outs, _, _ = select.select([self.master_out], [], [], select_timeout)
+            if len(outs) == 0:
+                print("[Runner WARNING]select timeout")
+                break
+
+            # first responding is slow, others are super fast
+            select_timeout = 0.05
+
+            data = os.read(self.master_out, 1024)
+            if len(data) == 0:
+                print("[Runner WARNING]just met an EOF")
+                break
+
+            print("[Runner WARNING]read {} bytes".format(len(data)))
+            res += data
+
+            if self.process.poll() is not None:
+                print("[Runner WARNING]the process has quitted")
+                break
+        else:
+            print("[Runner WARNING]after a long wait")
+
+        print("[Runner INFO]got {} bytes, \"{}\"".format(len(res), res))
+
+        # filter the prompts
+        buf = None
+        if len(res) > 0:
+            self.buf = res.decode("utf-8")
+            self.buf = self.buf.replace('\r\n', os.linesep)
+            for prompt in prompts:
+                match = re.search(prompt, self.buf)
+                if match:
+                    end = match.end()
+                    buf = self.buf[0 : (end - len(prompt))]
+                    self.buf = self.buf[end:]
+                    print("[Runner WARNING]find a match")
+                    break
+            else:
+                print("[Runner WARNING]doesn't find a match")
+
+            print("[Runner INFO]  buf is \"{}\"".format(buf))
+            print("[Runner INFO]  self.buf is \"{}\"".format(self.buf))
+        return buf
+
+    def writeline(self, str):
+        if self.process.poll() is not None:
+            return
+
+        str_to_write = str + "\n"
+        str_to_write = str_to_write.encode("utf-8")
+        os.write(self.master_in, str_to_write)
+
+    def cleanup(self):
+        if self.process.poll() is None:
+            try:
+                # _, _ = self.process.communicate()
+                # self.writeline("__exit__")
+
+                self.process.terminate()
+                self.process.communicate(timeout=0.3)
+                self.process.wait(timeout=0.3)
+            except Exception as e:
+                print("process shutdown time-out {}".format(e))
+                self.process.kill()
+        else:
+            print("[Runner INFO]process has already quitted")
+
+        for fd in [self.slave_in, self.slave_out, self.master_in, self.master_out]:
+            os.close(fd)
+
+        return self.process.returncode
+
+if __name__ == "__main__":
+    runner = TTYRunner(shlex.split("ls /"))
+    runner.read_to_prompt([" usr"])
+    runner.cleanup()
+
+    runner = TTYRunner(shlex.split("python3"))
+    runner.read_to_prompt([">>> "])
+    runner.writeline("3 + b")
+    runner.read_to_prompt([">>> "])
+    runner.writeline("3 + 2")
+    runner.read_to_prompt([">>> "])
+    runner.writeline("exit()")
+    runner.read_to_prompt([">>> "])
+    runner.cleanup()
+
+    runner = TTYRunner(shlex.split("python3"))
+    runner.read_to_prompt([">>> "])
+    runner.cleanup()
+
+    runner = TTYRunner(shlex.split("python3"))
+    runner.read_to_prompt([">>>>>> "])
+    runner.cleanup()


### PR DESCRIPTION
Can't make a simple modification to resolve the issue of accidentally meeting "EOF" on MacOS. Has to

- Upgrade test scripts to python3
- Use a new `TTYRunner` on MacOS
- Abandon parallel running on MacOS

The left problem is pretty much. The time consumption on MacOS is super long. It will take *1.75 - 2 hours* 😮  per workflow.