### PR TITLE
Fix bugs occurring in Instrument Test 

### DIFF
--- a/core/iwasm/fast-jit/fe/jit_emit_function.c
+++ b/core/iwasm/fast-jit/fe/jit_emit_function.c
@@ -262,6 +262,9 @@ pack_argv(JitCompContext *cc)
     stack_base = cc->total_frame_size + offsetof(WASMInterpFrame, lp);
     argv = jit_cc_new_reg_ptr(cc);
     GEN_INSN(ADD, argv, cc->fp_reg, NEW_CONST(PTR, stack_base));
+    if (jit_get_last_error(cc)) {
+        return (JitReg)0;
+    }
     return argv;
 }
 
@@ -341,7 +344,9 @@ jit_compile_op_call_indirect(JitCompContext *cc, uint32 type_idx,
     }
 
     argv = pack_argv(cc);
-
+    if (!argv) {
+        goto fail;
+    }
     native_ret = jit_cc_new_reg_I32(cc);
     arg_regs[0] = cc->exec_env_reg;
     arg_regs[1] = NEW_CONST(I32, tbl_idx);

--- a/core/iwasm/fast-jit/jit_ir.c
+++ b/core/iwasm/fast-jit/jit_ir.c
@@ -382,7 +382,7 @@ jit_cc_init(JitCompContext *cc, unsigned htab_size)
        blocks respectively.  */
     if (!(entry_block = jit_cc_new_basic_block(cc, 0)))
         goto fail;
-    if (!(exit_block = jit_cc_new_basic_block(cc, 0))){
+    if (!(exit_block = jit_cc_new_basic_block(cc, 0))) {
         jit_basic_block_delete(entry_block);
         goto fail;
     }

--- a/core/iwasm/fast-jit/jit_ir.c
+++ b/core/iwasm/fast-jit/jit_ir.c
@@ -380,9 +380,19 @@ jit_cc_init(JitCompContext *cc, unsigned htab_size)
 
     /* Create entry and exit blocks.  They must be the first two
        blocks respectively.  */
-    if (!(entry_block = jit_cc_new_basic_block(cc, 0))
-        || !(exit_block = jit_cc_new_basic_block(cc, 0)))
+    if (!(entry_block = jit_cc_new_basic_block(cc, 0)))
         goto fail;
+    if (!(exit_block = jit_cc_new_basic_block(cc, 0))){
+        jit_basic_block_delete(entry_block);
+        goto fail;
+    }
+
+    /* Record the entry and exit labels, whose indexes must be 0 and 1
+       respectively.  */
+    cc->entry_label = jit_basic_block_label(entry_block);
+    cc->exit_label = jit_basic_block_label(exit_block);
+    bh_assert(jit_reg_no(cc->entry_label) == 0
+              && jit_reg_no(cc->exit_label) == 1);
 
     if (!(cc->exce_basic_blocks =
               jit_calloc(sizeof(JitBasicBlock *) * JIT_EXCE_NUM)))
@@ -391,13 +401,6 @@ jit_cc_init(JitCompContext *cc, unsigned htab_size)
     if (!(cc->incoming_insns_for_exec_bbs =
               jit_calloc(sizeof(JitIncomingInsnList) * JIT_EXCE_NUM)))
         goto fail;
-
-    /* Record the entry and exit labels, whose indexes must be 0 and 1
-       respectively.  */
-    cc->entry_label = jit_basic_block_label(entry_block);
-    cc->exit_label = jit_basic_block_label(exit_block);
-    bh_assert(jit_reg_no(cc->entry_label) == 0
-              && jit_reg_no(cc->exit_label) == 1);
 
     cc->hreg_info = jit_codegen_get_hreg_info();
     bh_assert(cc->hreg_info->info[JIT_REG_KIND_I32].num > 3);


### PR DESCRIPTION
[1] In function `jit_compile_op_call_indirect`: ignoring to detect error after generate instruction or register
https://github.com/wasm-micro-runtime/wamr-internal-dev/issues/423
[2] In function `jit_cc_init`: ingore to free entry_block and exit_block
https://github.com/wasm-micro-runtime/wamr-internal-dev/issues/422