### PR TITLE
Adding an extension to the Visual Studio Marketplace

### DIFF
--- a/.github/workflows/build_wamr_vscode_ext.yml
+++ b/.github/workflows/build_wamr_vscode_ext.yml
@@ -32,11 +32,14 @@ jobs:
         working-directory: test-tools/wamr-ide/VSCode-Extension
 
       - name: generate wamr ide vscode extension
+        env: 
+          credentials: ${{ secrets.TOKEN }}
         run: |
           npm install -g vsce
           rm -rf node_modules
           npm install
           vsce package
+          vsce publish -p ${{ secrets.TOKEN }}
         working-directory: test-tools/wamr-ide/VSCode-Extension
 
       - name: compress the vscode extension

--- a/.github/workflows/release_process.yml
+++ b/.github/workflows/release_process.yml
@@ -150,6 +150,7 @@ jobs:
   release_wamr_ide_vscode_ext:
     needs: [create_tag, create_release]
     uses: ./.github/workflows/build_wamr_vscode_ext.yml
+    secrets: inherit
     with:
       upload_url: ${{ needs.create_release.outputs.upload_url }}
       ver_num: ${{ needs.create_tag.outputs.new_ver }}

--- a/test-tools/wamr-ide/VSCode-Extension/package.json
+++ b/test-tools/wamr-ide/VSCode-Extension/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wamride",
-    "publisher": "wamr",
+    "publisher": "wamr-publisher",
     "repository": {
         "url": "https://github.com/bytecodealliance/wasm-micro-runtime/tree/main/test-tools/wamr-ide"
     },


### PR DESCRIPTION
What 

Add an extension to the visual studio marketplace releasing new versions of the WAMR-IDE to download the extension from the marketplace .


Why

This allows for automation to take place because downloading and installing the extension is a manual process so it'd be  simpler if the extension was published automatically through the visual studio marketplace.

How

Alter the github action in build_wamr_vscode_ext.yml to publish to an account created for the WAMR publisher to maintain and a personal access token(PAT) that publishes to the account below. For every run of the binary release process job the WAMR-IDE is published to the registered account 
 
Record of the PAT is stored and will be sent over. 
 https://dev.azure.com/wamr-vs-marketplace/Wamr%20Extension.