### PR TITLE
Implement serialize and deserialize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ tests/wamr-test-suites/workspace
 samples/socket-api/wasm-src/inc/pthread.h
 
 **/__pycache__
+
+# ignore benchmarks generated
+tests/benchmarks/coremark/coremark*

--- a/core/iwasm/include/wasm_c_api.h
+++ b/core/iwasm/include/wasm_c_api.h
@@ -461,7 +461,7 @@ WASM_API_EXTERN bool wasm_module_validate(wasm_store_t*, const wasm_byte_vec_t* 
 WASM_API_EXTERN void wasm_module_imports(const wasm_module_t*, own wasm_importtype_vec_t* out);
 WASM_API_EXTERN void wasm_module_exports(const wasm_module_t*, own wasm_exporttype_vec_t* out);
 
-WASM_API_EXTERN void wasm_module_serialize(const wasm_module_t*, own wasm_byte_vec_t* out);
+WASM_API_EXTERN void wasm_module_serialize(wasm_module_t*, own wasm_byte_vec_t* out);
 WASM_API_EXTERN own wasm_module_t* wasm_module_deserialize(wasm_store_t*, const wasm_byte_vec_t*);
 
 

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -3321,6 +3321,7 @@ fast_jit_call_indirect(WASMExecEnv *exec_env, uint32 tbl_idx, uint32 elem_idx,
 #endif
 
 #if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+
 bool
 llvm_jit_call_indirect(WASMExecEnv *exec_env, uint32 tbl_idx, uint32 elem_idx,
                        uint32 argc, uint32 *argv)

--- a/samples/wasm-c-api/CMakeLists.txt
+++ b/samples/wasm-c-api/CMakeLists.txt
@@ -135,6 +135,12 @@ set(EXAMPLES
   trap
 )
 
+if(WAMR_BUILD_JIT AND WAMR_BUILD_LAZY_JIT)
+  if((${WAMR_BUILD_JIT} EQUAL 1) AND (${WAMR_BUILD_LAZY_JIT} EQUAL 1))
+    list(APPEND EXAMPLES serialize)
+  endif()
+endif()
+
 foreach(EX ${EXAMPLES})
   set(SRC ${CMAKE_CURRENT_LIST_DIR}/src/${EX}.c)
 

--- a/samples/wasm-c-api/src/serialize.c
+++ b/samples/wasm-c-api/src/serialize.c
@@ -1,0 +1,129 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include "wasm_c_api.h"
+
+#define own
+
+// A function to be called from Wasm code.
+own wasm_trap_t *
+hello_callback(const wasm_val_vec_t *args, wasm_val_vec_t *results)
+{
+    printf("Calling back...\n");
+    printf("> Hello World!\n");
+    return NULL;
+}
+
+int
+main(int argc, const char *argv[])
+{
+    // Initialize.
+    printf("Initializing...\n");
+    wasm_engine_t *engine = wasm_engine_new();
+    wasm_store_t *store = wasm_store_new(engine);
+
+    // Load binary.
+    printf("Loading binary...\n");
+    FILE *file = fopen("serialize.wasm", "rb");
+    if (!file) {
+        printf("> Error loading module!\n");
+        return 1;
+    }
+    fseek(file, 0L, SEEK_END);
+    size_t file_size = ftell(file);
+    fseek(file, 0L, SEEK_SET);
+    wasm_byte_vec_t binary;
+    wasm_byte_vec_new_uninitialized(&binary, file_size);
+    if (fread(binary.data, file_size, 1, file) != 1) {
+        printf("> Error loading module!\n");
+        return 1;
+    }
+    fclose(file);
+
+    // Compile.
+    printf("Compiling module...\n");
+    own wasm_module_t *module = wasm_module_new(store, &binary);
+    if (!module) {
+        printf("> Error compiling module!\n");
+        return 1;
+    }
+
+    wasm_byte_vec_delete(&binary);
+
+    // Serialize module.
+    printf("Serializing module...\n");
+    own wasm_byte_vec_t serialized;
+    wasm_module_serialize(module, &serialized);
+
+    wasm_module_delete(module);
+
+    // Deserialize module.
+    printf("Deserializing module...\n");
+    own wasm_module_t *deserialized =
+        wasm_module_deserialize(store, &serialized);
+    if (!deserialized) {
+        printf("> Error deserializing module!\n");
+        return 1;
+    }
+
+    wasm_byte_vec_delete(&serialized);
+
+    // Create external print functions.
+    printf("Creating callback...\n");
+    own wasm_functype_t *hello_type = wasm_functype_new_0_0();
+    own wasm_func_t *hello_func =
+        wasm_func_new(store, hello_type, hello_callback);
+
+    wasm_functype_delete(hello_type);
+
+    // Instantiate.
+    printf("Instantiating deserialized module...\n");
+    wasm_extern_t *externs[] = { wasm_func_as_extern(hello_func) };
+    wasm_extern_vec_t imports = WASM_ARRAY_VEC(externs);
+    own wasm_instance_t *instance =
+        wasm_instance_new(store, deserialized, &imports, NULL);
+    if (!instance) {
+        printf("> Error instantiating module!\n");
+        return 1;
+    }
+
+    wasm_func_delete(hello_func);
+
+    // Extract export.
+    printf("Extracting export...\n");
+    own wasm_extern_vec_t exports;
+    wasm_instance_exports(instance, &exports);
+    if (exports.size == 0) {
+        printf("> Error accessing exports!\n");
+        return 1;
+    }
+    const wasm_func_t *run_func = wasm_extern_as_func(exports.data[0]);
+    if (run_func == NULL) {
+        printf("> Error accessing export!\n");
+        return 1;
+    }
+
+    wasm_module_delete(deserialized);
+    wasm_instance_delete(instance);
+
+    // Call.
+    printf("Calling export...\n");
+    wasm_val_vec_t empty = WASM_EMPTY_VEC;
+    if (wasm_func_call(run_func, &empty, &empty)) {
+        printf("> Error calling function!\n");
+        return 1;
+    }
+
+    wasm_extern_vec_delete(&exports);
+
+    // Shut down.
+    printf("Shutting down...\n");
+    wasm_store_delete(store);
+    wasm_engine_delete(engine);
+
+    // All done.
+    printf("Done.\n");
+    return 0;
+}

--- a/samples/wasm-c-api/src/serialize.wat
+++ b/samples/wasm-c-api/src/serialize.wat
@@ -1,0 +1,4 @@
+(module
+  (func $hello (import "" "hello"))
+  (func (export "run") (call $hello))
+)


### PR DESCRIPTION
Decide to use the .aot content as the .wasm precompiled result.
- `wasm_module_serialize(...)` will return it.
- `wasm_module_deserialize(...)` will load the precompiled content as normal .aot files.