### PR TITLE
Fix wasm loader issues

### DIFF
--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -6915,11 +6915,12 @@ re_scan:
                     loader_ctx->frame_csp->end_addr = p - 1;
                 }
                 else {
-                    /* end of function block, function will return,
-                       ignore the following bytecodes */
-                    p = p_end;
-
-                    continue;
+                    /* end of function block, function will return */
+                    if (p < p_end) {
+                        set_error_buf(error_buf, error_buf_size,
+                                      "section size mismatch");
+                        goto fail;
+                    }
                 }
 
                 break;

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -7598,8 +7598,7 @@ re_scan:
                         if (table_seg->elem_type == VALUE_TYPE_FUNCREF
                             && wasm_elem_is_declarative(table_seg->mode)) {
                             for (j = 0; j < table_seg->function_count; j++) {
-                                if (table_seg->func_indexes[j]
-                                    == func_idx) {
+                                if (table_seg->func_indexes[j] == func_idx) {
                                     func_declared = true;
                                     break;
                                 }

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -6922,7 +6922,6 @@ re_scan:
                     continue;
                 }
 
-                SET_CUR_BLOCK_STACK_POLYMORPHIC_STATE(false);
                 break;
             }
 
@@ -7588,7 +7587,7 @@ re_scan:
                     goto fail;
                 }
 
-                if (func_idx == cur_func_idx) {
+                if (func_idx == cur_func_idx + module->import_function_count) {
                     WASMTableSeg *table_seg = module->table_segments;
                     bool func_declared = false;
                     uint32 j;
@@ -7599,7 +7598,7 @@ re_scan:
                             && wasm_elem_is_declarative(table_seg->mode)) {
                             for (j = 0; j < table_seg->function_count; j++) {
                                 if (table_seg->func_indexes[j]
-                                    == cur_func_idx) {
+                                    == func_idx) {
                                     func_declared = true;
                                     break;
                                 }

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -5195,7 +5195,6 @@ re_scan:
                     continue;
                 }
 
-                SET_CUR_BLOCK_STACK_POLYMORPHIC_STATE(false);
                 break;
             }
 
@@ -5763,7 +5762,7 @@ re_scan:
                     goto fail;
                 }
 
-                if (func_idx == cur_func_idx) {
+                if (func_idx == cur_func_idx + module->import_function_count) {
                     WASMTableSeg *table_seg = module->table_segments;
                     bool func_declared = false;
                     uint32 j;
@@ -5774,7 +5773,7 @@ re_scan:
                             && wasm_elem_is_declarative(table_seg->mode)) {
                             for (j = 0; j < table_seg->function_count; j++) {
                                 if (table_seg->func_indexes[j]
-                                    == cur_func_idx) {
+                                    == func_idx) {
                                     func_declared = true;
                                     break;
                                 }

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -5769,8 +5769,7 @@ re_scan:
                         if (table_seg->elem_type == VALUE_TYPE_FUNCREF
                             && wasm_elem_is_declarative(table_seg->mode)) {
                             for (j = 0; j < table_seg->function_count; j++) {
-                                if (table_seg->func_indexes[j]
-                                    == func_idx) {
+                                if (table_seg->func_indexes[j] == func_idx) {
                                     func_declared = true;
                                     break;
                                 }

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -5188,11 +5188,8 @@ re_scan:
                     loader_ctx->frame_csp->end_addr = p - 1;
                 }
                 else {
-                    /* end of function block, function will return,
-                       ignore the following bytecodes */
-                    p = p_end;
-
-                    continue;
+                    /* end of function block, function will return */
+                    bh_assert(p == p_end);
                 }
 
                 break;


### PR DESCRIPTION
Should not clear last label's polymorphic state after current label is popped
Fix invalid func_idx check in opcode REF_FUNC
Add check when there are extra unneeded bytecodes for a wasm function
