### PR TITLE
Spec test fast jit

### DIFF
--- a/.github/workflows/compilation_on_android_ubuntu.yml
+++ b/.github/workflows/compilation_on_android_ubuntu.yml
@@ -363,7 +363,7 @@ jobs:
             $SIMD_TEST_OPTIONS,
             $THREADS_TEST_OPTIONS,
           ]
-        includes:
+        include:
           - running_mode: "fast-jit"
             test_option: $DEFAULT_TEST_OPTIONS
     steps:
@@ -397,7 +397,7 @@ jobs:
 
       #only install x32 support libraries when to run x86_32 cases
       - name: install x32 support libraries
-        if: matrix.test_option == '$DEFAULT_TEST_OPTIONS' || matrix.test_option == '$THREADS_TEST_OPTIONS'
+        if: (matrix.test_option == '$DEFAULT_TEST_OPTIONS' && matrix.running_mode != 'fast-jit') || matrix.test_option == '$THREADS_TEST_OPTIONS'
         run:
           # Add another apt repository as some packages cannot
           # be downloaded with the github default repository
@@ -407,6 +407,6 @@ jobs:
           sudo apt install -y g++-multilib lib32gcc-9-dev
 
       - name: run spec tests x86_32
-        if: matrix.test_option == '$DEFAULT_TEST_OPTIONS' || matrix.test_option == '$THREADS_TEST_OPTIONS'
+        if: (matrix.test_option == '$DEFAULT_TEST_OPTIONS' && matrix.running_mode != 'fast-jit') || matrix.test_option == '$THREADS_TEST_OPTIONS'
         run: ./test_wamr.sh ${{ env.X86_32_TARGET_TEST_OPTIONS }} ${{ matrix.test_option }} -t ${{ matrix.running_mode }}
         working-directory: ./tests/wamr-test-suites

--- a/.github/workflows/compilation_on_android_ubuntu.yml
+++ b/.github/workflows/compilation_on_android_ubuntu.yml
@@ -216,8 +216,14 @@ jobs:
             $AOT_BUILD_OPTIONS,
           ]
         os: [ubuntu-20.04, ubuntu-22.04]
-        wasi_sdk_release: ["https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk-12.0-linux.tar.gz"]
-        wabt_release: ["https://github.com/WebAssembly/wabt/releases/download/1.0.24/wabt-1.0.24-ubuntu.tar.gz"]
+        wasi_sdk_release:
+          [
+            "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk-12.0-linux.tar.gz",
+          ]
+        wabt_release:
+          [
+            "https://github.com/WebAssembly/wabt/releases/download/1.0.24/wabt-1.0.24-ubuntu.tar.gz",
+          ]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -277,8 +283,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        wasi_sdk_release: ["https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk-12.0-linux.tar.gz"]
-        wabt_release: ["https://github.com/WebAssembly/wabt/releases/download/1.0.24/wabt-1.0.24-ubuntu.tar.gz"]
+        wasi_sdk_release:
+          [
+            "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk-12.0-linux.tar.gz",
+          ]
+        wabt_release:
+          [
+            "https://github.com/WebAssembly/wabt/releases/download/1.0.24/wabt-1.0.24-ubuntu.tar.gz",
+          ]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -355,7 +367,8 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        running_mode: ["classic-interp", "fast-interp", "jit", "aot"]
+        running_mode:
+          ["classic-interp", "fast-interp", "jit", "aot", "fast-jit"]
         test_option:
           [
             $DEFAULT_TEST_OPTIONS,
@@ -363,9 +376,25 @@ jobs:
             $SIMD_TEST_OPTIONS,
             $THREADS_TEST_OPTIONS,
           ]
-        include:
+        exclude:
+          # uncompatiable mode and feature
+          # classic-interp and fast-interp don't support simd
+          - running_mode: "classic-interp"
+            test_option: $SIMD_TEST_OPTIONS
+          - running_mode: "fast-interp"
+            test_option: $SIMD_TEST_OPTIONS
+          # aot and jit doesn't support multi module
+          - running_mode: "aot"
+            test_option: $MULTI_MODULES_TEST_OPTIONS
+          - running_mode: "jit"
+            test_option: $MULTI_MODULES_TEST_OPTIONS
+          # fast-jit only tested on default mode, exclude other three
           - running_mode: "fast-jit"
-            test_option: $DEFAULT_TEST_OPTIONS
+            test_option: $MULTI_MODULES_TEST_OPTIONS
+          - running_mode: "fast-jit"
+            test_option: $SIMD_TEST_OPTIONS
+          - running_mode: "fast-jit"
+            test_option: $THREADS_TEST_OPTIONS
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -385,7 +414,7 @@ jobs:
           key: ubuntu-20.04-${{ env.LLVM_CACHE_SUFFIX }}
 
       - name: Quit if cache miss
