### PR TITLE
Enable CI wasi test suite for x86-32 classic/fast interpreter

### DIFF
--- a/.github/workflows/compilation_on_android_ubuntu.yml
+++ b/.github/workflows/compilation_on_android_ubuntu.yml
@@ -424,7 +424,8 @@ jobs:
 
       - name: set env variable(if x86_32 test needed)
         if: >
-          (matrix.test_option == '$DEFAULT_TEST_OPTIONS' || matrix.test_option == '$THREADS_TEST_OPTIONS')
+          (matrix.test_option == '$DEFAULT_TEST_OPTIONS' || matrix.test_option == '$THREADS_TEST_OPTIONS'
+           || matrix.test_option == '$WASI_TEST_OPTIONS')
           && matrix.running_mode != 'fast-jit' && matrix.running_mode != 'jit'
         run: echo "TEST_ON_X86_32=true" >> $GITHUB_ENV
 

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -987,7 +987,7 @@ check_linked_symbol(AOTModule *module, char *error_buf, uint32 error_buf_size)
         AOTImportGlobal *global = module->import_globals + i;
         if (!global->is_linked) {
             set_error_buf_v(error_buf, error_buf_size,
-                            "warning: failed to link import global (%s, %s)",
+                            "failed to link import global (%s, %s)",
                             global->module_name, global->global_name);
             return false;
         }

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1252,7 +1252,7 @@ check_linked_symbol(WASMModuleInstance *module_inst, char *error_buf,
 #else
 #if WASM_ENABLE_WAMR_COMPILER == 0
             set_error_buf_v(error_buf, error_buf_size,
-                            "warning: failed to link import global (%s, %s)",
+                            "failed to link import global (%s, %s)",
                             global->module_name, global->field_name);
             return false;
 #else


### PR DESCRIPTION
The original CI didn't actually run wasi test suite for x86-32 since the `TEST_ON_X86_32=true`
isn't written into $GITHUB_ENV.

And refine the error output when failed to link import global.