### PR TITLE
Destroy fast-jit compiler after destroy loaded modules

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -341,10 +341,6 @@ wasm_runtime_init()
 void
 wasm_runtime_destroy()
 {
-#if WASM_ENABLE_FAST_JIT != 0
-    jit_compiler_destroy();
-#endif
-
 #if WASM_ENABLE_REF_TYPES != 0
     wasm_externref_map_destroy();
 #endif
@@ -366,6 +362,14 @@ wasm_runtime_destroy()
 
     wasm_runtime_destroy_registered_module_list();
     os_mutex_destroy(&registered_module_list_lock);
+#endif
+
+#if WASM_ENABLE_FAST_JIT != 0
+    /* Destroy Fast-JIT compiler after destroying the modules
+     * loaded by multi-module feature, since the Fast JIT's
+     * code cache allocator may be used by these modules.
+     */
+    jit_compiler_destroy();
 #endif
 
 #if WASM_ENABLE_SHARED_MEMORY

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -109,8 +109,11 @@ memories_deinstantiate(WASMModuleInstance *module_inst,
         for (i = 0; i < count; i++) {
             if (memories[i]) {
 #if WASM_ENABLE_MULTI_MODULE != 0
-                if (i < module_inst->module->import_memory_count)
+                WASMModule *module = module_inst->module;
+                if (i < module->import_memory_count
+                    && module->import_memories[i].u.memory.import_module) {
                     continue;
+                }
 #endif
 #if WASM_ENABLE_SHARED_MEMORY != 0
                 if (memories[i]->is_shared) {


### PR DESCRIPTION
Destroy Fast-JIT compiler after destroying the modules loaded by
multi-module feature, since the Fast JIT's code cache allocator may
be used by these modules. If the Fast JIT's code cache allocator was
destroyed, then runtime will fail to destroy these modules.

And fix the issue of destroying import module's memory instance.