-        if:  matrix.running_mode != 'classic-interp' && matrix.running_mode != 'fast-interp' && steps.cache_llvm.outputs.cache-hit != 'true'
+        if: matrix.running_mode != 'classic-interp' && matrix.running_mode != 'fast-interp' && steps.cache_llvm.outputs.cache-hit != 'true'
         run: echo "::error::can not get prebuilt llvm libraries" && exit 1
 
       - name: install Ninja
@@ -397,7 +426,7 @@ jobs:
 
       #only install x32 support libraries when to run x86_32 cases
       - name: install x32 support libraries
-        if: (matrix.test_option == '$DEFAULT_TEST_OPTIONS' && matrix.running_mode != 'fast-jit') || matrix.test_option == '$THREADS_TEST_OPTIONS'
+        if: (matrix.test_option == '$DEFAULT_TEST_OPTIONS' || matrix.test_option == '$THREADS_TEST_OPTIONS') && matrix.running_mode != 'fast-jit' && matrix.running_mode != 'jit'
         run:
           # Add another apt repository as some packages cannot
           # be downloaded with the github default repository
@@ -407,6 +436,6 @@ jobs:
           sudo apt install -y g++-multilib lib32gcc-9-dev
 
       - name: run spec tests x86_32
-        if: (matrix.test_option == '$DEFAULT_TEST_OPTIONS' && matrix.running_mode != 'fast-jit') || matrix.test_option == '$THREADS_TEST_OPTIONS'
+        if: (matrix.test_option == '$DEFAULT_TEST_OPTIONS' || matrix.test_option == '$THREADS_TEST_OPTIONS') && matrix.running_mode != 'fast-jit' && matrix.running_mode != 'jit'
         run: ./test_wamr.sh ${{ env.X86_32_TARGET_TEST_OPTIONS }} ${{ matrix.test_option }} -t ${{ matrix.running_mode }}
         working-directory: ./tests/wamr-test-suites

--- a/.github/workflows/compilation_on_android_ubuntu.yml
+++ b/.github/workflows/compilation_on_android_ubuntu.yml
@@ -377,18 +377,18 @@ jobs:
             $THREADS_TEST_OPTIONS,
           ]
         exclude:
-          # uncompatiable mode and feature
+          # uncompatiable modes and features
           # classic-interp and fast-interp don't support simd
           - running_mode: "classic-interp"
             test_option: $SIMD_TEST_OPTIONS
           - running_mode: "fast-interp"
             test_option: $SIMD_TEST_OPTIONS
-          # aot and jit doesn't support multi module
+          # aot and jit don't support multi module
           - running_mode: "aot"
             test_option: $MULTI_MODULES_TEST_OPTIONS
           - running_mode: "jit"
             test_option: $MULTI_MODULES_TEST_OPTIONS
-          # fast-jit only tested on default mode, exclude other three
+          # fast-jit is only tested on default mode, exclude other three
           - running_mode: "fast-jit"
             test_option: $MULTI_MODULES_TEST_OPTIONS
           - running_mode: "fast-jit"
@@ -399,9 +399,19 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
 
+      - name: set env variable(if llvm are used)
+        if: matrix.running_mode == 'aot' || matrix.running_mode == 'jit'
+        run: echo "USE_LLVM=true" >> $GITHUB_ENV
+
+      - name: set env variable(if x86_32 test needed)
+        if: > 
+            (matrix.test_option == '$DEFAULT_TEST_OPTIONS' || matrix.test_option == '$THREADS_TEST_OPTIONS') 
+            && matrix.running_mode != 'fast-jit' && matrix.running_mode != 'jit'
+        run: echo "TEST_ON_X86_32=true" >> $GITHUB_ENV
+
       #only download llvm libraries in jit and aot mode
       - name: Get LLVM libraries
-        if: matrix.running_mode != 'classic-interp' && matrix.running_mode != 'fast-interp'
+        if: env.USE_LLVM == 'true'
         id: cache_llvm
         uses: actions/cache@v3
         with:
@@ -414,7 +424,7 @@ jobs:
           key: ubuntu-20.04-${{ env.LLVM_CACHE_SUFFIX }}
 
       - name: Quit if cache miss
-        if: matrix.running_mode != 'classic-interp' && matrix.running_mode != 'fast-interp' && steps.cache_llvm.outputs.cache-hit != 'true'
+        if: env.USE_LLVM == 'true' && steps.cache_llvm.outputs.cache-hit != 'true'
         run: echo "::error::can not get prebuilt llvm libraries" && exit 1
 
       - name: install Ninja
