### PR TITLE
Fix syntax errors and undefined names in Python code

### DIFF
--- a/test-tools/IoT-APP-Store-Demo/wasm_django/devices/views.py
+++ b/test-tools/IoT-APP-Store-Demo/wasm_django/devices/views.py
@@ -268,6 +268,6 @@ def removeapps(req):
     return render(req, 'appstore.html', {'alist': json.dumps(avaliable_list),'flist': json.dumps(user_file_list)})
 
 # Test
-if __name__ == "__main__":
-    print(device_list[0]['IP'])
-    print(device['IP'])
+# if __name__ == "__main__":
+#    print(device_list[0]['IP'])
+#    print(device['IP'])

--- a/test-tools/component-test/framework/engine.py
+++ b/test-tools/component-test/framework/engine.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -28,7 +29,7 @@ def read_cases_from_file(file_path):
         content = f.readlines()
 
     content = [x.strip() for x in content]
-    print content
+    print(content)
     if len(content) == 0:
         return False, None
 

--- a/test-tools/component-test/framework/framework.py
+++ b/test-tools/component-test/framework/framework.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -66,7 +67,7 @@ class CTestFramework(object):
 
         api_set_root_path(path)
 
-        print "root_path is " + self.root_path
+        print("root_path is " + self.root_path)
 
     def gen_execution_stats(self):
         return '\nTest Execution Summary: '  \
@@ -103,7 +104,7 @@ class CTestFramework(object):
         module_name = 'suites.' + suite + ".cases." + case + ".case"
         try:
             module = my_import(module_name)
-        except Exception, e:
+        except Exception as e:
             report_fail("load case fail: " + str(e))
             api_log_error("load case fail: " + str(e))
             self.load_fails = self.load_fails +1
@@ -112,7 +113,7 @@ class CTestFramework(object):
 
         try:
             case = module.CTestCase(suite_instance)
-        except Exception, e:
+        except Exception as e:
             report_fail("initialize case fail: " + str(e))
             api_log_error("initialize case fail: " + str(e))
             self.load_fails = self.load_fails +1
@@ -122,7 +123,7 @@ class CTestFramework(object):
         try:
             case_description = case.on_get_case_description()
             result, message = case.on_setup_case()
-        except Exception, e:
+        except Exception as e:
             result = False
             message = str(e);
         if not result:
@@ -134,7 +135,7 @@ class CTestFramework(object):
         # call the case execution callaback
         try:
             result, message = case.on_run_case()
-        except Exception, e:
+        except Exception as e:
             result = False
             message = str(e);
         if not result:
@@ -148,7 +149,7 @@ class CTestFramework(object):
         # call the case cleanup callback
         try:
             clean_result, message = case.on_cleanup_case()
-        except Exception, e:
+        except Exception as e:
             clean_result = False
             message = str(e)
 
@@ -166,7 +167,7 @@ class CTestFramework(object):
         module_name = 'suites.' + suite + ".suite_setup"
         try:
             module = my_import(module_name)
-        except Exception, e:
+        except Exception as e:
             report_fail("load suite [" + suite +"] fail: " + str(e))
             self.load_fails = self.load_fails +1
             return False
@@ -174,7 +175,7 @@ class CTestFramework(object):
         try:
             suite_instance = module.CTestSuite(suite, \
                 self.root_path + '/suites/' + suite, running_folder)
-        except Exception, e:
+        except Exception as e:
             report_fail("initialize suite fail: " + str(e))
             self.load_fails = self.load_fails +1
             return False
@@ -187,7 +188,7 @@ class CTestFramework(object):
 
         try:
             result, message = suite_instance.on_suite_setup()
-        except Exception, e:
+        except Exception as e:
             result = False
             message = str(e);
         if not result:
@@ -213,7 +214,7 @@ class CTestFramework(object):
         self.running_suite = ''
         try:
             result, message = suite_instance.on_suite_cleanup()
-        except Exception, e:
+        except Exception as e:
             result = False
             message = str(e);
         if not result:
@@ -224,7 +225,7 @@ class CTestFramework(object):
 
     def start_run(self):
         if self.target_suites is None:
-            print "\n\nstart run: no target suites, exit.."
+            print("\n\nstart run: no target suites, exit..")
             return
 
         cur_time = time.localtime()
@@ -268,7 +269,7 @@ class CTestFramework(object):
         self.report.write(summary);
         self.report.flush()
         self.report.close()
-        print summary
+        print(summary)
 
 
 def report_fail(message, case_description=''):

--- a/test-tools/component-test/framework/test_api.py
+++ b/test-tools/component-test/framework/test_api.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -12,7 +13,7 @@ logger = None
 
 def api_init_log(log_path):
     global logger
-    print "api_init_log: " + log_path
+    print("api_init_log: " + log_path)
     logger = logging.getLogger(__name__)
 
     logger.setLevel(level = logging.INFO)
@@ -32,7 +33,7 @@ def api_init_log(log_path):
 def api_log(message):
     global logger
     if logger is None:
-        print message
+        print(message)
     else:
         logger.info (message)
     return
@@ -40,7 +41,7 @@ def api_log(message):
 def api_log_error(message):
     global logger
     if logger is None:
-        print message
+        print(message)
     else:
         logger.error (message)
     return
@@ -48,7 +49,7 @@ def api_log_error(message):
 def api_logv(message):
     global logger
     if logger is None:
-        print message
+        print(message)
     else:
         logger.info(message)
     return

