### PR TITLE
SGX: printf returns the msg size stored the buffer

### DIFF
--- a/core/shared/platform/linux-sgx/sgx_platform.c
+++ b/core/shared/platform/linux-sgx/sgx_platform.c
@@ -60,16 +60,18 @@ os_set_print_function(os_print_function_t pf)
 int
 os_printf(const char *message, ...)
 {
+    int bytes_written = 0;
+
     if (print_function != NULL) {
         char msg[FIXED_BUFFER_SIZE] = { '\0' };
         va_list ap;
         va_start(ap, message);
-        vsnprintf(msg, FIXED_BUFFER_SIZE, message, ap);
+        bytes_written += vsnprintf(msg, FIXED_BUFFER_SIZE, message, ap);
         va_end(ap);
         print_function(msg);
     }
 
-    return 0;
+    return bytes_written;
 }
 
 int


### PR DESCRIPTION
Dear WAMR developers,

When working with WASI calls inside Intel SGX, I discovered a glitch when writing into stdout/stderr using the code snippet present here:

https://github.com/bytecodealliance/wasm-micro-runtime/blob/0020b3ae6874d275a7de9fc95fe078355363aab5/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c#L1249-L1262

Indeed, when this code is executed for printing text into stdout/stderr, the implementation of `os_printf` for SGX always returns 0, since the return value of the OCALL is not considered. As a result, writing to stdout/stderr from the enclave creates an infinite loop, where the text is written in the console over and over.

While I could not find where the loop occurs (either in WAMR or in musl for Wasm), I propose to change the implementation of the `os_printf` for Intel SGX, so the number of bytes is returned by its implementation by using the return value of the formatting function (`vsnprintf`). Note that we could also use the return value of the `printf` called in the OCALL, but I prefer this approach since we can trust the return value of `vsnprintf`, which is not the case with the concrete `printf`.

Feel free to comment or suggest changes if you feel this approach is not the right way to fix the issue. I'll gladly apply them.

Cheers!
