### PR TITLE
linux-sgx: fix directional OCALL parameter for getsockname.

### DIFF
--- a/core/shared/platform/linux-sgx/sgx_wamr.edl
+++ b/core/shared/platform/linux-sgx/sgx_wamr.edl
@@ -122,7 +122,7 @@ enclave {
         int ocall_bind(int sockfd, [in, size=addrlen]const void *addr,
                  uint32_t addrlen);
         int ocall_connect(int sockfd, [in, size=addrlen]void *addr, uint32_t addrlen);
-        int ocall_getsockname(int sockfd, [in, size=addr_size]void *addr,
+        int ocall_getsockname(int sockfd, [out, size=addr_size]void *addr,
                               [in, out, size=4]uint32_t *addrlen, uint32_t addr_size);
         int ocall_getsockopt(int sockfd, int level, int optname,
                              [out, size=val_buf_size]void *val_buf,


### PR DESCRIPTION
Hello!

The function `getsockname` writes into the `addr` buffer; therefore, the correct OCALL declaration is to use the `out` keyword. That keyword copies the data from the untrusted side into the enclave when used for an OCALL.

I think the issue was unnoticed because a default value was assigned to the `addr` buffer before the OCALL, for the `bind` call.