### PR TITLE
Remove unnecessary ret value control when spec test is enabled

### DIFF
--- a/product-mini/platforms/linux-sgx/enclave-sample/App/App.cpp
+++ b/product-mini/platforms/linux-sgx/enclave-sample/App/App.cpp
@@ -796,12 +796,7 @@ fail1:
     /* Destroy runtime environment */
     destroy_runtime();
 
-#if WASM_ENABLE_SPEC_TEST != 0
-    (void)ret;
-    return 0;
-#else
     return ret;
-#endif
 }
 
 int

--- a/product-mini/platforms/posix/main.c
+++ b/product-mini/platforms/posix/main.c
@@ -696,10 +696,5 @@ fail1:
     /* destroy runtime environment */
     wasm_runtime_destroy();
 
-#if WASM_ENABLE_SPEC_TEST != 0
-    (void)ret;
-    return 0;
-#else
     return ret;
-#endif
 }

--- a/product-mini/platforms/windows/main.c
+++ b/product-mini/platforms/windows/main.c
@@ -496,10 +496,5 @@ fail1:
     /* destroy runtime environment */
     wasm_runtime_destroy();
 
-#if WASM_ENABLE_SPEC_TEST != 0
-    (void)ret;
-    return 0;
-#else
     return ret;
-#endif
 }


### PR DESCRIPTION
wamr-test-suites scripts can handle the return value correctly when
spec test is enabled.