### PR TITLE
optimize CI entry points

### DIFF
--- a/.github/workflows/compilation_on_android_ubuntu.yml
+++ b/.github/workflows/compilation_on_android_ubuntu.yml
@@ -6,20 +6,30 @@ name: compilation on android, ubuntu-20.04, ubuntu-22.04
 on:
   # will be triggered on PR events
   pull_request:
-    paths-ignore:
-      - "assembly-script/**"
-      - "ci/**"
-      - "doc/**"
-      - "test-tools/**"
-      - ".github/workflows/compilation_on_android_ubuntu.yml"
+    types:
+      - opened
+      - synchronize
+    paths:
+      - ".github/**"
+      - "core/**"
+      - "!core/deps/**"
+      - "product-mini/**"
+      - "samples/**"
+      - "!samples/workload/**"
+      - "wamr-comiler/**"
   # will be triggered on push events
   push:
-    paths-ignore:
-      - "assembly-script/**"
-      - "ci/**"
-      - "doc/**"
-      - "test-tools/**"
-      - ".github/workflows/compilation_on_android_ubuntu.yml"
+    branches:
+      - main
+      - "dev/**"
+    paths:
+      - ".github/**"
+      - "core/**"
+      - "!core/deps/**"
+      - "product-mini/**"
+      - "samples/**"
+      - "!samples/workload/**"
+      - "wamr-comiler/**"
   # allow to be triggered manually
   workflow_dispatch:
 
@@ -46,19 +56,6 @@ env:
   X86_32_TARGET_TEST_OPTIONS: "-m x86_32 -P"
 
 jobs:
-  # Cancel any in-flight jobs for the same PR/branch so there's only one active
-  # at a time
-  cancel_previous:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
-    steps:
-      - name: Cancel Workflow Action
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
   build_llvm_libraries:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/compilation_on_macos.yml
+++ b/.github/workflows/compilation_on_macos.yml
@@ -6,20 +6,30 @@ name: compilation on macos-latest
 on:
   # will be triggered on PR events
   pull_request:
-    paths-ignore:
-      - "assembly-script/**"
-      - "ci/**"
-      - "doc/**"
-      - "test-tools/**"
-      - ".github/workflows/compilation_on_macos.yml"
+    types:
+      - opened
+      - synchronize
+    paths:
+      - ".github/**"
+      - "core/**"
+      - "!core/deps/**"
+      - "product-mini/**"
+      - "samples/**"
+      - "!samples/workload/**"
+      - "wamr-comiler/**"
   # will be triggered on push events
   push:
-    paths-ignore:
-      - "assembly-script/**"
-      - "ci/**"
-      - "doc/**"
-      - "test-tools/**"
-      - ".github/workflows/compilation_on_macos.yml"
+    branches:
+      - main
+      - "dev/**"
+    paths:
+      - ".github/**"
+      - "core/**"
+      - "!core/deps/**"
+      - "product-mini/**"
+      - "samples/**"
+      - "!samples/workload/**"
+      - "wamr-comiler/**"
   # allow to be triggered manually
   workflow_dispatch:
 
@@ -38,19 +48,6 @@ env:
   LLVM_CACHE_SUFFIX: "build-llvm_libraries_ex"
 
 jobs:
-  # Cancel any in-flight jobs for the same PR/branch so there's only one active
-  # at a time
-  cancel_previous:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macos-latest]
-    steps:
-      - name: Cancel Workflow Action
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
   build_llvm_libraries:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/compilation_on_nuttx.yml
+++ b/.github/workflows/compilation_on_nuttx.yml
@@ -6,18 +6,30 @@ name: compilation on nuttx
 on:
   # will be triggered on PR events
   pull_request:
-    paths-ignore:
-      - "assembly-script/**"
-      - "ci/**"
-      - "doc/**"
-      - "test-tools/**"
+    types:
+      - opened
+      - synchronize
+    paths:
+      - ".github/**"
+      - "core/**"
+      - "!core/deps/**"
+      - "product-mini/**"
+      - "samples/**"
+      - "!samples/workload/**"
+      - "wamr-comiler/**"
   # will be triggered on push events
   push:
-    paths-ignore:
-      - "assembly-script/**"
-      - "ci/**"
-      - "doc/**"
-      - "test-tools/**"
+    branches:
+      - main
+      - "dev/**"
+    paths:
+      - ".github/**"
+      - "core/**"
+      - "!core/deps/**"
+      - "product-mini/**"
+      - "samples/**"
+      - "!samples/workload/**"
+      - "wamr-comiler/**"
   # allow to be triggered manually
   workflow_dispatch:
 
