### PR TITLE
esp32: Support app management and thread

### DIFF
--- a/core/shared/platform/esp-idf/espidf_thread.c
+++ b/core/shared/platform/esp-idf/espidf_thread.c
@@ -45,6 +45,25 @@ os_mutex_init(korp_mutex *mutex)
 }
 
 int
+os_recursive_mutex_init(korp_mutex *mutex)
+{
+    int ret;
+
+    pthread_mutexattr_t mattr;
+
+    assert(mutex);
+    ret = pthread_mutexattr_init(&mattr);
+    if (ret)
+        return BHT_ERROR;
+
+    pthread_mutexattr_settype(&mattr, PTHREAD_MUTEX_RECURSIVE);
+    ret = pthread_mutex_init(mutex, &mattr);
+    pthread_mutexattr_destroy(&mattr);
+
+    return ret == 0 ? BHT_OK : BHT_ERROR;
+}
+
+int
 os_mutex_destroy(korp_mutex *mutex)
 {
     return pthread_mutex_destroy(mutex);
@@ -205,4 +224,10 @@ int
 os_cond_signal(korp_cond *cond)
 {
     return pthread_cond_signal(cond);
+}
+
+int
+os_cond_broadcast(korp_cond *cond)
+{
+    return pthread_cond_broadcast(cond);
 }

--- a/core/shared/platform/esp-idf/platform_internal.h
+++ b/core/shared/platform/esp-idf/platform_internal.h
@@ -17,6 +17,7 @@
 #include <math.h>
 #include <unistd.h>
 #include <pthread.h>
+#include <arpa/inet.h>
 
 #include "esp_pthread.h"
 #include "esp_timer.h"


### PR DESCRIPTION
esp32: Support app management and thread

1. Fix compile issue when enable app management
2. Add missed thread related APIs