### PR TITLE
Update socket API samples documentation so it covers UDP client/server and address resolve samples

### DIFF
--- a/samples/socket-api/CMakeLists.txt
+++ b/samples/socket-api/CMakeLists.txt
@@ -87,6 +87,7 @@ ExternalProject_Add(wasm-app
                       ${CMAKE_CURRENT_SOURCE_DIR}/wasm-src
   BUILD_COMMAND     ${CMAKE_COMMAND} --build .
   INSTALL_COMMAND   ${CMAKE_COMMAND} -E copy
+                      addr_resolve.wasm ${CMAKE_BINARY_DIR}
                       tcp_client.wasm ${CMAKE_BINARY_DIR}
                       tcp_server.wasm ${CMAKE_BINARY_DIR}
                       send_recv.wasm ${CMAKE_BINARY_DIR}

--- a/samples/socket-api/README.md
+++ b/samples/socket-api/README.md
@@ -18,13 +18,20 @@ cmake ..
 make
 ```
 
-`iwasm` and three Wasm modules, `tcp_server.wasm`, `tcp_client.wasm`, `send_recv.wasm`
-will be generated. And their corresponding native version, `tcp_server`,
-`tcp_client`, `send_recv` are generated too.
+`iwasm` and the following Wasm modules (along with their corresponding native version) will be generated:
+ * `addr_resolve.wasm`, `addr_resolve`
+ * `send_recv.wasm`, `send_recv`
+ * `socket_opts.wasm`, `socket_opts`
+ * `tcp_client.wasm`, `tcp_client`
+ * `tcp_server.wasm`, `tcp_server`
+ * `udp_client.wasm`, `udp_client`
+ * `udp_server.wasm`, `udp_server`
 
 > Note that iwasm is built with libc-wasi and lib-pthread enabled.
 
 ## Run workload
+
+### TCP client/server
 
 Start the tcp server, which opens port 1234 and waits for clients to connect.
 
@@ -82,6 +89,8 @@ Data:
   And mourns for us
 ```
 
+### Socket options
+
 `socket_opts.wasm` shows an example of getting and setting various supported socket options
 ```bash
 $ ./iwasm ./socket_opts.wasm
@@ -97,5 +106,54 @@ SO_RCVTIMEO tv_usec is expected
 ...
 [Client] Close sockets
 ```
+
+### Domain name server resolution
+
+`addr_resolve.wasm` demonstrates the usage of resolving a domain name
+```
+$ ./iwasm --allow-resolve=*.com addr_resolve.wasm  github.com
+```
+
+The command displays the host name and its corresponding IP address:
+```
+Host: github.com
+IPv4 address: 140.82.121.4 (TCP)
+```
+
+### UDP client/server
+
+Start the UDP server, which opens port 1234 and waits for clients to send a message.
+
+```bash
+cd build
+./iwasm --addr-pool=0.0.0.0/15 udp_server.wasm
+```
+
+Start the tcp client, which sends a message to the server and waits for the response.
+
+```bash
+cd build
+./iwasm --addr-pool=127.0.0.1/15 udp_client.wasm
+```
+
+The output of client is like:
+
+```bash
+[Client] Create socket
+[Client] Client send
+[Client] Client receive
+[Client] Buffer recieved: Hello from server
+[Client] BYE
+```
+
+The output of the server is like:
+```
+[Server] Create socket
+[Server] Bind socket
+[Server] Wait for clients to connect ..
+[Server] received 17 bytes from 127.0.0.1:60927: Hello from client
+```
+
+## Documentation
 
 Refer to [socket api document](../../doc/socket_api.md) for more details.


### PR DESCRIPTION
Also fixed installing `addr_resolve.wasm` example

Resolves #1534
