### PR TITLE
Avoid generating some unused LLVM IRs

### DIFF
--- a/core/iwasm/interpreter/wasm.h
+++ b/core/iwasm/interpreter/wasm.h
@@ -247,11 +247,6 @@ struct WASMFunction {
 
     uint32 max_stack_cell_num;
     uint32 max_block_num;
-    /* Whether function has opcode memory.grow */
-    bool has_op_memory_grow;
-    /* Whether function has opcode call or
-       call_indirect */
-    bool has_op_func_call;
     uint32 code_size;
     uint8 *code;
 #if WASM_ENABLE_FAST_INTERP != 0
@@ -260,11 +255,28 @@ struct WASMFunction {
     uint8 *consts;
     uint32 const_cell_num;
 #endif
+
 #if WASM_ENABLE_FAST_JIT != 0
     void *fast_jit_jitted_code;
 #endif
 #if WASM_ENABLE_JIT != 0
     void *llvm_jit_func_ptr;
+#endif
+
+#if WASM_ENABLE_FAST_JIT != 0 || WASM_ENABLE_JIT != 0 \
+    || WASM_ENABLE_WAMR_COMPILER != 0
+    /* Whether function has opcode memory.grow */
+    bool has_op_memory_grow;
+    /* Whether function has opcode call or call_indirect */
+    bool has_op_func_call;
+#endif
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+    /* Whether function has memory operation opcodes */
+    bool has_memory_operations;
+    /* Whether function has opcode call_indirect */
+    bool has_op_call_indirect;
+    /* Whether function has opcode set_global_aux_stack */
+    bool has_op_set_global_aux_stack;
 #endif
 };
 

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -8245,6 +8245,9 @@ re_scan:
 #if WASM_ENABLE_FAST_INTERP != 0
                 emit_uint32(loader_ctx, mem_offset);
 #endif
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                func->has_memory_operations = true;
+#endif
                 switch (opcode) {
                     /* load */
                     case WASM_OP_I32_LOAD:
@@ -8294,9 +8297,6 @@ re_scan:
                     default:
                         break;
                 }
-#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
-                func->has_memory_operations = true;
-#endif
                 break;
             }
 
@@ -9567,6 +9567,9 @@ re_scan:
                     emit_uint32(loader_ctx, mem_offset);
 #endif
                 }
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                func->has_memory_operations = true;
+#endif
                 switch (opcode) {
                     case WASM_OP_ATOMIC_NOTIFY:
                         POP2_AND_PUSH(VALUE_TYPE_I32, VALUE_TYPE_I32);

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -8933,6 +8933,9 @@ re_scan:
                         read_leb_uint32(p, p_end, mem_offset); /* offset */
 
                         POP_AND_PUSH(VALUE_TYPE_I32, VALUE_TYPE_V128);
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                        func->has_memory_operations = true;
+#endif
                         break;
                     }
 
@@ -8950,6 +8953,9 @@ re_scan:
 
                         POP_V128();
                         POP_I32();
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                        func->has_memory_operations = true;
+#endif
                         break;
                     }
 
@@ -9174,6 +9180,9 @@ re_scan:
                         if (opcode < SIMD_v128_store8_lane) {
                             PUSH_V128();
                         }
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                        func->has_memory_operations = true;
+#endif
                         break;
                     }
 
@@ -9191,6 +9200,9 @@ re_scan:
                         read_leb_uint32(p, p_end, mem_offset); /* offset */
 
                         POP_AND_PUSH(VALUE_TYPE_I32, VALUE_TYPE_V128);
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                        func->has_memory_operations = true;
+#endif
                         break;
                     }
 

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -7448,7 +7448,10 @@ re_scan:
                     SET_CUR_BLOCK_STACK_POLYMORPHIC_STATE(true);
                 }
 #endif
+#if WASM_ENABLE_FAST_JIT != 0 || WASM_ENABLE_JIT != 0 \
+    || WASM_ENABLE_WAMR_COMPILER != 0
                 func->has_op_func_call = true;
+#endif
                 break;
             }
 
@@ -7542,7 +7545,13 @@ re_scan:
                     SET_CUR_BLOCK_STACK_POLYMORPHIC_STATE(true);
                 }
 #endif
+#if WASM_ENABLE_FAST_JIT != 0 || WASM_ENABLE_JIT != 0 \
+    || WASM_ENABLE_WAMR_COMPILER != 0
                 func->has_op_func_call = true;
+#endif
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                func->has_op_call_indirect = true;
+#endif
                 break;
             }
 
