### PR TITLE
Fix scenario where the timeout for atomic wait is set to negative number (i.e. wait forever)

### DIFF
--- a/core/iwasm/common/wasm_shared_memory.c
+++ b/core/iwasm/common/wasm_shared_memory.c
@@ -385,10 +385,8 @@ wasm_runtime_atomic_wait(WASMModuleInstanceCommon *module, void *address,
     /* condition wait start */
     os_mutex_lock(&wait_node->wait_lock);
 
-    if (timeout < 0)
-        timeout = BHT_WAIT_FOREVER;
     os_cond_reltimedwait(&wait_node->wait_cond, &wait_node->wait_lock,
-                         timeout / 1000);
+                         timeout < 0 ? BHT_WAIT_FOREVER : timeout / 1000);
 
     os_mutex_unlock(&wait_node->wait_lock);
 


### PR DESCRIPTION
The code, when received -1, performed -1/1000 operation which rounds to 0, i.e. no wait (instead of infinite wait)