### PR TITLE
wasm_application.c: Do not start debug instance automatically

### DIFF
--- a/core/iwasm/common/wasm_application.c
+++ b/core/iwasm/common/wasm_application.c
@@ -107,9 +107,6 @@ execute_main(WASMModuleInstanceCommon *module_inst, int32 argc, char *argv[])
        the actual main function. Directly calling main function
        may cause exception thrown. */
     if ((func = wasm_runtime_lookup_wasi_start_function(module_inst))) {
-#if WASM_ENABLE_DEBUG_INTERP != 0
-        wasm_runtime_start_debug_instance(exec_env);
-#endif
         return wasm_runtime_call_wasm(exec_env, func, 0, NULL);
     }
 #endif /* end of WASM_ENABLE_LIBC_WASI */
@@ -190,10 +187,6 @@ execute_main(WASMModuleInstanceCommon *module_inst, int32 argc, char *argv[])
         argv1[1] =
             (uint32)wasm_runtime_addr_native_to_app(module_inst, argv_offsets);
     }
-
-#if WASM_ENABLE_DEBUG_INTERP != 0
-    wasm_runtime_start_debug_instance(exec_env);
-#endif
 
     ret = wasm_runtime_call_wasm(exec_env, func, argc1, argv1);
     if (ret && func_type->result_count > 0 && argc > 0 && argv)
@@ -617,10 +610,6 @@ execute_func(WASMModuleInstanceCommon *module_inst, const char *name,
                                    "create singleton exec_env failed");
         goto fail;
     }
-
-#if WASM_ENABLE_DEBUG_INTERP != 0
-    wasm_runtime_start_debug_instance(exec_env);
-#endif
 
     if (!wasm_runtime_call_wasm(exec_env, target_func, argc1, argv1)) {
         goto fail;

--- a/product-mini/platforms/posix/main.c
+++ b/product-mini/platforms/posix/main.c
@@ -570,6 +570,23 @@ main(int argc, char *argv[])
         goto fail3;
     }
 
+#if WASM_ENABLE_DEBUG_INTERP != 0
+    if (ip_addr != NULL) {
+        wasm_exec_env_t exec_env =
+            wasm_runtime_get_exec_env_singleton(wasm_module_inst);
+        uint32_t debug_port;
+        if (exec_env == NULL) {
+            printf("%s\n", wasm_runtime_get_exception(wasm_module_inst));
+            goto fail4;
+        }
+        debug_port = wasm_runtime_start_debug_instance(exec_env);
+        if (debug_port == 0) {
+            printf("Failed to start debug instance\n");
+            goto fail4;
+        }
+    }
+#endif
+
     if (is_repl_mode)
         app_instance_repl(wasm_module_inst);
     else if (func_name)
@@ -579,6 +596,9 @@ main(int argc, char *argv[])
 
     ret = 0;
 
+#if WASM_ENABLE_DEBUG_INTERP != 0
+fail4:
+#endif
     /* destroy the module instance */
     wasm_runtime_deinstantiate(wasm_module_inst);
 

--- a/product-mini/platforms/windows/main.c
+++ b/product-mini/platforms/windows/main.c
@@ -437,6 +437,23 @@ main(int argc, char *argv[])
         goto fail3;
     }
 
+#if WASM_ENABLE_DEBUG_INTERP != 0
+    if (ip_addr != NULL) {
+        wasm_exec_env_t exec_env =
+            wasm_runtime_get_exec_env_singleton(wasm_module_inst);
+        uint32_t debug_port;
+        if (exec_env == NULL) {
+            printf("%s\n", wasm_runtime_get_exception(wasm_module_inst));
+            goto fail4;
+        }
+        debug_port = wasm_runtime_start_debug_instance(exec_env);
+        if (debug_port == 0) {
+            printf("Failed to start debug instance\n");
+            goto fail4;
+        }
+    }
+#endif
+
     if (is_repl_mode)
         app_instance_repl(wasm_module_inst);
     else if (func_name)
@@ -446,6 +463,9 @@ main(int argc, char *argv[])
 
     ret = 0;
 
+#if WASM_ENABLE_DEBUG_INTERP != 0
+fail4:
+#endif
     /* destroy the module instance */
     wasm_runtime_deinstantiate(wasm_module_inst);
 


### PR DESCRIPTION
It's better to leave the control to embedders. (eg. product-mini)

background: I have a use case where
* The application runs multiple module instances.
* I want to debug only one of them.
