### PR TITLE
Fix sample ref-types/wasm-c-api build error with wab2wasm low version

### DIFF
--- a/samples/ref-types/CMakeLists.txt
+++ b/samples/ref-types/CMakeLists.txt
@@ -102,7 +102,16 @@ find_program(WAT2WASM
 
 if(NOT WAT2WASM)
   message(SEND_ERROR "can not find wat2wasm")
+else ()
+  execute_process(COMMAND ${WAT2WASM} --version
+                  OUTPUT_VARIABLE WAT2WASM_VERSION_OUTPUT)
+  string(STRIP ${WAT2WASM_VERSION_OUTPUT} WAT2WASM_VERSION)
+  message("-- Found wat2wasm ${WAT2WASM_VERSION}")
 endif()
+
+if (${WAT2WASM_VERSION} VERSION_LESS 1.0.26)
+  set(WAT2WASM_FLAGS "--enable-reference-types")
+endif ()
 
 include (${SHARED_DIR}/utils/uncommon/shared_uncommon.cmake)
 
@@ -122,7 +131,7 @@ endif()
 # wat to wasm
 file(GLOB WAT_FILE src/hello.wat)
 add_custom_target(hello_wasm ALL
-  COMMAND ${WAT2WASM} ${WAT_FILE} --enable-reference-types -o ${PROJECT_BINARY_DIR}/hello.wasm
+  COMMAND ${WAT2WASM} ${WAT_FILE} ${WAT2WASM_FLAGS} -o ${PROJECT_BINARY_DIR}/hello.wasm
   DEPENDS ${WAT_FILE}
   BYPRODUCTS ${PROJECT_BINARY_DIR}/hello.wasm
   VERBATIM

--- a/samples/wasm-c-api/CMakeLists.txt
+++ b/samples/wasm-c-api/CMakeLists.txt
@@ -104,7 +104,16 @@ find_program(WAT2WASM
 
 if(NOT WAT2WASM)
   message(SEND_ERROR "can not find wat2wasm")
+else ()
+  execute_process(COMMAND ${WAT2WASM} --version
+                  OUTPUT_VARIABLE WAT2WASM_VERSION_OUTPUT)
+  string(STRIP ${WAT2WASM_VERSION_OUTPUT} WAT2WASM_VERSION)
+  message("-- Found wat2wasm ${WAT2WASM_VERSION}")
 endif()
+
+if (${WAT2WASM_VERSION} VERSION_LESS 1.0.26)
+  set(WAT2WASM_FLAGS "--enable-reference-types")
+endif ()
 
 if(${WAMR_BUILD_AOT} EQUAL 1)
   ## locate wamrc
@@ -161,7 +170,7 @@ foreach(EX ${EXAMPLES})
   set(WAT ${CMAKE_CURRENT_LIST_DIR}/src/${EX}.wat)
 
   add_custom_target(${EX}_WASM
-    COMMAND ${WAT2WASM} ${WAT} --enable-reference-types -o ${PROJECT_BINARY_DIR}/${EX}.wasm
+    COMMAND ${WAT2WASM} ${WAT} ${WAT2WASM_FLAGS} -o ${PROJECT_BINARY_DIR}/${EX}.wasm
     DEPENDS ${WAT}
     BYPRODUCTS ${PROJECT_BINARY_DIR}/${EX}.wasm
     VERBATIM

--- a/samples/wasm-c-api/src/callback_chain.wat
+++ b/samples/wasm-c-api/src/callback_chain.wat
@@ -3,7 +3,7 @@
 
 (module
   (func $get_pairs (import "" "get_pairs") (result i32))
-  (func $log (import"" "log") (param i32 i32))
+  (func $log (import "" "log") (param i32 i32))
 
   (func $on_start (export "on_start")
     (call $log (i32.const 0) (i32.const 9))

--- a/samples/wasm-c-api/src/reflect.wat
+++ b/samples/wasm-c-api/src/reflect.wat
@@ -1,6 +1,6 @@
 (module
   (func (export "func") (param i32 f64 f32) (result i32) (unreachable))
   (global (export "global") f64 (f64.const 0))
-  (table (export "table") 0 50 anyfunc)
+  (table (export "table") 0 50 funcref)
   (memory (export "memory") 1)
 )


### PR DESCRIPTION
Fix build error in sample ref-types and wasm-c-api caused by the
version of wat2wasm: refine makefile to auto detect the wat2wasm
version and add the compile flag accordingly.