### PR TITLE
Add a semantic version for WAMR

### DIFF
--- a/build-scripts/config_common.cmake
+++ b/build-scripts/config_common.cmake
@@ -116,6 +116,24 @@ else ()
   unset (LLVM_AVAILABLE_LIBS)
 endif ()
 
+########################################
+## semantic version information
+
+if (NOT DEFINED WAMR_VERSION_MAJOR)
+  set (WAMR_VERSION_MAJOR 1)
+endif ()
+
+if (NOT DEFINED WAMR_VERSION_MINOR)
+  set (WAMR_VERSION_MINOR 0)
+endif ()
+
+if (NOT DEFINED WAMR_VERSION_PATCH)
+  set (WAMR_VERSION_PATCH 0)
+endif ()
+
+configure_file(${WAMR_ROOT_DIR}/core/version.h.in ${WAMR_ROOT_DIR}/core/version.h @ONLY)
+########################################
+
 message ("-- Build Configurations:")
 message ("     Build as target ${WAMR_BUILD_TARGET}")
 message ("     CMAKE_BUILD_TYPE " ${CMAKE_BUILD_TYPE})

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -31,6 +31,7 @@
 #include "../fast-jit/jit_compiler.h"
 #endif
 #include "../common/wasm_c_api_internal.h"
+#include "../../version.h"
 
 /**
  * For runtime build, BH_MALLOC/BH_FREE should be defined as
@@ -5055,3 +5056,11 @@ wasm_runtime_destroy_custom_sections(WASMCustomSection *section_list)
     }
 }
 #endif /* end of WASM_ENABLE_LOAD_CUSTOM_SECTION */
+
+void
+wasm_runtime_get_version(uint32_t *major, uint32_t *minor, uint32_t *patch)
+{
+    *major = WAMR_VERSION_MAJOR;
+    *minor = WAMR_VERSION_MINOR;
+    *patch = WAMR_VERSION_PATCH;
+}

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -1137,6 +1137,12 @@ WASM_RUNTIME_API_EXTERN const uint8_t *
 wasm_runtime_get_custom_section(wasm_module_t const module_comm,
                                 const char *name, uint32_t *len);
 
+
+/**
+ * Get WAMR semantic version
+ */
+WASM_RUNTIME_API_EXTERN void
+wasm_runtime_get_version(uint32_t *major, uint32_t *minor, uint32_t *patch);
 /* clang-format on */
 
 #ifdef __cplusplus

--- a/core/version.h
+++ b/core/version.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2019 Intel Corporation.  All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+/* Please don't modify this header. It is automatically generated.
+   Any modification should be in config_common.cmake */
+
+#ifndef _WAMR_VERSION_H_
+#define _WAMR_VERSION_H_
+#define WAMR_VERSION_MAJOR 1
+#define WAMR_VERSION_MINOR 0
+#define WAMR_VERSION_PATCH 0
+#endif

--- a/core/version.h.in
+++ b/core/version.h.in
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2019 Intel Corporation.  All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+/* Please don't modify this header. It is automatically generated.
+   Any modification should be in config_common.cmake */
+
+#ifndef _WAMR_VERSION_H_
+#define _WAMR_VERSION_H_
+#cmakedefine WAMR_VERSION_MAJOR @WAMR_VERSION_MAJOR@
+#define WAMR_VERSION_MINOR @WAMR_VERSION_MINOR@
+#define WAMR_VERSION_PATCH @WAMR_VERSION_PATCH@
+#endif

