### PR TITLE
debug: Retire wasm_debug_(get|set)_engine_active mechanism

### DIFF
--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -2160,27 +2160,11 @@ wasm_module_malloc(WASMModuleInstance *module_inst, uint32 size,
         addr = mem_allocator_malloc(memory->heap_handle, size);
     }
     else if (module_inst->malloc_function && module_inst->free_function) {
-#if WASM_ENABLE_DEBUG_INTERP != 0
-        /* TODO: obviously, we can not create debug instance for
-         * module malloc here, so, just disable the engine here,
-         * it is strange, but we now are lack of ways to indicate
-         * which calls should not be debugged. And we have other
-         * execute_xxx_function may need to be taken care of
-         */
-        bool active = wasm_debug_get_engine_active();
-        wasm_debug_set_engine_active(false);
-#endif
         if (!execute_malloc_function(module_inst, module_inst->malloc_function,
                                      module_inst->retain_function, size,
                                      &offset)) {
-#if WASM_ENABLE_DEBUG_INTERP != 0
-            wasm_debug_set_engine_active(active);
-#endif
             return 0;
         }
-#if WASM_ENABLE_DEBUG_INTERP != 0
-        wasm_debug_set_engine_active(active);
-#endif
         /* If we use app's malloc function,
            the default memory may be changed while memory growing */
         memory = module_inst->default_memory;
@@ -2259,17 +2243,7 @@ wasm_module_free(WASMModuleInstance *module_inst, uint32 ptr)
         else if (module_inst->malloc_function && module_inst->free_function
                  && memory->memory_data <= addr
                  && addr < memory->memory_data_end) {
-#if WASM_ENABLE_DEBUG_INTERP != 0
-            /*TODO: obviously, we can not create debug instance for module
-            malloc here, so, just disable the engine here, it is strange. the
-            wasm's call should be marshed to its own thread */
-            bool active = wasm_debug_get_engine_active();
-            wasm_debug_set_engine_active(false);
-#endif
             execute_free_function(module_inst, module_inst->free_function, ptr);
-#if WASM_ENABLE_DEBUG_INTERP != 0
-            wasm_debug_set_engine_active(active);
-#endif
         }
     }
 }

--- a/core/iwasm/libraries/debug-engine/debug_engine.c
+++ b/core/iwasm/libraries/debug-engine/debug_engine.c
@@ -21,7 +21,6 @@ typedef struct WASMDebugEngine {
     int32 process_base_port;
     bh_list debug_instance_list;
     korp_mutex instance_list_lock;
-    bool active;
 } WASMDebugEngine;
 
 void
@@ -313,30 +312,12 @@ wasm_debug_engine_init(char *ip_addr, int32 platform_port, int32 process_port)
         else
             snprintf(g_debug_engine->ip_addr, sizeof(g_debug_engine->ip_addr),
                      "%s", "127.0.0.1");
-        g_debug_engine->active = true;
     }
     else {
         wasm_debug_handler_deinit();
     }
 
     return g_debug_engine != NULL ? true : false;
-}
-
-void
-wasm_debug_set_engine_active(bool active)
-{
-    if (g_debug_engine) {
-        g_debug_engine->active = active;
-    }
-}
-
-bool
-wasm_debug_get_engine_active(void)
-{
-    if (g_debug_engine) {
-        return g_debug_engine->active;
-    }
-    return false;
 }
 
 /* A debug Instance is a debug "process" in gdb remote protocol
@@ -348,7 +329,7 @@ wasm_debug_instance_create(WASMCluster *cluster)
     WASMExecEnv *exec_env = NULL;
     wasm_module_inst_t module_inst = NULL;
 
-    if (!g_debug_engine || !g_debug_engine->active) {
+    if (!g_debug_engine) {
         return NULL;
     }
 

--- a/core/iwasm/libraries/debug-engine/debug_engine.h
+++ b/core/iwasm/libraries/debug-engine/debug_engine.h
@@ -122,12 +122,6 @@ wasm_debug_engine_init(char *ip_addr, int32 platform_port, int32 process_port);
 void
 wasm_debug_engine_destroy();
 
-void
-wasm_debug_set_engine_active(bool active);
-
-bool
-wasm_debug_get_engine_active(void);
-
 WASMExecEnv *
 wasm_debug_instance_get_current_env(WASMDebugInstance *instance);
 


### PR DESCRIPTION
They are no longer necessary because we no longer create
debug instances automatically for exec env at this layer.