### PR TITLE
Implement sock_addr_remote syscall

### DIFF
--- a/core/iwasm/libraries/lib-socket/inc/wasi_socket_ext.h
+++ b/core/iwasm/libraries/lib-socket/inc/wasi_socket_ext.h
@@ -117,6 +117,9 @@ socket(int domain, int type, int protocol);
 
 int
 getsockname(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
+
+int
+getpeername(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
 #endif
 
 /**
@@ -164,16 +167,15 @@ __wasi_sock_addr_local(__wasi_fd_t fd, __wasi_addr_t *addr)
  * either IP4 or IP6.
  */
 int32_t
-__imported_wasi_snapshot_preview1_sock_addr_remote(int32_t arg0, int32_t arg1,
-                                                   int32_t arg2)
+__imported_wasi_snapshot_preview1_sock_addr_remote(int32_t arg0, int32_t arg1)
     __attribute__((__import_module__("wasi_snapshot_preview1"),
                    __import_name__("sock_addr_remote")));
 
 static inline __wasi_errno_t
-__wasi_sock_addr_remote(__wasi_fd_t fd, uint8_t *buf, __wasi_size_t buf_len)
+__wasi_sock_addr_remote(__wasi_fd_t fd, __wasi_addr_t *addr)
 {
     return (__wasi_errno_t)__imported_wasi_snapshot_preview1_sock_addr_remote(
-        (int32_t)fd, (int32_t)buf, (int32_t)buf_len);
+        (int32_t)fd, (int32_t)addr);
 }
 
 /**

--- a/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
+++ b/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
@@ -1028,8 +1028,8 @@ wasi_sock_addr_local(wasm_exec_env_t exec_env, wasi_fd_t fd,
 }
 
 static wasi_errno_t
-wasi_sock_addr_remote(wasm_exec_env_t exec_env, wasi_fd_t fd, uint8 *buf,
-                      wasi_size_t buf_len)
+wasi_sock_addr_remote(wasm_exec_env_t exec_env, wasi_fd_t fd,
+                      __wasi_addr_t *addr)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -1038,9 +1038,12 @@ wasi_sock_addr_remote(wasm_exec_env_t exec_env, wasi_fd_t fd, uint8 *buf,
     if (!wasi_ctx)
         return __WASI_EACCES;
 
+    if (!validate_native_addr(addr, sizeof(__wasi_addr_t)))
+        return __WASI_EINVAL;
+
     curfds = wasi_ctx_get_curfds(module_inst, wasi_ctx);
 
-    return wasi_ssp_sock_addr_remote(curfds, fd, buf, buf_len);
+    return wasi_ssp_sock_addr_remote(curfds, fd, addr);
 }
 
 static wasi_errno_t
@@ -1405,7 +1408,7 @@ static NativeSymbol native_symbols_libc_wasi[] = {
     REG_NATIVE_FUNC(random_get, "(*~)i"),
     REG_NATIVE_FUNC(sock_accept, "(i*)i"),
     REG_NATIVE_FUNC(sock_addr_local, "(i*)i"),
-    REG_NATIVE_FUNC(sock_addr_remote, "(i*i)i"),
+    REG_NATIVE_FUNC(sock_addr_remote, "(i*)i"),
     REG_NATIVE_FUNC(sock_addr_resolve, "($$**i*)i"),
     REG_NATIVE_FUNC(sock_bind, "(i*)i"),
     REG_NATIVE_FUNC(sock_close, "(i)i"),

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/include/wasmtime_ssp.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/include/wasmtime_ssp.h
@@ -1015,7 +1015,7 @@ wasi_ssp_sock_addr_remote(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t fd, uint8_t *buf, __wasi_size_t buf_len
+    __wasi_fd_t fd, __wasi_addr_t *addr
 ) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t

--- a/core/shared/platform/include/platform_api_extension.h
+++ b/core/shared/platform/include/platform_api_extension.h
@@ -393,6 +393,25 @@ int
 os_socket_addr_local(bh_socket_t socket, uint8_t *buf, size_t buflen,
                      uint16_t *port, uint8_t *is_ipv4);
 
+/**
+ * Returns an binary address and a port of the remote socket
+ *
+ * @param socket the remote socket
+ *
+ * @param buf buffer to store the address
+ *
+ * @param buflen length of the buf buffer
+ *
+ * @param port a buffer for storing socket's port
+ *
+ * @param is_ipv4 a buffer for storing information about the address family
+ *
+ * @return On success, returns 0; otherwise, it returns -1.
+ */
+int
+os_socket_addr_remote(bh_socket_t socket, uint8_t *buf, size_t buflen,
+                      uint16_t *port, uint8_t *is_ipv4);
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/shared/platform/linux-sgx/sgx_socket.c
+++ b/core/shared/platform/linux-sgx/sgx_socket.c
@@ -641,4 +641,13 @@ os_socket_addr_local(bh_socket_t socket, uint8_t *buf, size_t buflen,
     return BHT_ERROR;
 }
 
+int
+os_socket_addr_remote(bh_socket_t socket, uint8_t *buf, size_t buflen,
+                      uint16_t *port, uint8_t *is_ipv4)
+{
+    errno = ENOSYS;
+
+    return BHT_ERROR;
+}
+
 #endif

--- a/core/shared/platform/windows/win_socket.c
+++ b/core/shared/platform/windows/win_socket.c
@@ -182,3 +182,12 @@ os_socket_addr_local(bh_socket_t socket, uint8_t *buf, size_t buflen,
 
     return BHT_ERROR;
 }
+
+int
+os_socket_addr_remote(bh_socket_t socket, uint8_t *buf, size_t buflen,
+                      uint16_t *port, uint8_t *is_ipv4)
+{
+    errno = ENOSYS;
+
+    return BHT_ERROR;
+}

--- a/samples/socket-api/wasm-src/tcp_server.c
+++ b/samples/socket-api/wasm-src/tcp_server.c
@@ -49,6 +49,7 @@ main(int argc, char *argv[])
     unsigned connections = 0;
     pthread_t workers[WORKER_NUM] = { 0 };
     int client_sock_fds[WORKER_NUM] = { 0 };
+    char ip_string[16];
 
     printf("[Server] Create socket\n");
     socket_fd = socket(AF_INET, SOCK_STREAM, 0);
@@ -84,7 +85,11 @@ main(int argc, char *argv[])
             break;
         }
 
-        printf("[Server] Client connected\n");
+        inet_ntop(AF_INET, &addr.sin_addr, ip_string,
+                  sizeof(ip_string) / sizeof(ip_string[0]));
+
+        printf("[Server] Client connected (%s:%d)\n", ip_string,
+               ntohs(addr.sin_port));
         if (pthread_create(&workers[connections], NULL, run,
                            &client_sock_fds[connections])) {
             perror("Create a worker thread failed");


### PR DESCRIPTION
I also slightly changed the interface - since we already have a `__wasi_addr_t`
structure which is an union, there's no need for passing length around - the
address buffer will always have the right length (i.e. max of all address
families).