### PR TITLE
esp32: Support SSP for WASI

### DIFF
--- a/core/app-framework/app_framework.cmake
+++ b/core/app-framework/app_framework.cmake
@@ -33,6 +33,10 @@ function (add_module_native arg)
         ${APP_FRAMEWORK_ROOT_DIR}/${ARGV0}/native/*.h
         ${APP_FRAMEWORK_ROOT_DIR}/${ARGV0}/native/*.inl
     )
+
+    LIST (APPEND WASM_APP_LIBS_DIR ${APP_FRAMEWORK_ROOT_DIR}/${ARGV0}/native)
+    set (WASM_APP_LIBS_DIR ${WASM_APP_LIBS_DIR} PARENT_SCOPE)
+
     LIST (APPEND RUNTIME_LIB_HEADER_LIST ${header})
     set (RUNTIME_LIB_HEADER_LIST ${RUNTIME_LIB_HEADER_LIST} PARENT_SCOPE)
 

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
@@ -39,13 +39,13 @@
 #define CONFIG_HAS_CAP_ENTER 0
 #endif
 
-#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__EMSCRIPTEN__)
+#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__EMSCRIPTEN__) && !defined(ESP_PLATFORM)
 #define CONFIG_HAS_CLOCK_NANOSLEEP 1
 #else
 #define CONFIG_HAS_CLOCK_NANOSLEEP 0
 #endif
 
-#if !defined(__APPLE__) && !defined(__FreeBSD__)
+#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(ESP_PLATFORM)
 #define CONFIG_HAS_FDATASYNC 1
 #else
 #define CONFIG_HAS_FDATASYNC 0
@@ -63,13 +63,13 @@
 #endif
 #endif
 
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(ESP_PLATFORM)
 #define CONFIG_HAS_POSIX_FALLOCATE 1
 #else
 #define CONFIG_HAS_POSIX_FALLOCATE 0
 #endif
 
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(ESP_PLATFORM)
 #define CONFIG_HAS_PREADV 1
 #else
 #define CONFIG_HAS_PREADV 0
@@ -87,7 +87,7 @@
 #define CONFIG_HAS_PTHREAD_CONDATTR_SETCLOCK 0
 #endif
 
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(ESP_PLATFORM)
 #define CONFIG_HAS_PWRITEV 1
 #else
 #define CONFIG_HAS_PWRITEV 0

--- a/core/shared/platform/esp-idf/espidf_platform.c
+++ b/core/shared/platform/esp-idf/espidf_platform.c
@@ -58,3 +58,201 @@ os_usleep(uint32 usec)
 {
     return usleep(usec);
 }
+
+ssize_t
+readv(int fildes, const struct iovec *iov, int iovcnt)
+{
+  ssize_t ntotal;
+  ssize_t nread;
+  size_t remaining;
+  uint8_t *buffer;
+  int i;
+
+  /* Process each entry in the struct iovec array */
+
+  for (i = 0, ntotal = 0; i < iovcnt; i++)
+    {
+      /* Ignore zero-length reads */
+
+      if (iov[i].iov_len > 0)
+        {
+          buffer    = iov[i].iov_base;
+          remaining = iov[i].iov_len;
+
+          /* Read repeatedly as necessary to fill buffer */
+
+          do
+            {
+              /* NOTE:  read() is a cancellation point */
+
+              nread = read(fildes, buffer, remaining);
+
+              /* Check for a read error */
+
+              if (nread < 0)
+                {
+                  return nread;
+                }
+
+              /* Check for an end-of-file condition */
+
+              else if (nread == 0)
+                {
+                  return ntotal;
+                }
+
+              /* Update pointers and counts in order to handle partial
+               * buffer reads.
+               */
+
+              buffer    += nread;
+              remaining -= nread;
+              ntotal    += nread;
+            }
+          while (remaining > 0);
+        }
+    }
+
+  return ntotal;
+}
+
+ssize_t
+writev(int fildes, const struct iovec *iov, int iovcnt)
+{
+  ssize_t ntotal;
+  ssize_t nwritten;
+  size_t remaining;
+  uint8_t *buffer;
+  int i;
+
+  /* Process each entry in the struct iovec array */
+
+  for (i = 0, ntotal = 0; i < iovcnt; i++)
+    {
+      /* Ignore zero-length writes */
+
+      if (iov[i].iov_len > 0)
+        {
+          buffer    = iov[i].iov_base;
+          remaining = iov[i].iov_len;
+
+          /* Write repeatedly as necessary to write the entire buffer */
+
+          do
+            {
+              /* NOTE:  write() is a cancellation point */
+
+              nwritten = write(fildes, buffer, remaining);
+
+              /* Check for a write error */
+
+              if (nwritten < 0)
+                {
+                  return ntotal ? ntotal : -1;
+                }
+
+              /* Update pointers and counts in order to handle partial
+               * buffer writes.
+               */
+
+              buffer    += nwritten;
+              remaining -= nwritten;
+              ntotal    += nwritten;
+            }
+          while (remaining > 0);
+        }
+    }
+
+  return ntotal;
+}
+
+int
+openat(int fd, const char *path, int oflags, ...)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+int
+fstatat(int fd, const char *path, struct stat *buf, int flag)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+int
+mkdirat(int fd, const char *path, mode_t mode)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+ssize_t
+readlinkat(int fd, const char *path, char *buf, size_t bufsize)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+int
+linkat(int fd1, const char *path1, int fd2, const char *path2, int flag)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+int
+renameat(int fromfd, const char *from, int tofd, const char *to)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+int
+symlinkat(const char *target, int fd, const char *path)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+int
+unlinkat(int fd, const char *path, int flag)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+int
+utimensat(int fd, const char *path, const struct timespec ts[2], int flag)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+DIR *
+fdopendir(int fd)
+{
+    errno = ENOSYS;
+    return NULL;
+}
+
+int
+ftruncate(int fd, off_t length)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+int
+futimens(int fd, const struct timespec times[2])
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+int
+nanosleep(const struct timespec *req, struct timespec *rem)
+{
+    errno = ENOSYS;
+    return -1;
+}

