### PR TITLE
Handle thread exit

### DIFF
--- a/samples/wasi-threads/wasm-apps/CMakeLists.txt
+++ b/samples/wasi-threads/wasm-apps/CMakeLists.txt
@@ -36,4 +36,4 @@ function (compile_sample SOURCE_FILE)
 endfunction ()
 
 compile_sample(no_pthread.c wasi_thread_start.S)
-compile_sample(exception_propagation.c wasi_thread_start.S)
+compile_sample(thread_termination.c wasi_thread_start.S)


### PR DESCRIPTION
Implementation of what's described here: https://github.com/WebAssembly/wasi-threads/pull/17:
- a trap or `proc_exit` in the main thread should stop all the threads in the process
- a thread created with wasi_thread_spawn that calls `proc_exit` should terminate all the threads in the process
 
The sample has been modified to test combinations of trap or `proc_exit` for termination and termination forced in the main thread or a spawn thread.

Part of #1790.