### PR TITLE
Add memory watchpoint support to debugger

### DIFF
--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -71,20 +71,24 @@ typedef float64 CellType_F64;
     } while (0)
 
 #if WASM_ENABLE_DEBUG_INTERP != 0
-#define TRIGGER_WATCHPOINT_SIGTRAP()                          \
-    wasm_cluster_thread_send_signal(exec_env, WAMR_SIG_TRAP); \
-    CHECK_SUSPEND_FLAGS();
+#define TRIGGER_WATCHPOINT_SIGTRAP()                              \
+    do {                                                          \
+        wasm_cluster_thread_send_signal(exec_env, WAMR_SIG_TRAP); \
+        CHECK_SUSPEND_FLAGS();                                    \
+    } while (0)
 
-#define CHECK_WATCHPOINT(list, current_addr)                           \
-    WASMDebugWatchPoint *watchpoint = bh_list_first_elem(list);        \
-    while (watchpoint) {                                               \
-        WASMDebugWatchPoint *next = bh_list_elem_next(watchpoint);     \
-        if (watchpoint->addr <= current_addr                           \
-            && watchpoint->addr + watchpoint->length > current_addr) { \
-            TRIGGER_WATCHPOINT_SIGTRAP()                               \
-        }                                                              \
-        watchpoint = next;                                             \
-    }
+#define CHECK_WATCHPOINT(list, current_addr)                               \
+    do {                                                                   \
+        WASMDebugWatchPoint *watchpoint = bh_list_first_elem(list);        \
+        while (watchpoint) {                                               \
+            WASMDebugWatchPoint *next = bh_list_elem_next(watchpoint);     \
+            if (watchpoint->addr <= current_addr                           \
+                && watchpoint->addr + watchpoint->length > current_addr) { \
+                TRIGGER_WATCHPOINT_SIGTRAP();                              \
+            }                                                              \
+            watchpoint = next;                                             \
+        }                                                                  \
+    } while (0)
 
 #define CHECK_READ_WATCHPOINT(addr, offset) \
     CHECK_WATCHPOINT(watch_point_list_read, WASM_ADDR_OFFSET(addr + offset))
@@ -1813,8 +1817,8 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 addr = POP_I32();
                 CHECK_MEMORY_OVERFLOW(4);
                 PUSH_I32(LOAD_I32(maddr));
-                (void)flags;
                 CHECK_READ_WATCHPOINT(addr, offset);
+                (void)flags;
                 HANDLE_OP_END();
             }
 
@@ -1828,8 +1832,8 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 addr = POP_I32();
                 CHECK_MEMORY_OVERFLOW(8);
                 PUSH_I64(LOAD_I64(maddr));
-                (void)flags;
                 CHECK_READ_WATCHPOINT(addr, offset);
+                (void)flags;
                 HANDLE_OP_END();
             }
 
@@ -1842,8 +1846,8 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 addr = POP_I32();
                 CHECK_MEMORY_OVERFLOW(1);
                 PUSH_I32(sign_ext_8_32(*(int8 *)maddr));
-                (void)flags;
                 CHECK_READ_WATCHPOINT(addr, offset);
+                (void)flags;
                 HANDLE_OP_END();
             }
 
@@ -1856,8 +1860,8 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 addr = POP_I32();
                 CHECK_MEMORY_OVERFLOW(1);
                 PUSH_I32((uint32)(*(uint8 *)maddr));
-                (void)flags;
                 CHECK_READ_WATCHPOINT(addr, offset);
+                (void)flags;
                 HANDLE_OP_END();
             }
 
@@ -1870,8 +1874,8 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 addr = POP_I32();
                 CHECK_MEMORY_OVERFLOW(2);
                 PUSH_I32(sign_ext_16_32(LOAD_I16(maddr)));
-                (void)flags;
                 CHECK_READ_WATCHPOINT(addr, offset);
+                (void)flags;
                 HANDLE_OP_END();
             }
 
@@ -1884,8 +1888,8 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 addr = POP_I32();
                 CHECK_MEMORY_OVERFLOW(2);
                 PUSH_I32((uint32)(LOAD_U16(maddr)));
-                (void)flags;
                 CHECK_READ_WATCHPOINT(addr, offset);
+                (void)flags;
                 HANDLE_OP_END();
             }
 
@@ -1898,8 +1902,8 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 addr = POP_I32();
                 CHECK_MEMORY_OVERFLOW(1);
                 PUSH_I64(sign_ext_8_64(*(int8 *)maddr));
-                (void)flags;
                 CHECK_READ_WATCHPOINT(addr, offset);
+                (void)flags;
                 HANDLE_OP_END();
             }
 
