### PR TITLE
wamr-ide/VSCode-Extension: Make lldb binary path per platform

### DIFF
--- a/test-tools/wamr-ide/VSCode-Extension/package.json
+++ b/test-tools/wamr-ide/VSCode-Extension/package.json
@@ -125,9 +125,14 @@
                         "swift"
                     ]
                 },
-                "program": "./resource/debug/bin/lldb-vscode",
                 "windows": {
-                    "program": "./resource/debug/bin/lldb-vscode.exe"
+                    "program": "./resource/debug/windows/bin/lldb-vscode.exe"
+                },
+                "osx": {
+                    "program": "./resource/debug/osx/bin/lldb-vscode"
+                },
+                "linux": {
+                    "program": "./resource/debug/linux/bin/lldb-vscode"
                 },
                 "configurationAttributes": {
                     "attach": {

--- a/test-tools/wamr-ide/VSCode-Extension/resource/debug/README.md
+++ b/test-tools/wamr-ide/VSCode-Extension/resource/debug/README.md
@@ -1,11 +1,11 @@
 ### If you want to enable `source debugging` for this extension, please build `lldb` firstly following this [instruction](../../../../../doc/source_debugging.md#debugging-with-interpreter).
 
-### After building(`linux` for example), create `bin` folder and `lib` folder respectively in current directory, add following necessary target files into the folders.
+### After building(`linux` for example), create `bin` folder and `lib` folder respectively in `linux` directory, add following necessary target files into the folders.
 
     ```shell
-     /llvm/build-lldb/bin/lldb # move this file to resource/debug/bin/
-     /llvm/build-lldb/bin/lldb-vscode # move this file to resource/debug/bin/
-     /llvm/build-lldb/lib/liblldb.so.13 # move this file to resource/debug/lib/
+     /llvm/build-lldb/bin/lldb # move this file to resource/debug/linux/bin/
+     /llvm/build-lldb/bin/lldb-vscode # move this file to resource/debug/linux/bin/
+     /llvm/build-lldb/lib/liblldb.so.13 # move this file to resource/debug/linux/lib/
     ```
 
 Note: For macOS, the library is named like `liblldb.13.0.1.dylib`.


### PR DESCRIPTION
hopefully this allows an extension package to run on multiple platforms.

cf. https://code.visualstudio.com/api/extension-guides/debugger-extension#anatomy-of-the-package.json-of-a-debugger-extension