### PR TITLE
wamr-ide/VSCode-Extension: "set -e" in shell scripts

### DIFF
--- a/test-tools/wamr-ide/VSCode-Extension/resource/scripts/boot_debugger_server.sh
+++ b/test-tools/wamr-ide/VSCode-Extension/resource/scripts/boot_debugger_server.sh
@@ -3,6 +3,8 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+set -e
+
 docker run --rm -it --name=wasm-debug-server-ctr \
            -v "$(pwd)":/mnt \
            -p 1234:1234 \

--- a/test-tools/wamr-ide/VSCode-Extension/resource/scripts/build.sh
+++ b/test-tools/wamr-ide/VSCode-Extension/resource/scripts/build.sh
@@ -3,6 +3,8 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+set -e
+
 docker run --rm --name=wasm-toolchain-ctr \
                 -it -v "$(pwd)":/mnt \
                 --env=PROJ_PATH="$(pwd)" \

--- a/test-tools/wamr-ide/VSCode-Extension/resource/scripts/destroy.sh
+++ b/test-tools/wamr-ide/VSCode-Extension/resource/scripts/destroy.sh
@@ -3,6 +3,8 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+set -e
+
 docker -v>/dev/null
 if [ $? -ne 0 ]; then
     echo "\nDocker is not installed, please install docker firstly.\n"

--- a/test-tools/wamr-ide/VSCode-Extension/resource/scripts/run.sh
+++ b/test-tools/wamr-ide/VSCode-Extension/resource/scripts/run.sh
@@ -3,6 +3,8 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+set -e
+
 docker run --rm -it --name=wasm-debug-server-ctr \
            -v "$(pwd)":/mnt \
            wasm-debug-server:1.0 \


### PR DESCRIPTION
To avoid mysterious behaviors caused by ignored errors.