### PR TITLE
Create module hash for each module in SGX lib-rats

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -1160,6 +1160,12 @@ wasm_runtime_deinstantiate(WASMModuleInstanceCommon *module_inst)
     wasm_runtime_deinstantiate_internal(module_inst, false);
 }
 
+WASMModuleCommon *
+wasm_runtime_get_module(WASMModuleInstanceCommon *module_inst)
+{
+    return (WASMModuleCommon *)((WASMModuleInstance *)module_inst)->module;
+}
+
 WASMExecEnv *
 wasm_runtime_create_exec_env(WASMModuleInstanceCommon *module_inst,
                              uint32 stack_size)

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -485,6 +485,10 @@ WASM_RUNTIME_API_EXTERN void
 wasm_runtime_deinstantiate(WASMModuleInstanceCommon *module_inst);
 
 /* See wasm_export.h for description */
+WASM_RUNTIME_API_EXTERN WASMModuleCommon *
+wasm_runtime_get_module(WASMModuleInstanceCommon *module_inst);
+
+/* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN WASMFunctionInstanceCommon *
 wasm_runtime_lookup_function(WASMModuleInstanceCommon *const module_inst,
                              const char *name, const char *signature);

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -358,6 +358,17 @@ WASM_RUNTIME_API_EXTERN void
 wasm_runtime_unload(wasm_module_t module);
 
 /**
+ * Get the module hash of a WASM module, currently only available on
+ * linux-sgx platform when the remote attestation feature is enabled
+ *
+ * @param module the WASM module to retrieve
+ *
+ * @return the module hash of the WASM module
+ */
+char *
+wasm_runtime_get_module_hash(wasm_module_t module);
+
+/**
  * Set WASI parameters.
  *
  * While this API operates on a module, these parameters will be used

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -444,6 +444,16 @@ wasm_runtime_instantiate(const wasm_module_t module,
 WASM_RUNTIME_API_EXTERN void
 wasm_runtime_deinstantiate(wasm_module_inst_t module_inst);
 
+/**
+ * Get WASM module from WASM module instance
+ *
+ * @param module_inst the WASM module instance to retrieve
+ *
+ * @return the WASM module
+ */
+WASM_RUNTIME_API_EXTERN wasm_module_t
+wasm_runtime_get_module(wasm_module_inst_t module_inst);
+
 WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_is_wasi_mode(wasm_module_inst_t module_inst);
 

--- a/core/iwasm/libraries/lib-rats/lib_rats_common.h
+++ b/core/iwasm/libraries/lib-rats/lib_rats_common.h
@@ -11,9 +11,14 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define SGX_QUOTE_MAX_SIZE 8192
 #define SGX_USER_DATA_SIZE 64
 #define SGX_MEASUREMENT_SIZE 32
