### PR TITLE
Remove wasm_runtime_create_exec_env_and_call_wasm

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -1971,28 +1971,6 @@ fail1:
 }
 
 bool
-wasm_runtime_create_exec_env_and_call_wasm(
-    WASMModuleInstanceCommon *module_inst, WASMFunctionInstanceCommon *function,
-    uint32 argc, uint32 argv[])
-{
-    bool ret = false;
-
-#if WASM_ENABLE_INTERP != 0
-    if (module_inst->module_type == Wasm_Module_Bytecode)
-        ret = wasm_create_exec_env_and_call_function(
-            (WASMModuleInstance *)module_inst, (WASMFunctionInstance *)function,
-            argc, argv, true);
-#endif
-#if WASM_ENABLE_AOT != 0
-    if (module_inst->module_type == Wasm_Module_AoT)
-        ret = aot_create_exec_env_and_call_function(
-            (AOTModuleInstance *)module_inst, (AOTFunctionInstance *)function,
-            argc, argv);
-#endif
-    return ret;
-}
-
-bool
 wasm_runtime_create_exec_env_singleton(WASMModuleInstanceCommon *module_inst)
 {
 #if WASM_ENABLE_INTERP != 0


### PR DESCRIPTION
It's unused since the following commit.
```
commit 260d36a62da58aa8d59fbad61db678d938ab529f
Author: Wenyong Huang <wenyong.huang@intel.com>
Date:   Wed Jan 19 11:25:08 2022 +0800

    Refactor externref related APIs of reference types feature (#971)

    Currently when calling wasm_runtime_call_wasm() to invoke wasm function
    with externref type argument from runtime embedder, developer needs to
    use wasm_externref_obj2ref() to convert externref obj into an internal ref
    index firstly, which is not convenient to developer.
    To align with GC feature in which all the references passed to
    wasm_runtime_call_wasm() can be object pointers directly, we change the
    interface of wasm_runtime_call_wasm() to allow to pass object pointer
    directly for the externref argument, and refactor the related codes, update
    the related samples and the document.
```