### PR TITLE
Add wasm_native_unregister_natives

### DIFF
--- a/core/iwasm/common/wasm_native.h
+++ b/core/iwasm/common/wasm_native.h
@@ -64,6 +64,14 @@ wasm_native_register_natives_raw(const char *module_name,
                                  NativeSymbol *native_symbols,
                                  uint32 n_native_symbols);
 
+void *
+wasm_native_register_natives_handle(const char *module_name,
+                                    NativeSymbol *native_symbols,
+                                    uint32 n_native_symbols, bool raw);
+
+bool
+wasm_native_unregister_natives(void *handle);
+
 bool
 wasm_native_init();
 

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -2999,6 +2999,21 @@ wasm_runtime_register_natives_raw(const char *module_name,
                                             n_native_symbols);
 }
 
+void *
+wasm_runtime_register_natives_handle(const char *module_name,
+                                     NativeSymbol *native_symbols,
+                                     uint32 n_native_symbols, bool raw)
+{
+    return wasm_native_register_natives_handle(module_name, native_symbols,
+                                               n_native_symbols, raw);
+}
+
+bool
+wasm_runtime_unregister_natives(void *handle)
+{
+    return wasm_native_unregister_natives(handle);
+}
+
 bool
 wasm_runtime_invoke_native_raw(WASMExecEnv *exec_env, void *func_ptr,
                                const WASMType *func_type, const char *signature,

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -878,6 +878,16 @@ wasm_runtime_register_natives_raw(const char *module_name,
                                   NativeSymbol *native_symbols,
                                   uint32 n_native_symbols);
 
+/* See wasm_export.h for description */
+WASM_RUNTIME_API_EXTERN void *
+wasm_runtime_register_natives_handle(const char *module_name,
+                                     NativeSymbol *native_symbols,
+                                     uint32 n_native_symbols, bool raw);
+
+/* See wasm_export.h for description */
+WASM_RUNTIME_API_EXTERN bool
+wasm_runtime_unregister_natives(void *handle);
+
 bool
 wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
                            const WASMType *func_type, const char *signature,

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -973,6 +973,41 @@ wasm_runtime_register_natives_raw(const char *module_name,
                                   uint32_t n_native_symbols);
 
 /**
+ * Register native functions with same module name
+ *
+ * @param module_name    Same as wasm_runtime_register_natives
+ * @param native_symbols Same as wasm_runtime_register_natives
+ * @param raw            If true, uses the "raw" API as
+ *                       wasm_runtime_register_natives_raw.
+ *                       Otherwise, uses the default API as
+ *                       wasm_runtime_register_natives.
+ *
+ * @return On success, an opaque handle which can be used for undo
+ *         oprataion later.
+ *         On failure, returns NULL.
+ */
+
+WASM_RUNTIME_API_EXTERN void *
+wasm_runtime_register_natives_handle(const char *module_name,
+                                    NativeSymbol *native_symbols,
+                                    uint32_t n_native_symbols,
+                                    bool raw);
+
+/**
+ * Undo wasm_native_register_natives_handle
+ *
+ * Note: It's a caller's responsibility to ensure that the symbols
+ * being unregistered are not used anymore. For example, modules linked
+ * to the symbols should be unloaded before calling this function.
+ *
+ * @param handle the handle returned by wasm_native_register_natives_handle
+ *
+ * @return true if success, false otherwise
+ */
+WASM_RUNTIME_API_EXTERN bool
+wasm_runtime_unregister_natives(void *handle);
+
+/**
  * Get attachment of native function from execution environment
  *
  * @param exec_env the execution environment to retrieve


### PR DESCRIPTION
Sometimes it's more convenient to "unload" natives
than restarting the whole engine using
wasm_runtime_destroy/wasm_runtime_init.
