### PR TITLE
chore: Update MinGW docs

### DIFF
--- a/doc/build_wamr.md
+++ b/doc/build_wamr.md
@@ -385,18 +385,14 @@ arguments for cmake:
 
 ```Bash
 cmake .. -G"Unix Makefiles" \
-         -DWAMR_BUILD_LIBC_UVWASI=0 \
          -DWAMR_BUILD_INVOKE_NATIVE_GENERAL=1 \
          -DWAMR_DISABLE_HW_BOUND_CHECK=1
 ````
 
 Note that WASI will be disabled until further work is done towards full MinGW support.
 
-- uvwasi not building out of the box, though it reportedly supports MinGW.
 - Failing compilation of assembler files, the C version of `invokeNative()` will
 be used instead.
-- Compiler complaining about missing `UnwindInfoAddress` field in `RUNTIME_FUNCTION`
-struct (winnt.h).
 
 
 VxWorks


### PR DESCRIPTION
I'm not sure if these docs are outdated, but I'm able to build WAMR in a MinGW environment (for OCaml bindings). Was uvwasi support fixed for MinGW in the past?

While it builds fine, I'm investigating a `UVWASI_EINVAL` error, which shouldn't be related to these docs.