### PR TITLE
build_llvm.sh: pass through arguments

### DIFF
--- a/product-mini/platforms/android/build_llvm.sh
+++ b/product-mini/platforms/android/build_llvm.sh
@@ -3,4 +3,4 @@
 # Copyright (C) 2020 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-/usr/bin/env python3 ../../../build-scripts/build_llvm.py --platform android
+/usr/bin/env python3 ../../../build-scripts/build_llvm.py --platform android "$@"

--- a/product-mini/platforms/darwin/build_llvm.sh
+++ b/product-mini/platforms/darwin/build_llvm.sh
@@ -3,4 +3,4 @@
 # Copyright (C) 2020 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-/usr/bin/env python3 ../../../build-scripts/build_llvm.py --platform darwin
+/usr/bin/env python3 ../../../build-scripts/build_llvm.py --platform darwin "$@"

--- a/product-mini/platforms/linux/build_llvm.sh
+++ b/product-mini/platforms/linux/build_llvm.sh
@@ -3,4 +3,4 @@
 # Copyright (C) 2020 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-/usr/bin/env python3 ../../../build-scripts/build_llvm.py
+/usr/bin/env python3 ../../../build-scripts/build_llvm.py "$@"

--- a/wamr-compiler/build_llvm.sh
+++ b/wamr-compiler/build_llvm.sh
@@ -3,4 +3,4 @@
 # Copyright (C) 2020 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-/usr/bin/env python3 ../build-scripts/build_llvm.py
+/usr/bin/env python3 ../build-scripts/build_llvm.py "$@"

--- a/wamr-compiler/build_llvm_arc.sh
+++ b/wamr-compiler/build_llvm_arc.sh
@@ -3,4 +3,4 @@
 # Copyright (C) 2020 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-/usr/bin/env python3 ../build-scripts/build_llvm.py --platform arc
+/usr/bin/env python3 ../build-scripts/build_llvm.py --platform arc "$@"

--- a/wamr-compiler/build_llvm_xtensa.sh
+++ b/wamr-compiler/build_llvm_xtensa.sh
@@ -3,4 +3,4 @@
 # Copyright (C) 2020 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-/usr/bin/env python3 ../build-scripts/build_llvm.py --platform xtensa
+/usr/bin/env python3 ../build-scripts/build_llvm.py --platform xtensa "$@"


### PR DESCRIPTION
To make it simpler to specify --project.