### PR TITLE
Update __wasi_sock_accept signature to match wasi_snapshot_previev1

### DIFF
--- a/core/iwasm/libraries/lib-socket/inc/wasi_socket_ext.h
+++ b/core/iwasm/libraries/lib-socket/inc/wasi_socket_ext.h
@@ -140,8 +140,10 @@ struct addrinfo {
     struct addrinfo *ai_next; /* Pointer to next in list.  */
 };
 
+#ifndef __WASI_RIGHTS_SOCK_ACCEPT
 int
 accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
+#endif
 
 int
 bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen);
@@ -192,20 +194,29 @@ freeaddrinfo(struct addrinfo *res);
 #endif
 
 /**
+ * __wasi_sock_accept was introduced in wasi-sdk v15. To
+ * temporarily maintain backward compatibility with the old
+ * wasi-sdk, we explicitly add that implementation here so it works
+ * with older versions of the SDK.
+ */
+#ifndef __WASI_RIGHTS_SOCK_ACCEPT
+/**
  * Accept a connection on a socket
  * Note: This is similar to `accept`
  */
 int32_t
-__imported_wasi_snapshot_preview1_sock_accept(int32_t arg0, int32_t arg1)
+__imported_wasi_snapshot_preview1_sock_accept(int32_t arg0, int32_t arg1,
+                                              int32_t arg2)
     __attribute__((__import_module__("wasi_snapshot_preview1"),
                    __import_name__("sock_accept")));
 
 static inline __wasi_errno_t
-__wasi_sock_accept(__wasi_fd_t fd, __wasi_fd_t *fd_new)
+__wasi_sock_accept(__wasi_fd_t fd, __wasi_fdflags_t flags, __wasi_fd_t *fd_new)
 {
     return (__wasi_errno_t)__imported_wasi_snapshot_preview1_sock_accept(
-        (int32_t)fd, (int32_t)fd_new);
+        (int32_t)fd, (int32_t)flags, (int32_t)fd_new);
 }
