### PR TITLE
Reserve TID values for WASI threads

### DIFF
--- a/core/iwasm/libraries/lib-wasi-threads/lib_wasi_threads.cmake
+++ b/core/iwasm/libraries/lib-wasi-threads/lib_wasi_threads.cmake
@@ -8,4 +8,5 @@ add_definitions (-DWASM_ENABLE_LIB_WASI_THREADS=1 -DWASM_ENABLE_HEAP_AUX_STACK_A
 include_directories(${LIB_WASI_THREADS_DIR})
 
 set (LIB_WASI_THREADS_SOURCE
-    ${LIB_WASI_THREADS_DIR}/lib_wasi_threads_wrapper.c)
+    ${LIB_WASI_THREADS_DIR}/lib_wasi_threads_wrapper.c
+    ${LIB_WASI_THREADS_DIR}/tid_allocator.c)

--- a/core/iwasm/libraries/lib-wasi-threads/tid_allocator.c
+++ b/core/iwasm/libraries/lib-wasi-threads/tid_allocator.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#include "tid_allocator.h"
+#include "wasm_export.h"
+#include "bh_log.h"
+
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+
+struct tidAllocator {
+    int32 *ids;  // Array used to store the stack
+    uint32 size; // Stack capacity
+    uint32 pos;  // Index of the element after the stack top
+};
+
+TidAllocator *
+tid_allocator_init()
+{
+    TidAllocator *tid_allocator = wasm_runtime_malloc(sizeof(TidAllocator));
+    tid_allocator->size = MIN(TID_ALLOCATOR_INIT_SIZE, TID_MAX - TID_MIN + 1);
+    tid_allocator->pos = tid_allocator->size;
+    tid_allocator->ids =
+        wasm_runtime_malloc(tid_allocator->size * sizeof(int32));
+    if (tid_allocator->ids == NULL)
+        return NULL;
+
+    for (int64 i = tid_allocator->pos - 1; i >= 0; i--)
+        tid_allocator->ids[i] = TID_MIN + (tid_allocator->pos - 1 - i);
+
+    return tid_allocator;
+}
+
+void
+tid_allocator_destroy(TidAllocator *tid_allocator)
+{
+    wasm_runtime_free(tid_allocator->ids);
+    wasm_runtime_free(tid_allocator);
+}
+
+int32
+tid_allocator_get(TidAllocator *tid_allocator)
+{
+    if (tid_allocator->pos == 0) { // Resize stack and push new thread ids
+        if (tid_allocator->size == TID_MAX - TID_MIN + 1) {
+            LOG_ERROR("Maximum thread identifier reached");
+            return -1;
+        }
+
+        uint32 old_size = tid_allocator->size;
+        uint32 new_size = MIN(tid_allocator->size * 2, TID_MAX - TID_MIN + 1);
+        if (new_size != TID_MAX - TID_MIN + 1
+            && new_size / 2 != tid_allocator->size) {
+            LOG_ERROR("Overflow detected during new size calculation");
+            return -1;
+        }
+
+        size_t realloc_size = new_size * sizeof(int32);
+        if (realloc_size / sizeof(int32) != new_size) {
+            LOG_ERROR("Overflow detected during realloc");
+            return -1;
+        }
+        int32 *tmp = wasm_runtime_realloc(tid_allocator->ids, realloc_size);
+        if (tmp == NULL) {
+            LOG_ERROR("Thread ID allocator realloc failed");
+            return -1;
+        }
+
+        tid_allocator->size = new_size;
+        tid_allocator->pos = new_size - old_size;
+        tid_allocator->ids = tmp;
+        for (int64 i = tid_allocator->pos - 1; i >= 0; i--)
+            tid_allocator->ids[i] = TID_MIN + (tid_allocator->size - 1 - i);
+    }
+
+    // Pop available thread identifier from the stack
+    return tid_allocator->ids[--tid_allocator->pos];
+}
+
+void
+tid_allocator_put(TidAllocator *tid_allocator, int32 thread_id)
+{
+    // Release thread identifier by pushing it into the stack
+    bh_assert(tid_allocator->pos < tid_allocator->size);
+    tid_allocator->ids[tid_allocator->pos++] = thread_id;
+}

--- a/core/iwasm/libraries/lib-wasi-threads/tid_allocator.h
+++ b/core/iwasm/libraries/lib-wasi-threads/tid_allocator.h
@@ -15,18 +15,22 @@ enum {
 }; // Reserved TIDs (WASI specification)
 
 /* Stack data structure to track available thread identifiers */
-typedef struct tidAllocator TidAllocator;
+typedef struct {
+    int32 *ids;  // Array used to store the stack
+    uint32 size; // Stack capacity
+    uint32 pos;  // Index of the element after the stack top
+} TidAllocator;
 
-TidAllocator *
-tid_allocator_init();
+bool
+tid_allocator_init(TidAllocator *tid_allocator);
 
 void
-tid_allocator_destroy(TidAllocator *tid_allocator);
+tid_allocator_deinit(TidAllocator *tid_allocator);
 
 int32
-tid_allocator_get(TidAllocator *tid_allocator);
+tid_allocator_get_tid(TidAllocator *tid_allocator);
 
 void
-tid_allocator_put(TidAllocator *tid_allocator, int32 thread_id);
+tid_allocator_release_tid(TidAllocator *tid_allocator, int32 thread_id);
 
 #endif /* _TID_ALLOCATOR_H */

--- a/core/iwasm/libraries/lib-wasi-threads/tid_allocator.h
+++ b/core/iwasm/libraries/lib-wasi-threads/tid_allocator.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#ifndef _TID_ALLOCATOR_H
+#define _TID_ALLOCATOR_H
+
+#include "platform_common.h"
+
+#define TID_ALLOCATOR_INIT_SIZE CLUSTER_MAX_THREAD_NUM
+enum {
+    TID_MIN = 1,
+    TID_MAX = 0x1FFFFFFF
+}; // Reserved TIDs (WASI specification)
+
+/* Stack data structure to track available thread identifiers */
+typedef struct tidAllocator TidAllocator;
+
+TidAllocator *
+tid_allocator_init();
+
+void
+tid_allocator_destroy(TidAllocator *tid_allocator);
+
+int32
+tid_allocator_get(TidAllocator *tid_allocator);
+
+void
+tid_allocator_put(TidAllocator *tid_allocator, int32 thread_id);
+
+#endif /* _TID_ALLOCATOR_H */


### PR DESCRIPTION
According to the [WASI thread specification](https://github.com/WebAssembly/wasi-threads/pull/16), some thread identifiers are reserved and should not be used. In fact, only IDs between `1` and `0x1FFFFFFF` are valid.
The thread ID allocator has been moved to a separate class to avoid polluting the `lib_wasi_threads_wrapper` logic.