### PR TITLE
Suppress hadolint warnings for pinning versions part

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,6 +9,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/cpp:0-${VARIANT}
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Asian/Shanghai
 
+# hadolint ignore=DL3008
 RUN apt-get update \
   && apt-get install -y apt-transport-https apt-utils build-essential \
   ca-certificates curl g++-multilib git gnupg \
@@ -17,11 +18,12 @@ RUN apt-get update \
   software-properties-common tree tzdata \
   unzip valgrind vim wget zip --no-install-recommends \
   && apt-get clean -y \
-  && rm -rf /var/lib/apt/lists/* 
+  && rm -rf /var/lib/apt/lists/*
 
 #
 # CMAKE (https://apt.kitware.com/)
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+# hadolint ignore=DL3008
 RUN wget --progress=dot:giga -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg > /dev/null \
   && echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ bionic main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null \
   && apt-get update \
@@ -84,13 +86,15 @@ RUN wget --progress=dot:giga https://apt.llvm.org/llvm.sh \
 
 #
 # Install pip
+# hadolint ignore=DL3008
 RUN apt-get update \
   && apt-get install -y --reinstall python3-venv python3-pip --no-install-recommends \
   && apt-get clean -y \
-  && rm -rf /var/lib/apt/lists/* 
+  && rm -rf /var/lib/apt/lists/*
 
 #
 # Install required python packages
+# hadolint ignore=DL3013
 RUN python3 -m pip install --no-cache-dir --upgrade pip \
   && pip3 install --no-cache-dir --user black nose pycparser pylint
 

--- a/test-tools/IoT-APP-Store-Demo/wasm_django/Dockerfile
+++ b/test-tools/IoT-APP-Store-Demo/wasm_django/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.5
 WORKDIR /app
 COPY . /app
 
+# hadolint ignore=DL3013
 RUN pip install django --no-cache-dir
 
 ENTRYPOINT ["python", "manage.py", "runserver", "0.0.0.0:80"]
-

--- a/test-tools/wamr-ide/WASM-Debug-Server/Docker/Dockerfile
+++ b/test-tools/wamr-ide/WASM-Debug-Server/Docker/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /root/
 COPY resource /root/
 
 ##  - download cmake with wget and set up
+# hadolint ignore=DL3008
 RUN wget --progress=dot:giga https://github.com/Kitware/CMake/releases/download/v3.21.1/cmake-3.21.1-linux-x86_64.tar.gz \
     && tar -zxvf cmake-3.21.1-linux-x86_64.tar.gz \
     && rm -f cmake-3.21.1-linux-x86_64.tar.gz \

--- a/test-tools/wamr-ide/WASM-Toolchain/Docker/Dockerfile
+++ b/test-tools/wamr-ide/WASM-Toolchain/Docker/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /root/
 COPY resource /root/
 
 ##  - download cmake with wget and set up
+# hadolint ignore=DL3008
 RUN wget --progress=dot:giga https://github.com/Kitware/CMake/releases/download/v3.21.1/cmake-3.21.1-linux-x86_64.tar.gz \
     && tar -zxvf cmake-3.21.1-linux-x86_64.tar.gz \
     && rm -f cmake-3.21.1-linux-x86_64.tar.gz \
@@ -66,6 +67,7 @@ COPY --from=BASE /root/build_wasm.sh ${HOME_DIR}
 RUN ln -s /opt/cmake/bin/cmake /usr/bin/cmake \
     && ln -s ${HOME_DIR}/wamrc /usr/bin/wamrc
 
+# hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y make --no-install-recommends \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Related to https://github.com/bytecodealliance/wasm-micro-runtime/issues/1418.

I suppressed hadolint warnings for pinning version.
This is because these warnings for reproducible builds.
But, for development and CIs, ordinary cases developers have to use the latest packages.
So, it can be suppressed these linting errors.  