@@ -426,7 +436,7 @@ jobs:
 
       #only install x32 support libraries when to run x86_32 cases
       - name: install x32 support libraries
-        if: (matrix.test_option == '$DEFAULT_TEST_OPTIONS' || matrix.test_option == '$THREADS_TEST_OPTIONS') && matrix.running_mode != 'fast-jit' && matrix.running_mode != 'jit'
+        if: env.TEST_ON_X86_32 == 'true'
         run:
           # Add another apt repository as some packages cannot
           # be downloaded with the github default repository
@@ -436,6 +446,6 @@ jobs:
           sudo apt install -y g++-multilib lib32gcc-9-dev
 
       - name: run spec tests x86_32
-        if: (matrix.test_option == '$DEFAULT_TEST_OPTIONS' || matrix.test_option == '$THREADS_TEST_OPTIONS') && matrix.running_mode != 'fast-jit' && matrix.running_mode != 'jit'
+        if: env.TEST_ON_X86_32 == 'true'
         run: ./test_wamr.sh ${{ env.X86_32_TARGET_TEST_OPTIONS }} ${{ matrix.test_option }} -t ${{ matrix.running_mode }}
         working-directory: ./tests/wamr-test-suites

--- a/.github/workflows/compilation_on_android_ubuntu.yml
+++ b/.github/workflows/compilation_on_android_ubuntu.yml
@@ -363,13 +363,16 @@ jobs:
             $SIMD_TEST_OPTIONS,
             $THREADS_TEST_OPTIONS,
           ]
+        includes:
+          - running_mode: "fast-jit"
+            test_option: $DEFAULT_TEST_OPTIONS
     steps:
       - name: checkout
         uses: actions/checkout@v3
 
       #only download llvm libraries in jit and aot mode
       - name: Get LLVM libraries
-        if: matrix.running_mode == 'jit' || matrix.running_mode == 'aot'
+        if: matrix.running_mode != 'classic-interp' && matrix.running_mode != 'fast-interp'
         id: cache_llvm
         uses: actions/cache@v3
         with:
@@ -382,7 +385,7 @@ jobs:
           key: ubuntu-20.04-${{ env.LLVM_CACHE_SUFFIX }}
 
       - name: Quit if cache miss
-        if: (matrix.running_mode == 'jit' || matrix.running_mode == 'aot') && steps.cache_llvm.outputs.cache-hit != 'true'
+        if:  matrix.running_mode != 'classic-interp' && matrix.running_mode != 'fast-interp' && steps.cache_llvm.outputs.cache-hit != 'true'
         run: echo "::error::can not get prebuilt llvm libraries" && exit 1
 
       - name: install Ninja

--- a/.github/workflows/compilation_on_sgx.yml
+++ b/.github/workflows/compilation_on_sgx.yml
@@ -322,6 +322,12 @@ jobs:
       matrix:
         running_mode: ["classic-interp", "fast-interp", "aot"]
         test_option: ["-x -p -s spec -P", "-x -p -s spec -S -P"]
+        exclude:
+          - running_mode: "classic-interp"
+            test_option: "-x -p -s spec -S -P"
+          - running_mode: "fast-interp"
+            test_option: "-x -p -s spec -S -P"
+
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/compilation_on_sgx.yml
+++ b/.github/workflows/compilation_on_sgx.yml
@@ -322,6 +322,7 @@ jobs:
       matrix:
         running_mode: ["classic-interp", "fast-interp", "aot"]
         test_option: ["-x -p -s spec -P", "-x -p -s spec -S -P"]
+        # classic-interp and fast-interp don't support simd
         exclude:
           - running_mode: "classic-interp"
             test_option: "-x -p -s spec -S -P"

--- a/.github/workflows/compilation_on_sgx.yml
+++ b/.github/workflows/compilation_on_sgx.yml
@@ -327,6 +327,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Get LLVM libraries
+        if: matrix.running_mode == 'aot'
         id: cache_llvm
         uses: actions/cache@v3
         with:
@@ -339,7 +340,7 @@ jobs:
           key: ubuntu-20.04-${{ env.LLVM_CACHE_SUFFIX }}
 
       - name: Quit if cache miss
-        if: steps.cache_llvm.outputs.cache-hit != 'true'
+        if: matrix.running_mode == 'aot' && steps.cache_llvm.outputs.cache-hit != 'true'
         run: echo "::error::can not get prebuilt llvm libraries" && exit 1
 
       - name: install Ninja


### PR DESCRIPTION
1. Remove unnecessary download llvm cache for classic/fast interpreter spec test
2. Add Fast JIT to spec case test