### PR TITLE
vscode-extension: Run the docker image with the same version as WAMR

### DIFF
--- a/test-tools/wamr-ide/VSCode-Extension/resource/scripts/boot_debugger_server.bat
+++ b/test-tools/wamr-ide/VSCode-Extension/resource/scripts/boot_debugger_server.bat
@@ -6,5 +6,5 @@
 docker run --rm -it --name=wasm-debug-server-ctr ^
            -v "%cd%":/mnt ^
            -p 1234:1234 ^
-           wasm-debug-server:1.0 ^
+           wasm-debug-server:%2 ^
            /bin/bash -c "./debug.sh %1"

--- a/test-tools/wamr-ide/VSCode-Extension/resource/scripts/boot_debugger_server.sh
+++ b/test-tools/wamr-ide/VSCode-Extension/resource/scripts/boot_debugger_server.sh
@@ -8,5 +8,5 @@ set -e
 docker run --rm -it --name=wasm-debug-server-ctr \
            -v "$(pwd)":/mnt \
            -p 1234:1234 \
-           wasm-debug-server:1.0 \
+           wasm-debug-server:$2 \
            /bin/bash -c "./debug.sh $1"

--- a/test-tools/wamr-ide/VSCode-Extension/resource/scripts/build.bat
+++ b/test-tools/wamr-ide/VSCode-Extension/resource/scripts/build.bat
@@ -7,5 +7,5 @@
 docker run --rm --name=wasm-toolchain-ctr ^
                 -it -v "%cd%":/mnt ^
                 --env=PROJ_PATH="%cd%" ^
-                wasm-toolchain:1.0  ^
+                wasm-toolchain:%2  ^
                 /bin/bash -c "./build_wasm.sh %1"

--- a/test-tools/wamr-ide/VSCode-Extension/resource/scripts/build.sh
+++ b/test-tools/wamr-ide/VSCode-Extension/resource/scripts/build.sh
@@ -8,5 +8,5 @@ set -e
 docker run --rm --name=wasm-toolchain-ctr \
                 -it -v "$(pwd)":/mnt \
                 --env=PROJ_PATH="$(pwd)" \
-                wasm-toolchain:1.0  \
+                wasm-toolchain:$2  \
                 /bin/bash -c "./build_wasm.sh $1"

--- a/test-tools/wamr-ide/VSCode-Extension/resource/scripts/run.bat
+++ b/test-tools/wamr-ide/VSCode-Extension/resource/scripts/run.bat
@@ -5,5 +5,5 @@
 
 docker run --rm -it --name=wasm-debug-server-ctr ^
            -v "%cd%":/mnt ^
-           wasm-debug-server:1.0 ^
+           wasm-debug-server:%2 ^
            /bin/bash -c "./run.sh %1"

--- a/test-tools/wamr-ide/VSCode-Extension/resource/scripts/run.sh
+++ b/test-tools/wamr-ide/VSCode-Extension/resource/scripts/run.sh
@@ -7,5 +7,5 @@ set -e
 
 docker run --rm -it --name=wasm-debug-server-ctr \
            -v "$(pwd)":/mnt \
-           wasm-debug-server:1.0 \
+           wasm-debug-server:$2 \
            /bin/bash -c "./run.sh $1"