--- a/doc/semantic_version.md
+++ b/doc/semantic_version.md
@@ -1,0 +1,21 @@
+# WAMR uses semantic versioning
+
+WAMR uses the _semantic versioning_ to replace the current _date versioning_ system.
+
+There are three parts in the new version string:
+
+- _major_. Any incompatible modification, on both ABI and APIs, will lead an increment
+  in the value of _major_. APIs includes: `wasm_export.h`, `wasm_c_api.h`,
+  _sections in AOT files_, and so on.
+- _minor_. It represents new features. It includes not just MVP or POST-MVP features
+  but also WASI features and WAMR private ones.
+- _patch_. It represents patches.
+
+## Legacy versions
+
+All legacy versions(tags) will keep their current status. No existed releasings names
+and links will be changed.
+
+## Reference
+
+- [Semantic Versioning 2.0.0](https://semver.org/)

--- a/product-mini/platforms/linux-sgx/enclave-sample/Enclave/Enclave.cpp
+++ b/product-mini/platforms/linux-sgx/enclave-sample/Enclave/Enclave.cpp
@@ -44,6 +44,7 @@ typedef enum EcallCmd {
     CMD_DESTROY_RUNTIME,      /* wasm_runtime_destroy() */
     CMD_SET_WASI_ARGS,        /* wasm_runtime_set_wasi_args() */
     CMD_SET_LOG_LEVEL,        /* bh_log_set_verbose_level() */
+    CMD_GET_VERSION,          /* wasm_runtime_get_version() */
 } EcallCmd;
 
 typedef struct EnclaveModule {
@@ -522,6 +523,18 @@ handle_cmd_set_wasi_args(uint64 *args, int32 argc)
 }
 #endif /* end of SGX_DISABLE_WASI */
 
+static void
+handle_cmd_get_version(uint64 *args, uint32 argc)
+{
+    uint32 major, minor, patch;
+    bh_assert(argc == 3);
+
+    wasm_runtime_get_version(&major, &minor, &patch);
+    args[0] = major;
+    args[1] = minor;
+    args[2] = patch;
+}
+
 void
 ecall_handle_command(unsigned cmd, unsigned char *cmd_buf,
                      unsigned cmd_buf_size)
@@ -568,6 +581,9 @@ ecall_handle_command(unsigned cmd, unsigned char *cmd_buf,
             break;
         case CMD_SET_LOG_LEVEL:
             handle_cmd_set_log_level(args, argc);
+            break;
+        case CMD_GET_VERSION:
+            handle_cmd_get_version(args, argc);
             break;
         default:
             LOG_ERROR("Unknown command %d\n", cmd);

--- a/product-mini/platforms/posix/main.c
+++ b/product-mini/platforms/posix/main.c
@@ -68,6 +68,7 @@ print_help()
     printf("  -g=ip:port             Set the debug sever address, default is debug disabled\n");
     printf("                           if port is 0, then a random port will be used\n");
 #endif
+    printf("  --version              Show version information\n");
     return 1;
 }
 /* clang-format on */
@@ -461,6 +462,12 @@ main(int argc, char *argv[])
             ip_addr = argv[0] + 3;
         }
 #endif
+        else if (!strncmp(argv[0], "--version", 9)) {
+            uint32 major, minor, patch;
+            wasm_runtime_get_version(&major, &minor, &patch);
+            printf("iwasm %u.%u.%u\n", major, minor, patch);
+            return 0;
+        }
         else
             return print_help();
     }

--- a/product-mini/platforms/windows/main.c
+++ b/product-mini/platforms/windows/main.c
@@ -50,6 +50,7 @@ print_help()
     printf("  -g=ip:port             Set the debug sever address, default is debug disabled\n");
     printf("                           if port is 0, then a random port will be used\n");
 #endif
+    printf("  --version              Show version information\n");
     return 1;
 }
 /* clang-format on */
@@ -339,6 +340,12 @@ main(int argc, char *argv[])
             ip_addr = argv[0] + 3;
         }
 #endif
+        else if (!strncmp(argv[0], "--version", 9)) {
+            uint32 major, minor, patch;
+            wasm_runtime_get_version(&major, &minor, &patch);
+            printf("iwasm %u.%u.%u\n", major, minor, patch);
+            return 0;
+        }
         else
             return print_help();
     }

--- a/wamr-compiler/main.c
+++ b/wamr-compiler/main.c
@@ -63,6 +63,7 @@ print_help()
     printf("                            multiple names, e.g.\n");
     printf("                                --emit-custom-sections=section1,section2,sectionN\n");
     printf("  -v=n                      Set log verbose level (0 to 5, default is 2), larger with more log\n");
+    printf("  --version                 Show version information\n");
     printf("Examples: wamrc -o test.aot test.wasm\n");
     printf("          wamrc --target=i386 -o test.aot test.wasm\n");
     printf("          wamrc --target=i386 --format=object -o test.o test.wasm\n");
@@ -267,6 +268,12 @@ main(int argc, char *argv[])
             }
 
             option.custom_sections_count = len;
+        }
+        else if (!strncmp(argv[0], "--version", 9)) {
+            uint32 major, minor, patch;
+            wasm_runtime_get_version(&major, &minor, &patch);
+            printf("wamrc %u.%u.%u\n", major, minor, patch);
+            return 0;
         }
         else
             PRINT_HELP_AND_EXIT();


### PR DESCRIPTION
before publish a release
- manually change the content of config_common.cmake
- or pass the new version by `cmake -DWAMR_VERSION_MAJOR=XXX -DWAMR_VERSION_MINOR=YYY -DWAMR_VERSION_PATCH=ZZZ ...`