### PR TITLE
Fix sanitizer complaint: i32/i64 multiply integer overflow

### DIFF
--- a/core/iwasm/fast-jit/fe/jit_emit_numberic.c
+++ b/core/iwasm/fast-jit/fe/jit_emit_numberic.c
@@ -422,7 +422,17 @@ DEF_UNI_INT_CONST_OPS(mul)
     return 0;
 }
 
-DEF_BI_INT_CONST_OPS(mul, *)
+static int32
+do_i32_const_mul(int32 lhs, int32 rhs)
+{
+    return (int32)((uint64)lhs * (uint64)rhs);
+}
+
+static int64
+do_i64_const_mul(int64 lhs, int64 rhs)
+{
+    return (int64)((uint64)lhs * (uint64)rhs);
+}
 
 static JitReg
 compile_int_mul(JitCompContext *cc, JitReg left, JitReg right, bool is_i32)


### PR DESCRIPTION
Fix fast jit sanitizer complaint in fe/jit_emit_number.c:
    i32/i64 multiply integer overflow was detected