### PR TITLE
Fix function sub local count check in loader

### DIFF
--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -1950,8 +1950,8 @@ load_function_section(const uint8 *buf, const uint8 *buf_end,
             local_type_index = 0;
             for (j = 0; j < local_set_count; j++) {
                 read_leb_uint32(p_code, buf_code_end, sub_local_count);
-                if (!sub_local_count
-                    || local_type_index > UINT32_MAX - sub_local_count
+                /* Note: sub_local_count is allowed to be 0 */
+                if (local_type_index > UINT32_MAX - sub_local_count
                     || local_type_index + sub_local_count > local_count) {
                     set_error_buf(error_buf, error_buf_size,
                                   "invalid local count");

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -1013,8 +1013,8 @@ load_function_section(const uint8 *buf, const uint8 *buf_end,
             local_type_index = 0;
             for (j = 0; j < local_set_count; j++) {
                 read_leb_uint32(p_code, buf_code_end, sub_local_count);
-                bh_assert(sub_local_count
-                          && local_type_index <= UINT32_MAX - sub_local_count
+                /* Note: sub_local_count is allowed to be 0 */
+                bh_assert(local_type_index <= UINT32_MAX - sub_local_count
                           && local_type_index + sub_local_count <= local_count);
 
                 CHECK_BUF(p_code, buf_code_end, 1);


### PR DESCRIPTION
Sub local count is allowed to be 0 in each group of function local types.