### PR TITLE
Implement wasi_addr_resolve function

### DIFF
--- a/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
+++ b/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
@@ -1041,10 +1041,23 @@ wasi_sock_addr_remote(wasm_exec_env_t exec_env, wasi_fd_t fd, uint8 *buf,
 }
 
 static wasi_errno_t
-wasi_sock_addr_resolve(wasm_exec_env_t exec_env, wasi_fd_t fd, const char *host,
-                       wasi_ip_port_t port, uint8 *buf, wasi_size_t size)
+wasi_sock_addr_resolve(wasm_exec_env_t exec_env, const char *host,
+                       const char *service, __wasi_addr_info_hints_t *hints,
+                       __wasi_addr_info_t *addr_info,
+                       __wasi_size_t addr_info_size,
+                       __wasi_size_t *max_info_size)
 {
-    return __WASI_ENOSYS;
+    wasm_module_inst_t module_inst = get_module_inst(exec_env);
+    wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
+    struct fd_table *curfds = NULL;
+
+    if (!wasi_ctx)
+        return __WASI_EACCES;
+
+    curfds = wasi_ctx_get_curfds(module_inst, wasi_ctx);
+
+    return wasi_ssp_sock_addr_resolve(curfds, host, service, hints, addr_info,
+                                      addr_info_size, max_info_size);
 }
 
 static wasi_errno_t
@@ -1390,7 +1403,7 @@ static NativeSymbol native_symbols_libc_wasi[] = {
     REG_NATIVE_FUNC(sock_accept, "(i*)i"),
     REG_NATIVE_FUNC(sock_addr_local, "(i*i)i"),
     REG_NATIVE_FUNC(sock_addr_remote, "(i*i)i"),
-    REG_NATIVE_FUNC(sock_addr_resolve, "(i*i*i)i"),
+    REG_NATIVE_FUNC(sock_addr_resolve, "($$**i*)i"),
     REG_NATIVE_FUNC(sock_bind, "(i*)i"),
     REG_NATIVE_FUNC(sock_close, "(i)i"),
     REG_NATIVE_FUNC(sock_connect, "(i*)i"),

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/include/wasmtime_ssp.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/include/wasmtime_ssp.h
@@ -598,6 +598,18 @@ typedef struct __wasi_addr_t {
 
 typedef enum { INET4 = 0, INET6 } __wasi_address_family_t;
 
+typedef struct __wasi_addr_info_t {
+    __wasi_addr_t addr;
+    __wasi_sock_type_t type;
+} __wasi_addr_info_t;
+
+typedef struct __wasi_addr_info_hints_t {
+   __wasi_sock_type_t type;
+   __wasi_address_family_t family;
+   // this is to workaround lack of optional parameters
+   uint8_t hints_enabled;
+} __wasi_addr_info_hints_t;
+
 #if defined(WASMTIME_SSP_WASI_API)
 #define WASMTIME_SSP_SYSCALL_NAME(name) \
     asm("__wasi_" #name)
@@ -1021,6 +1033,16 @@ wasi_ssp_sock_bind(
     struct fd_table *curfds, struct addr_pool *addr_pool,
 #endif
     __wasi_fd_t fd, __wasi_addr_t *addr
+) __attribute__((__warn_unused_result__));
+
+__wasi_errno_t
+wasi_ssp_sock_addr_resolve(
+#if !defined(WASMTIME_SSP_STATIC_CURFDS)
+    struct fd_table *curfds,
+#endif
+    const char *host, const char* service,
+    __wasi_addr_info_hints_t *hints, __wasi_addr_info_t *addr_info,
+    __wasi_size_t addr_info_size, __wasi_size_t *max_info_size
 ) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t

--- a/core/shared/platform/include/platform_api_extension.h
+++ b/core/shared/platform/include/platform_api_extension.h
@@ -339,6 +339,41 @@ os_socket_shutdown(bh_socket_t socket);
 int
 os_socket_inet_network(const char *cp, uint32 *out);
 
+typedef struct {
+    uint8_t addr[16];
+    uint16_t port;
+    uint8_t is_ipv4;
+    uint8_t is_tcp;
+} bh_addr_info_t;
+
+/**
+ * Resolve a host a hostname and a service to one or more IP addresses
+ *
+ * @param host a host to resolve
+ *
+ * @param service a service to find a port for
+ *
+ * @param hint_is_tcp an optional flag that determines a preferred socket type
+ (TCP or UDP).
+ *
+ * @param hint_is_ipv4 an optional flag that determines a preferred address
+ family (IPv4 or IPv6)
+ *
+ * @param addr_info a buffer for resolved addresses
+ *
+ * @param addr_info_size a size of the buffer for resolved addresses
+
+ * @param max_info_size a maximum number of addresses available (can be bigger
+ or smaller than buffer size)
+
+ * @return On success, the function returns 0; otherwise, it returns -1
+ */
+int
+os_socket_addr_resolve(const char *host, const char *service,
+                       uint8_t *hint_is_tcp, uint8_t *hint_is_ipv4,
+                       bh_addr_info_t *addr_info, size_t addr_info_size,
+                       size_t *max_info_size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/shared/platform/linux-sgx/sgx_socket.c
+++ b/core/shared/platform/linux-sgx/sgx_socket.c
@@ -4,6 +4,7 @@
  */
 
 #include "platform_api_vmcore.h"
+#include "platform_api_extension.h"
 
 #ifndef SGX_DISABLE_WASI
 
@@ -618,6 +619,17 @@ int
 os_socket_shutdown(bh_socket_t socket)
 {
     return shutdown(socket, O_RDWR);
+}
+
+int
+os_socket_addr_resolve(const char *host, const char *service,
+                       uint8_t *hint_is_tcp, uint8_t *hint_is_ipv4,
+                       bh_addr_info_t *addr_info, size_t addr_info_size,
+                       size_t *max_info_size)
+{
+    errno = ENOSYS;
+
+    return BHT_ERROR;
 }
 
 #endif

--- a/core/shared/platform/windows/win_socket.c
+++ b/core/shared/platform/windows/win_socket.c
@@ -162,3 +162,14 @@ os_socket_inet_network(const char *cp, uint32 *out)
     *out = inet_addr(cp);
     return BHT_OK;
 }
+
+int
+os_socket_addr_resolve(const char *host, const char *service,
+                       uint8_t *hint_is_tcp, uint8_t *hint_is_ipv4,
+                       bh_addr_info_t *addr_info, size_t addr_info_size,
+                       size_t *max_info_size)
+{
+    errno = ENOSYS;
+
+    return BHT_ERROR;
+}


### PR DESCRIPTION
Implement wasi_addr_resolve function
    
I also slightly modified the interface to make it more accessible for the
end-user:
 * replaced port argument with the service - so the user can actually get the port for a given service if unknown
 * introduced __wasi_addr_info_t and used it as a buffer for addresses, instead of generic buffer
 * introduced __wasi_addr_info_hints_t so users can enable filtering on the syscall level (and therefore use smaller buffers for addresses)
 * added max_size parameter for the API as an output - in case the number of addresses is bigger than the buffer size, user can repeat the call with bigger buffer

This change is very minimalistic, and it doesn't include the following:
 1. implementation of getaddrinfo in the lib-socket
 2. sample application
 
The 1. and 2. will be added in the following change (I did want to keep the change as small as possible for easier review. 3. can be implemented if needed, but I'm not really sure if that is required at all

Fixes #1336