@@ -8160,6 +8169,9 @@ re_scan:
                     }
 #endif
                     *p_org = WASM_OP_SET_GLOBAL_AUX_STACK;
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                    func->has_op_set_global_aux_stack = true;
+#endif
                 }
 #else  /* else of WASM_ENABLE_FAST_INTERP */
                 if (global_type == VALUE_TYPE_I64
@@ -8282,6 +8294,9 @@ re_scan:
                     default:
                         break;
                 }
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                func->has_memory_operations = true;
+#endif
                 break;
             }
 
@@ -8296,6 +8311,9 @@ re_scan:
                 PUSH_I32();
 
                 module->possible_memory_grow = true;
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                func->has_memory_operations = true;
+#endif
                 break;
 
             case WASM_OP_MEMORY_GROW:
@@ -8308,8 +8326,14 @@ re_scan:
                 }
                 POP_AND_PUSH(VALUE_TYPE_I32, VALUE_TYPE_I32);
 
-                func->has_op_memory_grow = true;
                 module->possible_memory_grow = true;
+#if WASM_ENABLE_FAST_JIT != 0 || WASM_ENABLE_JIT != 0 \
+    || WASM_ENABLE_WAMR_COMPILER != 0
+                func->has_op_memory_grow = true;
+#endif
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                func->has_memory_operations = true;
+#endif
                 break;
 
             case WASM_OP_I32_CONST:
@@ -8659,6 +8683,9 @@ re_scan:
                         POP_I32();
                         POP_I32();
                         POP_I32();
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                        func->has_memory_operations = true;
+#endif
                         break;
                     }
                     case WASM_OP_DATA_DROP:
@@ -8676,6 +8703,9 @@ re_scan:
                         if (module->data_seg_count1 == 0)
                             goto fail_data_cnt_sec_require;
 
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                        func->has_memory_operations = true;
+#endif
                         break;
                     }
                     case WASM_OP_MEMORY_COPY:
@@ -8692,6 +8722,9 @@ re_scan:
                         POP_I32();
                         POP_I32();
                         POP_I32();
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                        func->has_memory_operations = true;
+#endif
                         break;
                     }
                     case WASM_OP_MEMORY_FILL:
@@ -8707,7 +8740,11 @@ re_scan:
                         POP_I32();
                         POP_I32();
                         POP_I32();
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                        func->has_memory_operations = true;
+#endif
                         break;
+                    }
                     fail_zero_byte_expected:
                         set_error_buf(error_buf, error_buf_size,
                                       "zero byte expected");
@@ -8721,7 +8758,6 @@ re_scan:
                         set_error_buf(error_buf, error_buf_size,
                                       "data count section required");
                         goto fail;
-                    }
 #endif /* WASM_ENABLE_BULK_MEMORY */
 #if WASM_ENABLE_REF_TYPES != 0
                     case WASM_OP_TABLE_INIT:

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -6398,6 +6398,9 @@ re_scan:
 #if WASM_ENABLE_FAST_INTERP != 0
                 emit_uint32(loader_ctx, mem_offset);
 #endif
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                func->has_memory_operations = true;
+#endif
                 switch (opcode) {
                     /* load */
                     case WASM_OP_I32_LOAD:
@@ -6447,9 +6450,6 @@ re_scan:
                     default:
                         break;
                 }
-#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
-                func->has_memory_operations = true;
-#endif
                 break;
             }
 
@@ -7037,6 +7037,9 @@ re_scan:
                     emit_uint32(loader_ctx, mem_offset);
 #endif
                 }
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                func->has_memory_operations = true;
+#endif
                 switch (opcode) {
                     case WASM_OP_ATOMIC_NOTIFY:
                         POP2_AND_PUSH(VALUE_TYPE_I32, VALUE_TYPE_I32);

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -5701,7 +5701,10 @@ re_scan:
                     }
                 }
 #endif
+#if WASM_ENABLE_FAST_JIT != 0 || WASM_ENABLE_JIT != 0 \
+    || WASM_ENABLE_WAMR_COMPILER != 0
                 func->has_op_func_call = true;
+#endif
                 break;
             }
 
@@ -5776,7 +5779,13 @@ re_scan:
                 }
 #endif
 
+#if WASM_ENABLE_FAST_JIT != 0 || WASM_ENABLE_JIT != 0 \
+    || WASM_ENABLE_WAMR_COMPILER != 0
                 func->has_op_func_call = true;
+#endif
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                func->has_op_call_indirect = true;
+#endif
                 break;
             }
 
