### PR TITLE
Fixing GitHub actions outputs deprecated syntax

### DIFF
--- a/.github/workflows/compilation_on_android_ubuntu.yml
+++ b/.github/workflows/compilation_on_android_ubuntu.yml
@@ -77,20 +77,16 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-20.04' }}
         run: |
           if [[ ${{ github.repository }} == */wasm-micro-runtime ]]; then
-            echo "::set-output name=light::green"
+            echo "light=green" >> "$GITHUB_OUTPUT"
           else
-            echo "::set-output name=light::red"
+            echo "light=red" >> "$GITHUB_OUTPUT"
           fi
 
       - name: do_check_on_ubuntu_2204
         id: do_check_on_ubuntu_2204
         if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: |
-          if [[ ${{ github.repository }} == */wasm-micro-runtime ]]; then
-            echo "::set-output name=light::green"
-          else
-            echo "::set-output name=light::green"
-          fi
+          echo "light=green" >> "$GITHUB_OUTPUT"
 
   build_llvm_libraries:
     needs: check_repo

--- a/.github/workflows/compilation_on_macos.yml
+++ b/.github/workflows/compilation_on_macos.yml
@@ -69,9 +69,9 @@ jobs:
         if: ${{ matrix.os == 'macos-latest' }}
         run: |
           if [[ ${{ github.repository }} == */wasm-micro-runtime ]]; then
-            echo "::set-output name=light::green"
+            echo "light=green" >> "$GITHUB_OUTPUT"
           else
-            echo "::set-output name=light::red"
+            echo "light=red" >> "$GITHUB_OUTPUT"
           fi
 
   build_llvm_libraries:

--- a/.github/workflows/compilation_on_sgx.yml
+++ b/.github/workflows/compilation_on_sgx.yml
@@ -68,11 +68,7 @@ jobs:
         id: do_check_on_ubuntu_2004
         if: ${{ matrix.os == 'ubuntu-20.04' }}
         run: |
-          if [[ ${{ github.repository }} == */wasm-micro-runtime ]]; then
-            echo "::set-output name=light::green"
-          else
-            echo "::set-output name=light::green"
-          fi
+          echo "light=green" >> "$GITHUB_OUTPUT"
 
   build_llvm_libraries:
     needs: check_repo


### PR DESCRIPTION
# About this PR

Current output syntax used in github actions is [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). This addresses https://github.com/bytecodealliance/wasm-micro-runtime/issues/1639.
Also, unnecessary conditionals, resulting always in `light=green`, have been removed.

Signed-off-by: Andrés Felipe Barco Santa <andres@engflow.com>