### PR TITLE
[CI] Fixing GitHub actions outputs deprecated syntax

### DIFF
--- a/.github/scripts/reuse_latest_release_binaries.py
+++ b/.github/scripts/reuse_latest_release_binaries.py
@@ -94,8 +94,9 @@ def main():
 
 if __name__ == "__main__":
     # use output to indicate results
-    # echo "::set-output name=result::${result}"
-    print(f'::set-output name=result::{"hit" if main() else "not-hit"}')
+    # echo "result=${result}" >> "$GITHUB_OUTPUT"
+    with open(os.environ.get("GITHUB_OUTPUT"), 'a') as output_file:
+        output_file.write("hit\n" if main() else "not-hit\n")
 
     # always return 0
     sys.exit(0)

--- a/.github/scripts/reuse_latest_release_binaries.py
+++ b/.github/scripts/reuse_latest_release_binaries.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
     # use output to indicate results
     # echo "result=${result}" >> "$GITHUB_OUTPUT"
     with open(os.environ.get("GITHUB_OUTPUT"), 'a') as output_file:
-        output_file.write("hit\n" if main() else "not-hit\n")
+        output_file.write("result=hit\n" if main() else "result=not-hit\n")
 
     # always return 0
     sys.exit(0)

--- a/.github/workflows/create_tag.yml
+++ b/.github/workflows/create_tag.yml
@@ -45,20 +45,20 @@ jobs:
           #
           # set output
           if [[ ${diff_versioning} == 'major_minor_change' ]];then
-            echo "::set-output name=minor_version::true"
+            echo "minor_version=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::set-output name=minor_version::false"
+            echo "minor_version=false" >> "$GITHUB_OUTPUT"
           fi
           #
           #
           if [[ -z ${new_ver} ]]; then
             echo "::error::please indicate the right semantic version in build-scripts/config_common.cmake"
-            echo "::set-output name=new_ver::''"
-            echo "::set-output name=new_tag::''"
+            echo "new_ver=''" >> "$GITHUB_OUTPUT"
+            echo "new_tag=''" >> "$GITHUB_OUTPUT"
             exit 1
           else
-            echo "::set-output name=new_ver::${new_ver}"
-            echo "::set-output name=new_tag::WAMR-${new_ver}"
+            echo "new_ver=${new_ver}" >> "$GITHUB_OUTPUT"
+            echo "new_tag=WAMR-${new_ver}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: push tag


### PR DESCRIPTION
# About this PR

Current output syntax used in github actions is [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). This addresses https://github.com/bytecodealliance/wasm-micro-runtime/issues/1639.


Signed-off-by: Andrés Felipe Barco Santa <andres@engflow.com>