### PR TITLE
linux-sgx: allow to open files with arbitrary pathes in the sandbox using IPFS.

### DIFF
--- a/core/shared/platform/linux-sgx/sgx_file.c
+++ b/core/shared/platform/linux-sgx/sgx_file.c
@@ -88,6 +88,8 @@ ocall_linkat(int *p_ret, int olddirfd, const char *oldpath, int newdirfd,
 int
 ocall_unlinkat(int *p_ret, int dirfd, const char *pathname, int flags);
 int
+ocall_readlink(ssize_t *p_ret, const char *pathname, char *buf, size_t bufsiz);
+int
 ocall_readlinkat(ssize_t *p_ret, int dirfd, const char *pathname, char *buf,
                  size_t bufsiz);
 int
@@ -190,17 +192,25 @@ openat(int dirfd, const char *pathname, int flags, ...)
         errno = get_errno();
 
 #if WASM_ENABLE_SGX_IPFS != 0
-    // When WAMR uses Intel SGX IPFS to enabled, it opens a second
-    // file descriptor to interact with the secure file.
-    // The first file descriptor opened earlier is used to interact
-    // with the metadata of the file (e.g., time, flags, etc.).
-    int ret;
-    void *file_ptr = ipfs_fopen(fd, pathname, flags);
-    if (file_ptr == NULL) {
-        if (ocall_close(&ret, fd) != SGX_SUCCESS) {
-            TRACE_OCALL_FAIL();
-        }
+    struct stat sb;
+    int ret = fstatat(dirfd, pathname, &sb, 0);
+    if (ret < 0)
         return -1;
+
+    // Ony files are managed by SGX IPFS
+    if (S_ISREG(sb.st_mode)) {
+        // When WAMR uses Intel SGX IPFS to enabled, it opens a second
+        // file descriptor to interact with the secure file.
+        // The first file descriptor opened earlier is used to interact
+        // with the metadata of the file (e.g., time, flags, etc.).
+        int ret;
+        void *file_ptr = ipfs_fopen(fd, flags);
+        if (file_ptr == NULL) {
+            if (ocall_close(&ret, fd) != SGX_SUCCESS) {
+                TRACE_OCALL_FAIL();
+            }
+            return -1;
+        }
     }
 #endif
 
@@ -690,6 +700,24 @@ unlinkat(int dirfd, const char *pathname, int flags)
     int ret;
 
     if (ocall_unlinkat(&ret, dirfd, pathname, flags) != SGX_SUCCESS) {
+        TRACE_OCALL_FAIL();
+        return -1;
+    }
+
+    if (ret == -1)
+        errno = get_errno();
+    return ret;
+}
+
+ssize_t
+readlink(const char *pathname, char *buf, size_t bufsiz)
+{
+    ssize_t ret;
+
+    if (buf == NULL)
+        return -1;
+
+    if (ocall_readlink(&ret, pathname, buf, bufsiz) != SGX_SUCCESS) {
         TRACE_OCALL_FAIL();
         return -1;
     }

--- a/core/shared/platform/linux-sgx/sgx_file.h
+++ b/core/shared/platform/linux-sgx/sgx_file.h
@@ -219,6 +219,8 @@ linkat(int olddirfd, const char *oldpath, int newdirfd, const char *newpath,
 int
 unlinkat(int dirfd, const char *pathname, int flags);
 ssize_t
+readlink(const char *pathname, char *buf, size_t bufsiz);
+ssize_t
 readlinkat(int dirfd, const char *pathname, char *buf, size_t bufsiz);
 int
 symlinkat(const char *target, int newdirfd, const char *linkpath);

--- a/core/shared/platform/linux-sgx/sgx_ipfs.c
+++ b/core/shared/platform/linux-sgx/sgx_ipfs.c
@@ -306,9 +306,8 @@ ipfs_fopen(int fd, int flags)
     // Resolve the symbolic link to real absolute path, because IPFS can only
     // open a file with a same file name it was initially created. Otherwise,
     // IPFS throws SGX_ERROR_FILE_NAME_MISMATCH.
-    char real_path[PATH_MAX];
-    ret = readlink(symbolic_path, real_path, PATH_MAX);
-    real_path[PATH_MAX - 1] = '\0';
+    char real_path[PATH_MAX] = { 0 };
+    ret = readlink(symbolic_path, real_path, PATH_MAX - 1);
     if (ret == -1)
         return NULL;
 

--- a/core/shared/platform/linux-sgx/sgx_ipfs.c
+++ b/core/shared/platform/linux-sgx/sgx_ipfs.c
@@ -295,22 +295,20 @@ ipfs_fopen(int fd, int flags)
     // support opening a relative path to a file descriptor (i.e., openat).
     // Using the symbolic link in /proc/self allows to retrieve the same path as
     // opened by the initial openat and respects the chroot of WAMR.
-    int size_of_path = snprintf(NULL, 0, "/proc/self/fd/%d", fd) + 1;
-    if (size_of_path < 0) {
-        errno = EINVAL;
+    size_t ret;
+    char symbolic_path[32];
+    ret = snprintf(symbolic_path, sizeof(symbolic_path), "/proc/self/fd/%d", fd);
+    if (ret >= sizeof(symbolic_path)) {
+        errno = ENAMETOOLONG;
         return NULL;
     }
-
-    char *symbolic_path = BH_MALLOC(size_of_path);
-    snprintf(symbolic_path, size_of_path, "/proc/self/fd/%d", fd);
 
     // Resolve the symbolic link to real absolute path, because IPFS can only
     // open a file with a same file name it was initially created. Otherwise,
     // IPFS throws SGX_ERROR_FILE_NAME_MISMATCH.
     char real_path[PATH_MAX];
-    size_t ret = readlink(symbolic_path, real_path, PATH_MAX);
+    ret = readlink(symbolic_path, real_path, PATH_MAX);
     real_path[PATH_MAX - 1] = '\0';
-    BH_FREE(symbolic_path);
     if (ret == -1)
         return NULL;
 

--- a/core/shared/platform/linux-sgx/sgx_ipfs.c
+++ b/core/shared/platform/linux-sgx/sgx_ipfs.c
@@ -297,7 +297,8 @@ ipfs_fopen(int fd, int flags)
     // opened by the initial openat and respects the chroot of WAMR.
     size_t ret;
     char symbolic_path[32];
-    ret = snprintf(symbolic_path, sizeof(symbolic_path), "/proc/self/fd/%d", fd);
+    ret =
+        snprintf(symbolic_path, sizeof(symbolic_path), "/proc/self/fd/%d", fd);
     if (ret >= sizeof(symbolic_path)) {
         errno = ENAMETOOLONG;
         return NULL;

--- a/core/shared/platform/linux-sgx/sgx_ipfs.h
+++ b/core/shared/platform/linux-sgx/sgx_ipfs.h
@@ -28,7 +28,7 @@ ipfs_write(int fd, const struct iovec *iov, int iovcnt, bool has_offset,
 int
 ipfs_close(int fd);
 void *
-ipfs_fopen(int fd, const char *filename, int flags);
+ipfs_fopen(int fd, int flags);
 int
 ipfs_fflush(int fd);
 off_t

--- a/core/shared/platform/linux-sgx/sgx_wamr.edl
+++ b/core/shared/platform/linux-sgx/sgx_wamr.edl
@@ -48,6 +48,9 @@ enclave {
                          int flags);
         int ocall_unlinkat(int dirfd, [in, string]const char *pathname,
                            int flags);
+        ssize_t ocall_readlink([in, string]const char *pathname,
+                               [out, size=bufsiz]char *buf,
+                               size_t bufsiz);
         ssize_t ocall_readlinkat(int dirfd,
                                  [in, string]const char *pathname,
                                  [out, size=bufsiz]char *buf,

--- a/core/shared/platform/linux-sgx/untrusted/file.c
+++ b/core/shared/platform/linux-sgx/untrusted/file.c
@@ -187,6 +187,12 @@ ocall_unlinkat(int dirfd, const char *pathname, int flags)
 }
 
 ssize_t
+ocall_readlink(const char *pathname, char *buf, size_t bufsiz)
+{
+    return readlink(pathname, buf, bufsiz);
+}
+
+ssize_t
 ocall_readlinkat(int dirfd, const char *pathname, char *buf, size_t bufsiz)
 {
     return readlinkat(dirfd, pathname, buf, bufsiz);

--- a/samples/file/wasm-app/main.c
+++ b/samples/file/wasm-app/main.c
@@ -12,7 +12,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#define PATH_TEST_FILE "test.txt"
+#define PATH_TEST_FOLDER "/test"
+#define PATH_TEST_FILE (PATH_TEST_FOLDER "/test.txt")
 #define FILE_TEXT "Hello, world!"
 #define WORLD_OFFSET 7
 #define NAME_REPLACMENT "James"
@@ -27,6 +28,10 @@ main(int argc, char **argv)
     char buffer[1000];
     int ret;
     long long stat_size;
+
+    // Test: Create a folder to store the file, if it does not exist yet
+    ret = mkdir(PATH_TEST_FOLDER, 777);
+    assert(ret == 0 || (ret == -1 && errno == EEXIST));
 
     // Test: File opening (fopen)
     printf("Opening a file..\n");

--- a/samples/file/wasm-app/main.c
+++ b/samples/file/wasm-app/main.c
@@ -12,7 +12,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#define PATH_TEST_FOLDER "/test"
+#define PATH_TEST_FOLDER "./test"
 #define PATH_TEST_FILE (PATH_TEST_FOLDER "/test.txt")
 #define FILE_TEXT "Hello, world!"
 #define WORLD_OFFSET 7


### PR DESCRIPTION
Hello,

A limitation of the current implementation of SGX IPFS in WAMR prevented to openof files which were not in the current directory. This restriction is lifted and can now open files in paths, similarly to the WASI openat call, which takes into account the sandbox of the file system.

Under the scenes, SGX IPFS retrieves the path of the symbolic link of the file descriptor using `/proc/self` and resolves the path of the opened file using `readlink`.

Cheers