### PR TITLE
wasm_runtime_start_debug_instance: Allow to override port

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -507,7 +507,7 @@ wasm_runtime_is_xip_file(const uint8 *buf, uint32 size)
 
 #if (WASM_ENABLE_THREAD_MGR != 0) && (WASM_ENABLE_DEBUG_INTERP != 0)
 uint32
-wasm_runtime_start_debug_instance(WASMExecEnv *exec_env)
+wasm_runtime_start_debug_instance_with_port(WASMExecEnv *exec_env, int32_t port)
 {
     WASMModuleInstanceCommon *module_inst =
         wasm_runtime_get_module_inst(exec_env);
@@ -525,11 +525,17 @@ wasm_runtime_start_debug_instance(WASMExecEnv *exec_env)
         return cluster->debug_inst->control_thread->port;
     }
 
-    if (wasm_debug_instance_create(cluster)) {
+    if (wasm_debug_instance_create(cluster, port)) {
         return cluster->debug_inst->control_thread->port;
     }
 
     return 0;
+}
+
+uint32
+wasm_runtime_start_debug_instance(WASMExecEnv *exec_env)
+{
+    return wasm_runtime_start_debug_instance_with_port(exec_env, -1);
 }
 #endif
 

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -565,6 +565,11 @@ wasm_runtime_call_wasm_v(WASMExecEnv *exec_env,
 #if WASM_ENABLE_DEBUG_INTERP != 0
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN uint32
+wasm_runtime_start_debug_instance_with_port(WASMExecEnv *exec_env,
+                                            int32_t port);
+
+/* See wasm_export.h for description */
+WASM_RUNTIME_API_EXTERN uint32
 wasm_runtime_start_debug_instance(WASMExecEnv *exec_env);
 #endif
 

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -516,8 +516,17 @@ wasm_runtime_get_exec_env_singleton(wasm_module_inst_t module_inst);
  *   they are sharing the same cluster with the main exec_env.
  *
  * @param exec_env the execution environment to start debug instance
+ * @param port     the port for the debug server to listen on.
+ *                 0 means automatic assignment.
+ *                 -1 means to use the global setting in RuntimeInitArgs.
  *
  * @return debug port if success, 0 otherwise.
+ */
+WASM_RUNTIME_API_EXTERN uint32_t
+wasm_runtime_start_debug_instance_with_port(wasm_exec_env_t exec_env, int32_t port);
+
+/**
+ * Same as wasm_runtime_start_debug_instance_with_port(env, -1).
  */
 WASM_RUNTIME_API_EXTERN uint32_t
 wasm_runtime_start_debug_instance(wasm_exec_env_t exec_env);

--- a/core/iwasm/libraries/debug-engine/debug_engine.h
+++ b/core/iwasm/libraries/debug-engine/debug_engine.h
@@ -108,7 +108,7 @@ void
 on_thread_stop_event(WASMDebugInstance *debug_inst, WASMExecEnv *exec_env);
 
 WASMDebugInstance *
-wasm_debug_instance_create(WASMCluster *cluster);
+wasm_debug_instance_create(WASMCluster *cluster, int32 port);
 
 void
 wasm_debug_instance_destroy(WASMCluster *cluster);


### PR DESCRIPTION
This allows the embedder to manage port numbers for this purpose
by itself.