### PR TITLE
Fix aot rotl/rotr 0 issue

### DIFF
--- a/core/iwasm/compilation/aot_emit_numberic.c
+++ b/core/iwasm/compilation/aot_emit_numberic.c
@@ -690,6 +690,12 @@ compile_int_rot(AOTCompContext *comp_ctx, LLVMValueRef left, LLVMValueRef right,
     LLVMValueRef bits_minus_shift_count, res, tmp_l, tmp_r;
     char *name = is_rotl ? "rotl" : "rotr";
 
+    /* right is 0 */
+    if (LLVMIsConstant(right)
+        && (uint64)LLVMConstIntGetZExtValue(right) == 0) {
+        return left;
+    }
+
     SHIFT_COUNT_MASK;
 
     /* Calculate (bits - shif_count) */

--- a/core/iwasm/compilation/aot_emit_numberic.c
+++ b/core/iwasm/compilation/aot_emit_numberic.c
@@ -690,12 +690,11 @@ compile_int_rot(AOTCompContext *comp_ctx, LLVMValueRef left, LLVMValueRef right,
     LLVMValueRef bits_minus_shift_count, res, tmp_l, tmp_r;
     char *name = is_rotl ? "rotl" : "rotr";
 
-    /* right is 0 */
-    if (LLVMIsConstant(right) && (uint64)LLVMConstIntGetZExtValue(right) == 0) {
-        return left;
-    }
-
     SHIFT_COUNT_MASK;
+
+    /* rotl/rotr with 0 */
+    if (IS_CONST_ZERO(right))
+        return left;
 
     /* Calculate (bits - shif_count) */
     LLVM_BUILD_OP(Sub, is_i32 ? I32_32 : I64_64, right, bits_minus_shift_count,

--- a/core/iwasm/compilation/aot_emit_numberic.c
+++ b/core/iwasm/compilation/aot_emit_numberic.c
@@ -691,8 +691,7 @@ compile_int_rot(AOTCompContext *comp_ctx, LLVMValueRef left, LLVMValueRef right,
     char *name = is_rotl ? "rotl" : "rotr";
 
     /* right is 0 */
-    if (LLVMIsConstant(right)
-        && (uint64)LLVMConstIntGetZExtValue(right) == 0) {
+    if (LLVMIsConstant(right) && (uint64)LLVMConstIntGetZExtValue(right) == 0) {
         return left;
     }
 


### PR DESCRIPTION
Fix the issue reported in #1282.
When 64-bit rotate (rotl/rotr) with 0, the LLVM IRs translated are:
  `left<<0 | left>>64` and `left >>0 | left<<64`
The value of `left >> 64` and `left <<64` in LLVM are treated as `poison`,
which causes invalid result when executing the aot function.

Directly return left when right is 0 to fix the issue.