### PR TITLE
Fix Windows/MSVC build

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -249,13 +249,12 @@ table_instantiate(AOTModuleInstance *module_inst, AOTModule *module,
             table_seg->offset.init_expr_type == INIT_EXPR_TYPE_I32_CONST
             || table_seg->offset.init_expr_type == INIT_EXPR_TYPE_GET_GLOBAL
             || table_seg->offset.init_expr_type == INIT_EXPR_TYPE_FUNCREF_CONST
-            || table_seg->offset.init_expr_type == INIT_EXPR_TYPE_REFNULL_CONST
-        );
+            || table_seg->offset.init_expr_type
+                   == INIT_EXPR_TYPE_REFNULL_CONST);
 #else
-        bh_assert(
-            table_seg->offset.init_expr_type == INIT_EXPR_TYPE_I32_CONST
-            || table_seg->offset.init_expr_type == INIT_EXPR_TYPE_GET_GLOBAL
-        );
+        bh_assert(table_seg->offset.init_expr_type == INIT_EXPR_TYPE_I32_CONST
+                  || table_seg->offset.init_expr_type
+                         == INIT_EXPR_TYPE_GET_GLOBAL);
 #endif
 
         /* Resolve table data base offset */

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -244,14 +244,19 @@ table_instantiate(AOTModuleInstance *module_inst, AOTModule *module,
         tbl_inst = aot_get_table_inst(module_inst, table_seg->table_index);
         bh_assert(tbl_inst);
 
+#if WASM_ENABLE_REF_TYPES != 0
         bh_assert(
             table_seg->offset.init_expr_type == INIT_EXPR_TYPE_I32_CONST
             || table_seg->offset.init_expr_type == INIT_EXPR_TYPE_GET_GLOBAL
-#if WASM_ENABLE_REF_TYPES != 0
             || table_seg->offset.init_expr_type == INIT_EXPR_TYPE_FUNCREF_CONST
             || table_seg->offset.init_expr_type == INIT_EXPR_TYPE_REFNULL_CONST
-#endif
         );
+#else
+        bh_assert(
+            table_seg->offset.init_expr_type == INIT_EXPR_TYPE_I32_CONST
+            || table_seg->offset.init_expr_type == INIT_EXPR_TYPE_GET_GLOBAL
+        );
+#endif
 
         /* Resolve table data base offset */
         if (table_seg->offset.init_expr_type == INIT_EXPR_TYPE_GET_GLOBAL) {

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1587,17 +1587,23 @@ wasm_instantiate(WASMModule *module, bool is_sub_inst, uint32 stack_size,
 #endif
 
         /* init vec(funcidx) or vec(expr) */
+#if WASM_ENABLE_REF_TYPES != 0
         bh_assert(
             table_seg->base_offset.init_expr_type == INIT_EXPR_TYPE_I32_CONST
             || table_seg->base_offset.init_expr_type
                    == INIT_EXPR_TYPE_GET_GLOBAL
-#if WASM_ENABLE_REF_TYPES != 0
             || table_seg->base_offset.init_expr_type
                    == INIT_EXPR_TYPE_FUNCREF_CONST
             || table_seg->base_offset.init_expr_type
                    == INIT_EXPR_TYPE_REFNULL_CONST
-#endif
         );
+#else
+        bh_assert(
+            table_seg->base_offset.init_expr_type == INIT_EXPR_TYPE_I32_CONST
+            || table_seg->base_offset.init_expr_type
+                   == INIT_EXPR_TYPE_GET_GLOBAL
+        );
+#endif
 
         if (table_seg->base_offset.init_expr_type
             == INIT_EXPR_TYPE_GET_GLOBAL) {

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1588,21 +1588,19 @@ wasm_instantiate(WASMModule *module, bool is_sub_inst, uint32 stack_size,
 
         /* init vec(funcidx) or vec(expr) */
 #if WASM_ENABLE_REF_TYPES != 0
-        bh_assert(
-            table_seg->base_offset.init_expr_type == INIT_EXPR_TYPE_I32_CONST
-            || table_seg->base_offset.init_expr_type
-                   == INIT_EXPR_TYPE_GET_GLOBAL
-            || table_seg->base_offset.init_expr_type
-                   == INIT_EXPR_TYPE_FUNCREF_CONST
-            || table_seg->base_offset.init_expr_type
-                   == INIT_EXPR_TYPE_REFNULL_CONST
-        );
+        bh_assert(table_seg->base_offset.init_expr_type
+                      == INIT_EXPR_TYPE_I32_CONST
+                  || table_seg->base_offset.init_expr_type
+                         == INIT_EXPR_TYPE_GET_GLOBAL
+                  || table_seg->base_offset.init_expr_type
+                         == INIT_EXPR_TYPE_FUNCREF_CONST
+                  || table_seg->base_offset.init_expr_type
+                         == INIT_EXPR_TYPE_REFNULL_CONST);
 #else
-        bh_assert(
-            table_seg->base_offset.init_expr_type == INIT_EXPR_TYPE_I32_CONST
-            || table_seg->base_offset.init_expr_type
-                   == INIT_EXPR_TYPE_GET_GLOBAL
-        );
+        bh_assert(table_seg->base_offset.init_expr_type
+                      == INIT_EXPR_TYPE_I32_CONST
+                  || table_seg->base_offset.init_expr_type
+                         == INIT_EXPR_TYPE_GET_GLOBAL);
 #endif
 
         if (table_seg->base_offset.init_expr_type

--- a/wamr-compiler/build_llvm.py
+++ b/wamr-compiler/build_llvm.py
@@ -11,4 +11,4 @@ import sys
 script = (
     pathlib.Path(__file__).parent.joinpath("../build-scripts/build_llvm.py").resolve()
 )
-subprocess.check_call([sys.executable, script.name])
+subprocess.check_call([sys.executable, script])


### PR DESCRIPTION
Two issues I came across while experimenting with WAMR on Windows.

- The build_llvm.py script calls itself, spawning instances faster than they expire, which made Python3 eat up my entire RAM in a pretty short time. This change was made about a year ago in 03494f9. I don't believe this was intentional.
- The MSVC compiler doesn't support preprocessor statements inside macro expressions. Only used in those two places inside bt_assert() as far as I've noticed.