### PR TITLE
Remove unused LLVM JIT wapper functions

### DIFF
--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -125,11 +125,11 @@ aot_add_llvm_func(AOTCompContext *comp_ctx, LLVMModuleRef module,
 
     /* Add the jit wrapper function with simple prototype, so that we
        can easily call it to trigger its compilation and let LLVM JIT
-       compile the actual jit functions by adding the latter to the
-       function list in the PartitionFunction callback */
+       compile the actual jit functions by adding them into the function
+       list in the PartitionFunction callback */
     if (comp_ctx->is_jit_mode
-        && func_index % (backend_thread_num * compile_thread_num)
-               < backend_thread_num) {
+        && (func_index % (backend_thread_num * compile_thread_num)
+            < backend_thread_num)) {
         func_type_wrapper = LLVMFunctionType(VOID_TYPE, NULL, 0, false);
         if (!func_type_wrapper) {
             aot_set_last_error("create LLVM function type failed.");

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -54,6 +54,7 @@ aot_add_llvm_func(AOTCompContext *comp_ctx, LLVMModuleRef module,
     char func_name[48];
     uint64 size;
     uint32 i, j = 0, param_count = (uint64)aot_func_type->param_count;
+    uint32 backend_thread_num, compile_thread_num;
 
     /* exec env as first parameter */
     param_count++;
@@ -119,7 +120,16 @@ aot_add_llvm_func(AOTCompContext *comp_ctx, LLVMModuleRef module,
     if (p_func_type)
         *p_func_type = func_type;
 
-    if (comp_ctx->is_jit_mode) {
+    backend_thread_num = WASM_ORC_JIT_BACKEND_THREAD_NUM;
+    compile_thread_num = WASM_ORC_JIT_COMPILE_THREAD_NUM;
+
+    /* Add the jit wrapper function with simple prototype, so that we
+       can easily call it to trigger its compilation and let LLVM JIT
+       compile the actual jit functions by adding the latter to the
+       function list in the PartitionFunction callback */
+    if (comp_ctx->is_jit_mode
+        && func_index % (backend_thread_num * compile_thread_num)
+               < compile_thread_num) {
         func_type_wrapper = LLVMFunctionType(VOID_TYPE, NULL, 0, false);
         if (!func_type_wrapper) {
             aot_set_last_error("create LLVM function type failed.");

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -129,7 +129,7 @@ aot_add_llvm_func(AOTCompContext *comp_ctx, LLVMModuleRef module,
        function list in the PartitionFunction callback */
     if (comp_ctx->is_jit_mode
         && func_index % (backend_thread_num * compile_thread_num)
-               < compile_thread_num) {
+               < backend_thread_num) {
         func_type_wrapper = LLVMFunctionType(VOID_TYPE, NULL, 0, false);
         if (!func_type_wrapper) {
             aot_set_last_error("create LLVM function type failed.");

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -2955,7 +2955,7 @@ orcjit_thread_callback(void *arg)
             LLVMOrcLLLazyJITLookup(comp_ctx->orc_jit, &func_addr, func_name);
         if (error != LLVMErrorSuccess) {
             char *err_msg = LLVMGetErrorMessage(error);
-            os_printf("failed to compile orc jit function: %s", err_msg);
+            os_printf("failed to compile orc jit function: %s\n", err_msg);
             LLVMDisposeErrorMessage(err_msg);
             continue;
         }

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -1930,8 +1930,8 @@ compile_llvm_jit_functions(WASMModule *module, char *error_buf,
         if (error != LLVMErrorSuccess) {
             char *err_msg = LLVMGetErrorMessage(error);
             char buf[128];
-            snprintf(buf, sizeof(buf), "failed to compile orc jit function: %s",
-                     err_msg);
+            snprintf(buf, sizeof(buf),
+                     "failed to compile orc jit function: %s\n", err_msg);
             set_error_buf(error_buf, error_buf_size, buf);
             LLVMDisposeErrorMessage(err_msg);
             return false;


### PR DESCRIPTION
Only create the necessary wrapper functions for LLVM JIT