### PR TITLE
Update document and clear compile warnings

### DIFF
--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -1963,8 +1963,8 @@ wasm_module_new(wasm_store_t *store, const wasm_byte_vec_t *binary)
 destroy_lock:
     os_mutex_destroy(&module_ex->lock);
 remove_last:
-    bh_vector_remove((Vector *)store->modules, store->modules->num_elems - 1,
-                     NULL);
+    bh_vector_remove((Vector *)store->modules,
+                     (uint32)(store->modules->num_elems - 1), NULL);
 unload:
     wasm_runtime_unload(module_ex->module_comm_rt);
 free_vec:
@@ -2560,7 +2560,7 @@ wasm_module_share(wasm_module_t *module)
 void
 wasm_shared_module_delete(own wasm_shared_module_t *shared_module)
 {
-    return wasm_module_delete_internal((wasm_module_t *)shared_module);
+    wasm_module_delete_internal((wasm_module_t *)shared_module);
 }
 
 static wasm_func_t *

--- a/core/iwasm/compilation/aot_emit_numberic.c
+++ b/core/iwasm/compilation/aot_emit_numberic.c
@@ -243,19 +243,19 @@ compile_op_float_min_max(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     if (comp_ctx->disable_llvm_intrinsics
         && aot_intrinsic_check_capability(comp_ctx,
                                           is_f32 ? "f32_cmp" : "f64_cmp")) {
-        LLVMTypeRef param_types[3];
+        LLVMTypeRef param_types_intrinsic[3];
         LLVMValueRef opcond = LLVMConstInt(I32_TYPE, FLOAT_UNO, true);
-        param_types[0] = I32_TYPE;
-        param_types[1] = is_f32 ? F32_TYPE : F64_TYPE;
-        param_types[2] = param_types[1];
+        param_types_intrinsic[0] = I32_TYPE;
+        param_types_intrinsic[1] = is_f32 ? F32_TYPE : F64_TYPE;
+        param_types_intrinsic[2] = param_types_intrinsic[1];
         is_nan = aot_call_llvm_intrinsic(
             comp_ctx, func_ctx, is_f32 ? "f32_cmp" : "f64_cmp", I32_TYPE,
-            param_types, 3, opcond, left, right);
+            param_types_intrinsic, 3, opcond, left, right);
 
         opcond = LLVMConstInt(I32_TYPE, FLOAT_EQ, true);
         is_eq = aot_call_llvm_intrinsic(
             comp_ctx, func_ctx, is_f32 ? "f32_cmp" : "f64_cmp", I32_TYPE,
-            param_types, 3, opcond, left, right);
+            param_types_intrinsic, 3, opcond, left, right);
 
         if (!is_nan || !is_eq) {
             return NULL;

--- a/doc/build_wasm_app.md
+++ b/doc/build_wasm_app.md
@@ -126,6 +126,18 @@ If we want to build the wasm app with wasi mode, we may build the wasm app with 
 
 to generate a wasm binary with wasi mode, the auxiliary stack size is 8192 bytes, initial memory size is 64 KB,  heap base global and data end global are exported, wasi entry function exported (_start function), and all symbols are stripped. Note that it is wasi mode, so libc-wasi should be enabled by runtime embedder or iwasm (with `cmake -DWAMR_BUILD_LIBC_WASI=1`, enabled by iwasm in Linux by default), and normally no need to export main function, by default _start function is executed by iwasm.
 
+> Note: for the Rust project, we can set these flags by setting the `rustflags` in the Cargo configuration file, e.g. `<project_dir>/.cargo/config.toml` or `$CARGO_HOME/config.toml`, for example:
+> ```
+> [build]
+> rustflags = [
+>   "-C", "link-arg=--initial-memory=65536",
+>   "-C", "link-arg=-zstack-size=8192",
+>   "-C", "link-arg=--export=__heap_base",
+>   "-C", "link-arg=--export=__data_end",
+>   "-C", "link-arg=--strip-all",
+> ]
+> ```
+
 ## 2. How to reduce the footprint?
 
 Firstly if libc-builtin (-nostdlib) mode meets the requirements, e.g. there are no file io operations in wasm app, we should build the wasm app with -nostdlib option as possible as we can, since the compiler doesn't build the libc source code into wasm bytecodes, which greatly reduces the binary size.
@@ -138,11 +150,35 @@ Firstly if libc-builtin (-nostdlib) mode meets the requirements, e.g. there are 
   ```
   If the two globals are exported, and there are no memory.grow and memory.size opcodes (normally nostdlib mode doesn't introduce these opcodes since the libc malloc function isn't built into wasm bytecode), WAMR runtime will truncate the linear memory at the place of \__heap_base and append app heap to the end, so we don't need to allocate the memory specified by `-Wl,--initial-memory=n` which must be at least 64 KB. This is helpful for some embedded devices whose memory resource might be limited.
 
+> For the Rust project, please set the flags in the Cargo configuration file, for example:
+> ```
+> [build]
+> rustflags = [
+>   "-C", "link-arg=--export=__heap_base",
+>   "-C", "link-arg=--export=__data_end",
+>   "-C", "link-arg=--initial-memory=65536",
+> ]
+> ```
+
 - reduce auxiliary stack size
 
   The auxiliary stack is an area of linear memory, normally the size is 64 KB by default which might be a little large for embedded devices and partly used, we can use `-z stack-size=n` to set its size.
 
+> For the Rust project, please set the flag in the Cargo configuration file, for example:
+> [build]
+> rustflags = [
+>   "-C", "link-arg=-zstack-size=8192"
+> ]
+
 - use -O3 and -Wl,--strip-all
+
+> For the Rust project, please set the flag in the Cargo configuration file, for example:
+> ```
+> [build]
+> rustflags = [
+>  "-C", "link-arg=--strip-all"
+> ]
+> ```
 
 - reduce app heap size when running iwasm
 


### PR DESCRIPTION
Update build wasm app document, add how to set build sflags for Rust
project to reduce the footprint.

Clear Windows warnings and a shadow warning in aot_emit_numberic.c.