@@ -1912,8 +1916,8 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 addr = POP_I32();
                 CHECK_MEMORY_OVERFLOW(1);
                 PUSH_I64((uint64)(*(uint8 *)maddr));
-                (void)flags;
                 CHECK_READ_WATCHPOINT(addr, offset);
+                (void)flags;
                 HANDLE_OP_END();
             }
 
@@ -1926,8 +1930,8 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 addr = POP_I32();
                 CHECK_MEMORY_OVERFLOW(2);
                 PUSH_I64(sign_ext_16_64(LOAD_I16(maddr)));
-                (void)flags;
                 CHECK_READ_WATCHPOINT(addr, offset);
+                (void)flags;
                 HANDLE_OP_END();
             }
 
@@ -1940,8 +1944,8 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 addr = POP_I32();
                 CHECK_MEMORY_OVERFLOW(2);
                 PUSH_I64((uint64)(LOAD_U16(maddr)));
-                (void)flags;
                 CHECK_READ_WATCHPOINT(addr, offset);
+                (void)flags;
                 HANDLE_OP_END();
             }
 
@@ -1955,8 +1959,8 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 addr = POP_I32();
                 CHECK_MEMORY_OVERFLOW(4);
                 PUSH_I64(sign_ext_32_64(LOAD_I32(maddr)));
-                (void)flags;
                 CHECK_READ_WATCHPOINT(addr, offset);
+                (void)flags;
                 HANDLE_OP_END();
             }
 
@@ -1969,8 +1973,8 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 addr = POP_I32();
                 CHECK_MEMORY_OVERFLOW(4);
                 PUSH_I64((uint64)(LOAD_U32(maddr)));
-                (void)flags;
                 CHECK_READ_WATCHPOINT(addr, offset);
+                (void)flags;
                 HANDLE_OP_END();
             }
 
@@ -1986,8 +1990,8 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 addr = POP_I32();
                 CHECK_MEMORY_OVERFLOW(4);
                 STORE_U32(maddr, frame_sp[1]);
-                (void)flags;
                 CHECK_WRITE_WATCHPOINT(addr, offset);
+                (void)flags;
                 HANDLE_OP_END();
             }
 
@@ -2003,8 +2007,8 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 CHECK_MEMORY_OVERFLOW(8);
                 PUT_I64_TO_ADDR((uint32 *)maddr,
                                 GET_I64_FROM_ADDR(frame_sp + 1));
-                (void)flags;
                 CHECK_WRITE_WATCHPOINT(addr, offset);
+                (void)flags;
                 HANDLE_OP_END();
             }
 
@@ -2028,9 +2032,8 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     CHECK_MEMORY_OVERFLOW(2);
                     STORE_U16(maddr, (uint16)sval);
                 }
-
-                (void)flags;
                 CHECK_WRITE_WATCHPOINT(addr, offset);
+                (void)flags;
                 HANDLE_OP_END();
             }
 
@@ -2059,8 +2062,8 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     CHECK_MEMORY_OVERFLOW(4);
                     STORE_U32(maddr, (uint32)sval);
                 }
-                (void)flags;
                 CHECK_WRITE_WATCHPOINT(addr, offset);
+                (void)flags;
                 HANDLE_OP_END();
             }
 

--- a/core/iwasm/libraries/debug-engine/debug_engine.h
+++ b/core/iwasm/libraries/debug-engine/debug_engine.h
@@ -36,6 +36,12 @@ typedef struct WASMDebugBreakPoint {
     uint64 orignal_data;
 } WASMDebugBreakPoint;
 