@@ -28,16 +40,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Cancel any in-flight jobs for the same PR/branch so there's only one active
-  # at a time
-  cancel_previous:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Cancel Workflow Action
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}  
-
   build_iwasm_on_nuttx:
     runs-on: ubuntu-22.04
     strategy:
@@ -72,7 +74,7 @@ jobs:
 
     steps:
       - name: Install Utilities
-        run: | 
+        run: |
           sudo apt install -y kconfig-frontends-nox genromfs
           pip3 install pyelftools
           pip3 install cxxfilt
@@ -104,7 +106,7 @@ jobs:
           path: apps/interpreters/wamr/wamr
 
       - name: Enable WAMR for NuttX
-        run: | 
+        run: |
           find nuttx/boards -name defconfig | xargs sed -i '$a\CONFIG_EOL_IS_CR=y\n${{ matrix.wamr_config_option }}'
           find nuttx/boards/sim -name defconfig | xargs sed -i '$a\CONFIG_LIBM=y\n'
           find nuttx/boards/risc-v -name defconfig | xargs sed -i '$a\CONFIG_LIBM=y\n'

--- a/.github/workflows/compilation_on_sgx.yml
+++ b/.github/workflows/compilation_on_sgx.yml
@@ -6,20 +6,30 @@ name: compilation on SGX
 on:
   # will be triggered on PR events
   pull_request:
-    paths-ignore:
-      - "assembly-script/**"
-      - "ci/**"
-      - "doc/**"
-      - "test-tools/**"
-      - ".github/workflows/compilation_on_sgx.yml"
+    types:
+      - opened
+      - synchronize
+    paths:
+      - ".github/**"
+      - "core/**"
+      - "!core/deps/**"
+      - "product-mini/**"
+      - "samples/**"
+      - "!samples/workload/**"
+      - "wamr-comiler/**"
   # will be triggered on push events
   push:
-    paths-ignore:
-      - "assembly-script/**"
-      - "ci/**"
-      - "doc/**"
-      - "test-tools/**"
-      - ".github/workflows/compilation_on_sgx.yml"
+    branches:
+      - main
+      - "dev/**"
+    paths:
+      - ".github/**"
+      - "core/**"
+      - "!core/deps/**"
+      - "product-mini/**"
+      - "samples/**"
+      - "!samples/workload/**"
+      - "wamr-comiler/**"
   # allow to be triggered manually
   workflow_dispatch:
 
@@ -38,19 +48,6 @@ env:
   LLVM_CACHE_SUFFIX: "build-llvm_libraries_ex"
 
 jobs:
-  # Cancel any in-flight jobs for the same PR/branch so there's only one active
-  # at a time
-  cancel_previous:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04]
-    steps:
-      - name: Cancel Workflow Action
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
   build_llvm_libraries:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/compilation_on_windows.yml
+++ b/.github/workflows/compilation_on_windows.yml
@@ -6,20 +6,30 @@ name: compilation on windows-latest
 on:
   # will be triggered on PR events
   pull_request:
-    paths-ignore:
-      - "assembly-script/**"
-      - "ci/**"
-      - "doc/**"
-      - "test-tools/**"
-      - ".github/workflows/compilation_on_windows.yml"
+    types:
+      - opened
+      - synchronize
+    paths:
+      - ".github/**"
+      - "core/**"
+      - "!core/deps/**"
+      - "product-mini/**"
+      - "samples/**"
+      - "!samples/workload/**"
+      - "wamr-comiler/**"
   # will be triggered on push events
   push:
-    paths-ignore:
-      - "assembly-script/**"
-      - "ci/**"
-      - "doc/**"
-      - "test-tools/**"
-      - ".github/workflows/compilation_on_windows.yml"
+    branches:
+      - main
+      - "dev/**"
+    paths:
+      - ".github/**"
+      - "core/**"
+      - "!core/deps/**"
+      - "product-mini/**"
+      - "samples/**"
+      - "!samples/workload/**"
+      - "wamr-comiler/**"
   # allow to be triggered manually
   workflow_dispatch:
 
@@ -30,18 +40,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Cancel any in-flight jobs for the same PR/branch so there's only one active
-  # at a time
-  cancel_previous:
-    runs-on: windows-latest
-    steps:
-      - name: Cancel Workflow Action
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
   build:
-    needs: cancel_previous
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
- run CI when a PR is opened and updated
- run CI when a PR is merged into *main* and *dev* branches. It based on https://github.com/bytecodealliance/wasm-micro-runtime branch rules
- `cancel_previous` is duplicated with `concurrency`