### PR TITLE
Remove handling unsupported opcodes in loader

### DIFF
--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -7313,7 +7313,6 @@ re_scan:
             }
 
             case WASM_OP_DROP:
-            case WASM_OP_DROP_64:
             {
                 BranchBlock *cur_block = loader_ctx->frame_csp - 1;
                 int32 available_stack_cell =
@@ -7381,7 +7380,6 @@ re_scan:
             }
 
             case WASM_OP_SELECT:
-            case WASM_OP_SELECT_64:
             {
                 uint8 ref_type;
                 BranchBlock *cur_block = loader_ctx->frame_csp - 1;

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -5519,7 +5519,6 @@ re_scan:
             }
 
             case WASM_OP_DROP:
-            case WASM_OP_DROP_64:
             {
                 BranchBlock *cur_block = loader_ctx->frame_csp - 1;
                 int32 available_stack_cell =
@@ -5572,7 +5571,6 @@ re_scan:
             }
 
             case WASM_OP_SELECT:
-            case WASM_OP_SELECT_64:
             {
                 uint8 ref_type;
                 BranchBlock *cur_block = loader_ctx->frame_csp - 1;


### PR DESCRIPTION
Remove handling opcode DROP_64/SELECT_64 in loader stage
prepare_bytecode, as they are the modified opcodes of DROP/SELECT
for optimization purpose, but not the opcodes defined by spec.