### PR TITLE
linux-sgx: use non-destructive modes for opening files using SGX IPFS.

### DIFF
--- a/samples/file/wasm-app/main.c
+++ b/samples/file/wasm-app/main.c
@@ -26,6 +26,7 @@ main(int argc, char **argv)
     const char *text = FILE_TEXT;
     char buffer[1000];
     int ret;
+    long long stat_size;
 
     // Test: File opening (fopen)
     printf("Opening a file..\n");
@@ -114,17 +115,25 @@ main(int argc, char **argv)
     assert(ftell(file) == strlen(text) + 2 * ADDITIONAL_SPACE);
     printf("[Test] Extension of the file size passed.\n");
 
+    // Display some debug information
+    printf("Getting the size of the file on disk..\n");
+    struct stat st;
+    stat(PATH_TEST_FILE, &st);
+    stat_size = st.st_size;
+    assert(stat_size != 0);
+
+    // Compare with the size from fstat
+    fstat(fileno(file), &st);
+    printf("The file size is: %lld (stat), %lld (fstat).\n", stat_size,
+           st.st_size);
+    assert(stat_size != 0);
+    assert(stat_size == st.st_size);
+
     // Test: closing the file (fclose)
     printf("Closing from the file..\n");
     ret = fclose(file);
     assert(ret == 0);
     printf("[Test] Closing file passed.\n");
-
-    // Display some debug information
-    printf("Getting the size of the file on disk..\n");
-    struct stat st;
-    stat(PATH_TEST_FILE, &st);
-    printf("The file size is %lld.\n", st.st_size);
 
     printf("All the tests passed!\n");
 


### PR DESCRIPTION
Hello,

I'm benchmarking some applications using SGX IPFS, and I realized an issue when a file is opened with a _destructive mode_ (i.e., a mode that truncates the target file). Indeed, the following operations are performed when a file is opened with SGX IPFS:

 1. the WASI layer opens a file descriptor on the file (the standard fd),
 2. the SGX IPFS API opens a file descriptor on the same file (the IPFS fd).

While there is no issue with opening modes that do not truncate files, when a file is opened with the modes "w" or "w+", the two steps truncate the same file. As a result, some POSIX calls done on the standard file descriptor works on the truncated (no longer existing) file. This is typically the case with `fstat`, which returns some attributes of a file. When used on the file descriptor of the first step, the values returned are never updated (e.g., the file size).

The fix is to honour the original opening mode of the first step but uses an alternate (non-destructive) opening mode for the second step. This PR substitutes the destructive modes (w and w+) with non-destructive alternatives (r+). As a result, the truncate operation is still honoured by the first step, and the file descriptor of the first step remains valid afterwards.

I provided additional assertions in the file sample to validate this use case (typically, these assertions fail in the `main` branch).

Cheers