### PR TITLE
Fix issue #1484

### DIFF
--- a/core/shared/platform/esp-idf/espidf_platform.c
+++ b/core/shared/platform/esp-idf/espidf_platform.c
@@ -228,12 +228,14 @@ fdopendir(int fd)
     return NULL;
 }
 
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 4, 2)
 int
 ftruncate(int fd, off_t length)
 {
     errno = ENOSYS;
     return -1;
 }
+#endif
 
 int
 futimens(int fd, const struct timespec times[2])


### PR DESCRIPTION
Platform ESP-IDF broken for WAMR 1.0.0 with ESP-IDF 4.4.2 
Let the dummy ftruncate only work with ESP-IDF earlier than 4.4.2