--- a/core/shared/platform/esp-idf/espidf_socket.c
+++ b/core/shared/platform/esp-idf/espidf_socket.c
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2021 Intel Corporation.  All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#include "platform_api_vmcore.h"
+#include "platform_api_extension.h"
+
+#include <arpa/inet.h>
+
+static void
+textual_addr_to_sockaddr(const char *textual, int port, struct sockaddr_in *out)
+{
+    assert(textual);
+
+    out->sin_family = AF_INET;
+    out->sin_port = htons(port);
+    out->sin_addr.s_addr = inet_addr(textual);
+}
+
+int
+os_socket_create(bh_socket_t *sock, int tcp_or_udp)
+{
+    if (!sock) {
+        return BHT_ERROR;
+    }
+
+    if (1 == tcp_or_udp) {
+        *sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    }
+    else if (0 == tcp_or_udp) {
+        *sock = socket(AF_INET, SOCK_DGRAM, 0);
+    }
+
+    return (*sock == -1) ? BHT_ERROR : BHT_OK;
+}
+
+int
+os_socket_bind(bh_socket_t socket, const char *host, int *port)
+{
+    struct sockaddr_in addr;
+    struct linger ling;
+    socklen_t socklen;
+    int ret;
+
+    assert(host);
+    assert(port);
+
+    ling.l_onoff = 1;
+    ling.l_linger = 0;
+
+    ret = fcntl(socket, F_SETFD, FD_CLOEXEC);
+    if (ret < 0) {
+        goto fail;
+    }
+
+    ret = setsockopt(socket, SOL_SOCKET, SO_LINGER, &ling, sizeof(ling));
+    if (ret < 0) {
+        goto fail;
+    }
+
+    addr.sin_addr.s_addr = inet_addr(host);
+    addr.sin_port = htons(*port);
+    addr.sin_family = AF_INET;
+
+    ret = bind(socket, (struct sockaddr *)&addr, sizeof(addr));
+    if (ret < 0) {
+        goto fail;
+    }
+
+    socklen = sizeof(addr);
+    if (getsockname(socket, (void *)&addr, &socklen) == -1) {
+        goto fail;
+    }
+
+    *port = ntohs(addr.sin_port);
+
+    return BHT_OK;
+
+fail:
+    return BHT_ERROR;
+}
+
+int
+os_socket_settimeout(bh_socket_t socket, uint64 timeout_us)
+{
+    struct timeval tv;
+    tv.tv_sec = timeout_us / 1000000UL;
+    tv.tv_usec = timeout_us % 1000000UL;
+
+    if (setsockopt(socket, SOL_SOCKET, SO_RCVTIMEO, (const char *)&tv,
+                   sizeof(tv))
+        != 0) {
+        return BHT_ERROR;
+    }
+
+    return BHT_OK;
+}
+
+int
+os_socket_listen(bh_socket_t socket, int max_client)
+{
+    if (listen(socket, max_client) != 0) {
+        return BHT_ERROR;
+    }
+
+    return BHT_OK;
+}
+
+int
+os_socket_accept(bh_socket_t server_sock, bh_socket_t *sock, void *addr,
+                 unsigned int *addrlen)
+{
+    struct sockaddr addr_tmp;
+    unsigned int len = sizeof(struct sockaddr);
+
+    *sock = accept(server_sock, (struct sockaddr *)&addr_tmp, &len);
+
+    if (*sock < 0) {
+        return BHT_ERROR;
+    }
+
+    return BHT_OK;
+}
+
+int
+os_socket_connect(bh_socket_t socket, const char *addr, int port)
+{
+    struct sockaddr_in addr_in = { 0 };
+    socklen_t addr_len = sizeof(struct sockaddr_in);
+    int ret = 0;
+
+    textual_addr_to_sockaddr(addr, port, &addr_in);
+
+    ret = connect(socket, (struct sockaddr *)&addr_in, addr_len);
+    if (ret == -1) {
+        return BHT_ERROR;
+    }
+
+    return BHT_OK;
+}
+
+int
+os_socket_recv(bh_socket_t socket, void *buf, unsigned int len)
+{
+    return recv(socket, buf, len, 0);
+}
+
+int
+os_socket_send(bh_socket_t socket, const void *buf, unsigned int len)
+{
+    return send(socket, buf, len, 0);
+}
+
+int
+os_socket_close(bh_socket_t socket)
+{
+    close(socket);
+    return BHT_OK;
+}
+
+int
+os_socket_shutdown(bh_socket_t socket)
+{
+    shutdown(socket, O_RDWR);
+    return BHT_OK;
+}
+
+int
+os_socket_inet_network(const char *cp, uint32 *out)
+{
+    if (!cp)
+        return BHT_ERROR;
+
+    /* Note: ntohl(INADDR_NONE) == INADDR_NONE */
+    *out = ntohl(inet_addr(cp));
+    return BHT_OK;
+}

