### PR TITLE
[bugfix] initialize "module->retain_function" for wasm_mini_loader

### DIFF
--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -1988,6 +1988,7 @@ load_from_sections(WASMModule *module, WASMSection *sections,
 
     module->malloc_function = (uint32)-1;
     module->free_function = (uint32)-1;
+    module->retain_function = (uint32)-1;
 
     /* Resolve malloc/free function exported by wasm module */
     export = module->exports;


### PR DESCRIPTION
Before resolving the module function's export in wasm_mini_loader,
"module->retain_function" need to be initialized, otherwise,
the "__new" function export will lead to abort.

issue: https://github.com/bytecodealliance/wasm-micro-runtime/issues/1332