### PR TITLE
A workflow for releasing binaries

### DIFF
--- a/.github/scripts/fetch_and_compare_version.py
+++ b/.github/scripts/fetch_and_compare_version.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2019 Intel Corporation.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+import re
+import shlex
+import subprocess
+import sys
+
+
+def fetch_version_from_code():
+    """
+    search the semantic version definition in build-scripts/config_common.cmake
+    """
+    major, minor, patch = "", "", ""
+    with open("build-scripts/config_common.cmake", encoding="utf-8") as f:
+        for line in f.readlines():
+            if "WAMR_VERSION" not in line:
+                continue
+
+            major_match = re.search(r"WAMR_VERSION_MAJOR (\d+)", line)
+            if major_match is not None:
+                major = major_match.groups()[0]
+                continue
+
+            minor_match = re.search(r"WAMR_VERSION_MINOR (\d+)", line)
+            if minor_match is not None:
+                minor = minor_match.groups()[0]
+                continue
+
+            patch_match = re.search(r"WAMR_VERSION_PATCH (\d+)", line)
+            if patch_match is not None:
+                patch = patch_match.groups()[0]
+
+    if len(major) == 0 or len(minor) == 0 or len(patch) == 0:
+        raise Exception(
+            "can't find the semantic version definition likes WAMR_VERSION_*"
+        )
+    return f"WAMR-{major}.{minor}.{patch}"
+
+
+def fetch_latest_git_tag():
+    list_tag_cmd = (
+        'git tag --list WAMR-*.*.* --sort=committerdate --format="%(refname:short)"'
+    )
+    p = subprocess.run(shlex.split(list_tag_cmd), capture_output=True, check=True)
+
+    all_tags = p.stdout.decode().strip()
+    latest_tag = all_tags.split("\n")[-1]
+    return latest_tag
+
+
+def match_version_pattern(v):
+    pattern = r"WAMR-\d+\.\d+\.\d+"
+    m = re.match(pattern, v)
+    return m is not None
+
+
+def split_version_string(v):
+    """
+    return the semantic version as an integer list
+    """
+    pattern = r"WAMR-(\d+)\.(\d+)\.(\d+)"
+    m = re.match(pattern, v)
+    return [int(x) for x in m.groups()]
+
+
+def compare_version_string(v1, v2):
+    """
+    return value:
+      - 1. if v1 > v2
+      - -1. if v1 < v2
+      - 0. if v1 == v2
+    """
+    if not match_version_pattern(v1):
+        raise Exception(f"{v1} doesn't match the version pattern")
+
+    if not match_version_pattern(v2):
+        raise Exception(f"{v2} doesn't match the version pattern")
+
+    v1_sem_ver = split_version_string(v1)
+    v2_sem_ver = split_version_string(v2)
+
+    return 0 if v1_sem_ver == v2_sem_ver else (1 if v1_sem_ver > v2_sem_ver else -1)
+
+
+def is_major_or_minor_changed(v1, v2):
+    """
+    return true if change either major of v2 or minor of v2
+    return false or else
+    """
+    if not match_version_pattern(v1):
+        raise Exception(f"{v1} doesn't match the version pattern")
+
+    if not match_version_pattern(v2):
+        raise Exception(f"{v2} doesn't match the version pattern")
+
+    v1_major, v1_minor, _ = split_version_string(v1)
+    v2_major, v2_minor, _ = split_version_string(v2)
+
+    return v2_major != v1_major or v2_minor != v1_minor
+
+
+def next_version():
+    definition = fetch_version_from_code()
+    tag = fetch_latest_git_tag()
+
+    new_version = ""
+    minor_changed = False
+    if compare_version_string(definition, tag) == 1:
+        new_version = definition.split("-")[-1]
+
+        if is_major_or_minor_changed(tag, definition):
+            minor_changed = True
+
+    return new_version, "major_minor_change" if minor_changed else "patch_change"
+
+
+if __name__ == "__main__":
+    print(f"{next_version()[0]},{next_version()[1]}")
+    sys.exit(0)

