### PR TITLE
Refine fast-jit load func pointers

### DIFF
--- a/core/iwasm/fast-jit/fe/jit_emit_function.c
+++ b/core/iwasm/fast-jit/fe/jit_emit_function.c
@@ -153,15 +153,15 @@ jit_compile_op_call(JitCompContext *cc, uint32 func_idx, bool tail_call)
     WASMType *func_type;
     JitFrame *jit_frame = cc->jit_frame;
     JitReg native_ret;
-    JitReg func_ptrs, jitted_code = 0;
+    JitReg fast_jit_func_ptrs, jitted_code = 0;
     uint32 jitted_func_idx;
 
     if (func_idx >= wasm_module->import_function_count) {
-        func_ptrs = get_func_ptrs_reg(jit_frame);
+        fast_jit_func_ptrs = get_fast_jit_func_ptrs_reg(jit_frame);
         jitted_code = jit_cc_new_reg_ptr(cc);
         /* jitted_code = func_ptrs[func_idx - import_function_count] */
         jitted_func_idx = func_idx - wasm_module->import_function_count;
-        GEN_INSN(LDPTR, jitted_code, func_ptrs,
+        GEN_INSN(LDPTR, jitted_code, fast_jit_func_ptrs,
                  NEW_CONST(I32, (uint32)sizeof(void *) * jitted_func_idx));
     }
 

--- a/core/iwasm/fast-jit/jit_frontend.c
+++ b/core/iwasm/fast-jit/jit_frontend.c
@@ -56,31 +56,18 @@ get_module_inst_reg(JitFrame *frame)
 }
 
 JitReg
-get_module_reg(JitFrame *frame)
+get_fast_jit_func_ptrs_reg(JitFrame *frame)
 {
     JitCompContext *cc = frame->cc;
     JitReg module_inst_reg = get_module_inst_reg(frame);
 
-    if (!frame->module_reg) {
-        frame->module_reg = cc->module_reg;
-        GEN_INSN(LDPTR, frame->module_reg, module_inst_reg,
-                 NEW_CONST(I32, offsetof(WASMModuleInstance, module)));
+    if (!frame->fast_jit_func_ptrs_reg) {
+        frame->fast_jit_func_ptrs_reg = cc->fast_jit_func_ptrs_reg;
+        GEN_INSN(
+            LDPTR, frame->fast_jit_func_ptrs_reg, module_inst_reg,
+            NEW_CONST(I32, offsetof(WASMModuleInstance, fast_jit_func_ptrs)));
     }
-    return frame->module_reg;
-}
-
-JitReg
-get_func_ptrs_reg(JitFrame *frame)
-{
-    JitCompContext *cc = frame->cc;
-    JitReg module_reg = get_module_reg(frame);
-
-    if (!frame->func_ptrs_reg) {
-        frame->func_ptrs_reg = cc->func_ptrs_reg;
-        GEN_INSN(LDPTR, frame->func_ptrs_reg, module_reg,
-                 NEW_CONST(I32, offsetof(WASMModule, fast_jit_func_ptrs)));
-    }
-    return frame->func_ptrs_reg;
+    return frame->fast_jit_func_ptrs_reg;
 }
 
 JitReg
@@ -373,8 +360,7 @@ clear_fixed_virtual_regs(JitFrame *frame)
     uint32 count, i;
 
     frame->module_inst_reg = 0;
-    frame->module_reg = 0;
-    frame->func_ptrs_reg = 0;
+    frame->fast_jit_func_ptrs_reg = 0;
     frame->global_data_reg = 0;
     frame->aux_stack_bound_reg = 0;
     frame->aux_stack_bottom_reg = 0;
@@ -569,8 +555,7 @@ create_fixed_virtual_regs(JitCompContext *cc)
     uint32 i, count;
 
     cc->module_inst_reg = jit_cc_new_reg_ptr(cc);
-    cc->module_reg = jit_cc_new_reg_ptr(cc);
-    cc->func_ptrs_reg = jit_cc_new_reg_ptr(cc);
+    cc->fast_jit_func_ptrs_reg = jit_cc_new_reg_ptr(cc);
     cc->global_data_reg = jit_cc_new_reg_ptr(cc);
     cc->aux_stack_bound_reg = jit_cc_new_reg_I32(cc);
     cc->aux_stack_bottom_reg = jit_cc_new_reg_I32(cc);

--- a/core/iwasm/fast-jit/jit_frontend.h
+++ b/core/iwasm/fast-jit/jit_frontend.h
@@ -212,10 +212,7 @@ JitReg
 get_module_inst_reg(JitFrame *frame);
 
 JitReg
-get_module_reg(JitFrame *frame);
-
-JitReg
-get_func_ptrs_reg(JitFrame *frame);
+get_fast_jit_func_ptrs_reg(JitFrame *frame);
 
 JitReg
 get_global_data_reg(JitFrame *frame);

--- a/core/iwasm/fast-jit/jit_ir.h
+++ b/core/iwasm/fast-jit/jit_ir.h
@@ -949,10 +949,8 @@ typedef struct JitFrame {
 
     /* WASM module instance */
     JitReg module_inst_reg;
-    /* WASM module */
-    JitReg module_reg;
-    /* module->fast_jit_func_ptrs */
-    JitReg func_ptrs_reg;
+    /* module_inst->fast_jit_func_ptrs */
+    JitReg fast_jit_func_ptrs_reg;
     /* Base address of global data */
     JitReg global_data_reg;
     /* Boundary of auxiliary stack */
@@ -1067,10 +1065,8 @@ typedef struct JitCompContext {
 
     /* WASM module instance */
     JitReg module_inst_reg;
-    /* WASM module */
-    JitReg module_reg;
-    /* module->fast_jit_func_ptrs */
-    JitReg func_ptrs_reg;
+    /* module_inst->fast_jit_func_ptrs */
+    JitReg fast_jit_func_ptrs_reg;
     /* Base address of global data */
     JitReg global_data_reg;
     /* Boundary of auxiliary stack */

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -654,6 +654,10 @@ functions_instantiate(const WASMModule *module, WASMModuleInstance *module_inst,
         function++;
     }
 
+#if WASM_ENABLE_FAST_JIT != 0
+    module_inst->fast_jit_func_ptrs = module->fast_jit_func_ptrs;
+#endif
+
     bh_assert((uint32)(function - functions) == function_count);
     (void)module_inst;
     return functions;

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -183,6 +183,10 @@ struct WASMModuleInstance {
 
     /* Array of function pointers to import functions */
     void **import_func_ptrs;
+#if WASM_ENABLE_FAST_JIT != 0
+    /* point to JITed functions */
+    void **fast_jit_func_ptrs;
+#endif
 
     WASMMemoryInstance **memories;
     WASMTableInstance **tables;


### PR DESCRIPTION
Copy fast jit function pointers array from wasm module into wasm
module instance, and load fast jit func pointer from module instance
instead wasm module, so as to reduce one load operation when callbc.