### PR TITLE
Add our own legacy loop unswitch pass

### DIFF
--- a/core/iwasm/compilation/aot_compiler.c
+++ b/core/iwasm/compilation/aot_compiler.c
@@ -2643,9 +2643,8 @@ apply_func_passes(AOTCompContext *comp_ctx)
         LLVMAddLoopRotatePass(pass_mgr);
 #if LLVM_VERSION_MAJOR < 15
         LLVMAddLoopUnswitchPass(pass_mgr);
-        /* Binding disabled in LLVM 15, don't add the pass util we can either
-           add a binding to SimpleLoopUnswitchPass, or add it to
-           aot_llvm_extra.cpp */
+#else
+        aot_add_simple_loop_unswitch_pass(pass_mgr);
 #endif
         LLVMAddInstructionCombiningPass(pass_mgr);
         LLVMAddCFGSimplificationPass(pass_mgr);

--- a/core/iwasm/compilation/aot_llvm.h
+++ b/core/iwasm/compilation/aot_llvm.h
@@ -500,6 +500,9 @@ void
 aot_add_expand_memory_op_pass(LLVMPassManagerRef pass);
 
 void
+aot_add_simple_loop_unswitch_pass(LLVMPassManagerRef pass);
+
+void
 aot_apply_llvm_new_pass_manager(AOTCompContext *comp_ctx);
 
 #if WASM_ENABLE_LAZY_JIT != 0

--- a/core/iwasm/compilation/aot_llvm_extra.cpp
+++ b/core/iwasm/compilation/aot_llvm_extra.cpp
@@ -67,6 +67,9 @@ void
 aot_add_expand_memory_op_pass(LLVMPassManagerRef pass);
 
 void
+aot_add_simple_loop_unswitch_pass(LLVMPassManagerRef pass);
+
+void
 aot_func_disable_tce(LLVMValueRef func);
 
 void
@@ -256,6 +259,12 @@ void
 aot_add_expand_memory_op_pass(LLVMPassManagerRef pass)
 {
     unwrap(pass)->add(new ExpandMemoryOpPass());
+}
+
+void
+aot_add_simple_loop_unswitch_pass(LLVMPassManagerRef pass)
+{
+    unwrap(pass)->add(createSimpleLoopUnswitchLegacyPass());
 }
 
 bool


### PR DESCRIPTION
Since legacy binding for loop unswitch pass was removed and we can't get
it back implement its equivalent `aot_llvm_extra.cpp` and use in
`aot_compiler.c`.

Follow up to #1183