### PR TITLE
libc-wasi: Fix spurious poll timeout

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -2696,7 +2696,7 @@ wasmtime_ssp_poll_oneoff(
         timeout = ts > INT_MAX ? -1 : (int)ts;
     }
     else {
-        timeout = 1000;
+        timeout = -1;
     }
     int ret = poll(pfds, nsubscriptions, timeout);
 


### PR DESCRIPTION
This reverts the "Fix libc-wasi poll_oneoff hang issue" change. https://github.com/bytecodealliance/wasm-micro-runtime/pull/1300

My app usng poll(,,-1) timed out and surprised me today.