--- a/.github/workflows/build_iwasm_release.yml
+++ b/.github/workflows/build_iwasm_release.yml
@@ -1,0 +1,90 @@
+# Copyright (C) 2019 Intel Corporation.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+name: build iwasm release
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        description: arch of the release
+        type: string
+        required: false
+        default: x86_64
+      cwd:
+        description: workfing directory
+        type: string
+        required: true
+      runner:
+        description: OS of compilation
+        type: string
+        required: true
+      upload_url:
+        description: a semantic version number. it is required when `release` is true.
+        type: string
+        required: false
+      ver_num:
+        description: a semantic version number. it is required when `release` is true.
+        type: string
+        required: false
+
+jobs:
+  build:
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: generate iwasm binary release
+        run: |
+          cmake -S . -B build \
+            -DWAMR_BUILD_AOT=1 -DWAMR_BUILD_INTERP=1 -DWAMR_BUILD_JIT=0 \
+            -DWAMR_BUILD_CUSTOM_NAME_SECTION=0 \
+            -DWAMR_BUILD_DEBUG_INTERP=0 \
+            -DWAMR_BUILD_DEBUG_AOT=0 \
+            -DWAMR_BUILD_DUMP_CALL_STACK=0 \
+            -DWAMR_BUILD_LIBC_UVWASI=0 \
+            -DWAMR_BUILD_LIBC_EMCC=0 \
+            -DWAMR_BUILD_LIB_RATS=0 \
+            -DWAMR_BUILD_LOAD_CUSTOM_SECTION=0 \
+            -DWAMR_BUILD_MEMORY_PROFILING=0 \
+            -DWAMR_BUILD_MINI_LOADER=0 \
+            -DWAMR_BUILD_MULTI_MODULE=0 \
+            -DWAMR_BUILD_PERF_PROFILING=0 \
+            -DWAMR_BUILD_SPEC_TEST=0 \
+            -DWAMR_BUILD_BULK_MEMORY=1 \
+            -DWAMR_BUILD_LIB_PTHREAD=1 \
+            -DWAMR_BUILD_LIB_PTHREAD_SEMAPHORE=1 \
+            -DWAMR_BUILD_LIBC_BUILTIN=1 \
+            -DWAMR_BUILD_LIBC_WASI=1 \
+            -DWAMR_BUILD_REF_TYPES=1 \
+            -DWAMR_BUILD_SIMD=1 \
+            -DWAMR_BUILD_SHARED_MEMORY=1 \
+            -DWAMR_BUILD_TAIL_CALL=1 \
+            -DWAMR_BUILD_THREAD_MGR=1
+          cmake --build build --config Release --parallel 4
+        working-directory: ${{ inputs.cwd }}
+
+      - name: compress the binary
+        run: |
+          tar czf iwasm-${{ inputs.ver_num }}-${{ inputs.runner }}.tar.gz iwasm
+          zip iwasm-${{ inputs.ver_num }}-${{ inputs.runner }}.zip iwasm
+        working-directory: ${{ inputs.cwd }}/build
+
+      - name: upload release tar.gz
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: ${{ inputs.cwd }}/build/iwasm-${{ inputs.ver_num }}-${{ inputs.runner }}.tar.gz
+          asset_name: iwasm-${{ inputs.ver_num }}-${{ inputs.arch }}-${{ inputs.runner }}.tar.gz
+          asset_content_type: application/x-gzip
+
+      - name: upload release zip
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: ${{ inputs.cwd }}/build/iwasm-${{ inputs.ver_num }}-${{ inputs.runner }}.zip
+          asset_name: iwasm-${{ inputs.ver_num }}-${{ inputs.arch }}-${{ inputs.runner }}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/build_wamrc.yml
+++ b/.github/workflows/build_wamrc.yml
@@ -1,0 +1,90 @@
+# Copyright (C) 2019 Intel Corporation.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+name: build wamrc
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        description: arch of the release
+        type: string
+        required: false
+        default: x86_64
+      llvm_cache_key:
+        description: the cache key of llvm libraries
+        type: string
+        required: true
+      release:
+        description: it is a part of the release process
+        type: boolean
+        required: true
+      runner:
+        description: OS of compilation
+        type: string
+        required: true
+      upload_url:
+        description: a semantic version number. it is required when `release` is true.
+        type: string
+        required: false
+      ver_num:
+        description: a semantic version number. it is required when `release` is true.
+        type: string
+        required: false
+
+jobs:
+  build:
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: get cached LLVM libraries
+        id: cache_llvm
+        uses: actions/cache@v3
+        with:
+          path: |
+            ./core/deps/llvm/build/bin
+            ./core/deps/llvm/build/include
+            ./core/deps/llvm/build/lib
+            ./core/deps/llvm/build/libexec
+            ./core/deps/llvm/build/share
+          key: ${{ inputs.llvm_cache_key }}
+
+      - name: Build llvm and clang from source
+        if: steps.cache_llvm.outputs.cache-hit != 'true'
+        run: /usr/bin/env python3 ./build_llvm.py --arch X86
+        working-directory: build-scripts
+
+      - name: generate wamrc binary release
+        run: |
+          cmake -S . -B build
+          cmake --build build --config Release --parallel 4
+        working-directory: wamr-compiler
+
+      - name: compress the binary
+        if: inputs.release
+        run: |
+          tar czf wamrc-${{ inputs.ver_num }}-${{ inputs.runner }}.tar.gz wamrc
+          zip wamrc-${{ inputs.ver_num }}-${{ inputs.runner }}.zip wamrc
+        working-directory: wamr-compiler/build
+
+      - name: upload release tar.gz
+        if: inputs.release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: wamr-compiler/build/wamrc-${{ inputs.ver_num }}-${{ inputs.runner }}.tar.gz
+          asset_name: wamrc-${{ inputs.ver_num }}-${{ inputs.arch }}-${{ inputs.runner }}.tar.gz
+          asset_content_type: application/x-gzip
+
+      - name: upload release zip
+        if: inputs.release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: wamr-compiler/build/wamrc-${{ inputs.ver_num }}-${{ inputs.runner }}.zip
+          asset_name: wamrc-${{ inputs.ver_num }}-${{ inputs.arch }}-${{ inputs.runner }}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/create_tag.yml
+++ b/.github/workflows/create_tag.yml
@@ -1,0 +1,68 @@
+# Copyright (C) 2019 Intel Corporation.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+name: create a tag
+
+on:
+  workflow_call:
+    outputs:
+      minor_version:
+        description: "the new version is a minor version or a major version"
+        value: ${{ jobs.create_tag.outputs.minor_version}}
+      new_ver:
+        description: "the new version"
+        value: ${{ jobs.create_tag.outputs.new_ver}}
+      new_tag:
+        description: "the new tag just created"
+        value: ${{ jobs.create_tag.outputs.new_tag}}
+
+jobs:
+  create_tag:
+    runs-on: ubuntu-latest
+    outputs:
+      minor_version: ${{ steps.preparation.outputs.minor_version }}
+      new_ver: ${{ steps.preparation.outputs.new_ver }}
+      new_tag: ${{ steps.preparation.outputs.new_tag }}
+
+    steps:
+      - uses: actions/checkout@v3
+        # Full git history is needed to get a proper list of commits and tags
+        with:
+          fetch-depth: 0
+
+      - name: prepare
+        id: preparation
+        run: |
+          # show latest 3 versions
+          git tag --list WAMR-*.*.* --sort=committerdate --format="%(refname:short)" | tail -n 3
+          # compare latest git tag and semantic version definition
+          result=$(python3 ./.github/scripts/fetch_and_compare_version.py)
+          echo "script result is ${result}"
+          #
+          # return in a form like "WAMR-X.Y.Z,change_minor" or ",change_patch"
+          new_ver=$(echo "${result}" | awk -F',' '{print $1}')
+          diff_versioning=$(echo "${result}" | awk -F',' '{print $2}')
+          echo "next version is ${new_ver}, it ${diff_versioning}"
+          #
+          # set output
+          if [[ ${diff_versioning} == 'change_minor' ]];then
+            echo "::set-output name=minor_version::true"
+          else
+            echo "::set-output name=minor_version::false"
+          fi
+          #
+          #
+          if [[ -z ${new_ver} ]]; then
+            echo "::error::please indicate the right semantic version in build-scripts/config_common.cmake"
+            echo "::set-output name=new_ver::''"
+            echo "::set-output name=new_tag::''"
+            exit 1
+          else
+            echo "::set-output name=new_ver::${new_ver}"
+            echo "::set-output name=new_tag::WAMR-${new_ver}"
+          fi
+
+      - name: push tag
+        if: steps.preparation.outputs.new_tag != ''
+        run: |
+          git tag ${{ steps.preparation.outputs.new_tag }}
+          git push origin --force --tags