@@ -6316,6 +6325,9 @@ re_scan:
                 else if (module->aux_stack_size > 0
                          && global_idx == module->aux_stack_top_global_index) {
                     *p_org = WASM_OP_SET_GLOBAL_AUX_STACK;
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                    func->has_op_set_global_aux_stack = true;
+#endif
                 }
 #else  /* else of WASM_ENABLE_FAST_INTERP */
                 if (is_64bit_type(global_type)) {
@@ -6435,6 +6447,9 @@ re_scan:
                     default:
                         break;
                 }
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                func->has_memory_operations = true;
+#endif
                 break;
             }
 
@@ -6446,6 +6461,9 @@ re_scan:
                 PUSH_I32();
 
                 module->possible_memory_grow = true;
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                func->has_memory_operations = true;
+#endif
                 break;
 
             case WASM_OP_MEMORY_GROW:
@@ -6455,8 +6473,14 @@ re_scan:
                 p++;
                 POP_AND_PUSH(VALUE_TYPE_I32, VALUE_TYPE_I32);
 
-                func->has_op_memory_grow = true;
                 module->possible_memory_grow = true;
+#if WASM_ENABLE_FAST_JIT != 0 || WASM_ENABLE_JIT != 0 \
+    || WASM_ENABLE_WAMR_COMPILER != 0
+                func->has_op_memory_grow = true;
+#endif
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                func->has_memory_operations = true;
+#endif
                 break;
 
             case WASM_OP_I32_CONST:
@@ -6781,6 +6805,7 @@ re_scan:
                         break;
 #if WASM_ENABLE_BULK_MEMORY != 0
                     case WASM_OP_MEMORY_INIT:
+                    {
                         read_leb_uint32(p, p_end, segment_index);
 #if WASM_ENABLE_FAST_INTERP != 0
                         emit_uint32(loader_ctx, segment_index);
@@ -6798,16 +6823,26 @@ re_scan:
                         POP_I32();
                         POP_I32();
                         POP_I32();
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                        func->has_memory_operations = true;
+#endif
                         break;
+                    }
                     case WASM_OP_DATA_DROP:
+                    {
                         read_leb_uint32(p, p_end, segment_index);
 #if WASM_ENABLE_FAST_INTERP != 0
                         emit_uint32(loader_ctx, segment_index);
 #endif
                         bh_assert(segment_index < module->data_seg_count);
                         bh_assert(module->data_seg_count1 > 0);
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                        func->has_memory_operations = true;
+#endif
                         break;
+                    }
                     case WASM_OP_MEMORY_COPY:
+                    {
                         /* both src and dst memory index should be 0 */
                         bh_assert(*(int16 *)p == 0x0000);
                         p += 2;
@@ -6819,8 +6854,13 @@ re_scan:
                         POP_I32();
                         POP_I32();
                         POP_I32();
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                        func->has_memory_operations = true;
+#endif
                         break;
+                    }
                     case WASM_OP_MEMORY_FILL:
+                    {
                         bh_assert(*p == 0);
                         p++;
 
@@ -6831,7 +6871,11 @@ re_scan:
                         POP_I32();
                         POP_I32();
                         POP_I32();
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_WAMR_COMPILER != 0
+                        func->has_memory_operations = true;
+#endif
                         break;
+                    }
 #endif /* WASM_ENABLE_BULK_MEMORY */
 #if WASM_ENABLE_REF_TYPES != 0
                     case WASM_OP_TABLE_INIT:

--- a/product-mini/platforms/zephyr/simple/CMakeLists.txt
+++ b/product-mini/platforms/zephyr/simple/CMakeLists.txt
@@ -43,7 +43,7 @@ endif ()
 # Override the global heap usage
 if (NOT DEFINED WAMR_BUILD_GLOBAL_HEAP_POOL)
   add_definitions (-DWASM_ENABLE_GLOBAL_HEAP_POOL=1)
-endif
+endif ()
 
 # Override the global heap size for small devices
 if (NOT DEFINED WAMR_BUILD_GLOBAL_HEAP_SIZE)


### PR DESCRIPTION
Refine the generated LLVM IRs at each function beginning, so as to fasten the LLVM IR optimization:
- Only create argv_buf if there are func calls in this function
- Only create native stack bound if stack bound check is enabled
- Only create aux stack info if there is op set_global_aux_stack
- Only create native symbol if indirect_mode is enabled
- Only create memory info if there are memory operations
- Only create func_type_indexes if there is op call_indirect