### PR TITLE
linux-sgx: implement getpeername, recvfrom and sendto.

### DIFF
--- a/core/shared/platform/common/posix/posix_socket.c
+++ b/core/shared/platform/common/posix/posix_socket.c
@@ -262,8 +262,11 @@ os_socket_recv_from(bh_socket_t socket, void *buf, unsigned int len, int flags,
     }
 
     if (src_addr) {
-        sockaddr_to_bh_sockaddr((struct sockaddr *)&sock_addr, socklen,
-                                src_addr);
+        if (sockaddr_to_bh_sockaddr((struct sockaddr *)&sock_addr, socklen,
+                                    src_addr)
+            == BHT_ERROR) {
+            return -1;
+        }
     }
 
     return ret;
@@ -391,8 +394,14 @@ os_socket_addr_resolve(const char *host, const char *service,
                 continue;
             }
 
-            sockaddr_to_bh_sockaddr(res->ai_addr, sizeof(struct sockaddr_in),
-                                    &addr_info[pos].sockaddr);
+            ret = sockaddr_to_bh_sockaddr(res->ai_addr,
+                                          sizeof(struct sockaddr_in),
+                                          &addr_info[pos].sockaddr);
+
+            if (ret == BHT_ERROR) {
+                freeaddrinfo(result);
+                return BHT_ERROR;
+            }
 
             addr_info[pos].is_tcp = res->ai_socktype == SOCK_STREAM;
         }

--- a/core/shared/platform/common/posix/posix_socket.c
+++ b/core/shared/platform/common/posix/posix_socket.c
@@ -261,7 +261,7 @@ os_socket_recv_from(bh_socket_t socket, void *buf, unsigned int len, int flags,
         return ret;
     }
 
-    if (src_addr) {
+    if (src_addr && socklen > 0) {
         if (sockaddr_to_bh_sockaddr((struct sockaddr *)&sock_addr, socklen,
                                     src_addr)
             == BHT_ERROR) {

--- a/core/shared/platform/linux-sgx/sgx_socket.c
+++ b/core/shared/platform/linux-sgx/sgx_socket.c
@@ -735,7 +735,7 @@ os_socket_recv_from(bh_socket_t socket, void *buf, unsigned int len, int flags,
         return ret;
     }
 
-    if (src_addr) {
+    if (src_addr && addr_len > 0) {
         if (sockaddr_to_bh_sockaddr((struct sockaddr *)&addr, addr_len,
                                     src_addr)
             == BHT_ERROR) {

--- a/core/shared/platform/linux-sgx/sgx_wamr.edl
+++ b/core/shared/platform/linux-sgx/sgx_wamr.edl
@@ -124,17 +124,24 @@ enclave {
         int ocall_connect(int sockfd, [in, size=addrlen]void *addr, uint32_t addrlen);
         int ocall_getsockname(int sockfd, [out, size=addr_size]void *addr,
                               [in, out, size=4]uint32_t *addrlen, uint32_t addr_size);
+        int ocall_getpeername(int sockfd, [out, size=addr_size]void *addr,
+                              [in, out, size=4]uint32_t *addrlen, uint32_t addr_size);
         int ocall_getsockopt(int sockfd, int level, int optname,
                              [out, size=val_buf_size]void *val_buf,
                              unsigned int val_buf_size,
                              [in, out, size=4]void *len_buf);
         int ocall_listen(int sockfd, int backlog);
         int ocall_recv(int sockfd, [out, size=len]void *buf, size_t len, int flags);
+        ssize_t ocall_recvfrom(int sockfd, [out, size=len]void *buf, size_t len, int flags,
+                               [out, size=addr_size]void *src_addr,
+                               [in, out, size=4]uint32_t *addrlen, uint32_t addr_size);
         ssize_t ocall_recvmsg(int sockfd,
                               [in, out, size=msg_buf_size]void *msg_buf,
                               unsigned int msg_buf_size,
                               int flags);
         int ocall_send(int sockfd, [in, size=len]const void *buf, size_t len, int flags);
+        ssize_t ocall_sendto(int sockfd, [in, size=len]const void *buf, size_t len, int flags,
+                             [in, size=addrlen]void *dest_addr, uint32_t addrlen);
         ssize_t ocall_sendmsg(int sockfd,
                               [in, size=msg_buf_size]void *msg_buf,
                               unsigned int msg_buf_size,

--- a/core/shared/platform/linux-sgx/untrusted/socket.c
+++ b/core/shared/platform/linux-sgx/untrusted/socket.c
@@ -96,6 +96,12 @@ ocall_getsockname(int sockfd, void *addr, uint32_t *addrlen, uint32_t addr_size)
 }
 
 int
+ocall_getpeername(int sockfd, void *addr, uint32_t *addrlen, uint32_t addr_size)
+{
+    return getpeername(sockfd, (struct sockaddr *)addr, addrlen);
+}
+
+int
 ocall_listen(int sockfd, int backlog)
 {
     return listen(sockfd, backlog);
@@ -113,10 +119,26 @@ ocall_recv(int sockfd, void *buf, size_t len, int flags)
     return recv(sockfd, buf, len, flags);
 }
 
+ssize_t
+ocall_recvfrom(int sockfd, void *buf, size_t len, int flags, void *src_addr,
+               uint32_t *addrlen, uint32_t addr_size)
+{
+    return recvfrom(sockfd, buf, len, flags, (struct sockaddr *)src_addr,
+                    addrlen);
+}
+
 int
 ocall_send(int sockfd, const void *buf, size_t len, int flags)
 {
     return send(sockfd, buf, len, flags);
+}
+
+ssize_t
+ocall_sendto(int sockfd, const void *buf, size_t len, int flags,
+             void *dest_addr, uint32_t addrlen)
+{
+    return sendto(sockfd, buf, len, flags, (struct sockaddr *)dest_addr,
+                  addrlen);
 }
 
 int


### PR DESCRIPTION
Hey,

Nothing crazy here, implemented some of the popular socket APIs left unimplemented for SGX, following the merge of `dev/socket`.

An orthogonal note to this PR: I notice that `posix_socket.c` (the backend of POSIX) now handles the structures for ipv4 and ipv6. A next step would also be to port that adaptation for the POSIX backend of SGX.

Cheers