### PR TITLE
wasm_create_exec_env_and_call_function: Remove "enable_debug" argument

### DIFF
--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -977,7 +977,7 @@ execute_post_inst_function(WASMModuleInstance *module_inst)
         return true;
 
     return wasm_create_exec_env_and_call_function(module_inst, post_inst_func,
-                                                  0, NULL, false);
+                                                  0, NULL);
 }
 
 #if WASM_ENABLE_BULK_MEMORY != 0
@@ -1006,7 +1006,7 @@ execute_memory_init_function(WASMModuleInstance *module_inst)
         return true;
 
     return wasm_create_exec_env_and_call_function(module_inst, memory_init_func,
-                                                  0, NULL, false);
+                                                  0, NULL);
 }
 #endif
 
@@ -1021,8 +1021,7 @@ execute_start_function(WASMModuleInstance *module_inst)
     bh_assert(!func->is_import_func && func->param_cell_num == 0
               && func->ret_cell_num == 0);
 
-    return wasm_create_exec_env_and_call_function(module_inst, func, 0, NULL,
-                                                  false);
+    return wasm_create_exec_env_and_call_function(module_inst, func, 0, NULL);
 }
 
 static bool
@@ -1066,11 +1065,11 @@ execute_malloc_function(WASMModuleInstance *module_inst,
 #endif
     {
         ret = wasm_create_exec_env_and_call_function(module_inst, malloc_func,
-                                                     argc, argv, false);
+                                                     argc, argv);
 
         if (retain_func && ret) {
-            ret = wasm_create_exec_env_and_call_function(
-                module_inst, retain_func, 1, argv, false);
+            ret = wasm_create_exec_env_and_call_function(module_inst,
+                                                         retain_func, 1, argv);
         }
     }
 
@@ -1099,7 +1098,7 @@ execute_free_function(WASMModuleInstance *module_inst,
 #endif
     {
         return wasm_create_exec_env_and_call_function(module_inst, free_func, 1,
-                                                      argv, false);
+                                                      argv);
     }
 }
 
@@ -1159,7 +1158,7 @@ sub_module_instantiate(WASMModule *module, WASMModuleInstance *module_inst,
                 wasm_lookup_function(sub_module_inst, "_initialize", NULL);
             if (initialize
                 && !wasm_create_exec_env_and_call_function(
-                    sub_module_inst, initialize, 0, NULL, false)) {
+                    sub_module_inst, initialize, 0, NULL)) {
                 set_error_buf(error_buf, error_buf_size,
                               "Call _initialize failed ");
                 goto failed;
@@ -2032,8 +2031,7 @@ wasm_call_function(WASMExecEnv *exec_env, WASMFunctionInstance *function,
 bool
 wasm_create_exec_env_and_call_function(WASMModuleInstance *module_inst,
                                        WASMFunctionInstance *func,
-                                       unsigned argc, uint32 argv[],
-                                       bool enable_debug)
+                                       unsigned argc, uint32 argv[])
 {
     WASMExecEnv *exec_env = NULL, *existing_exec_env = NULL;
     bool ret;
@@ -2052,14 +2050,6 @@ wasm_create_exec_env_and_call_function(WASMModuleInstance *module_inst,
             wasm_set_exception(module_inst, "allocate memory failed");
             return false;
         }
-
-#if WASM_ENABLE_THREAD_MGR != 0
-#if WASM_ENABLE_DEBUG_INTERP != 0
-        if (enable_debug) {
-            wasm_runtime_start_debug_instance(exec_env);
-        }
-#endif
-#endif
     }
 
     ret = wasm_call_function(exec_env, func, argc, argv);

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -334,8 +334,7 @@ wasm_call_function(WASMExecEnv *exec_env, WASMFunctionInstance *function,
 bool
 wasm_create_exec_env_and_call_function(WASMModuleInstance *module_inst,
                                        WASMFunctionInstance *function,
-                                       unsigned argc, uint32 argv[],
-                                       bool enable_debug);
+                                       unsigned argc, uint32 argv[]);
 
 bool
 wasm_create_exec_env_singleton(WASMModuleInstance *module_inst);


### PR DESCRIPTION
* No one uses it after removal of
  wasm_runtime_create_exec_env_and_call_wasm.
  (commit 0ec99e95223b3a17bad98d96031831b1d7eee18c)

* debug instance is launched differently these days.
  cf. commit 68fd6454c2265ae32f5c9c00509052f798f9aba8