### PR TITLE
Dev/docker publish fix

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -6,6 +6,10 @@ name: Create and publish Docker images
 on:
   workflow_call:
     inputs:
+      upload_url:
+        description: upload binary assets to the URL of release
+        type: string
+        required: true
       ver_num:
         description: a semantic version number.
         type: string
@@ -22,27 +26,67 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Downcase github actor
-        id: downcase_github_actor
-        uses: ASzc/change-string-case-action@v2
-        with:
-          string: ${{ github.repository_owner }}
-
-      - name: Login to the Container registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push Docker image(wasm-toolchain:${{ inputs.ver_num }}) to Container registry
+      - name: Build and save Docker image(wasm-debug-server:${{ inputs.ver_num }}) to tar file
         run: |
-          docker build -t ghcr.io/${{ github.repository_owner }}/wasm-toolchain:${{ inputs.ver_num }} .
-          docker push ghcr.io/${{ github.repository_owner }}/wasm-toolchain:${{ inputs.ver_num }}
+          docker build -t wasm-debug-server:${{ inputs.ver_num }} .
+          docker save -o wasm-debug-server.tar wasm-debug-server:${{ inputs.ver_num }}
+        working-directory: test-tools/wamr-ide/WASM-Debug-Server/Docker
+      
+      - name: compress the tar file
+        run: |
+          tar czf wasm-debug-server-${{ inputs.ver_num }}.tar.gz wasm-debug-server.tar
+          zip wasm-debug-server-${{ inputs.ver_num }}.zip wasm-debug-server.tar
+        working-directory: test-tools/wamr-ide/WASM-Debug-Server/Docker
+
+      - name: upload release tar.gz
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: test-tools/wamr-ide/WASM-Debug-Server/Docker/wasm-debug-server-${{ inputs.ver_num }}.tar.gz
+          asset_name: wasm-debug-server-${{ inputs.ver_num }}.tar.gz
+          asset_content_type: application/x-gzip
+
+      - name: upload release zip
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: test-tools/wamr-ide/WASM-Debug-Server/Docker/wasm-debug-server-${{ inputs.ver_num }}.zip
+          asset_name: wasm-debug-server-${{ inputs.ver_num }}.zip
+          asset_content_type: application/zip
+
+      - name: Build and save Docker image(wasm-toolchain:${{ inputs.ver_num }}) to tar file
+        run: |
+          docker build -t wasm-toolchain:${{ inputs.ver_num }} .
+          docker save -o wasm-toolchain.tar wasm-toolchain:${{ inputs.ver_num }}
         working-directory: test-tools/wamr-ide/WASM-Toolchain/Docker
 
-      - name: Build and push Docker image(wasm-debug-server:${{ inputs.ver_num }}) to Container registry
+      - name: compress the tar file
         run: |
-          docker build -t ghcr.io/${{ github.repository_owner }}/wasm-debug-server:${{ inputs.ver_num }} .
-          docker push ghcr.io/${{ github.repository_owner }}/wasm-debug-server:${{ inputs.ver_num }}
-        working-directory: test-tools/wamr-ide/WASM-Debug-Server/Docker
+          tar czf wasm-toolchain-${{ inputs.ver_num }}.tar.gz wasm-toolchain.tar
+          zip wasm-toolchain-${{ inputs.ver_num }}.zip wasm-toolchain.tar
+        working-directory: test-tools/wamr-ide/WASM-Toolchain/Docker
+
+      - name: upload release tar.gz
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: test-tools/wamr-ide/WASM-Toolchain/Docker/wasm-toolchain-${{ inputs.ver_num }}.tar.gz
+          asset_name: wasm-toolchain-${{ inputs.ver_num }}.tar.gz
+          asset_content_type: application/x-gzip
+
+      - name: upload release zip
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: test-tools/wamr-ide/WASM-Toolchain/Docker/wasm-toolchain-${{ inputs.ver_num }}.zip
+          asset_name: wasm-toolchain-${{ inputs.ver_num }}.zip
+          asset_content_type: application/zip
+          

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -18,9 +18,6 @@ on:
 jobs:
   build-and-push-images:
     runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-      packages: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release_process.yml
+++ b/.github/workflows/release_process.yml
@@ -160,6 +160,7 @@ jobs:
     needs: [create_tag, create_release]
     uses: ./.github/workflows/build_docker_images.yml
     with:
+      upload_url: ${{ needs.create_release.outputs.upload_url }}
       ver_num: ${{ needs.create_tag.outputs.new_ver }}
 
   #

--- a/test-tools/wamr-ide/README.md
+++ b/test-tools/wamr-ide/README.md
@@ -37,23 +37,35 @@ under `resource/debug/bin`.
        - Ubuntu Bionic 18.04(LTS)
        ```
 
-#### 3. Pull docker images from the registry(recommended) or build docker images on the host
+#### 3. Load docker images from the release tar file or build docker images on the host
 
-##### 3.1 Pull docker images from registry
+##### 3.1 Load docker images from the release tar file
 
-From now on, for each release, we have the same version tagged docker image pushed to GitHub package.
+From now on, for each release, we have the same version tagged docker image saved as a tar file, which you can find and download in the release.
 
-You could simply pull a certain version of docker images using the following commands:
+You could download the tar archive files for docker images from the release, and then load them using the following commands:
 
 ```sh
-# pull and retag wasm-toolchain 
-docker pull ghcr.io/bytecodealliance/wasm-toolchain:{version number}
-docker tag ghcr.io/bytecodealliance/wasm-toolchain:{version number} wasm-toolchain:{version number}
-docker rmi ghcr.io/bytecodealliance/wasm-toolchain:{version number} 
-# pull and retag wasm-debug-server
-docker pull ghcr.io/bytecodealliance/wasm-debug-server:{version number}
-docker tag ghcr.io/bytecodealliance/wasm-debug-server:{version number} wasm-debug-server:{version number}
-docker rmi ghcr.io/bytecodealliance/wasm-debug-server:{version number}
+# download the zip or tar.gz from release depending on your platform 
+# decompress and get the tar file
+
+# on Linux/MacOS, you could use tar
+tar xf wasm-toolchain-{version number}.tar.gz
+tar xf wasm-debug-server-{version number}.tar.gz
+# or you could use unzip
+unzip wasm-toolchain-{version number}.zip
+unzip wasm-debug-server-{version number}.zip
+# load wasm-toolchain 
+docker load --input wasm-toolchain.tar
+# load wasm-debug-server
+docker load --input wasm-debug-server.tar
+
+# on Windows, you could use any unzip software you like 
+# then loading docker images using powershell or git bash
+# load wasm-toolchain 
+docker load --input ./wasm-toolchain.tar
+# load wasm-debug-server
+docker load --input ./wasm-debug-server.tar
 ```
 
 ##### 3.2 Build docker images on host


### PR DESCRIPTION
Instead of publishing docker images to GitHub container registry, saving docker images to tar files, compress (tar/zip) them and upload to release binary directly