+
 /* clang-format off */
 typedef struct rats_sgx_evidence {
     uint8_t quote[SGX_QUOTE_MAX_SIZE];          /* The quote of the Enclave */
@@ -27,5 +32,9 @@ typedef struct rats_sgx_evidence {
     uint64_t att_xfrm;                          /* XSAVE Feature Request Mask */
 } rats_sgx_evidence_t;
 /* clang-format on */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/core/iwasm/libraries/lib-rats/lib_rats_wrapper.c
+++ b/core/iwasm/libraries/lib-rats/lib_rats_wrapper.c
@@ -16,13 +16,16 @@
 #include "bh_common.h"
 #include "lib_rats_common.h"
 
-extern char wasm_module_hash[SHA256_DIGEST_LENGTH];
+char *
+wasm_runtime_get_module_hash(wasm_module_t module);
 
 static int
 librats_collect_wrapper(wasm_exec_env_t exec_env, char **evidence_json,
                         const char *buffer, uint32_t buffer_size)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
+    wasm_module_t module = wasm_runtime_get_module(module_inst);
+    char *wasm_module_hash = wasm_runtime_get_module_hash(module);
 
     char *json, *str_ret;
     uint32_t str_ret_offset;

--- a/core/iwasm/libraries/lib-rats/lib_rats_wrapper.c
+++ b/core/iwasm/libraries/lib-rats/lib_rats_wrapper.c
@@ -16,9 +16,6 @@
 #include "bh_common.h"
 #include "lib_rats_common.h"
 
-char *
-wasm_runtime_get_module_hash(wasm_module_t module);
-
 static int
 librats_collect_wrapper(wasm_exec_env_t exec_env, char **evidence_json,
                         const char *buffer, uint32_t buffer_size)

--- a/core/iwasm/libraries/lib-rats/lib_rats_wrapper.h
+++ b/core/iwasm/libraries/lib-rats/lib_rats_wrapper.h
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 #include <string.h>
+
 #include "lib_rats_common.h"
 
 #ifdef __cplusplus

--- a/product-mini/platforms/linux-sgx/CMakeLists.txt
+++ b/product-mini/platforms/linux-sgx/CMakeLists.txt
@@ -140,14 +140,14 @@ endif()
 
 if (WAMR_BUILD_SGX_IPFS EQUAL 1)
     execute_process(
-        COMMAND bash -c "sed -i -E 's/^#define SGX_IPFS 0/#define SGX_IPFS 1/g' ${CMAKE_CURRENT_SOURCE_DIR}/enclave-sample/Enclave/Enclave.edl"
-        COMMAND bash -c "sed -i -E 's/^SGX_IPFS = 0/SGX_IPFS = 1/g' ${CMAKE_CURRENT_SOURCE_DIR}/enclave-sample/Makefile"
+        COMMAND bash -c "sed -i -E 's/^#define WASM_ENABLE_SGX_IPFS 0/#define WASM_ENABLE_SGX_IPFS 1/g' ${CMAKE_CURRENT_SOURCE_DIR}/enclave-sample/Enclave/Enclave.edl"
+        COMMAND bash -c "sed -i -E 's/^WAMR_BUILD_SGX_IPFS = 0/WAMR_BUILD_SGX_IPFS = 1/g' ${CMAKE_CURRENT_SOURCE_DIR}/enclave-sample/Makefile"
         OUTPUT_VARIABLE cmdOutput
     )
 else()
     execute_process(
-        COMMAND bash -c "sed -i -E 's/^#define SGX_IPFS 1/#define SGX_IPFS 0/g' ${CMAKE_CURRENT_SOURCE_DIR}/enclave-sample/Enclave/Enclave.edl"
-        COMMAND bash -c "sed -i -E 's/^SGX_IPFS = 1/SGX_IPFS = 0/g' ${CMAKE_CURRENT_SOURCE_DIR}/enclave-sample/Makefile"
+        COMMAND bash -c "sed -i -E 's/^#define WASM_ENABLE_SGX_IPFS 1/#define WASM_ENABLE_SGX_IPFS 0/g' ${CMAKE_CURRENT_SOURCE_DIR}/enclave-sample/Enclave/Enclave.edl"
+        COMMAND bash -c "sed -i -E 's/^WAMR_BUILD_SGX_IPFS = 1/WAMR_BUILD_SGX_IPFS = 0/g' ${CMAKE_CURRENT_SOURCE_DIR}/enclave-sample/Makefile"
         OUTPUT_VARIABLE cmdOutput
     )
 endif()

--- a/product-mini/platforms/linux-sgx/enclave-sample/App/App.cpp
+++ b/product-mini/platforms/linux-sgx/enclave-sample/App/App.cpp
@@ -103,7 +103,7 @@ enclave_init(sgx_enclave_id_t *p_eid)
                <= MAX_PATH - 1 - sizeof(TOKEN_FILENAME) - strlen("/")) {
         /* compose the token path */
         strncpy(token_path, home_dir, MAX_PATH);
-        strncat(token_path, "/", strlen("/"));
+        strncat(token_path, "/", strlen("/") + 1);
         strncat(token_path, TOKEN_FILENAME, sizeof(TOKEN_FILENAME) + 1);
     }
     else {

--- a/product-mini/platforms/linux-sgx/enclave-sample/Enclave/Enclave.cpp
+++ b/product-mini/platforms/linux-sgx/enclave-sample/Enclave/Enclave.cpp
@@ -303,7 +303,6 @@ handle_cmd_unload_module(uint64 *args, uint32 argc)
 #endif
 
     /* Destroy enclave module resources */
-
     if (enclave_module->wasi_arg_buf)
         wasm_runtime_free(enclave_module->wasi_arg_buf);
 
@@ -317,11 +316,6 @@ handle_cmd_unload_module(uint64 *args, uint32 argc)
 }
 
 #if WASM_ENABLE_LIB_RATS != 0
