### PR TITLE
Remove an improper assumption when creating wasm_trap

### DIFF
--- a/samples/wasm-c-api/src/trap.c
+++ b/samples/wasm-c-api/src/trap.c
@@ -143,6 +143,8 @@ int main(int argc, const char* argv[]) {
     own wasm_name_t message;
     wasm_trap_message(trap, &message);
     printf("> %s\n", message.data);
+    assert(message.num_elems > 0);
+    assert(strncmp(message.data, "Exception: ", strlen("Exception: ")) == 0);
 
     printf("Printing origin...\n");
     own wasm_frame_t* frame = wasm_trap_origin(trap);


### PR DESCRIPTION
it is allowed to have mutltiple stores in an engine and instances in a store. Let a wasm_function_t pass its wasm_store_t is more efficient than searching in all.