### PR TITLE
fix a potential integer overflow issue

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -464,13 +464,13 @@ memory_instantiate(AOTModuleInstance *module_inst, AOTModule *module,
         }
         init_page_count += inc_page_count;
         max_page_count += inc_page_count;
-        if (init_page_count > 65536) {
+        if (init_page_count > DEFAULT_MAX_PAGES) {
             set_error_buf(error_buf, error_buf_size,
                           "memory size must be at most 65536 pages (4GiB)");
             return NULL;
         }
-        if (max_page_count > 65536)
-            max_page_count = 65536;
+        if (max_page_count > DEFAULT_MAX_PAGES)
+            max_page_count = DEFAULT_MAX_PAGES;
     }
 
     LOG_VERBOSE("Memory instantiate:");

--- a/core/iwasm/interpreter/wasm.h
+++ b/core/iwasm/interpreter/wasm.h
@@ -29,6 +29,7 @@ extern "C" {
 #define VALUE_TYPE_ANY 0x42
 
 #define DEFAULT_NUM_BYTES_PER_PAGE 65536
+#define DEFAULT_MAX_PAGES 65535
 
 #define NULL_REF (0xFFFFFFFF)
 

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -1237,7 +1237,7 @@ fail:
 static bool
 check_memory_init_size(uint32 init_size, char *error_buf, uint32 error_buf_size)
 {
-    if (init_size > 65536) {
+    if (init_size > DEFAULT_MAX_PAGES) {
         set_error_buf(error_buf, error_buf_size,
                       "memory size must be at most 65536 pages (4GiB)");
         return false;
@@ -1255,7 +1255,7 @@ check_memory_max_size(uint32 init_size, uint32 max_size, char *error_buf,
         return false;
     }
 
-    if (max_size > 65536) {
+    if (max_size > DEFAULT_MAX_PAGES) {
         set_error_buf(error_buf, error_buf_size,
                       "memory size must be at most 65536 pages (4GiB)");
         return false;
@@ -1270,12 +1270,12 @@ load_memory_import(const uint8 **p_buf, const uint8 *buf_end,
                    char *error_buf, uint32 error_buf_size)
 {
     const uint8 *p = *p_buf, *p_end = buf_end;
-    uint32 pool_size = wasm_runtime_memory_pool_size();
 #if WASM_ENABLE_APP_FRAMEWORK != 0
+    uint32 pool_size = wasm_runtime_memory_pool_size();
     uint32 max_page_count = pool_size * APP_MEMORY_MAX_GLOBAL_HEAP_PERCENT
                             / DEFAULT_NUM_BYTES_PER_PAGE;
 #else
-    uint32 max_page_count = pool_size / DEFAULT_NUM_BYTES_PER_PAGE;
+    uint32 max_page_count = DEFAULT_MAX_PAGES;
 #endif /* WASM_ENABLE_APP_FRAMEWORK */
     uint32 declare_max_page_count_flag = 0;
     uint32 declare_init_page_count = 0;
@@ -3288,14 +3288,14 @@ load_from_sections(WASMModule *module, WASMSection *sections,
 #if WASM_ENABLE_MULTI_MODULE == 0
         if (module->import_memory_count) {
             memory_import = &module->import_memories[0].u.memory;
-            /* Memory init page count cannot be larger than 65536, we don't
-               check integer overflow again. */
+            /* Memory init page count cannot be larger than DEFAULT_MAX_PAGES,
+               we don't check integer overflow again. */
             memory_import->num_bytes_per_page *= memory_import->init_page_count;
             memory_import->init_page_count = memory_import->max_page_count = 1;
         }
         if (module->memory_count) {
-            /* Memory init page count cannot be larger than 65536, we don't
-               check integer overflow again. */
+            /* Memory init page count cannot be larger than DEFAULT_MAX_PAGES,
+               we don't check integer overflow again. */
             memory = &module->memories[0];
             memory->num_bytes_per_page *= memory->init_page_count;
             memory->init_page_count = memory->max_page_count = 1;

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -256,13 +256,13 @@ memory_instantiate(WASMModuleInstance *module_inst, uint32 num_bytes_per_page,
         }
         init_page_count += inc_page_count;
         max_page_count += inc_page_count;
-        if (init_page_count > 65536) {
+        if (init_page_count > DEFAULT_MAX_PAGES) {
             set_error_buf(error_buf, error_buf_size,
                           "memory size must be at most 65536 pages (4GiB)");
             return NULL;
         }
-        if (max_page_count > 65536)
-            max_page_count = 65536;
+        if (max_page_count > DEFAULT_MAX_PAGES)
+            max_page_count = DEFAULT_MAX_PAGES;
     }
 
     LOG_VERBOSE("Memory instantiate:");

--- a/tests/wamr-test-suites/spec-test-script/ignore_cases.patch
+++ b/tests/wamr-test-suites/spec-test-script/ignore_cases.patch
@@ -329,6 +329,19 @@ index 994e0f4..d0bfb5f 100644
  (assert_return (invoke $Ms "get memory[0]") (i32.const 104))  ;; 'h'
  (assert_return (invoke $Ms "get table[0]") (i32.const 0xdead))
 +;)
+diff --git a/test/core/memory.wast b/test/core/memory.wast
+index 497b69f..2feba4a 100644
+--- a/test/core/memory.wast
++++ b/test/core/memory.wast
+@@ -5,7 +5,7 @@
+ (module (memory 0 0))
+ (module (memory 0 1))
+ (module (memory 1 256))
+-(module (memory 0 65536))
++(module (memory 0 65535))
+ 
+ (assert_invalid (module (memory 0) (memory 0)) "multiple memories")
+ (assert_invalid (module (memory (import "spectest" "memory") 0) (memory 0)) "multiple memories")
 diff --git a/test/core/ref_func.wast b/test/core/ref_func.wast
 index adb5cb7..590f626 100644
 --- a/test/core/ref_func.wast


### PR DESCRIPTION
- allow max_page_count to be 65536
- allow init_page_count to be 65536
- `num_bytes_per_page * XXX_page_count` will be great than UINT32_MAX