### PR TITLE
Use cmake POSITION_INDEPENDENT_CODE instead of hardcoding -pie -fPIE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,8 +107,6 @@ set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 include (${WAMR_ROOT_DIR}/build-scripts/runtime_lib.cmake)
 
-set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections -pie -fPIE")
-
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security -Wshadow")
 # set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wconversion -Wsign-conversion")
 

--- a/product-mini/platforms/linux/CMakeLists.txt
+++ b/product-mini/platforms/linux/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required (VERSION 2.9)
+cmake_minimum_required (VERSION 3.14)
+
+include(CheckPIESupported)
 
 project (iwasm)
 
@@ -119,7 +121,7 @@ set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 include (${WAMR_ROOT_DIR}/build-scripts/runtime_lib.cmake)
 add_library(vmlib ${WAMR_RUNTIME_LIB_SOURCE})
 
-set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections -pie -fPIE")
+set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
 
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security -Wshadow")
 # set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wconversion -Wsign-conversion")
@@ -163,6 +165,9 @@ endif ()
 include (${SHARED_DIR}/utils/uncommon/shared_uncommon.cmake)
 
 add_executable (iwasm main.c ${UNCOMMON_SHARED_SOURCE})
+
+check_pie_supported()
+set_target_properties (iwasm PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 install (TARGETS iwasm DESTINATION bin)
 

--- a/samples/basic/CMakeLists.txt
+++ b/samples/basic/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required (VERSION 2.9)
+cmake_minimum_required (VERSION 3.14)
+
+include(CheckPIESupported)
 
 if (NOT WAMR_BUILD_PLATFORM STREQUAL "windows")
   project (basic)
@@ -56,7 +58,6 @@ endif ()
 
 if (NOT MSVC)
   # linker flags
-  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie -fPIE")
   if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
   endif ()
@@ -79,6 +80,9 @@ include_directories(${CMAKE_CURRENT_LIST_DIR}/src)
 include (${SHARED_DIR}/utils/uncommon/shared_uncommon.cmake)
 
 add_executable (basic src/main.c src/native_impl.c ${UNCOMMON_SHARED_SOURCE})
+
+check_pie_supported()
+set_target_properties (basic PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 if (APPLE)
   target_link_libraries (basic vmlib -lm -ldl -lpthread)

--- a/samples/file/src/CMakeLists.txt
+++ b/samples/file/src/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Copyright (C) 2022 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.14)
+
+include(CheckPIESupported)
 
 if (NOT WAMR_BUILD_PLATFORM STREQUAL "windows")
   project (iwasm)
@@ -56,7 +58,6 @@ endif ()
 
 if (NOT MSVC)
   # linker flags
-  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie -fPIE")
   if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
   endif ()
@@ -79,6 +80,9 @@ include_directories(${CMAKE_CURRENT_LIST_DIR})
 include (${SHARED_DIR}/utils/uncommon/shared_uncommon.cmake)
 
 add_executable (iwasm main.c ${UNCOMMON_SHARED_SOURCE})
+
+check_pie_supported()
+set_target_properties (iwasm PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 if (APPLE)
   target_link_libraries (iwasm vmlib -lm -ldl -lpthread)

--- a/samples/multi-module/CMakeLists.txt
+++ b/samples/multi-module/CMakeLists.txt
@@ -1,7 +1,10 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required (VERSION 2.8...3.16)
+cmake_minimum_required (VERSION 3.14)
+
+include(CheckPIESupported)
+
 project(multi_module)
 
 ################  runtime settings  ################
@@ -47,7 +50,6 @@ set(WAMR_BUILD_LIBC_WASI 1)
 set(WAMR_BUILD_MULTI_MODULE 1)
 
 # compiling and linking flags
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie -fPIE")
 if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))
   set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
 endif ()
@@ -149,6 +151,9 @@ include (${SHARED_DIR}/utils/uncommon/shared_uncommon.cmake)
 add_executable(multi_module src/main.c ${UNCOMMON_SHARED_SOURCE})
 
 add_dependencies(multi_module vmlib WASM_MODULE)
+
+check_pie_supported()
+set_target_properties (multi_module PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # libraries
 target_link_libraries(multi_module PRIVATE vmlib -lpthread -lm)

--- a/samples/multi-thread/CMakeLists.txt
+++ b/samples/multi-thread/CMakeLists.txt
@@ -1,7 +1,10 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.14)
+
+include(CheckPIESupported)
+
 project(pthread)
 
 ################  runtime settings  ################
@@ -48,7 +51,6 @@ set(WAMR_BUILD_LIB_PTHREAD 1)
 set(WAMR_BUILD_LIB_PTHREAD_SEMAPHORE 1)
 
 # compiling and linking flags
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie -fPIE")
 if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))
   set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
 endif ()
@@ -73,5 +75,7 @@ set (RUNTIME_SOURCE_ALL
     ${UNCOMMON_SHARED_SOURCE}
 )
 add_executable (iwasm ${RUNTIME_SOURCE_ALL})
+check_pie_supported()
+set_target_properties (iwasm PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(iwasm vmlib -lpthread -lm -ldl)
 

--- a/samples/native-lib/CMakeLists.txt
+++ b/samples/native-lib/CMakeLists.txt
@@ -1,7 +1,10 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.14)
+
+include(CheckPIESupported)
+
 project(native_lib)
 
 ################ runtime settings  ##############
@@ -46,7 +49,6 @@ set (WAMR_BUILD_LIBC_BUILTIN 1)
 set (WAMR_BUILD_FAST_INTERP 1)
 
 # compiling and linking flags
-set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie -fPIE")
 if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))
   set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
 endif ()
