### PR TITLE
Fix: thread-mgr: prevent an already detached thread from being detached again

### DIFF
--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -697,6 +697,9 @@ wasm_cluster_join_thread(WASMExecEnv *exec_env, void **ret_val)
 int32
 wasm_cluster_detach_thread(WASMExecEnv *exec_env)
 {
+    if (exec_env->thread_is_detached)
+        return 0;
+
     int32 ret = 0;
 
     os_mutex_lock(&cluster_list_lock);

--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -697,9 +697,6 @@ wasm_cluster_join_thread(WASMExecEnv *exec_env, void **ret_val)
 int32
 wasm_cluster_detach_thread(WASMExecEnv *exec_env)
 {
-    if (exec_env->thread_is_detached)
-        return 0;
-
     int32 ret = 0;
 
     os_mutex_lock(&cluster_list_lock);
@@ -708,7 +705,7 @@ wasm_cluster_detach_thread(WASMExecEnv *exec_env)
         os_mutex_unlock(&cluster_list_lock);
         return 0;
     }
-    if (exec_env->wait_count == 0) {
+    if (exec_env->wait_count == 0 && !exec_env->thread_is_detached) {
         /* Only detach current thread when there is no other thread
            joining it, otherwise let the system resources for the
            thread be released after joining */


### PR DESCRIPTION
If WASM app has called pthread_detach() to detach a thread, it will be detached again at thread exit. Attempting to detach an already detached thread results crash in musl-libc. This patch will fix it.