--- a/.github/workflows/release_process.yml
+++ b/.github/workflows/release_process.yml
@@ -1,0 +1,105 @@
+# Copyright (C) 2019 Intel Corporation.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: the binary release processes
+
+on:
+  workflow_dispatch:
+    inputs:
+      require_confirmation:
+        description: "If the process requires a confirmation"
+        type: boolean
+        required: false
+        default: false
+
+# Cancel any in-flight jobs for the same PR/branch so there's only one active
+# at a time
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  LLVM_CACHE_SUFFIX: "build-llvm_libraries_ex"
+
+jobs:
+  create_tag:
+    uses: ./.github/workflows/create_tag.yml
+
+  create_release:
+    needs: [create_tag]
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: create a release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ needs.create_tag.outputs.new_tag }}
+          release_name: ${{ needs.create_tag.outputs.new_tag }}
+          prerelease: ${{ inputs.require_confirmation || needs.create_tag.outputs.minor_version }}
+          draft: false
+          body: |
+            TODO: fill the content of RELEASE_NOTE.md in
+
+  release_wamrc_on_ubuntu_2004:
+    needs: [create_tag, create_release]
+    uses: ./.github/workflows/build_wamrc.yml
+    with:
+      # can't take an env variable here
+      llvm_cache_key: ubuntu-20.04-build-llvm_libraries_ex
+      release: true
+      runner: ubuntu-20.04
+      upload_url: ${{ needs.create_release.outputs.upload_url }}
+      ver_num: ${{ needs.create_tag.outputs.new_ver}}
+
+  release_wamrc_on_ubuntu_2204:
+    needs: [create_tag, create_release]
+    uses: ./.github/workflows/build_wamrc.yml
+    with:
+      # can't take an env variable here
+      llvm_cache_key: ubuntu-22.04-build-llvm_libraries_ex
+      release: true
+      runner: ubuntu-22.04
+      upload_url: ${{ needs.create_release.outputs.upload_url }}
+      ver_num: ${{ needs.create_tag.outputs.new_ver }}
+
+  release_wamrc_on_ubuntu_macos:
+    needs: [create_tag, create_release]
+    uses: ./.github/workflows/build_wamrc.yml
+    with:
+      # can't take an env variable here
+      llvm_cache_key: macos-latest-build-llvm_libraries_ex
+      release: true
+      runner: macos-latest
+      upload_url: ${{ needs.create_release.outputs.upload_url }}
+      ver_num: ${{ needs.create_tag.outputs.new_ver }}
+
+  release_iwasm_on_ubuntu_2004:
+    needs: [create_tag, create_release]
+    uses: ./.github/workflows/build_iwasm_release.yml
+    with:
+      cwd: product-mini/platforms/linux
+      runner: ubuntu-20.04
+      upload_url: ${{ needs.create_release.outputs.upload_url }}
+      ver_num: ${{ needs.create_tag.outputs.new_ver}}
+
+  release_iwasm_on_ubuntu_2204:
+    needs: [create_tag, create_release]
+    uses: ./.github/workflows/build_iwasm_release.yml
+    with:
+      cwd: product-mini/platforms/linux
+      runner: ubuntu-22.04
+      upload_url: ${{ needs.create_release.outputs.upload_url }}
+      ver_num: ${{ needs.create_tag.outputs.new_ver}}
+
+  release_iwasm_on_macos:
+    needs: [create_tag, create_release]
+    uses: ./.github/workflows/build_iwasm_release.yml
+    with:
+      cwd: product-mini/platforms/darwin
+      runner: macos-latest
+      upload_url: ${{ needs.create_release.outputs.upload_url }}
+      ver_num: ${{ needs.create_tag.outputs.new_ver}}


### PR DESCRIPTION
`release_process` is only triggered manually. It will create a git tag with the semantic versioning definition in *config_common.cmake*. And generate binaries for *iwasm* and *wamrc* on variant OSes.