### PR TITLE
debug: Remove unused platform_port

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -404,7 +404,6 @@ wasm_runtime_full_init(RuntimeInitArgs *init_args)
 #if WASM_ENABLE_DEBUG_INTERP != 0
     if (strlen(init_args->ip_addr))
         if (!wasm_debug_engine_init(init_args->ip_addr,
-                                    init_args->platform_port,
                                     init_args->instance_port)) {
             wasm_runtime_destroy();
             return false;

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -137,7 +137,7 @@ typedef struct RuntimeInitArgs {
     /* Debug settings, only used when
        WASM_ENABLE_DEBUG_INTERP != 0 */
     char ip_addr[128];
-    int platform_port;
+    int unused; /* was platform_port */
     int instance_port;
 
     /* Fast JIT code cache size */

--- a/core/iwasm/libraries/debug-engine/debug_engine.c
+++ b/core/iwasm/libraries/debug-engine/debug_engine.c
@@ -17,7 +17,6 @@ typedef struct WASMDebugEngine {
     struct WASMDebugEngine *next;
     WASMDebugControlThread *control_thread;
     char ip_addr[128];
-    int32 platform_port;
     int32 process_base_port;
     bh_list debug_instance_list;
     korp_mutex instance_list_lock;
@@ -291,7 +290,7 @@ wasm_debug_engine_destroy()
 }
 
 bool
-wasm_debug_engine_init(char *ip_addr, int32 platform_port, int32 process_port)
+wasm_debug_engine_init(char *ip_addr, int32 process_port)
 {
     if (wasm_debug_handler_init() != 0) {
         return false;
@@ -303,8 +302,6 @@ wasm_debug_engine_init(char *ip_addr, int32 platform_port, int32 process_port)
 
     if (g_debug_engine) {
         process_port -= 1;
-        g_debug_engine->platform_port =
-            platform_port > 0 ? platform_port : 1234;
         g_debug_engine->process_base_port =
             (process_port > 0) ? process_port : 0;
         if (ip_addr)

--- a/core/iwasm/libraries/debug-engine/debug_engine.h
+++ b/core/iwasm/libraries/debug-engine/debug_engine.h
@@ -117,7 +117,7 @@ WASMDebugInstance *
 wasm_exec_env_get_instance(WASMExecEnv *exec_env);
 
 bool
-wasm_debug_engine_init(char *ip_addr, int32 platform_port, int32 process_port);
+wasm_debug_engine_init(char *ip_addr, int32 process_port);
 
 void
 wasm_debug_engine_destroy();

--- a/product-mini/platforms/posix/main.c
+++ b/product-mini/platforms/posix/main.c
@@ -329,7 +329,6 @@ main(int argc, char *argv[])
 #endif
 #if WASM_ENABLE_DEBUG_INTERP != 0
     char *ip_addr = NULL;
-    /* int platform_port = 0; */
     int instance_port = 0;
 #endif
 
@@ -497,7 +496,6 @@ main(int argc, char *argv[])
 #endif
 
 #if WASM_ENABLE_DEBUG_INTERP != 0
-    init_args.platform_port = 0;
     init_args.instance_port = instance_port;
     if (ip_addr)
         strcpy(init_args.ip_addr, ip_addr);

--- a/product-mini/platforms/windows/main.c
+++ b/product-mini/platforms/windows/main.c
@@ -247,7 +247,6 @@ main(int argc, char *argv[])
 #endif
 #if WASM_ENABLE_DEBUG_INTERP != 0
     char *ip_addr = NULL;
-    /* int platform_port = 0; */
     int instance_port = 0;
 #endif
 
@@ -371,7 +370,6 @@ main(int argc, char *argv[])
 #endif
 
 #if WASM_ENABLE_DEBUG_INTERP != 0
-    init_args.platform_port = 0;
     init_args.instance_port = instance_port;
     if (ip_addr)
         strcpy(init_args.ip_addr, ip_addr);


### PR DESCRIPTION
I left a placeholder in RuntimeInitArgs just because I don't want to
bump the major verision for this change alone.