### PR TITLE
Adding ARM aeabi symbols for AOT bulk memory ops

### DIFF
--- a/core/iwasm/aot/arch/aot_reloc_arm.c
+++ b/core/iwasm/aot/arch/aot_reloc_arm.c
@@ -37,6 +37,9 @@ void __aeabi_idivmod();
 void __aeabi_l2d();
 void __aeabi_l2f();
 void __aeabi_ldivmod();
+void __aeabi_memcpy();
+void __aeabi_memmove();
+void __aeabi_memset();
 void __aeabi_uidiv();
 void __aeabi_uidivmod();
 void __aeabi_ul2d();
@@ -120,6 +123,9 @@ static SymbolMap target_sym_map[] = {
     REG_SYM(__aeabi_l2d),
     REG_SYM(__aeabi_l2f),
     REG_SYM(__aeabi_ldivmod),
+    REG_SYM(__aeabi_memcpy),
+    REG_SYM(__aeabi_memmove),
+    REG_SYM(__aeabi_memset),
     REG_SYM(__aeabi_uidiv),
     REG_SYM(__aeabi_uidivmod),
     REG_SYM(__aeabi_ul2d),


### PR DESCRIPTION
I'm building for Android and attempting to use AOT with bulk memory operations enabled. I run in to an issue when loading the module:

```
AOT module load failed: resolve symbol __aeabi_memmove failed
```

This change allows the module to load and run successfully.