### PR TITLE
Remove wasm_runtime_is_module_registered

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -702,12 +702,6 @@ wasm_runtime_find_module_registered(const char *module_name)
     return module ? module->module : NULL;
 }
 
-bool
-wasm_runtime_is_module_registered(const char *module_name)
-{
-    return NULL != wasm_runtime_find_module_registered(module_name);
-}
-
 /*
  * simply destroy all
  */

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -719,9 +719,6 @@ void
 wasm_runtime_unregister_module(const WASMModuleCommon *module);
 
 bool
-wasm_runtime_is_module_registered(const char *module_name);
-
-bool
 wasm_runtime_add_loading_module(const char *module_name, char *error_buf,
                                 uint32 error_buf_size);
 


### PR DESCRIPTION
* It's unused

* The same functionality is provided by wasm_runtime_find_module_registered