-extern "C" {
-char *
-wasm_runtime_get_module_hash(wasm_module_t module);
-}
-
 char *
 wasm_runtime_get_module_hash(wasm_module_t module)
 {

--- a/product-mini/platforms/linux-sgx/enclave-sample/Enclave/Enclave.cpp
+++ b/product-mini/platforms/linux-sgx/enclave-sample/Enclave/Enclave.cpp
@@ -14,8 +14,6 @@
 
 #if WASM_ENABLE_LIB_RATS != 0
 #include <openssl/sha.h>
-
-char wasm_module_hash[SHA256_DIGEST_LENGTH];
 #endif
 
 extern "C" {
@@ -68,7 +66,16 @@ typedef struct EnclaveModule {
     uint32 wasi_argc;
     bool is_xip_file;
     uint32 total_size_mapped;
+#if WASM_ENABLE_LIB_RATS != 0
+    char module_hash[SHA256_DIGEST_LENGTH];
+    struct EnclaveModule *next;
+#endif
 } EnclaveModule;
+
+#if WASM_ENABLE_LIB_RATS != 0
+static EnclaveModule *enclave_module_list = NULL;
+static korp_mutex enclave_module_list_lock = OS_THREAD_MUTEX_INITIALIZER;
+#endif
 
 #if WASM_ENABLE_GLOBAL_HEAP_POOL != 0
 static char global_heap_buf[WASM_GLOBAL_HEAP_SIZE] = { 0 };
@@ -250,10 +257,17 @@ handle_cmd_load_module(uint64 *args, uint32 argc)
     *(EnclaveModule **)args_org = enclave_module;
 
 #if WASM_ENABLE_LIB_RATS != 0
+    /* Calculate the module hash */
     SHA256_CTX sha256;
     SHA256_Init(&sha256);
     SHA256_Update(&sha256, wasm_file, wasm_file_size);
-    SHA256_Final((unsigned char *)wasm_module_hash, &sha256);
+    SHA256_Final((unsigned char *)enclave_module->module_hash, &sha256);
+
+    /* Insert enclave module to enclave module list */
+    os_mutex_lock(&enclave_module_list_lock);
+    enclave_module->next = enclave_module_list;
+    enclave_module_list = enclave_module;
+    os_mutex_unlock(&enclave_module_list_lock);
 #endif
 
     LOG_VERBOSE("Load module success.\n");
@@ -267,6 +281,29 @@ handle_cmd_unload_module(uint64 *args, uint32 argc)
 
     bh_assert(argc == 1);
 
+#if WASM_ENABLE_LIB_RATS != 0
+    /* Remove enclave module from enclave module list */
+    os_mutex_lock(&enclave_module_list_lock);
+
+    EnclaveModule *node_prev = NULL;
+    EnclaveModule *node = enclave_module_list;
+
+    while (node && node != enclave_module) {
+        node_prev = node;
+        node = node->next;
+    }
+    bh_assert(node == enclave_module);
+
+    if (!node_prev)
+        enclave_module_list = node->next;
+    else
+        node_prev->next = node->next;
+
+    os_mutex_unlock(&enclave_module_list_lock);
+#endif
+
+    /* Destroy enclave module resources */
+
     if (enclave_module->wasi_arg_buf)
         wasm_runtime_free(enclave_module->wasi_arg_buf);
 
@@ -278,6 +315,34 @@ handle_cmd_unload_module(uint64 *args, uint32 argc)
 
     LOG_VERBOSE("Unload module success.\n");
 }
+
+#if WASM_ENABLE_LIB_RATS != 0
+extern "C" {
+char *
+wasm_runtime_get_module_hash(wasm_module_t module);
+}
+
+char *
+wasm_runtime_get_module_hash(wasm_module_t module)
+{
+    EnclaveModule *enclave_module;
+    char *module_hash = NULL;
+
+    os_mutex_lock(&enclave_module_list_lock);
+
+    enclave_module = enclave_module_list;
+    while (enclave_module) {
+        if (enclave_module->module == module) {
+            module_hash = enclave_module->module_hash;
+            break;
+        }
+        enclave_module = enclave_module->next;
+    }
+    os_mutex_unlock(&enclave_module_list_lock);
+
+    return module_hash;
+}
+#endif
 
 static void
 handle_cmd_instantiate_module(uint64 *args, uint32 argc)

--- a/product-mini/platforms/linux-sgx/enclave-sample/Enclave/Enclave.edl
+++ b/product-mini/platforms/linux-sgx/enclave-sample/Enclave/Enclave.edl
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
+#define WASM_ENABLE_SGX_IPFS 0
 #define WASM_ENABLE_LIB_RATS 0
-#define SGX_IPFS 0
 
 enclave {
     from "sgx_tstdc.edl" import *;
@@ -14,7 +14,7 @@ enclave {
     from "rats.edl" import *;
     from "sgx_tsgxssl.edl" import *;
 #endif
-#if SGX_IPFS != 0
+#if WASM_ENABLE_SGX_IPFS != 0
     from "sgx_tprotected_fs.edl" import *;
 #endif
 

--- a/product-mini/platforms/linux-sgx/enclave-sample/Makefile
+++ b/product-mini/platforms/linux-sgx/enclave-sample/Makefile
@@ -11,7 +11,7 @@ SGX_DEBUG ?= 0
 SPEC_TEST ?= 0
 
 # These variables are automatically set by CMakeLists.txt
-SGX_IPFS = 0
+WAMR_BUILD_SGX_IPFS = 0
 WAMR_BUILD_LIB_RATS = 0
 WAMR_BUILD_GLOBAL_HEAP_POOL = 0
 WAMR_BUILD_GLOBAL_HEAP_SIZE = 10485760
@@ -112,7 +112,7 @@ else
 	Service_Library_Name := sgx_tservice
 endif
 
-ifeq ($(SGX_IPFS), 1)
+ifeq ($(WAMR_BUILD_SGX_IPFS), 1)
 	Intel_Ipfs_Trusted_Flag = -lsgx_tprotected_fs
 	App_Link_Flags += -lsgx_uprotected_fs
 endif

--- a/samples/sgx-ra/README.md
+++ b/samples/sgx-ra/README.md
@@ -15,33 +15,38 @@ Before starting, we need to download and install [SGX SDK](https://download.01.o
 
 The following commands are an example of the SGX environment installation on Ubuntu 18.04.
 ``` shell
+# Set your platform, you can get the platforms list on
+# https://download.01.org/intel-sgx/latest/linux-latest/distro
 $ cd $HOME
-$ # Set your platform, you can get the platforms list on 
-$ # https://download.01.org/intel-sgx/latest/linux-latest/distro
 $ SGX_PLATFORM=ubuntu18.04-server
 $ SGX_SDK_VERSION=2.17.100.3
 $ SGX_DRIVER_VERSION=1.41
-$ # install the dependencies
+
+# install the dependencies
 $ sudo apt-get update
 $ sudo apt-get install -y dkms
-$ # install SGX Driver
+
+# install SGX Driver
 $ wget https://download.01.org/intel-sgx/latest/linux-latest/distro/$SGX_PLATFORM/sgx_linux_x64_driver_$SGX_DRIVER_VERSION.bin
 $ chmod +x sgx_linux_x64_driver_$SGX_DRIVER_VERSION.bin
 $ sudo ./sgx_linux_x64_driver_$SGX_DRIVER_VERSION.bin
-$ # install SGX SDK
+
+# install SGX SDK
 $ wget https://download.01.org/intel-sgx/latest/linux-latest/distro/$SGX_PLATFORM/sgx_linux_x64_sdk_$SGX_SDK_VERSION.bin
 $ chmod +x sgx_linux_x64_sdk_$SGX_SDK_VERSION.bin
 $ sudo ./sgx_linux_x64_sdk_$SGX_SDK_VERSION.bin
-$ # install SGX DCAP Library
+
+# install SGX DCAP Library
 $ echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list > /dev/null
 $ wget -O - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
 $ sudo apt-get update
 $ sudo apt-get install -y libsgx-uae-service libsgx-dcap-default-qpl-dev libsgx-dcap-ql-dev libsgx-dcap-quote-verify-dev
-$ # install SGX SSL Library
+
+# install SGX SSL Library
 $ git clone https://github.com/intel/linux-sgx.git
 $ cd linux-sgx && make preparation
 $ sudo cp external/toolset/{current_distr}/* /usr/local/bin
-$ # Verify that the paths are correctly set 
+$ # Verify that the paths are correctly set
 $ which ar as ld objcopy objdump ranlib
 $ cd ../
 $ git clone https://github.com/intel/intel-sgx-ssl.git


### PR DESCRIPTION
Current SGX lib-rats wasm module hash is stored in a global buffer,
which may be overwritten if there are multiple wasm module loadings.
We move the module hash into the enclave module to resolve the issue.

And rename the SGX_IPFS macro/variable in Makefile and Enclave.edl to
make the code more consistent.

And refine the sgx-ra sample document.