+typedef struct WASMDebugWatchPoint {
+    struct WASMDebugWatchPoint *next;
+    uint64 addr;
+    uint64 length;
+} WASMDebugWatchPoint;
+
 typedef enum debug_state_t {
     /* Debugger state conversion sequence:
      *   DBG_LAUNCHING ---> APP_STOPPED <---> APP_RUNNING
@@ -56,6 +62,8 @@ struct WASMDebugInstance {
     struct WASMDebugInstance *next;
     WASMDebugControlThread *control_thread;
     bh_list break_point_list;
+    bh_list watch_point_list_read;
+    bh_list watch_point_list_write;
     WASMCluster *cluster;
     uint32 id;
     korp_tid current_tid;
@@ -183,6 +191,22 @@ wasm_debug_instance_add_breakpoint(WASMDebugInstance *instance, uint64 addr,
 bool
 wasm_debug_instance_remove_breakpoint(WASMDebugInstance *instance, uint64 addr,
                                       uint64 length);
+
+bool
+wasm_debug_instance_watchpoint_write_add(WASMDebugInstance *instance,
+                                         uint64 addr, uint64 length);
+
+bool
+wasm_debug_instance_watchpoint_write_remove(WASMDebugInstance *instance,
+                                            uint64 addr, uint64 length);
+
+bool
+wasm_debug_instance_watchpoint_read_add(WASMDebugInstance *instance,
+                                        uint64 addr, uint64 length);
+
+bool
+wasm_debug_instance_watchpoint_read_remove(WASMDebugInstance *instance,
+                                           uint64 addr, uint64 length);
 
 bool
 wasm_debug_instance_on_failure(WASMDebugInstance *instance);

--- a/core/iwasm/libraries/debug-engine/debug_engine.h
+++ b/core/iwasm/libraries/debug-engine/debug_engine.h
@@ -37,7 +37,7 @@ typedef struct WASMDebugBreakPoint {
 } WASMDebugBreakPoint;
 
 typedef struct WASMDebugWatchPoint {
-    struct WASMDebugWatchPoint *next;
+    bh_list_link next;
     uint64 addr;
     uint64 length;
 } WASMDebugWatchPoint;

--- a/core/iwasm/libraries/debug-engine/handler.c
+++ b/core/iwasm/libraries/debug-engine/handler.c
@@ -358,6 +358,14 @@ handle_general_query(WASMGDBServer *server, char *payload)
 
         send_thread_stop_status(server, status, tid);
     }
+
+    if (!strcmp(name, "WatchpointSupportInfo")) {
+        os_mutex_lock(&tmpbuf_lock);
+        // Any uint32 is OK for the watchpoint support
+        snprintf(tmpbuf, MAX_PACKET_SIZE, "num:32;");
+        write_packet(server, tmpbuf);
+        os_mutex_unlock(&tmpbuf_lock);
+    }
 }
 
 void
@@ -644,45 +652,131 @@ handle_get_write_memory(WASMGDBServer *server, char *payload)
 }
 
 void
+handle_breakpoint_software_add(WASMGDBServer *server, uint64 addr,
+                               size_t length)
+{
+    bool ret = wasm_debug_instance_add_breakpoint(
+        (WASMDebugInstance *)server->thread->debug_instance, addr, length);
+    write_packet(server, ret ? "OK" : "EO1");
+}
+
+void
+handle_breakpoint_software_remove(WASMGDBServer *server, uint64 addr,
+                                  size_t length)
+{
+    bool ret = wasm_debug_instance_remove_breakpoint(
+        (WASMDebugInstance *)server->thread->debug_instance, addr, length);
+    write_packet(server, ret ? "OK" : "EO1");
+}
+
+void
+handle_watchpoint_write_add(WASMGDBServer *server, uint64 addr, size_t length)
+{
+    bool ret = wasm_debug_instance_watchpoint_write_add(
+        (WASMDebugInstance *)server->thread->debug_instance, addr, length);
+    write_packet(server, ret ? "OK" : "EO1");
+}
+
+void
+handle_watchpoint_write_remove(WASMGDBServer *server, uint64 addr,
+                               size_t length)
+{
+    bool ret = wasm_debug_instance_watchpoint_write_remove(
+        (WASMDebugInstance *)server->thread->debug_instance, addr, length);
+    write_packet(server, ret ? "OK" : "EO1");
+}
+
+void
+handle_watchpoint_read_add(WASMGDBServer *server, uint64 addr, size_t length)
+{
+    bool ret = wasm_debug_instance_watchpoint_read_add(
+        (WASMDebugInstance *)server->thread->debug_instance, addr, length);
+    write_packet(server, ret ? "OK" : "EO1");
+}
+
+void
+handle_watchpoint_read_remove(WASMGDBServer *server, uint64 addr, size_t length)
+{
+    bool ret = wasm_debug_instance_watchpoint_read_remove(
+        (WASMDebugInstance *)server->thread->debug_instance, addr, length);
+    write_packet(server, ret ? "OK" : "EO1");
+}
+
+void
 handle_add_break(WASMGDBServer *server, char *payload)
 {
+    int arg_c;
     size_t type, length;
     uint64 addr;
 
-    if (sscanf(payload, "%zx,%" SCNx64 ",%zx", &type, &addr, &length) == 3) {
-        if (type == eBreakpointSoftware) {
-            bool ret = wasm_debug_instance_add_breakpoint(
-                (WASMDebugInstance *)server->thread->debug_instance, addr,
-                length);
-            if (ret)
-                write_packet(server, "OK");
-            else
-                write_packet(server, "E01");
-            return;
-        }
+    if ((arg_c = sscanf(payload, "%zx,%" SCNx64 ",%zx", &type, &addr, &length))
+        != 3) {
+        LOG_ERROR("Unsupported number of add break arguments %d", arg_c);
+        write_packet(server, "");
+        return;
     }
-    write_packet(server, "");
+
+    switch (type) {
+        case eBreakpointSoftware:
+            handle_breakpoint_software_add(server, addr, length);
+            break;
+            break;
+        case eWatchpointWrite:
+            handle_watchpoint_write_add(server, addr, length);
+            break;
+            break;
+        case eWatchpointRead:
+            handle_watchpoint_read_add(server, addr, length);
+            break;
+            break;
+        case eWatchpointReadWrite:
+            handle_watchpoint_write_add(server, addr, length);
+            handle_watchpoint_read_add(server, addr, length);
+            break;
+            break;
+        default:
+            LOG_ERROR("Unsupported breakpoint type %d", type);
+            write_packet(server, "");
+            break;
+    }
 }
 
 void
 handle_remove_break(WASMGDBServer *server, char *payload)
 {
+    int arg_c;
     size_t type, length;
     uint64 addr;
 
-    if (sscanf(payload, "%zx,%" SCNx64 ",%zx", &type, &addr, &length) == 3) {
-        if (type == eBreakpointSoftware) {
-            bool ret = wasm_debug_instance_remove_breakpoint(
-                (WASMDebugInstance *)server->thread->debug_instance, addr,
-                length);
-            if (ret)
-                write_packet(server, "OK");
-            else
-                write_packet(server, "E01");
-            return;
-        }
+    if ((arg_c = sscanf(payload, "%zx,%" SCNx64 ",%zx", &type, &addr, &length))
+        != 3) {
+        LOG_ERROR("Unsupported number of remove break arguments %d", arg_c);
+        write_packet(server, "");
+        return;
     }
-    write_packet(server, "");
+
+    switch (type) {
+        case eBreakpointSoftware:
+            handle_breakpoint_software_remove(server, addr, length);
+            break;
+            break;
+        case eWatchpointWrite:
+            handle_watchpoint_write_remove(server, addr, length);
+            break;
+            break;
+        case eWatchpointRead:
+            handle_watchpoint_read_remove(server, addr, length);
+            break;
+            break;
+        case eWatchpointReadWrite:
+            handle_watchpoint_write_remove(server, addr, length);
+            handle_watchpoint_read_remove(server, addr, length);
+            break;
+        default:
+            LOG_ERROR("Unsupported breakpoint type %d", type);
+            write_packet(server, "");
+            break;
+    }
 }
 
 void

--- a/core/iwasm/libraries/debug-engine/handler.c
+++ b/core/iwasm/libraries/debug-engine/handler.c
@@ -720,19 +720,15 @@ handle_add_break(WASMGDBServer *server, char *payload)
         case eBreakpointSoftware:
             handle_breakpoint_software_add(server, addr, length);
             break;
-            break;
         case eWatchpointWrite:
             handle_watchpoint_write_add(server, addr, length);
-            break;
             break;
         case eWatchpointRead:
             handle_watchpoint_read_add(server, addr, length);
             break;
-            break;
         case eWatchpointReadWrite:
             handle_watchpoint_write_add(server, addr, length);
             handle_watchpoint_read_add(server, addr, length);
-            break;
             break;
         default:
             LOG_ERROR("Unsupported breakpoint type %d", type);
@@ -759,14 +755,11 @@ handle_remove_break(WASMGDBServer *server, char *payload)
         case eBreakpointSoftware:
             handle_breakpoint_software_remove(server, addr, length);
             break;
-            break;
         case eWatchpointWrite:
             handle_watchpoint_write_remove(server, addr, length);
             break;
-            break;
         case eWatchpointRead:
             handle_watchpoint_read_remove(server, addr, length);
-            break;
             break;
         case eWatchpointReadWrite:
             handle_watchpoint_write_remove(server, addr, length);


### PR DESCRIPTION
### What

Added memory watchpoint support to the WAMR debug engine

### Why

This allows us to add watchpoints to variables for debugging. For instance:

```
breakpoint set variable var
```

Will pause WAMR execution when the address at `var` is written to. You can also set read (and r/w) watchpoints by passing this flag. This will pause execution when the address at var is read.

```
watchpoint set variable -w read var
```

### How

Added two linked lists for read/write watchpoints. When the debug message handler receives a watchpoint request, it adds/removes to one/both of these lists. In the interpreter, when an address is read or stored to, check whether the address is in these lists. If so, throw a sigtrap and suspend the process. 

This can support an arbitrary number of watchpoints. But there's some tradeoff that the more watchpoints, the more checks. This could be improved with a hashmap, although I think a small number of watchpoints (1 or 2) would be typical for most debugging sessions. 