--- a/test-tools/wamr-ide/VSCode-Extension/src/extension.ts
+++ b/test-tools/wamr-ide/VSCode-Extension/src/extension.ts
@@ -45,8 +45,9 @@ export async function activate(context: vscode.ExtensionContext) {
         includePathArr = new Array(),
         /* exclude files array used for written into config file */
         excludeFileArr = new Array(),
-        scriptMap = new Map(),
-        wamrVersion = '';
+        scriptMap = new Map();
+
+    const wamrVersion = getWAMRExtensionVersion(context);
 
     /**
      * Get OS platform information for differ windows and linux execution script
@@ -87,8 +88,6 @@ export async function activate(context: vscode.ExtensionContext) {
     typeMap.set('Run', 'Run');
     typeMap.set('Debug', 'Debug');
     typeMap.set('Destroy', 'Destroy');
-
-    wamrVersion = getWAMRExtensionVersion(context);
 
     wasmTaskProvider = new WasmTaskProvider(typeMap, scriptMap, wamrVersion);
 

--- a/test-tools/wamr-ide/VSCode-Extension/src/extension.ts
+++ b/test-tools/wamr-ide/VSCode-Extension/src/extension.ts
@@ -18,7 +18,11 @@ import {
 } from './utilities/directoryUtilities';
 import { decorationProvider } from './decorationProvider';
 import { WasmDebugConfigurationProvider } from './debugConfigurationProvider';
-import { isLLDBInstalled, promptInstallLLDB } from './utilities/lldbUtilities';
+import {
+    isLLDBInstalled,
+    promptInstallLLDB,
+    getWAMRExtensionVersion,
+} from './utilities/lldbUtilities';
 
 let wasmTaskProvider: WasmTaskProvider;
 let wasmDebugConfigProvider: WasmDebugConfigurationProvider;
@@ -41,7 +45,8 @@ export async function activate(context: vscode.ExtensionContext) {
         includePathArr = new Array(),
         /* exclude files array used for written into config file */
         excludeFileArr = new Array(),
-        scriptMap = new Map();
+        scriptMap = new Map(),
+        wamrVersion = '';
 
     /**
      * Get OS platform information for differ windows and linux execution script
@@ -83,7 +88,9 @@ export async function activate(context: vscode.ExtensionContext) {
     typeMap.set('Debug', 'Debug');
     typeMap.set('Destroy', 'Destroy');
 
-    wasmTaskProvider = new WasmTaskProvider(typeMap, scriptMap);
+    wamrVersion = getWAMRExtensionVersion(context);
+
+    wasmTaskProvider = new WasmTaskProvider(typeMap, scriptMap, wamrVersion);
 
     vscode.tasks.registerTaskProvider('wasm', wasmTaskProvider);
 
@@ -670,7 +677,8 @@ export async function activate(context: vscode.ExtensionContext) {
                                 let _path = curWorkspace.concat(
                                     OS_PLATFORM === 'win32'
                                         ? '\\'
-                                        : OS_PLATFORM === 'linux' || OS_PLATFORM === 'darwin'
+                                        : OS_PLATFORM === 'linux' ||
+                                          OS_PLATFORM === 'darwin'
                                         ? '/'
                                         : '',
                                     option

--- a/test-tools/wamr-ide/VSCode-Extension/src/taskProvider.ts
+++ b/test-tools/wamr-ide/VSCode-Extension/src/taskProvider.ts
@@ -15,7 +15,8 @@ export interface OwnShellOption {
 export class WasmTaskProvider implements vscode.TaskProvider {
     constructor(
         public _type: Map<string, string>,
-        public _script: Map<string, string>
+        public _script: Map<string, string>,
+        public _wamrVersion: string
     ) {}
 
     buildShellOption: OwnShellOption | undefined;
@@ -31,7 +32,11 @@ export class WasmTaskProvider implements vscode.TaskProvider {
             let targetName =
                 TargetConfigPanel.BUILD_ARGS.output_file_name.split('.')[0];
 
-            if (os.platform() === 'linux' || os.platform() === 'darwin' || os.platform() === 'win32') {
+            if (
+                os.platform() === 'linux' ||
+                os.platform() === 'darwin' ||
+                os.platform() === 'win32'
+            ) {
                 /* build */
                 this.buildShellOption = {
                     cmd:
@@ -40,7 +45,11 @@ export class WasmTaskProvider implements vscode.TaskProvider {
                             : (this._script.get('buildScript') as string),
                     options: {
                         executable: this._script.get('buildScript'),
-                        shellArgs: [targetName, os.platform()],
+                        shellArgs: [
+                            targetName,
+                            this._wamrVersion,
+                            os.platform(),
+                        ],
                     },
                 };
 
@@ -52,7 +61,7 @@ export class WasmTaskProvider implements vscode.TaskProvider {
                             : (this._script.get('debugScript') as string),
                     options: {
                         executable: this._script.get('debugScript'),
-                        shellArgs: [targetName],
+                        shellArgs: [targetName, this._wamrVersion],
                     },
                 };
 
@@ -64,7 +73,7 @@ export class WasmTaskProvider implements vscode.TaskProvider {
                             : (this._script.get('runScript') as string),
                     options: {
                         executable: this._script.get('runScript'),
-                        shellArgs: [targetName],
+                        shellArgs: [targetName, this._wamrVersion],
                     },
                 };
 

--- a/test-tools/wamr-ide/VSCode-Extension/src/taskProvider.ts
+++ b/test-tools/wamr-ide/VSCode-Extension/src/taskProvider.ts
@@ -45,11 +45,7 @@ export class WasmTaskProvider implements vscode.TaskProvider {
                             : (this._script.get('buildScript') as string),
                     options: {
                         executable: this._script.get('buildScript'),
-                        shellArgs: [
-                            targetName,
-                            this._wamrVersion,
-                            os.platform(),
-                        ],
+                        shellArgs: [targetName, this._wamrVersion],
                     },
                 };
 

--- a/test-tools/wamr-ide/VSCode-Extension/src/utilities/lldbUtilities.ts
+++ b/test-tools/wamr-ide/VSCode-Extension/src/utilities/lldbUtilities.ts
@@ -7,27 +7,41 @@ import * as vscode from 'vscode';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
-import { checkIfFileExists, downloadFile, unzipFile } from './directoryUtilities';
+import {
+    checkIfFileExists,
+    downloadFile,
+    unzipFile,
+} from './directoryUtilities';
 
-const LLDB_RESOURCE_DIR = "resource/debug";
-const LLDB_OS_DOWNLOAD_URL_SUFFIX_MAP: Partial<Record<NodeJS.Platform, string>> = {
-    "linux": "x86_64-ubuntu-22.04",
-    "darwin": "universal-macos-latest"
+const LLDB_RESOURCE_DIR = 'resource/debug';
+const LLDB_OS_DOWNLOAD_URL_SUFFIX_MAP: Partial<
+    Record<NodeJS.Platform, string>
+> = {
+    linux: 'x86_64-ubuntu-22.04',
+    darwin: 'universal-macos-latest',
 };
 
-const WAMR_LLDB_NOT_SUPPORTED_ERROR = new Error("WAMR LLDB is not supported on this platform");
+const WAMR_LLDB_NOT_SUPPORTED_ERROR = new Error(
+    'WAMR LLDB is not supported on this platform'
+);
 
 function getLLDBUnzipFilePath(destinationFolder: string, filename: string) {
-    const dirs = filename.split("/");
-    if (dirs[0] === "inst") {
+    const dirs = filename.split('/');
+    if (dirs[0] === 'inst') {
         dirs.shift();
     }
 
     return path.join(destinationFolder, ...dirs);
 }
 
+export function getWAMRExtensionVersion(
+    context: vscode.ExtensionContext
+): string {
+    return require(path.join(context.extensionPath, 'package.json')).version;
+}
+
 function getLLDBDownloadUrl(context: vscode.ExtensionContext): string {
-    const wamrVersion = require(path.join(context.extensionPath, "package.json")).version;
+    const wamrVersion = getWAMRExtensionVersion(context);
     const lldbOsUrlSuffix = LLDB_OS_DOWNLOAD_URL_SUFFIX_MAP[os.platform()];
 
     if (!lldbOsUrlSuffix) {
@@ -40,15 +54,25 @@ function getLLDBDownloadUrl(context: vscode.ExtensionContext): string {
 export function isLLDBInstalled(context: vscode.ExtensionContext): boolean {
     const extensionPath = context.extensionPath;
     const lldbOSDir = os.platform();
-    const lldbBinaryPath = path.join(extensionPath, LLDB_RESOURCE_DIR, lldbOSDir, "bin", "lldb");
+    const lldbBinaryPath = path.join(
+        extensionPath,
+        LLDB_RESOURCE_DIR,
+        lldbOSDir,
+        'bin',
+        'lldb'
+    );
     return checkIfFileExists(lldbBinaryPath);
 }
 
 export async function promptInstallLLDB(context: vscode.ExtensionContext) {
     const extensionPath = context.extensionPath;
-    const setupPrompt = "setup";
-    const skipPrompt = "skip";
-    const response = await vscode.window.showWarningMessage('No LLDB instance found. Setup now?', setupPrompt, skipPrompt);
+    const setupPrompt = 'setup';
+    const skipPrompt = 'skip';
+    const response = await vscode.window.showWarningMessage(
+        'No LLDB instance found. Setup now?',
+        setupPrompt,
+        skipPrompt
+    );
 
     if (response === skipPrompt) {
         return;
@@ -61,23 +85,31 @@ export async function promptInstallLLDB(context: vscode.ExtensionContext) {
         throw WAMR_LLDB_NOT_SUPPORTED_ERROR;
     }
 
-    const lldbDestinationFolder = path.join(extensionPath, LLDB_RESOURCE_DIR, destinationDir);
-    const lldbZipPath = path.join(lldbDestinationFolder, "bundle.zip");
+    const lldbDestinationFolder = path.join(
+        extensionPath,
+        LLDB_RESOURCE_DIR,
+        destinationDir
+    );
+    const lldbZipPath = path.join(lldbDestinationFolder, 'bundle.zip');
 
     vscode.window.showInformationMessage(`Downloading LLDB...`);
 
     await downloadFile(downloadUrl, lldbZipPath);
 
-    vscode.window.showInformationMessage(`LLDB downloaded to ${lldbZipPath}. Installing...`);
+    vscode.window.showInformationMessage(
+        `LLDB downloaded to ${lldbZipPath}. Installing...`
+    );
 
-    const lldbFiles = await unzipFile(lldbZipPath, filename => getLLDBUnzipFilePath(lldbDestinationFolder, filename));
+    const lldbFiles = await unzipFile(lldbZipPath, filename =>
+        getLLDBUnzipFilePath(lldbDestinationFolder, filename)
+    );
     // Allow execution of lldb
-    lldbFiles.forEach(file => fs.chmodSync(file, "0775"));
+    lldbFiles.forEach(file => fs.chmodSync(file, '0775'));
 
-    vscode.window.showInformationMessage(`LLDB installed at ${lldbDestinationFolder}`);
+    vscode.window.showInformationMessage(
+        `LLDB installed at ${lldbDestinationFolder}`
+    );
 
     // Remove the bundle.zip
     fs.unlink(lldbZipPath, () => {});
 }
-
-


### PR DESCRIPTION
Modify the VS Code extension, making it run the docker image with the same version of WAMR release, other than fixed version 1.0