### PR TITLE
Implement sock_addr_local syscall

### DIFF
--- a/core/iwasm/libraries/lib-socket/inc/wasi_socket_ext.h
+++ b/core/iwasm/libraries/lib-socket/inc/wasi_socket_ext.h
@@ -114,6 +114,9 @@ sendmsg(int sockfd, const struct msghdr *msg, int flags);
 
 int
 socket(int domain, int type, int protocol);
+
+int
+getsockname(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
 #endif
 
 /**
@@ -141,16 +144,15 @@ __wasi_sock_accept(__wasi_fd_t fd, __wasi_fd_t *fd_new)
  * either IP4 or IP6.
  */
 int32_t
-__imported_wasi_snapshot_preview1_sock_addr_local(int32_t arg0, int32_t arg1,
-                                                  int32_t arg2)
+__imported_wasi_snapshot_preview1_sock_addr_local(int32_t arg0, int32_t arg1)
     __attribute__((__import_module__("wasi_snapshot_preview1"),
                    __import_name__("sock_addr_local")));
 
 static inline __wasi_errno_t
-__wasi_sock_addr_local(__wasi_fd_t fd, uint8_t *buf, __wasi_size_t buf_len)
+__wasi_sock_addr_local(__wasi_fd_t fd, __wasi_addr_t *addr)
 {
     return (__wasi_errno_t)__imported_wasi_snapshot_preview1_sock_addr_local(
-        (int32_t)fd, (int32_t)buf, (int32_t)buf_len);
+        (int32_t)fd, (int32_t)addr);
 }
 
 /**

--- a/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
+++ b/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
@@ -1009,8 +1009,8 @@ wasi_sock_accept(wasm_exec_env_t exec_env, wasi_fd_t fd, wasi_fd_t *fd_new)
 }
 
 static wasi_errno_t
-wasi_sock_addr_local(wasm_exec_env_t exec_env, wasi_fd_t fd, uint8 *buf,
-                     wasi_size_t buf_len)
+wasi_sock_addr_local(wasm_exec_env_t exec_env, wasi_fd_t fd,
+                     __wasi_addr_t *addr)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -1019,9 +1019,12 @@ wasi_sock_addr_local(wasm_exec_env_t exec_env, wasi_fd_t fd, uint8 *buf,
     if (!wasi_ctx)
         return __WASI_EACCES;
 
+    if (!validate_native_addr(addr, sizeof(__wasi_addr_t)))
+        return __WASI_EINVAL;
+
     curfds = wasi_ctx_get_curfds(module_inst, wasi_ctx);
 
-    return wasi_ssp_sock_addr_local(curfds, fd, buf, buf_len);
+    return wasi_ssp_sock_addr_local(curfds, fd, addr);
 }
 
 static wasi_errno_t
@@ -1401,7 +1404,7 @@ static NativeSymbol native_symbols_libc_wasi[] = {
     REG_NATIVE_FUNC(proc_raise, "(i)i"),
     REG_NATIVE_FUNC(random_get, "(*~)i"),
     REG_NATIVE_FUNC(sock_accept, "(i*)i"),
-    REG_NATIVE_FUNC(sock_addr_local, "(i*i)i"),
+    REG_NATIVE_FUNC(sock_addr_local, "(i*)i"),
     REG_NATIVE_FUNC(sock_addr_remote, "(i*i)i"),
     REG_NATIVE_FUNC(sock_addr_resolve, "($$**i*)i"),
     REG_NATIVE_FUNC(sock_bind, "(i*)i"),

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/include/wasmtime_ssp.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/include/wasmtime_ssp.h
@@ -1007,7 +1007,7 @@ wasi_ssp_sock_addr_local(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t fd, uint8_t *buf, __wasi_size_t buf_len
+    __wasi_fd_t fd, __wasi_addr_t *addr
 ) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -203,12 +203,14 @@ convert_clockid(__wasi_clockid_t in, clockid_t *out)
 static void
 ipv4_addr_to_wasi_addr(uint32_t addr, __wasi_ip_port_t port, __wasi_addr_t *out)
 {
+    addr = ntohl(addr);
+
     out->kind = IPv4;
     out->addr.ip4.port = port;
-    out->addr.ip4.addr.n3 = (addr & 0xFF000000) >> 24;
-    out->addr.ip4.addr.n2 = (addr & 0x00FF0000) >> 16;
-    out->addr.ip4.addr.n1 = (addr & 0x0000FF00) >> 8;
-    out->addr.ip4.addr.n0 = (addr & 0x000000FF);
+    out->addr.ip4.addr.n0 = (addr & 0xFF000000) >> 24;
+    out->addr.ip4.addr.n1 = (addr & 0x00FF0000) >> 16;
+    out->addr.ip4.addr.n2 = (addr & 0x0000FF00) >> 8;
+    out->addr.ip4.addr.n3 = (addr & 0x000000FF);
 }
 
 // Converts an IPv6 binary address object to WASI address object.
@@ -2881,16 +2883,34 @@ wasi_ssp_sock_addr_local(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t fd, uint8 *buf, __wasi_size_t buf_len)
+    __wasi_fd_t fd, __wasi_addr_t *addr)
 {
     struct fd_object *fo;
+    uint8 buf[16];
+    __wasi_ip_port_t port;
+    uint8 is_ipv4;
+    int ret;
+
     __wasi_errno_t error =
         fd_object_get(curfds, &fo, fd, __WASI_RIGHT_SOCK_ADDR_LOCAL, 0);
     if (error != __WASI_ESUCCESS)
         return error;
 
+    ret = os_socket_addr_local(fd_number(fo), buf, sizeof(buf) / sizeof(buf[0]),
+                               &port, &is_ipv4);
     fd_object_release(fo);
-    return __WASI_ENOSYS;
+    if (ret != BHT_OK) {
+        return convert_errno(errno);
+    }
+
+    if (is_ipv4) {
+        ipv4_addr_to_wasi_addr(*(uint32_t *)buf, port, addr);
+    }
+    else {
+        ipv6_addr_to_wasi_addr((uint16 *)buf, port, addr);
+    }
+
+    return __WASI_ESUCCESS;
 }
 
 __wasi_errno_t

--- a/core/shared/platform/include/platform_api_extension.h
+++ b/core/shared/platform/include/platform_api_extension.h
@@ -374,6 +374,25 @@ os_socket_addr_resolve(const char *host, const char *service,
                        bh_addr_info_t *addr_info, size_t addr_info_size,
                        size_t *max_info_size);
 
+/**
+ * Returns an binary address and a port of the local socket
+ *
+ * @param socket the local socket
+ *
+ * @param buf buffer to store the address
+ *
+ * @param buflen length of the buf buffer
+ *
+ * @param port a buffer for storing socket's port
+ *
+ * @param is_ipv4 a buffer for storing information about the address family
+ *
+ * @return On success, returns 0; otherwise, it returns -1.
+ */
+int
+os_socket_addr_local(bh_socket_t socket, uint8_t *buf, size_t buflen,
+                     uint16_t *port, uint8_t *is_ipv4);
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/shared/platform/linux-sgx/sgx_socket.c
+++ b/core/shared/platform/linux-sgx/sgx_socket.c
@@ -105,7 +105,7 @@ htonl(uint32 value)
     return value;
 }
 