--- a/core/shared/platform/esp-idf/platform_internal.h
+++ b/core/shared/platform/esp-idf/platform_internal.h
@@ -17,6 +17,10 @@
 #include <math.h>
 #include <unistd.h>
 #include <pthread.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <dirent.h>
 
 #include "esp_pthread.h"
 #include "esp_timer.h"
@@ -40,6 +44,133 @@ typedef pthread_t korp_thread;
 
 /* Default thread priority */
 #define BH_THREAD_DEFAULT_PRIORITY 5
+
+extern int errno;
+
+typedef TaskHandle_t korp_thread;
+typedef korp_thread korp_tid;
+typedef struct {
+    bool is_recursive;
+    SemaphoreHandle_t sem;
+} korp_mutex;
+
+struct os_thread_wait_node;
+typedef struct os_thread_wait_node *os_thread_wait_list;
+typedef struct korp_cond {
+    SemaphoreHandle_t wait_list_lock;
+    os_thread_wait_list thread_wait_list;
+} korp_cond;
+
+int
+os_printf(const char *format, ...);
+int
+os_vprintf(const char *format, va_list ap);
+
+/* clang-format off */
+/* math functions which are not provided by os */
+double sqrt(double x);
+double floor(double x);
+double ceil(double x);
+double fmin(double x, double y);
+double fmax(double x, double y);
+double rint(double x);
+double fabs(double x);
+double trunc(double x);
+float floorf(float x);
+float ceilf(float x);
+float fminf(float x, float y);
+float fmaxf(float x, float y);
+float rintf(float x);
+float truncf(float x);
+int signbit(double x);
+int isnan(double x);
+
+int atoi(const char *s);
+int strncasecmp(const char *s1, const char *s2, size_t n);
+long int strtol(const char *str, char **endptr, int base);
+unsigned long int strtoul(const char *str, char **endptr, int base);
+unsigned long long int strtoull(const char *nptr, char **endptr, int base);
+double strtod(const char *nptr, char **endptr);
+float strtof(const char *nptr, char **endptr);
+char *strstr(const char *haystack, const char *needle);
+size_t strspn(const char *s, const char *accept);
+size_t strcspn(const char *s, const char *reject);
+void *memchr(const void *s, int c, size_t n);
+int isalnum(int c);
+int isxdigit(int c);
+int isdigit(int c);
+int isprint(int c);
+int isgraph(int c);
+int isspace(int c);
+int isalpha(int c);
+int isupper(int c);
+int toupper(int c);
+int tolower(int c);
+void *memmove(void *dest, const void *src, size_t n);
+
+uint32_t htonl(uint32_t hostlong);
+uint16_t htons(uint16_t hostshort);
+uint32_t ntohl(uint32_t netlong);
+uint16_t ntohs(uint16_t netshort);
+/* clang-format on */
+/* Special value for tv_nsec field of timespec */
+
+#define UTIME_NOW     ((1l << 30) - 1l)
+#ifndef __cplusplus
+#  define UTIME_OMIT  ((1l << 30) - 2l)
+#endif
+
+#ifdef DT_UNKNOWN
+#undef DT_UNKNOWN
+#endif
+
+#ifdef DT_REG
+#undef DT_REG
+#endif
+
+#ifdef DT_DIR
+#undef DT_DIR
+#endif
+
+/* Below parts of d_type define are ported from Nuttx, under Apache License v2.0 */
+
+/* File type code for the d_type field in dirent structure.
+ * Note that because of the simplified filesystem organization of the NuttX,
+ * top-level, pseudo-file system, an inode can be BOTH a file and a directory
+ */
+
+#define DTYPE_UNKNOWN             0
+#define DTYPE_FIFO                1
+#define DTYPE_CHR                 2
+#define DTYPE_SEM                 3
+#define DTYPE_DIRECTORY           4
+#define DTYPE_MQ                  5
+#define DTYPE_BLK                 6
+#define DTYPE_SHM                 7
+#define DTYPE_FILE                8
+#define DTYPE_MTD                 9
+#define DTYPE_LINK                10
+#define DTYPE_SOCK                12
+
+/* The d_type field of the dirent structure is not specified by POSIX.  It
+ * is a non-standard, 4.5BSD extension that is implemented by most OSs.  A
+ * POSIX compliant OS may not implement the d_type field at all.  Many OS's
+ * (including glibc) may use the following alternative naming for the file
+ * type names:
+ */
+
+#define DT_UNKNOWN                DTYPE_UNKNOWN
+#define DT_FIFO                   DTYPE_FIFO
+#define DT_CHR                    DTYPE_CHR
+#define DT_SEM                    DTYPE_SEM
+#define DT_DIR                    DTYPE_DIRECTORY
+#define DT_MQ                     DTYPE_MQ
+#define DT_BLK                    DTYPE_BLK
+#define DT_SHM                    DTYPE_SHM
+#define DT_REG                    DTYPE_FILE
+#define DT_MTD                    DTYPE_MTD
+#define DT_LNK                    DTYPE_LINK
+#define DT_SOCK                   DTYPE_SOCK
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
esp32: Support SSP for WASI

1. Support to get WASM APP libs' DIR from upper layer
2. Add SSP support for esp-idf platform
3. Only excute main if wasi is enabled and app is wasi mode

