### PR TITLE
Refine Windows thread waiting list operations

### DIFF
--- a/core/shared/platform/windows/platform_internal.h
+++ b/core/shared/platform/windows/platform_internal.h
@@ -72,6 +72,7 @@ typedef struct os_thread_wait_node *os_thread_wait_list;
 typedef struct korp_cond {
     korp_mutex wait_list_lock;
     os_thread_wait_list thread_wait_list;
+    struct os_thread_wait_node *thread_wait_list_end;
 } korp_cond;
 
 #define bh_socket_t SOCKET


### PR DESCRIPTION
Add thread_wait_list_end node for thread data and cond for Windows platform
to speedup the thread join and cond wait operations: no need to traverse the
wait list to get the end node to append the wait node.