--- a/test-tools/component-test/framework/test_utils.py
+++ b/test-tools/component-test/framework/test_utils.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -52,7 +53,7 @@ def t_process_exists(proc, kill = 0):
             if kill == 0:
                 return True
             else:
-                print "kill [" + proc + "], pid=" + str(pid)
+                print("kill [" + proc + "], pid=" + str(pid))
                 os.kill((pid), 9)
                 ret = True
     return ret
@@ -60,11 +61,11 @@ def t_process_exists(proc, kill = 0):
 def t_copy_files(source_dir, pattern, dest_dir):
     files = os.listdir(source_dir)
     for file in files:
-        if file is '/' or file is '.' or file is '..':
+        if file in ('/', '.', '..'):
             continue
 
-        if pattern == '*' or pattern is '' or files.endswith(pattern):
-            shutil.copy(source_dir+"/"+ file,dest_dir)
+        if pattern in ('*', '') or files.endswith(pattern):
+            shutil.copy(source_dir+"/"+ file, dest_dir)
 
 
 

--- a/test-tools/component-test/start.py
+++ b/test-tools/component-test/start.py
@@ -10,6 +10,7 @@
 It is the entrance of the iagent test framework.
 
 """
+from __future__ import print_function
 
 import argparse
 import datetime
@@ -84,9 +85,9 @@ if __name__ == "__main__":
             help = 'rebuild all test binaries')
     args = parser.parse_args()
 
-    print "------------------------------------------------------------"
-    print "parsing arguments ... ..."
-    print args
+    print("------------------------------------------------------------")
+    print("parsing arguments ... ...")
+    print(args)
 
     '''
     logger = logging.getLogger('coapthon.server.coap')
@@ -95,8 +96,8 @@ if __name__ == "__main__":
     console.setLevel(logging.DEBUG)
     logger.addHandler(console)
     '''
-    print "------------------------------------------------------------"
-    print "preparing wamr binary and test tools ... ..."
+    print("------------------------------------------------------------")
+    print("preparing wamr binary and test tools ... ...")
     os.system("cd ../../samples/simple/ && bash build.sh -p host-interp")
 
     Register_signal_handler()
@@ -124,9 +125,9 @@ if __name__ == "__main__":
     if  binary_path is None:
         binary_path = os.path.abspath(dirname + '/../..')
 
-    print "checking execution binary path: " + binary_path
+    print("checking execution binary path: " + binary_path)
     if not os.path.exists(binary_path):
-        print "The execution binary path was not available. quit..."
+        print("The execution binary path was not available. quit...")
         os._exit(0)
     api_set_value('binary_path', binary_path)
 
@@ -138,11 +139,11 @@ if __name__ == "__main__":
     framework.target_cases = cases_list
     framework.start_run()
 
-    print "\n\n------------------------------------------------------------"
-    print "The run folder is [" + framework.running_folder +"]"
-    print "that's all. bye"
+    print("\n\n------------------------------------------------------------")
+    print("The run folder is [" + framework.running_folder +"]")
+    print("that's all. bye")
 
-    print "kill to quit.."
+    print("kill to quit..")
     t_kill_process_by_name("start.py")
 
     sys.exit(0)

--- a/tests/wamr-test-suites/spec-test-script/runtest.py
+++ b/tests/wamr-test-suites/spec-test-script/runtest.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 import os, sys, re
+from pickletools import long1
 import argparse, time
 import signal, atexit, tempfile, subprocess
 
@@ -17,7 +18,12 @@ import struct
 import math
 import traceback
 
-IS_PY_3 = sys.version_info[0] == 3
+try:
+    long
+    IS_PY_3 = False
+except NameError:
+    long = int
+    IS_PY_3 = True
 
 test_aot = False
 # "x86_64", "i386", "aarch64", "armv7" or "thumbv7"
@@ -312,7 +318,7 @@ def get_module_exp_from_assert(string):
 
 def string_to_unsigned(number_in_string, lane_type):
     if not lane_type in ['i8x16', 'i16x8', 'i32x4', 'i64x2']:
-        raise Exception("invalid value {} and type {} and lane_type {}".format(numbers, type, lane_type))
+        raise Exception("invalid value {} and type {} and lane_type {}".format(number_in_string, type, lane_type))
 
     number = int(number_in_string, 16) if '0x' in number_in_string else int(number_in_string)
 
@@ -896,7 +902,7 @@ def skip_test(form, skip_list):
 
 def compile_wast_to_wasm(form, wast_tempfile, wasm_tempfile, opts):
     log("Writing WAST module to '%s'" % wast_tempfile)
-    file(wast_tempfile, 'w').write(form)
+    open(wast_tempfile, 'w').write(form)
     log("Compiling WASM to '%s'" % wasm_tempfile)
 
     # default arguments
@@ -1122,7 +1128,7 @@ if __name__ == "__main__":
                     # workaround: spec test changes error message to "malformed" while iwasm still use "invalid"
                     error_msg = m.group(2).replace("malformed", "invalid")
                     log("Testing(malformed)")
-                    f = file(wasm_tempfile, 'w')
+                    f = open(wasm_tempfile, 'w')
                     s = m.group(1)
                     while s:
                         res = re.match("[^\"]*\"([^\"]*)\"(.*)", s, re.DOTALL)


### PR DESCRIPTION
Python 2 died 997 days ago on 1/1/2020.

`flake8 --count --show-source --statistics --select=E9,F63,F72,F82 .`

https://devguide.python.org/versions
https://portingguide.readthedocs.io/en/latest/index.html