### PR TITLE
Using trap for error message from wasm_instance_new

### DIFF
--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -4427,25 +4427,25 @@ failed:
 
 wasm_instance_t *
 wasm_instance_new(wasm_store_t *store, const wasm_module_t *module,
-                  const wasm_extern_vec_t *imports, own wasm_trap_t **traps)
+                  const wasm_extern_vec_t *imports, own wasm_trap_t **trap)
 {
-    return wasm_instance_new_with_args(store, module, imports, traps,
+    return wasm_instance_new_with_args(store, module, imports, trap,
                                        KILOBYTE(32), KILOBYTE(32));
 }
 
 wasm_instance_t *
 wasm_instance_new_with_args(wasm_store_t *store, const wasm_module_t *module,
                             const wasm_extern_vec_t *imports,
-                            own wasm_trap_t **traps, const uint32 stack_size,
+                            own wasm_trap_t **trap, const uint32 stack_size,
                             const uint32 heap_size)
 {
-    char error_buf[128] = { 0 };
+    char sub_error_buf[128] = { 0 };
+    char error_buf[256] = { 0 };
     uint32 import_count = 0;
     bool import_count_verified = false;
     wasm_instance_t *instance = NULL;
     uint32 i = 0;
     bool processed = false;
-    (void)traps;
 
     bh_assert(singleton_engine);
 
@@ -4455,6 +4455,8 @@ wasm_instance_new_with_args(wasm_store_t *store, const wasm_module_t *module,
 
     instance = malloc_internal(sizeof(wasm_instance_t));
     if (!instance) {
+        snprintf(sub_error_buf, sizeof(sub_error_buf),
+                 "Failed to malloc instance");
         goto failed;
     }
 
@@ -4471,6 +4473,8 @@ wasm_instance_new_with_args(wasm_store_t *store, const wasm_module_t *module,
                 /* make sure a complete import list */
                 if ((int32)import_count < 0
                     || import_count != actual_link_import_count) {
+                    snprintf(sub_error_buf, sizeof(sub_error_buf),
+                             "Failed to validate imports");
                     goto failed;
                 }
             }
@@ -4489,6 +4493,8 @@ wasm_instance_new_with_args(wasm_store_t *store, const wasm_module_t *module,
                 import_count = aot_link(instance, MODULE_AOT(module),
                                         (wasm_extern_t **)imports->data);
                 if ((int32)import_count < 0) {
+                    snprintf(sub_error_buf, sizeof(sub_error_buf),
+                             "Failed to validate imports");
                     goto failed;
                 }
             }
@@ -4501,18 +4507,21 @@ wasm_instance_new_with_args(wasm_store_t *store, const wasm_module_t *module,
          * also leads to below branch
          */
         if (!import_count_verified) {
+            snprintf(sub_error_buf, sizeof(sub_error_buf),
+                     "Failed to verify import count");
             goto failed;
         }
     }
 
     instance->inst_comm_rt = wasm_runtime_instantiate(
-        *module, stack_size, heap_size, error_buf, sizeof(error_buf));
+        *module, stack_size, heap_size, sub_error_buf, sizeof(sub_error_buf));
     if (!instance->inst_comm_rt) {
-        LOG_ERROR(error_buf);
         goto failed;
     }
 
     if (!wasm_runtime_create_exec_env_singleton(instance->inst_comm_rt)) {
+        snprintf(sub_error_buf, sizeof(sub_error_buf),
+                 "Failed to create exec env singleton");
         goto failed;
     }
 
@@ -4537,6 +4546,8 @@ wasm_instance_new_with_args(wasm_store_t *store, const wasm_module_t *module,
                     instance->inst_comm_rt;
                 break;
             default:
+                snprintf(sub_error_buf, sizeof(sub_error_buf),
+                         "Unknown import kind");
                 goto failed;
         }
     }
@@ -4553,6 +4564,8 @@ wasm_instance_new_with_args(wasm_store_t *store, const wasm_module_t *module,
         if (!interp_process_export(store,
                                    (WASMModuleInstance *)instance->inst_comm_rt,
                                    instance->exports)) {
+            snprintf(sub_error_buf, sizeof(sub_error_buf),
+                     "Interpreter failed to process exports");
             goto failed;
         }
 
@@ -4575,6 +4588,8 @@ wasm_instance_new_with_args(wasm_store_t *store, const wasm_module_t *module,
         if (!aot_process_export(store,
                                 (AOTModuleInstance *)instance->inst_comm_rt,
                                 instance->exports)) {
+            snprintf(sub_error_buf, sizeof(sub_error_buf),
+                     "AOT failed to process exports");
             goto failed;
         }
 
@@ -4587,18 +4602,30 @@ wasm_instance_new_with_args(wasm_store_t *store, const wasm_module_t *module,
      * leads to below branch
      */
     if (!processed) {
+        snprintf(sub_error_buf, sizeof(sub_error_buf),
+                 "Incorrect filetype and compilation flags");
         goto failed;
     }
 
     /* add it to a watching list in store */
     if (!bh_vector_append((Vector *)store->instances, &instance)) {
+        snprintf(sub_error_buf, sizeof(sub_error_buf),
+                 "Failed to add to store instances");
         goto failed;
     }
 
     return instance;
 
 failed:
-    LOG_DEBUG("%s failed", __FUNCTION__);
+    snprintf(error_buf, sizeof(error_buf), "%s failed: %s", __FUNCTION__,
+             sub_error_buf);
+    if (trap != NULL) {
+        wasm_message_t message = { 0 };
+        wasm_name_new_from_string(&message, error_buf);
+        *trap = wasm_trap_new(store, &message);
+        wasm_byte_vec_delete(&message);
+    }
+    LOG_DEBUG(error_buf);
     wasm_instance_delete_internal(instance);
     return NULL;
 }

--- a/core/iwasm/include/wasm_c_api.h
+++ b/core/iwasm/include/wasm_c_api.h
@@ -592,13 +592,13 @@ WASM_DECLARE_REF(instance)
 
 WASM_API_EXTERN own wasm_instance_t* wasm_instance_new(
   wasm_store_t*, const wasm_module_t*, const wasm_extern_vec_t *imports,
-  own wasm_trap_t**
+  own wasm_trap_t** trap
 );
 
 // please refer to wasm_runtime_instantiate(...) in core/iwasm/include/wasm_export.h
 WASM_API_EXTERN own wasm_instance_t* wasm_instance_new_with_args(
   wasm_store_t*, const wasm_module_t*, const wasm_extern_vec_t *imports,
-  own wasm_trap_t**, const uint32_t stack_size, const uint32_t heap_size
+  own wasm_trap_t** trap, const uint32_t stack_size, const uint32_t heap_size
 );
 
 WASM_API_EXTERN void wasm_instance_exports(const wasm_instance_t*, own wasm_extern_vec_t* out);


### PR DESCRIPTION
* Similar to [this PR](https://github.com/bytecodealliance/wasm-micro-runtime/pull/1526) but uses a wasm_trap_t instead of adding error_buf to the API.
* Trap will need to be deleted by the caller but is not a breaking change as it is only created if trap is not NULL.
* Added error messages for all failure cases here, tried to make them accurate but welcome feedback for improvements.