+#endif
 
 /**
  * Returns the local address to which the socket is bound.

--- a/core/iwasm/libraries/lib-socket/src/wasi/wasi_socket_ext.c
+++ b/core/iwasm/libraries/lib-socket/src/wasi/wasi_socket_ext.c
@@ -140,7 +140,7 @@ accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
     __wasi_fd_t new_sockfd;
     __wasi_errno_t error;
 
-    error = __wasi_sock_accept(sockfd, &new_sockfd);
+    error = __wasi_sock_accept(sockfd, 0, &new_sockfd);
     HANDLE_ERROR(error)
 
     error = getpeername(new_sockfd, addr, addrlen);

--- a/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
+++ b/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
@@ -1004,7 +1004,8 @@ wasi_random_get(wasm_exec_env_t exec_env, void *buf, uint32 buf_len)
 }
 
 static wasi_errno_t
-wasi_sock_accept(wasm_exec_env_t exec_env, wasi_fd_t fd, wasi_fd_t *fd_new)
+wasi_sock_accept(wasm_exec_env_t exec_env, wasi_fd_t fd, wasi_fdflags_t flags,
+                 wasi_fd_t *fd_new)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_ctx_t wasi_ctx = get_wasi_ctx(module_inst);
@@ -1015,7 +1016,7 @@ wasi_sock_accept(wasm_exec_env_t exec_env, wasi_fd_t fd, wasi_fd_t *fd_new)
 
     curfds = wasi_ctx_get_curfds(module_inst, wasi_ctx);
 
-    return wasi_ssp_sock_accept(curfds, fd, fd_new);
+    return wasi_ssp_sock_accept(curfds, fd, flags, fd_new);
 }
 
 static wasi_errno_t
@@ -2156,7 +2157,7 @@ static NativeSymbol native_symbols_libc_wasi[] = {
     REG_NATIVE_FUNC(proc_exit, "(i)"),
     REG_NATIVE_FUNC(proc_raise, "(i)i"),
     REG_NATIVE_FUNC(random_get, "(*~)i"),
-    REG_NATIVE_FUNC(sock_accept, "(i*)i"),
+    REG_NATIVE_FUNC(sock_accept, "(ii*)i"),
     REG_NATIVE_FUNC(sock_addr_local, "(i*)i"),
     REG_NATIVE_FUNC(sock_addr_remote, "(i*)i"),
     REG_NATIVE_FUNC(sock_addr_resolve, "($$**i*)i"),

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/include/wasmtime_ssp.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/include/wasmtime_ssp.h
@@ -1008,7 +1008,7 @@ wasi_ssp_sock_accept(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t fd, __wasi_fd_t *fd_new
+    __wasi_fd_t fd, __wasi_fdflags_t flags, __wasi_fd_t *fd_new
 ) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t
@@ -1199,7 +1199,7 @@ __wasi_errno_t wasmtime_ssp_sock_get_keep_alive(
     struct fd_table *curfds,
 #endif
     __wasi_fd_t sock,
-    bool *is_enabled 
+    bool *is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_keep_alive) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_reuse_addr(
@@ -1215,7 +1215,7 @@ __wasi_errno_t wasmtime_ssp_sock_get_reuse_addr(
     struct fd_table *curfds,
 #endif
     __wasi_fd_t sock,
-    bool *is_enabled 
+    bool *is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_reuse_addr) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_reuse_port(
@@ -1231,15 +1231,15 @@ __wasi_errno_t wasmtime_ssp_sock_get_reuse_port(
     struct fd_table *curfds,
 #endif
     __wasi_fd_t sock,
-    bool *is_enabled 
+    bool *is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_reuse_port) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_linger(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t sock, 
-    bool is_enabled, 
+    __wasi_fd_t sock,
+    bool is_enabled,
     int linger_s
 ) WASMTIME_SSP_SYSCALL_NAME(sock_set_linger) __attribute__((__warn_unused_result__));
 
@@ -1263,7 +1263,7 @@ __wasi_errno_t wasmtime_ssp_sock_get_broadcast(
     struct fd_table *curfds,
 #endif
     __wasi_fd_t sock,
-    bool *is_enabled 
+    bool *is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_broadcast) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_tcp_no_delay(
@@ -1279,7 +1279,7 @@ __wasi_errno_t wasmtime_ssp_sock_get_tcp_no_delay(
     struct fd_table *curfds,
 #endif
     __wasi_fd_t sock,
-    bool *is_enabled 
+    bool *is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_tcp_no_delay) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_tcp_quick_ack(
@@ -1295,7 +1295,7 @@ __wasi_errno_t wasmtime_ssp_sock_get_tcp_quick_ack(
     struct fd_table *curfds,
 #endif
     __wasi_fd_t sock,
-    bool *is_enabled 
+    bool *is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_tcp_quick_ack) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_tcp_keep_idle(
@@ -1343,7 +1343,7 @@ __wasi_errno_t wasmtime_ssp_sock_get_tcp_fastopen_connect(
     struct fd_table *curfds,
 #endif
     __wasi_fd_t sock,
-    bool *is_enabled 
+    bool *is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_tcp_fastopen_connect) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_ip_multicast_loop(
@@ -1361,7 +1361,7 @@ __wasi_errno_t wasmtime_ssp_sock_get_ip_multicast_loop(
 #endif
     __wasi_fd_t sock,
     bool ipv6,
-    bool *is_enabled 
+    bool *is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_ip_multicast_loop) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_ip_add_membership(
@@ -1427,7 +1427,7 @@ __wasi_errno_t wasmtime_ssp_sock_get_ipv6_only(
     struct fd_table *curfds,
 #endif
     __wasi_fd_t sock,
-    bool *is_enabled 
+    bool *is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_ipv6_only) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sched_yield(void)

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -2905,7 +2905,7 @@ wasi_ssp_sock_accept(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
 #endif
-    __wasi_fd_t fd, __wasi_fd_t *fd_new)
+    __wasi_fd_t fd, __wasi_fdflags_t flags, __wasi_fd_t *fd_new)
 {
     __wasi_filetype_t wasi_type;
     __wasi_rights_t max_base, max_inheriting;


### PR DESCRIPTION
The function was introduced to WASI about half a year ago after it already existed in WAMR.

It caused problems with compiling `wasi_socket_ext.c` with the wasi-sdk that already had this hostcall exported (wasi-sdk >= 15).

The approach we take is the following:
* we update WASI interface to be compatible with the preview1
* compilation with `wasi_socket_ext.c` supports both wasi_sdk >= 15 and wasi_sdk < 15 (although we intend to drop support for < 15 at one point of time)
* we override `accept()` from wasi-libc - we do that because `accept()` in `wasi-libc` doesn't support returning address (as it doesn't have `getpeername()` implemented), so `wasi_socket_ext.c` offers more functionality right now

Resolves #1528

[wasi_snapshot_preview1](https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/witx/wasi_snapshot_preview1.witx)
