### PR TITLE
Reuse latest release binaries

### DIFF
--- a/.github/scripts/reuse_latest_release_binaries.py
+++ b/.github/scripts/reuse_latest_release_binaries.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2019 Intel Corporation.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+from urllib.error import HTTPError, URLError
+import urllib.request
+
+
+def get_last_commit(target_path, cwd):
+    last_commit_cmd = f"git log -n 1 --pretty=format:%H -- {target_path}"
+    p = subprocess.run(
+        shlex.split(last_commit_cmd), capture_output=True, check=True, cwd=cwd
+    )
+    return p.stdout.decode().strip()
+
+
+def fetch_git_tags():
+    list_tag_cmd = (
+        'git tag --list WAMR-*.*.* --sort=committerdate --format="%(refname:short)"'
+    )
+    p = subprocess.run(shlex.split(list_tag_cmd), capture_output=True, check=True)
+
+    all_tags = p.stdout.decode().strip()
+    return all_tags.split("\n")
+
+
+def download_binaries(binary_name_stem, cwd):
+    """
+    1. find the latest release name
+    2. form assets download url:
+    """
+    try:
+        all_tags = fetch_git_tags()
+        # *release_process.yml* will create a tag and release at first
+        second_last_tag = all_tags[-2]
+        latest_tag = all_tags[-1]
+
+        latest_url = "https://api.github.com/repos/bytecodealliance/wasm-micro-runtime/releases/latest"
+        print(f"::notice::query the latest release with {latest_url}...")
+        with urllib.request.urlopen(latest_url) as response:
+            body = response.read()
+
+        release_name = json.loads(body)["name"]
+
+        # WAMR-X.Y.Z -> X.Y.Z
+        second_last_sem_ver = second_last_tag[5:]
+        latest_sem_ver = latest_tag[5:]
+        assert latest_sem_ver in binary_name_stem
+        name_stem_in_release = binary_name_stem.replace(
+            latest_sem_ver, second_last_sem_ver
+        )
+
+        # download and rename
+        for file_ext in (".zip", ".tar.gz"):
+            assets_url = f"https://github.com/bytecodealliance/wasm-micro-runtime/releases/download/{release_name}/{name_stem_in_release}{file_ext}"
+            local_path = f"{binary_name_stem}{file_ext}"
+            print(f"::notice::download from {assets_url} and save as {local_path}...")
+            urllib.request.urlretrieve(assets_url, local_path)
+        return True
+    except HTTPError as error:
+        print(error.status, error.reason)
+    except URLError as error:
+        print(error.reason)
+    except TimeoutError:
+        print("Request timeout")
+
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Reuse binaries of the latest release if no more modification on the_path since last_commit"
+    )
+    parser.add_argument("working_directory", type=str)
+    parser.add_argument("--binary_name_stem", type=str)
+    parser.add_argument("--last_commit", type=str)
+    parser.add_argument("--the_path", type=str)
+    args = parser.parse_args()
+
+    last_commit = get_last_commit(args.the_path, args.working_directory)
+    if last_commit == args.last_commit:
+        return download_binaries(args.binary_name_stem, args.working_directory)
+    else:
+        return False
+
+
+if __name__ == "__main__":
+    # use output to indicate results
+    # echo "::set-output name=result::${result}"
+    print(f'::set-output name=result::{"hit" if main() else "not-hit"}')
+
+    # always return 0
+    sys.exit(0)

--- a/.github/workflows/build_wamr_lldb.yml
+++ b/.github/workflows/build_wamr_lldb.yml
@@ -24,12 +24,20 @@ on:
         required: true
 
 jobs:
+  try_reuse:
+    uses: ./.github/workflows/reuse_latest_release_binaries.yml
+    with:
+      binary_name_stem: "wamr-lldb-${{ inputs.ver_num }}-${{ inputs.arch }}-${{ inputs.runner }}"
+      last_commit: "ea63ba4bd010c2285623ad4acc0262a4d63bcfea"
+      the_path: "./build-scripts/lldb-wasm.patch"
+      upload_url: ${{ inputs.upload_url }}
+
   build:
+    needs: try_reuse
+    if: needs.try_reuse.outputs.result != 'hit'
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v3
-
-      #TODO: reuse the binary in pevious release?
 
       - name: Cache build
         id: lldb_build_cache

--- a/.github/workflows/release_process.yml
+++ b/.github/workflows/release_process.yml
@@ -159,7 +159,7 @@ jobs:
 
   #
   # WAMR_LLDB
-  release_wamr_lldb_on_ubuntu:
+  release_wamr_lldb_on_ubuntu_2004:
     needs: [create_tag, create_release]
     uses: ./.github/workflows/build_wamr_lldb.yml
     with:
@@ -167,7 +167,7 @@ jobs:
       upload_url: ${{ needs.create_release.outputs.upload_url }}
       ver_num: ${{ needs.create_tag.outputs.new_ver}}
 
-  release_wamr_lldb_on_ubuntu:
+  release_wamr_lldb_on_ubuntu_2204:
     needs: [create_tag, create_release]
     uses: ./.github/workflows/build_wamr_lldb.yml
     with:

--- a/.github/workflows/reuse_latest_release_binaries.yml
+++ b/.github/workflows/reuse_latest_release_binaries.yml
@@ -1,0 +1,68 @@
+# Copyright (C) 2019 Intel Corporation.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+name: reuse binaries of the latest release if no more modification on the_path since last_commit
+
+on:
+  workflow_call:
+    inputs:
+      binary_name_stem:
+        type: string
+        required: true
+      last_commit:
+        type: string
+        required: true
+      the_path:
+        type: string
+        required: true
+      upload_url:
+        description: upload binary assets to the URL of release
+        type: string
+        required: true
+    outputs:
+      result:
+        value: ${{ jobs.build.outputs.result }}
+
+jobs:
+  reuse:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.try_reuse.outputs.result }}
+    steps:
+      - uses: actions/checkout@v3
+        # Full git history is needed to get a proper list of commits and tags
+        with:
+          fetch-depth: 0
+
+      - name: try to reuse binaries
+        id: try_reuse
+        run: |
+          echo '::echo::on'
+          python3 ./.github/scripts/reuse_latest_release_binaries.py \
+              --binary_name_stem ${{ inputs.binary_name_stem }} \
+              --last_commit ${{ inputs.last_commit }} \
+              --the_path ${{ inputs.the_path }} .
+          ls -lh .
+
+      - run: echo ${{ steps.try_reuse.outputs.result }}
+
+      - name: upload release tar.gz
+        if: steps.try_reuse.outputs.result == 'hit'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: ${{ inputs.binary_name_stem }}.tar.gz
+          asset_name: ${{ inputs.binary_name_stem }}.tar.gz
+          asset_content_type: application/x-gzip
+
+      - name: upload release zip
+        if: steps.try_reuse.outputs.result == 'hit'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: ${{ inputs.binary_name_stem }}.zip
+          asset_name: ${{ inputs.binary_name_stem }}.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
To speed up *build_wamr_lldb.yml* by reusing binaries of previous release if there is no more modification