-static uint32
+uint32
 ntohl(uint32 value)
 {
     return htonl(value);
@@ -626,6 +626,15 @@ os_socket_addr_resolve(const char *host, const char *service,
                        uint8_t *hint_is_tcp, uint8_t *hint_is_ipv4,
                        bh_addr_info_t *addr_info, size_t addr_info_size,
                        size_t *max_info_size)
+{
+    errno = ENOSYS;
+
+    return BHT_ERROR;
+}
+
+int
+os_socket_addr_local(bh_socket_t socket, uint8_t *buf, size_t buflen,
+                     uint16_t *port, uint8_t *is_ipv4)
 {
     errno = ENOSYS;
 

--- a/core/shared/platform/linux-sgx/sgx_socket.h
+++ b/core/shared/platform/linux-sgx/sgx_socket.h
@@ -95,6 +95,9 @@ struct sockaddr {
     char sa_data[14];             /* Address data.  */
 };
 
+uint32_t
+ntohl(uint32_t value);
+
 int
 socket(int domain, int type, int protocol);
 

--- a/core/shared/platform/windows/win_socket.c
+++ b/core/shared/platform/windows/win_socket.c
@@ -173,3 +173,12 @@ os_socket_addr_resolve(const char *host, const char *service,
 
     return BHT_ERROR;
 }
+
+int
+os_socket_addr_local(bh_socket_t socket, uint8_t *buf, size_t buflen,
+                     uint16_t *port, uint8_t *is_ipv4)
+{
+    errno = ENOSYS;
+
+    return BHT_ERROR;
+}

--- a/samples/socket-api/wasm-src/tcp_client.c
+++ b/samples/socket-api/wasm-src/tcp_client.c
@@ -19,7 +19,10 @@ main(int argc, char *argv[])
 {
     int socket_fd, ret, total_size = 0;
     char buffer[1024] = { 0 };
+    char ip_string[16] = { 0 };
     struct sockaddr_in server_address = { 0 };
+    struct sockaddr_in local_address = { 0 };
+    socklen_t len;
 
     printf("[Client] Create socket\n");
     socket_fd = socket(AF_INET, SOCK_STREAM, 0);
@@ -41,6 +44,20 @@ main(int argc, char *argv[])
         close(socket_fd);
         return EXIT_FAILURE;
     }
+
+    len = sizeof(local_address);
+    ret = getsockname(socket_fd, (struct sockaddr *)&local_address, &len);
+    if (ret == -1) {
+        perror("Failed to retrieve socket address");
+        close(socket_fd);
+        return EXIT_FAILURE;
+    }
+
+    inet_ntop(AF_INET, &local_address.sin_addr, ip_string,
+              sizeof(ip_string) / sizeof(ip_string[0]));
+
+    printf("[Client] Local address is: %s:%d\n", ip_string,
+           ntohs(local_address.sin_port));
 
     printf("[Client] Client receive\n");
     while (1) {


### PR DESCRIPTION
I also slightly changed the interface - since we already have a `__wasi_addr_t`
structure which is an union, there's no need for passing length around - the
address buffer will always have the right length (i.e. max of all address
families).