### PR TITLE
Fix watchpoint segfault when using debug interpreter without server

### DIFF
--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -1157,8 +1157,10 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 #if WASM_ENABLE_DEBUG_INTERP != 0
     uint8 *frame_ip_orig = NULL;
     WASMDebugInstance *debug_instance = wasm_exec_env_get_instance(exec_env);
-    bh_list *watch_point_list_read = &debug_instance->watch_point_list_read;
-    bh_list *watch_point_list_write = &debug_instance->watch_point_list_write;
+    bh_list *watch_point_list_read =
+        debug_instance ? &debug_instance->watch_point_list_read : NULL;
+    bh_list *watch_point_list_write =
+        debug_instance ? &debug_instance->watch_point_list_write : NULL;
 #endif
 
 #if WASM_ENABLE_LABELS_AS_VALUES != 0


### PR DESCRIPTION
### Summary

In a [previous PR](https://github.com/bytecodealliance/wasm-micro-runtime/pull/1762) I had introduced memory watchpoint support. This adds two linked lists containing watchpoint locations that are checked on variable reads/writes. However, there is an edge-case where one could be using the `WASM_ENABLE_DEBUG_INTERP`, but not within a debugging instance. 

In this, the interpreter attempts to read the debugging instance lists which are not initialised. This results in a segmentation fault in `bh_list_first_elem`

This change checks whether the interpreter is running within a debugging instance. If not, it assigns the list pointers to null and `bh_list_first_elem` handles this gracefully