@@ -67,6 +69,9 @@ set (RUNTIME_SOURCE_ALL
 )
 
 add_executable (iwasm ${RUNTIME_SOURCE_ALL})
+
+check_pie_supported()
+set_target_properties (iwasm PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 target_link_libraries(iwasm vmlib -lpthread -lm -ldl)
 

--- a/samples/ref-types/CMakeLists.txt
+++ b/samples/ref-types/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Copyright (C) 2019 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required (VERSION 2.9)
+cmake_minimum_required (VERSION 3.14)
+
+include(CheckPIESupported)
 
 if (NOT WAMR_BUILD_PLATFORM STREQUAL "windows")
   project(ref-types)
@@ -70,7 +72,6 @@ set(WAMR_BUILD_REF_TYPES 1)
 
 if (NOT MSVC)
   # compiling and linking flags
-  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie -fPIE")
   if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
   endif ()
@@ -106,6 +107,9 @@ endif()
 include (${SHARED_DIR}/utils/uncommon/shared_uncommon.cmake)
 
 add_executable(hello src/hello.c ${UNCOMMON_SHARED_SOURCE})
+
+check_pie_supported()
+set_target_properties (hello PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 target_include_directories(hello PRIVATE ${UNCOMMON_SHARED_DIR})
 

--- a/samples/socket-api/CMakeLists.txt
+++ b/samples/socket-api/CMakeLists.txt
@@ -1,7 +1,10 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 2.8...3.18)
+cmake_minimum_required(VERSION 3.14)
+
+include(CheckPIESupported)
+
 project(socket_api_sample)
 
 #######################################
@@ -170,7 +173,6 @@ set(WAMR_BUILD_LIBC_WASI 1)
 set(WAMR_BUILD_LIB_PTHREAD 1)
 
 # compiling and linking flags
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie -fPIE")
 if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))
   set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
 endif ()
@@ -188,4 +190,6 @@ set (RUNTIME_SOURCE_ALL
     ${UNCOMMON_SHARED_SOURCE}
 )
 add_executable (iwasm ${RUNTIME_SOURCE_ALL})
+check_pie_supported()
+set_target_properties (iwasm PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(iwasm vmlib -lpthread -lm -ldl)

--- a/samples/spawn-thread/CMakeLists.txt
+++ b/samples/spawn-thread/CMakeLists.txt
@@ -1,7 +1,10 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.14)
+
+include(CheckPIESupported)
+
 project(spawn_thread)
 
 ################  runtime settings  ################
@@ -47,7 +50,6 @@ set(WAMR_BUILD_FAST_INTERP 1)
 set(WAMR_BUILD_LIB_PTHREAD 1)
 
 # compiling and linking flags
-set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie -fPIE")
 if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))
   set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
 endif ()
@@ -72,4 +74,6 @@ set (RUNTIME_SOURCE_ALL
     ${UNCOMMON_SHARED_SOURCE}
 )
 add_executable (spawn_thread ${RUNTIME_SOURCE_ALL})
+check_pie_supported()
+set_target_properties (spawn_thread PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(spawn_thread vmlib -lpthread -lm)

--- a/samples/wasm-c-api/CMakeLists.txt
+++ b/samples/wasm-c-api/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Copyright (C) 2019 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required (VERSION 2.9)
+cmake_minimum_required (VERSION 3.14)
+
+include(CheckPIESupported)
 
 if (NOT WAMR_BUILD_PLATFORM STREQUAL "windows")
   project(c-api)
@@ -71,7 +73,6 @@ endif()
 
 if (NOT MSVC)
   # compiling and linking flags
-  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie -fPIE")
   if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
   endif ()
@@ -142,10 +143,13 @@ if(WAMR_BUILD_JIT AND WAMR_BUILD_LAZY_JIT)
   endif()
 endif()
 
+check_pie_supported()
+
 foreach(EX ${EXAMPLES})
   set(SRC ${CMAKE_CURRENT_LIST_DIR}/src/${EX}.c)
 
   add_executable(${EX} ${SRC} ${UNCOMMON_SHARED_SOURCE} ${MM_UTIL})
+  set_target_properties (${EX} PROPERTIES POSITION_INDEPENDENT_CODE ON)
   target_include_directories(${EX} PRIVATE ${UNCOMMON_SHARED_DIR})
   target_link_libraries(${EX} vmlib -lpthread -lm)
   if (MSVC)

--- a/wamr-compiler/CMakeLists.txt
+++ b/wamr-compiler/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Copyright (C) 2019 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required (VERSION 2.9)
+cmake_minimum_required (VERSION 3.14)
+
+include(CheckPIESupported)
 
 if (NOT DEFINED WAMR_BUILD_PLATFORM)
   if (CMAKE_SYSTEM_NAME)
@@ -237,9 +239,6 @@ endif()
 if (NOT MSVC)
   add_definitions(-D_FORTIFY_SOURCE=2)
   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ftrapv")
-  if (NOT WIN32)
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pie -fPIE")
-  endif()
 endif()
 
 if (WIN32)
@@ -264,6 +263,8 @@ add_library (vmlib
 add_library (aotclib ${IWASM_COMPL_SOURCE})
 
 add_executable (wamrc main.c)
+check_pie_supported()
+set_target_properties (wamrc PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 if (LLVM_LINK_LLVM_DYLIB)
   set(WAMRC_LINK_LLVM_LIBS LLVM)


### PR DESCRIPTION
This fixes unused option warnings on -pie for macOS. (On macOS cmake produces "-fPIE -Xlinker -pie")

Bump required cmake version to 3.14 for CheckPIESupported.

References:
https://cmake.org/cmake/help/latest/prop_tgt/POSITION_INDEPENDENT_CODE.html https://cmake.org/cmake/help/latest/module/CheckPIESupported.html#module:CheckPIESupported