### PR TITLE
Socket: Explicit narrowing type cast and add missing static keywords.

### DIFF
--- a/core/iwasm/libraries/lib-socket/src/wasi/wasi_socket_ext.c
+++ b/core/iwasm/libraries/lib-socket/src/wasi/wasi_socket_ext.c
@@ -143,7 +143,7 @@ accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
     error = __wasi_sock_accept(sockfd, 0, &new_sockfd);
     HANDLE_ERROR(error)
 
-    error = getpeername(new_sockfd, addr, addrlen);
+    error = (__wasi_errno_t)getpeername(new_sockfd, addr, addrlen);
     HANDLE_ERROR(error)
 
     return new_sockfd;
@@ -543,7 +543,7 @@ freeaddrinfo(struct addrinfo *res)
     free(res);
 }
 
-struct timeval
+static struct timeval
 time_us_to_timeval(uint64_t time_us)
 {
     struct timeval tv;
@@ -552,13 +552,13 @@ time_us_to_timeval(uint64_t time_us)
     return tv;
 }
 
-uint64_t
+static uint64_t
 timeval_to_time_us(struct timeval tv)
 {
     return (tv.tv_sec * 1000000UL) + tv.tv_usec;
 }
 
-int
+static int
 get_sol_socket_option(int sockfd, int optname, void *__restrict optval,
                       socklen_t *__restrict optlen)
 {
@@ -625,7 +625,7 @@ get_sol_socket_option(int sockfd, int optname, void *__restrict optval,
     }
 }
 
-int
+static int
 get_ipproto_tcp_option(int sockfd, int optname, void *__restrict optval,
                        socklen_t *__restrict optlen)
 {
@@ -664,7 +664,7 @@ get_ipproto_tcp_option(int sockfd, int optname, void *__restrict optval,
     }
 }
 
-int
+static int
 get_ipproto_ip_option(int sockfd, int optname, void *__restrict optval,
                       socklen_t *__restrict optlen)
 {
@@ -694,7 +694,7 @@ get_ipproto_ip_option(int sockfd, int optname, void *__restrict optval,
     }
 }
 
-int
+static int
 get_ipproto_ipv6_option(int sockfd, int optname, void *__restrict optval,
                         socklen_t *__restrict optlen)
 {
@@ -741,7 +741,7 @@ getsockopt(int sockfd, int level, int optname, void *__restrict optval,
     }
 }
 
-int
+static int
 set_sol_socket_option(int sockfd, int optname, const void *optval,
                       socklen_t optlen)
 {
@@ -805,7 +805,7 @@ set_sol_socket_option(int sockfd, int optname, const void *optval,
     }
 }
 
-int
+static int
 set_ipproto_tcp_option(int sockfd, int optname, const void *optval,
                        socklen_t optlen)
 {
@@ -845,7 +845,7 @@ set_ipproto_tcp_option(int sockfd, int optname, const void *optval,
     }
 }
 
-int
+static int
 set_ipproto_ip_option(int sockfd, int optname, const void *optval,
                       socklen_t optlen)
 {
@@ -898,7 +898,7 @@ set_ipproto_ip_option(int sockfd, int optname, const void *optval,
     }
 }
 
-int
+static int
 set_ipproto_ipv6_option(int sockfd, int optname, const void *optval,
                         socklen_t optlen)
 {


### PR DESCRIPTION
Dear WAMR developers,

While compiling the file `wasi_socket_ext.c` with pedantic options (typically `-Wimplicit-int-conversion`, `-Wmissing-prototypes`), some warnings are raised.

This PR addresses those warnings by adding missing `static` statements before functions and explicitly casting a narrowing conversion.

Cheers
