### PR TITLE
Enable running mode control for runtime and module instance

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -132,7 +132,7 @@ static JitCompOptions jit_options = { 0 };
 static LLVMJITOptions llvm_jit_options = { 3, 3 };
 #endif
 
-static RunningMode runtime_running_mode = { 0 };
+static RunningMode runtime_running_mode = Mode_Default;
 
 #ifdef OS_ENABLE_HW_BOUND_CHECK
 /* The exec_env of thread local storage, set before calling function
@@ -587,7 +587,7 @@ wasm_runtime_full_init(RuntimeInitArgs *init_args)
 bool
 wasm_runtime_is_running_mode_supported(RunningMode running_mode)
 {
-    if (running_mode == 0) {
+    if (running_mode == Mode_Default) {
         return true;
     }
     else if (running_mode == Mode_Interp) {
@@ -1255,14 +1255,16 @@ wasm_runtime_set_running_mode(wasm_module_inst_t module_inst,
         WASMModuleInstance *module_inst_interp =
             (WASMModuleInstance *)module_inst;
 
-        if (running_mode == 0) {
+        if (running_mode == Mode_Default) {
 #if WASM_ENABLE_FAST_JIT == 0 && WASM_ENABLE_JIT == 0
             running_mode = Mode_Interp;
 #elif WASM_ENABLE_FAST_JIT != 0 && WASM_ENABLE_JIT == 0
             running_mode = Mode_Fast_JIT;
-#elif WASM_ENABLE_FAST_JIT == 0 && WASM_ENABLE_JIT != 0
+#elif (WASM_ENABLE_FAST_JIT == 0 || WASM_ENABLE_LAZY_JIT == 0) \
+    && WASM_ENABLE_JIT != 0
             running_mode = Mode_LLVM_JIT;
-#elif WASM_ENABLE_FAST_JIT != 0 && WASM_ENABLE_JIT != 0
+#elif WASM_ENABLE_FAST_JIT != 0 && WASM_ENABLE_JIT != 0 \
+    && WASM_ENABLE_LAZY_JIT != 0
             running_mode = Mode_Multi_Tier_JIT;
 #endif
         }

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -128,6 +128,10 @@ runtime_malloc(uint64 size, WASMModuleInstanceCommon *module_inst,
 static JitCompOptions jit_options = { 0 };
 #endif
 
+#if WASM_ENABLE_JIT != 0
+static LLVMJITOptions llvm_jit_options = { 3, 3 };
+#endif
+
 #if WASM_ENABLE_JIT != 0 || WASM_ENABLE_FAST_JIT != 0
 static RuntimeOptions runtime_options = { 0 };
 #endif
@@ -526,6 +530,14 @@ wasm_runtime_get_default_running_mode(void)
 }
 #endif
 
+#if WASM_ENABLE_JIT != 0
+LLVMJITOptions
+wasm_runtime_get_llvm_jit_options(void)
+{
+    return llvm_jit_options;
+}
+#endif
+
 bool
 wasm_runtime_full_init(RuntimeInitArgs *init_args)
 {
@@ -541,6 +553,11 @@ wasm_runtime_full_init(RuntimeInitArgs *init_args)
 
 #if WASM_ENABLE_FAST_JIT != 0
     jit_options.code_cache_size = init_args->fast_jit_code_cache_size;
+#endif
+
+#if WASM_ENABLE_JIT != 0
+    llvm_jit_options.size_level = init_args->llvm_jit_size_level;
+    llvm_jit_options.opt_level = init_args->llvm_jit_opt_level;
 #endif
 
     if (!wasm_runtime_env_init()) {

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -587,7 +587,7 @@ wasm_runtime_is_running_mode_supported(RunningMode running_mode)
 #if WASM_ENABLE_JIT != 0
     ret |= (running_mode == Mode_LLVM_JIT);
 #endif
-#if WASM_ENABLE_FAST_JIT != 0 && WASM_ENABLE_JIT != 0
+#if WASM_ENABLE_FAST_JIT != 0 && WASM_ENABLE_JIT != 0 && WASM_ENABLE_LAZY_JIT != 0
     ret |= (running_mode == Mode_Multi_Tier_JIT);
 #endif
     return ret;

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -25,6 +25,9 @@
 extern "C" {
 #endif
 
+/* Internal use for setting default running mode */
+#define Mode_Default 0
+
 #if WASM_CPU_SUPPORTS_UNALIGNED_ADDR_ACCESS != 0
 
 #define PUT_I64_TO_ADDR(addr, value)       \
@@ -509,10 +512,12 @@ wasm_runtime_instantiate(WASMModuleCommon *module, uint32 stack_size,
                          uint32 heap_size, char *error_buf,
                          uint32 error_buf_size);
 
+/* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_set_running_mode(wasm_module_inst_t module_inst,
                               RunningMode running_mode);
 
+/* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN RunningMode
 wasm_runtime_get_running_mode(wasm_module_inst_t module_inst);
 

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -419,6 +419,13 @@ typedef struct RuntimeOptions {
 } RuntimeOptions;
 #endif
 
+#ifdef WASM_ENABLE_JIT
+typedef struct LLVMJITOptions {
+    uint32 opt_level;
+    uint32 size_level;
+} LLVMJITOptions;
+#endif
+
 #ifdef OS_ENABLE_HW_BOUND_CHECK
 /* Signal info passing to interp/aot signal handler */
 typedef struct WASMSignalInfo {
@@ -447,6 +454,12 @@ wasm_runtime_init(void);
 /* Internal API */
 RunningMode
 wasm_runtime_get_default_running_mode(void);
+#endif
+
+#if WASM_ENABLE_JIT != 0
+/* Internal API */
+LLVMJITOptions
+wasm_runtime_get_llvm_jit_options(void);
 #endif
 
 /* See wasm_export.h for description */

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -413,12 +413,6 @@ typedef struct wasm_frame_t {
     const char *func_name_wp;
 } WASMCApiFrame;
 
-#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_FAST_JIT != 0
-typedef struct RuntimeOptions {
-    RunningMode running_mode;
-} RuntimeOptions;
-#endif
-
 #ifdef WASM_ENABLE_JIT
 typedef struct LLVMJITOptions {
     uint32 opt_level;
@@ -450,11 +444,9 @@ wasm_runtime_get_exec_env_tls(void);
 WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_init(void);
 
-#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_FAST_JIT != 0
 /* Internal API */
 RunningMode
 wasm_runtime_get_default_running_mode(void);
-#endif
 
 #if WASM_ENABLE_JIT != 0
 /* Internal API */

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -413,6 +413,12 @@ typedef struct wasm_frame_t {
     const char *func_name_wp;
 } WASMCApiFrame;
 
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_FAST_JIT != 0
+typedef struct RuntimeOptions {
+    RunningMode running_mode;
+} RuntimeOptions;
+#endif
+
 #ifdef OS_ENABLE_HW_BOUND_CHECK
 /* Signal info passing to interp/aot signal handler */
 typedef struct WASMSignalInfo {
@@ -436,6 +442,12 @@ wasm_runtime_get_exec_env_tls(void);
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_init(void);
+
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_FAST_JIT != 0
+/* Internal API */
+RunningMode
+wasm_runtime_get_running_mode(void);
+#endif
 
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN bool

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -446,12 +446,20 @@ wasm_runtime_init(void);
 #if WASM_ENABLE_JIT != 0 || WASM_ENABLE_FAST_JIT != 0
 /* Internal API */
 RunningMode
-wasm_runtime_get_running_mode(void);
+wasm_runtime_get_default_running_mode(void);
 #endif
 
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_full_init(RuntimeInitArgs *init_args);
+
+/* See wasm_export.h for description */
+WASM_RUNTIME_API_EXTERN bool
+wasm_runtime_is_running_mode_supported(RunningMode running_mode);
+
+/* See wasm_export.h for description */
+WASM_RUNTIME_API_EXTERN bool
+wasm_runtime_set_default_running_mode(RunningMode running_mode);
 
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN void
@@ -495,6 +503,13 @@ WASM_RUNTIME_API_EXTERN WASMModuleInstanceCommon *
 wasm_runtime_instantiate(WASMModuleCommon *module, uint32 stack_size,
                          uint32 heap_size, char *error_buf,
                          uint32 error_buf_size);
+
+WASM_RUNTIME_API_EXTERN bool
+wasm_runtime_set_running_mode(wasm_module_inst_t module_inst,
+                              RunningMode running_mode);
+
+WASM_RUNTIME_API_EXTERN RunningMode
+wasm_runtime_get_running_mode(wasm_module_inst_t module_inst);
 
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN void

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -222,7 +222,7 @@ WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_full_init(RuntimeInitArgs *init_args);
 
 /**
- * Query whether a certain running mode is supported for this runtime
+ * Query whether a certain running mode is supported for the runtime
  *
  * @param running_mode the running mode to query
  *

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -164,6 +164,10 @@ typedef struct RuntimeInitArgs {
      * || WASM_ENABLE_FAST_JIT != 0*/
     RunningMode running_mode;
 
+    /* LLVM JIT opt and size level */
+    uint32_t llvm_jit_opt_level;
+    uint32_t llvm_jit_size_level;
+
 } RuntimeInitArgs;
 
 #ifndef WASM_VALKIND_T_DEFINED

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -131,6 +131,13 @@ typedef struct mem_alloc_info_t {
     uint32_t highmark_size;
 } mem_alloc_info_t;
 
+typedef enum RunningMode{
+    Mode_Interp = 1,
+    Mode_Fast_JIT,
+    Mode_LLVM_JIT,
+    Mode_Multi_Tier_JIT,
+} RunningMode;
+
 /* WASM runtime initialize arguments */
 typedef struct RuntimeInitArgs {
     mem_alloc_type_t mem_alloc_type;
@@ -152,6 +159,11 @@ typedef struct RuntimeInitArgs {
 
     /* Fast JIT code cache size */
     uint32_t fast_jit_code_cache_size;
+
+    /* Running mode settings, only used when WASM_ENABLE_JIT != 0
+     * || WASM_ENABLE_FAST_JIT != 0*/
+    RunningMode running_mode;
+
 } RuntimeInitArgs;
 
 #ifndef WASM_VALKIND_T_DEFINED
@@ -195,9 +207,9 @@ WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_init(void);
 
 /**
- * Initialize the WASM runtime environment, and also initialize
- * the memory allocator and register native symbols, which are specified
- * with init arguments
+ * Initialize the WASM runtime environment, WASM running mode,
+ * and also initialize the memory allocator and register native symbols,
+ * which are specified with init arguments
  *
  * @param init_args specifies the init arguments
  *
@@ -205,6 +217,27 @@ wasm_runtime_init(void);
  */
 WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_full_init(RuntimeInitArgs *init_args);
+
+/**
+ * Query whether a certain running mode is supported for this runtime
+ *
+ * @param running_mode the running mode to query
+ *
+ * @return return true if this running mode is supported, false otherwise
+ */
+WASM_RUNTIME_API_EXTERN bool
+wasm_runtime_is_running_mode_supported(RunningMode running_mode);
+
+/**
+ * Setting the default running mode for the WAMR runtime. If a WASM module
+ * instance not specify running mode, this default running mode will be used
+ *
+ * @param running_mode the WASM module instance to destroy
+ *
+ * @return return true if success, false otherwise
+ */
+WASM_RUNTIME_API_EXTERN bool
+wasm_runtime_set_default_running_mode(RunningMode running_mode);
 
 /**
  * Destroy the WASM runtime environment.

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -484,6 +484,31 @@ wasm_runtime_instantiate(const wasm_module_t module,
                          char *error_buf, uint32_t error_buf_size);
 
 /**
+ * Setting the running mode of a WASM module instance, override the
+ * default running mode of WAMR runtime
+ *
+ * @param module_inst the WASM module instance to set running mode
+ * @param running_mode the running mode to set
+ *
+ * @return return true if success, false otherwise
+ */
+WASM_RUNTIME_API_EXTERN bool
+wasm_runtime_set_running_mode(wasm_module_inst_t module_inst,
+                              RunningMode running_mode);
+
+/**
+ * Getting the running mode of a WASM module instance, if no running mode
+ * is explicit set for this module instance, running mode of runtime will
+ * be used and returned
+ *
+ * @param module_inst the WASM module instance to query for running mode
+ *
+ * @return return the running mode this module instance currently use
+ */
+WASM_RUNTIME_API_EXTERN RunningMode
+wasm_runtime_get_running_mode(wasm_module_inst_t module_inst);
+
+/**
  * Deinstantiate a WASM module instance, destroy the resources.
  *
  * @param module_inst the WASM module instance to destroy

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -131,7 +131,8 @@ typedef struct mem_alloc_info_t {
     uint32_t highmark_size;
 } mem_alloc_info_t;
 
-typedef enum RunningMode{
+/* Running mode of runtime and module instance*/
+typedef enum RunningMode {
     Mode_Interp = 1,
     Mode_Fast_JIT,
     Mode_LLVM_JIT,
@@ -160,14 +161,12 @@ typedef struct RuntimeInitArgs {
     /* Fast JIT code cache size */
     uint32_t fast_jit_code_cache_size;
 
-    /* Running mode settings, only used when WASM_ENABLE_JIT != 0
-     * || WASM_ENABLE_FAST_JIT != 0*/
+    /* Default running mode of the runtime */
     RunningMode running_mode;
 
     /* LLVM JIT opt and size level */
     uint32_t llvm_jit_opt_level;
     uint32_t llvm_jit_size_level;
-
 } RuntimeInitArgs;
 
 #ifndef WASM_VALKIND_T_DEFINED
@@ -227,18 +226,19 @@ wasm_runtime_full_init(RuntimeInitArgs *init_args);
  *
  * @param running_mode the running mode to query
  *
- * @return return true if this running mode is supported, false otherwise
+ * @return true if this running mode is supported, false otherwise
  */
 WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_is_running_mode_supported(RunningMode running_mode);
 
 /**
- * Setting the default running mode for the WAMR runtime. If a WASM module
- * instance not specify running mode, this default running mode will be used
+ * Set the default running mode for the runtime. It is inherited
+ * to set the running mode of a module instance when it is instantiated,
+ * and can be changed by calling wasm_runtime_set_running_mode
  *
- * @param running_mode the WASM module instance to destroy
+ * @param running_mode the running mode to set
  *
- * @return return true if success, false otherwise
+ * @return true if success, false otherwise
  */
 WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_set_default_running_mode(RunningMode running_mode);
@@ -488,26 +488,26 @@ wasm_runtime_instantiate(const wasm_module_t module,
                          char *error_buf, uint32_t error_buf_size);
 
 /**
- * Setting the running mode of a WASM module instance, override the
- * default running mode of WAMR runtime
+ * Set the running mode of a WASM module instance, override the
+ * default running mode of the runtime
  *
  * @param module_inst the WASM module instance to set running mode
  * @param running_mode the running mode to set
  *
- * @return return true if success, false otherwise
+ * @return true if success, false otherwise
  */
 WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_set_running_mode(wasm_module_inst_t module_inst,
                               RunningMode running_mode);
 
 /**
- * Getting the running mode of a WASM module instance, if no running mode
- * is explicit set for this module instance, running mode of runtime will
+ * Get the running mode of a WASM module instance, if no running mode
+ * is explicitly set the default running mode of runtime will
  * be used and returned
  *
  * @param module_inst the WASM module instance to query for running mode
  *
- * @return return the running mode this module instance currently use
+ * @return the running mode this module instance currently use
  */
 WASM_RUNTIME_API_EXTERN RunningMode
 wasm_runtime_get_running_mode(wasm_module_inst_t module_inst);

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -4240,7 +4240,7 @@ wasm_interp_call_wasm(WASMModuleInstance *module_inst, WASMExecEnv *exec_env,
          * With interpreter and both JIT enabled, run multi-tier JIT.
          * The running mode can be overridden with CLI argument */
         if (running_mode == 0) {
-#if WASM_ENABLE_JIT != 0 && WASM_ENABLE_FAST_JIT != 0
+#if WASM_ENABLE_JIT != 0 && WASM_ENABLE_FAST_JIT != 0 && WASM_ENABLE_LAZY_JIT != 0
             running_mode = Mode_Multi_Tier_JIT;
 #elif WASM_ENABLE_JIT != 0
             running_mode = Mode_LLVM_JIT;
@@ -4317,17 +4317,6 @@ wasm_interp_call_wasm(WASMModuleInstance *module_inst, WASMExecEnv *exec_env,
 #if WASM_ENABLE_FAST_JIT != 0
         else if (running_mode == Mode_Fast_JIT) {
             fast_jit_call_func_bytecode(module_inst, exec_env, function, frame);
-        }
-#endif
-        /* Fast JIT to LLVM JIT tier-up is enabled */
-#if WASM_ENABLE_FAST_JIT != 0 && WASM_ENABLE_JIT != 0
-        /* in eager jit mode, multi-tier use llvm jit */
-        else if (running_mode == Mode_Multi_Tier_JIT) {
-            llvm_jit_call_func_bytecode(module_inst, exec_env, function, argc,
-                                        argv);
-            /* For llvm jit, the results have been stored in argv,
-               no need to copy them from stack frame again */
-            copy_argv_from_frame = false;
         }
 #endif
 

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -1183,10 +1183,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 goto got_exception;
             }
 
-            HANDLE_OP(WASM_OP_NOP)
-            {
-                HANDLE_OP_END();
-            }
+            HANDLE_OP(WASM_OP_NOP) { HANDLE_OP_END(); }
 
             HANDLE_OP(EXT_OP_BLOCK)
             {
@@ -3023,10 +3020,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
             HANDLE_OP(WASM_OP_I32_REINTERPRET_F32)
             HANDLE_OP(WASM_OP_I64_REINTERPRET_F64)
             HANDLE_OP(WASM_OP_F32_REINTERPRET_I32)
-            HANDLE_OP(WASM_OP_F64_REINTERPRET_I64)
-            {
-                HANDLE_OP_END();
-            }
+            HANDLE_OP(WASM_OP_F64_REINTERPRET_I64) { HANDLE_OP_END(); }
 
             HANDLE_OP(WASM_OP_I32_EXTEND8_S)
             {
@@ -4232,33 +4226,9 @@ wasm_interp_call_wasm(WASMModuleInstance *module_inst, WASMExecEnv *exec_env,
         }
     }
     else {
-#if WASM_ENABLE_FAST_JIT != 0 || WASM_ENABLE_JIT != 0
-        /*  priority of choosing running mode:
-         * 1. user-set module instance running mode
-         * 2. user-set default running mode
-         * 3. system default running mode */
-        RunningMode running_mode;
-        running_mode =
+        RunningMode running_mode =
             wasm_runtime_get_running_mode((wasm_module_inst_t)module_inst);
 
-        if (running_mode == 0)
-            running_mode = wasm_runtime_get_default_running_mode();
-
-        if (running_mode == 0) {
-            /* if user didn't set one
-             * use the system default running mode:
-             * With only interpreter and one of JIT enabled run LLVM JIT/Fast
-             * JIT. With interpreter and both JIT enabled, run multi-tier JIT */
-#if WASM_ENABLE_JIT != 0 && WASM_ENABLE_FAST_JIT != 0 \
-    && WASM_ENABLE_LAZY_JIT != 0
-            running_mode = Mode_Multi_Tier_JIT;
-#elif WASM_ENABLE_JIT != 0
-            running_mode = Mode_LLVM_JIT;
-#elif WASM_ENABLE_FAST_JIT != 0
-            running_mode = Mode_Fast_JIT;
-#endif
-        }
-#endif
 #if WASM_ENABLE_LAZY_JIT != 0
 
         /* choose to run interpreter mode */
@@ -4306,8 +4276,6 @@ wasm_interp_call_wasm(WASMModuleInstance *module_inst, WASMExecEnv *exec_env,
 
 #else /* else of WASM_ENABLE_LAZY_JIT != 0 */
 
-#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_FAST_JIT != 0
-
         /* choose to run interpreter mode */
         if (running_mode == Mode_Interp) {
             wasm_interp_call_func_bytecode(module_inst, exec_env, function,
@@ -4329,10 +4297,6 @@ wasm_interp_call_wasm(WASMModuleInstance *module_inst, WASMExecEnv *exec_env,
             fast_jit_call_func_bytecode(module_inst, exec_env, function, frame);
         }
 #endif
-
-#else  /* else of WASM_ENABLE_JIT != 0 || WASM_ENABLE_FAST_JIT != 0 */
-        wasm_interp_call_func_bytecode(module_inst, exec_env, function, frame);
-#endif /* end of WASM_ENABLE_JIT != 0 || WASM_ENABLE_FAST_JIT != 0 */
 
 #endif /* end of WASM_ENABLE_LAZY_JIT != 0 */
 

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -3027,9 +3027,11 @@ init_llvm_jit_functions_stage1(WASMModule *module, char *error_buf,
     }
 
     option.is_jit_mode = true;
-    /* TODO: opt level and size level*/
-    option.opt_level = 3;
-    option.size_level = 3;
+
+    LLVMJITOptions llvm_jit_options = wasm_runtime_get_llvm_jit_options();
+    option.opt_level = llvm_jit_options.opt_level;
+    option.size_level = llvm_jit_options.size_level;
+
 #if WASM_ENABLE_BULK_MEMORY != 0
     option.enable_bulk_memory = true;
 #endif

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -3027,6 +3027,7 @@ init_llvm_jit_functions_stage1(WASMModule *module, char *error_buf,
     }
 
     option.is_jit_mode = true;
+    /* TODO: opt level and size level*/
     option.opt_level = 3;
     option.size_level = 3;
 #if WASM_ENABLE_BULK_MEMORY != 0

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -2989,6 +2989,7 @@ static bool
 init_llvm_jit_functions_stage1(WASMModule *module, char *error_buf,
                                uint32 error_buf_size)
 {
+    LLVMJITOptions llvm_jit_options;
     AOTCompOption option = { 0 };
     char *aot_last_error;
     uint64 size;
@@ -3028,7 +3029,7 @@ init_llvm_jit_functions_stage1(WASMModule *module, char *error_buf,
 
     option.is_jit_mode = true;
 
-    LLVMJITOptions llvm_jit_options = wasm_runtime_get_llvm_jit_options();
+    llvm_jit_options = wasm_runtime_get_llvm_jit_options();
     option.opt_level = llvm_jit_options.opt_level;
     option.size_level = llvm_jit_options.size_level;
 

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1419,6 +1419,8 @@ wasm_instantiate(WASMModule *module, bool is_sub_inst, uint32 stack_size,
     module_inst->e =
         (WASMModuleInstanceExtra *)((uint8 *)module_inst + extra_info_offset);
 
+    module_inst->e->running_mode = 0;
+
 #if WASM_ENABLE_SHARED_MEMORY != 0
     if (os_mutex_init(&module_inst->e->mem_lock) != 0) {
         set_error_buf(error_buf, error_buf_size,

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1419,7 +1419,8 @@ wasm_instantiate(WASMModule *module, bool is_sub_inst, uint32 stack_size,
     module_inst->e =
         (WASMModuleInstanceExtra *)((uint8 *)module_inst + extra_info_offset);
 
-    module_inst->e->running_mode = 0;
+    wasm_runtime_set_running_mode((wasm_module_inst_t)module_inst,
+                                  wasm_runtime_get_default_running_mode());
 
 #if WASM_ENABLE_SHARED_MEMORY != 0
     if (os_mutex_init(&module_inst->e->mem_lock) != 0) {

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -219,6 +219,7 @@ typedef struct WASMModuleInstanceExtra {
     WASMFunctionInstance *retain_function;
 
     CApiFuncImport *c_api_func_imports;
+    RunningMode running_mode;
 
 #if WASM_ENABLE_SHARED_MEMORY != 0
     /* lock for shared memory atomic operations */
@@ -242,7 +243,6 @@ typedef struct WASMModuleInstanceExtra {
         && WASM_ENABLE_LAZY_JIT != 0)
     WASMModuleInstance *next;
 #endif
-    RunningMode running_mode;
 } WASMModuleInstanceExtra;
 
 struct AOTFuncPerfProfInfo;

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -242,6 +242,7 @@ typedef struct WASMModuleInstanceExtra {
         && WASM_ENABLE_LAZY_JIT != 0)
     WASMModuleInstance *next;
 #endif
+    RunningMode running_mode;
 } WASMModuleInstanceExtra;
 
 struct AOTFuncPerfProfInfo;

--- a/product-mini/platforms/posix/main.c
+++ b/product-mini/platforms/posix/main.c
@@ -416,7 +416,8 @@ main(int argc, char *argv[])
             init_args.running_mode = Mode_LLVM_JIT;
         }
 #endif
-#if WASM_ENABLE_JIT != 0 && WASM_ENABLE_FAST_JIT != 0 && WASM_ENABLE_LAZY_JIT != 0
+#if WASM_ENABLE_JIT != 0 && WASM_ENABLE_FAST_JIT != 0 \
+    && WASM_ENABLE_LAZY_JIT != 0
         else if (!strcmp(argv[0], "--multi-tier-jit")) {
             init_args.running_mode = Mode_Multi_Tier_JIT;
         }

--- a/product-mini/platforms/posix/main.c
+++ b/product-mini/platforms/posix/main.c
@@ -45,6 +45,10 @@ print_help()
 #if WASM_ENABLE_JIT != 0 && WASM_ENABLE_FAST_JIT != 0
     printf("  --multi-tier-jit         Choose to run iwasm in multi-tier jit mode\n");
 #endif
+#if WASM_ENABLE_JIT != 0
+    printf("  --size-level=n           Set LLVM JIT size level, default is 3\n");
+    printf("  --opt-level=n            Set LLVM JIT optimization level, default is 3\n");
+#endif
     printf("  --stack-size=n           Set maximum stack size in bytes, default is 64 KB\n");
     printf("  --heap-size=n            Set maximum heap size in bytes, default is 16 KB\n");
 #if WASM_ENABLE_FAST_JIT != 0
@@ -420,6 +424,28 @@ main(int argc, char *argv[])
     && WASM_ENABLE_LAZY_JIT != 0
         else if (!strcmp(argv[0], "--multi-tier-jit")) {
             init_args.running_mode = Mode_Multi_Tier_JIT;
+        }
+#endif
+#if WASM_ENABLE_JIT != 0
+        else if (!strncmp(argv[0], "--size-level=", 13)) {
+            if (argv[0][13] == '\0')
+                return print_help();
+            init_args.llvm_jit_size_level = atoi(argv[0] + 13);
+            if (init_args.llvm_jit_size_level < 1
+                || init_args.llvm_jit_size_level > 3) {
+                printf("LLVM JIT size level should in range [1,3]\n");
+                return 1;
+            }
+        }
+        else if (!strncmp(argv[0], "--opt-level=", 12)) {
+            if (argv[0][12] == '\0')
+                return print_help();
+            init_args.llvm_jit_opt_level = atoi(argv[0] + 12);
+            if (init_args.llvm_jit_opt_level < 1
+                || init_args.llvm_jit_opt_level > 3) {
+                printf("LLVM JIT opt level should in range [1,3]\n");
+                return 1;
+            }
         }
 #endif
 #if WASM_ENABLE_LOG != 0

--- a/product-mini/platforms/posix/main.c
+++ b/product-mini/platforms/posix/main.c
@@ -45,15 +45,15 @@ print_help()
 #if WASM_ENABLE_JIT != 0 && WASM_ENABLE_FAST_JIT != 0 && WASM_ENABLE_LAZY_JIT != 0
     printf("  --multi-tier-jit         Run the wasm app with multi-tier jit mode\n");
 #endif
-#if WASM_ENABLE_JIT != 0
-    printf("  --size-level=n           Set LLVM JIT size level, default is 3\n");
-    printf("  --opt-level=n            Set LLVM JIT optimization level, default is 3\n");
-#endif
     printf("  --stack-size=n           Set maximum stack size in bytes, default is 64 KB\n");
     printf("  --heap-size=n            Set maximum heap size in bytes, default is 16 KB\n");
 #if WASM_ENABLE_FAST_JIT != 0
     printf("  --jit-codecache-size=n   Set fast jit maximum code cache size in bytes,\n");
     printf("                           default is %u KB\n", FAST_JIT_DEFAULT_CODE_CACHE_SIZE / 1024);
+#endif
+#if WASM_ENABLE_JIT != 0
+    printf("  --llvm-jit-size-level=n  Set LLVM JIT size level, default is 3\n");
+    printf("  --llvm-jit-opt-level=n   Set LLVM JIT optimization level, default is 3\n");
 #endif
     printf("  --repl                   Start a very simple REPL (read-eval-print-loop) mode\n"
            "                           that runs commands in the form of \"FUNC ARG...\"\n");
@@ -364,6 +364,10 @@ main(int argc, char *argv[])
 #if WASM_ENABLE_FAST_JIT != 0
     uint32 jit_code_cache_size = FAST_JIT_DEFAULT_CODE_CACHE_SIZE;
 #endif
+#if WASM_ENABLE_JIT != 0
+    uint32 llvm_jit_size_level = 3;
+    uint32 llvm_jit_opt_level = 3;
+#endif
     wasm_module_t wasm_module = NULL;
     wasm_module_inst_t wasm_module_inst = NULL;
     RunningMode running_mode = 0;
@@ -425,38 +429,6 @@ main(int argc, char *argv[])
             running_mode = Mode_Multi_Tier_JIT;
         }
 #endif
-#if WASM_ENABLE_JIT != 0
-        else if (!strncmp(argv[0], "--size-level=", 13)) {
-            if (argv[0][13] == '\0')
-                return print_help();
-            init_args.llvm_jit_size_level = atoi(argv[0] + 13);
-            if (init_args.llvm_jit_size_level < 1) {
-                printf("LLVM JIT size level shouldn't be smaller than 1, "
-                       "setting it to 1\n");
-                init_args.llvm_jit_size_level = 1;
-            }
-            else if (init_args.llvm_jit_size_level > 3) {
-                printf("LLVM JIT size level shouldn't be greater than 3, "
-                       "setting it to 3\n");
-                init_args.llvm_jit_size_level = 3;
-            }
-        }
-        else if (!strncmp(argv[0], "--opt-level=", 12)) {
-            if (argv[0][12] == '\0')
-                return print_help();
-            init_args.llvm_jit_opt_level = atoi(argv[0] + 12);
-            if (init_args.llvm_jit_opt_level < 1) {
-                printf("LLVM JIT opt level shouldn't be smaller than 1, "
-                       "setting it to 1\n");
-                init_args.llvm_jit_opt_level = 1;
-            }
-            else if (init_args.llvm_jit_opt_level > 3) {
-                printf("LLVM JIT opt level shouldn't be greater than 3, "
-                       "setting it to 3\n");
-                init_args.llvm_jit_opt_level = 3;
-            }
-        }
-#endif
 #if WASM_ENABLE_LOG != 0
         else if (!strncmp(argv[0], "-v=", 3)) {
             log_verbose_level = atoi(argv[0] + 3);
@@ -482,6 +454,38 @@ main(int argc, char *argv[])
             if (argv[0][21] == '\0')
                 return print_help();
             jit_code_cache_size = atoi(argv[0] + 21);
+        }
+#endif
+#if WASM_ENABLE_JIT != 0
+        else if (!strncmp(argv[0], "--llvm-jit-size-level=", 22)) {
+            if (argv[0][22] == '\0')
+                return print_help();
+            llvm_jit_size_level = atoi(argv[0] + 22);
+            if (llvm_jit_size_level < 1) {
+                printf("LLVM JIT size level shouldn't be smaller than 1, "
+                       "setting it to 1\n");
+                llvm_jit_size_level = 1;
+            }
+            else if (llvm_jit_size_level > 3) {
+                printf("LLVM JIT size level shouldn't be greater than 3, "
+                       "setting it to 3\n");
+                llvm_jit_size_level = 3;
+            }
+        }
+        else if (!strncmp(argv[0], "--llvm-jit-opt-level=", 21)) {
+            if (argv[0][21] == '\0')
+                return print_help();
+            llvm_jit_opt_level = atoi(argv[0] + 21);
+            if (llvm_jit_opt_level < 1) {
+                printf("LLVM JIT opt level shouldn't be smaller than 1, "
+                       "setting it to 1\n");
+                llvm_jit_opt_level = 1;
+            }
+            else if (llvm_jit_opt_level > 3) {
+                printf("LLVM JIT opt level shouldn't be greater than 3, "
+                       "setting it to 3\n");
+                llvm_jit_opt_level = 3;
+            }
         }
 #endif
 #if WASM_ENABLE_LIBC_WASI != 0
@@ -623,6 +627,11 @@ main(int argc, char *argv[])
 
 #if WASM_ENABLE_FAST_JIT != 0
     init_args.fast_jit_code_cache_size = jit_code_cache_size;
+#endif
+
+#if WASM_ENABLE_JIT != 0
+    init_args.llvm_jit_size_level = llvm_jit_size_level;
+    init_args.llvm_jit_opt_level = llvm_jit_opt_level;
 #endif
 
 #if WASM_ENABLE_DEBUG_INTERP != 0

--- a/product-mini/platforms/posix/main.c
+++ b/product-mini/platforms/posix/main.c
@@ -33,6 +33,18 @@ print_help()
     printf("  -v=n                     Set log verbose level (0 to 5, default is 2) larger\n"
            "                           level with more log\n");
 #endif
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_FAST_JIT != 0
+    printf("  --interp                 Choose to run iwasm in interpreter mode\n");
+#endif
+#if WASM_ENABLE_FAST_JIT != 0
+    printf("  --fast-jit               Choose to run iwasm in fast jit mode\n");
+#endif
+#if WASM_ENABLE_JIT != 0
+    printf("  --llvm-jit               Choose to run iwasm in llvm jit mode\n");
+#endif
+#if WASM_ENABLE_JIT != 0 && WASM_ENABLE_FAST_JIT != 0
+    printf("  --multi-tier-jit         Choose to run iwasm in multi-tier jit mode\n");
+#endif
     printf("  --stack-size=n           Set maximum stack size in bytes, default is 64 KB\n");
     printf("  --heap-size=n            Set maximum heap size in bytes, default is 16 KB\n");
 #if WASM_ENABLE_FAST_JIT != 0
@@ -378,6 +390,8 @@ main(int argc, char *argv[])
     int instance_port = 0;
 #endif
 
+    memset(&init_args, 0, sizeof(RuntimeInitArgs));
+
     /* Process options. */
     for (argc--, argv++; argc > 0 && argv[0][0] == '-'; argc--, argv++) {
         if (!strcmp(argv[0], "-f") || !strcmp(argv[0], "--function")) {
@@ -387,6 +401,26 @@ main(int argc, char *argv[])
             }
             func_name = argv[0];
         }
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_FAST_JIT != 0
+        else if (!strcmp(argv[0], "--interp")) {
+            init_args.running_mode = Mode_Interp;
+        }
+#endif
+#if WASM_ENABLE_FAST_JIT != 0
+        else if (!strcmp(argv[0], "--fast-jit")) {
+            init_args.running_mode = Mode_Fast_JIT;
+        }
+#endif
+#if WASM_ENABLE_INTERP != 0 && WASM_ENABLE_JIT != 0
+        else if (!strcmp(argv[0], "--llvm-jit")) {
+            init_args.running_mode = Mode_LLVM_JIT;
+        }
+#endif
+#if WASM_ENABLE_JIT != 0 && WASM_ENABLE_FAST_JIT != 0
+        else if (!strcmp(argv[0], "--multi-tier-jit")) {
+            init_args.running_mode = Mode_Multi_Tier_JIT;
+        }
+#endif
 #if WASM_ENABLE_LOG != 0
         else if (!strncmp(argv[0], "-v=", 3)) {
             log_verbose_level = atoi(argv[0] + 3);
@@ -536,8 +570,6 @@ main(int argc, char *argv[])
     wasm_file = argv[0];
     app_argc = argc;
     app_argv = argv;
-
-    memset(&init_args, 0, sizeof(RuntimeInitArgs));
 
 #if WASM_ENABLE_GLOBAL_HEAP_POOL != 0
     init_args.mem_alloc_type = Alloc_With_Pool;

--- a/product-mini/platforms/posix/main.c
+++ b/product-mini/platforms/posix/main.c
@@ -416,7 +416,7 @@ main(int argc, char *argv[])
             init_args.running_mode = Mode_LLVM_JIT;
         }
 #endif
-#if WASM_ENABLE_JIT != 0 && WASM_ENABLE_FAST_JIT != 0
+#if WASM_ENABLE_JIT != 0 && WASM_ENABLE_FAST_JIT != 0 && WASM_ENABLE_LAZY_JIT != 0
         else if (!strcmp(argv[0], "--multi-tier-jit")) {
             init_args.running_mode = Mode_Multi_Tier_JIT;
         }

--- a/product-mini/platforms/posix/main.c
+++ b/product-mini/platforms/posix/main.c
@@ -33,15 +33,17 @@ print_help()
     printf("  -v=n                     Set log verbose level (0 to 5, default is 2) larger\n"
            "                           level with more log\n");
 #endif
-    printf("  --interp                 Choose to run iwasm in interpreter mode\n");
+#if WASM_ENABLE_INTERP != 0
+    printf("  --interp                 Run the wasm app with interpreter mode\n");
+#endif
 #if WASM_ENABLE_FAST_JIT != 0
-    printf("  --fast-jit               Choose to run iwasm in fast jit mode\n");
+    printf("  --fast-jit               Run the wasm app with fast jit mode\n");
 #endif
 #if WASM_ENABLE_JIT != 0
-    printf("  --llvm-jit               Choose to run iwasm in llvm jit mode\n");
+    printf("  --llvm-jit               Run the wasm app with llvm jit mode\n");
 #endif
-#if WASM_ENABLE_JIT != 0 && WASM_ENABLE_FAST_JIT != 0
-    printf("  --multi-tier-jit         Choose to run iwasm in multi-tier jit mode\n");
+#if WASM_ENABLE_JIT != 0 && WASM_ENABLE_FAST_JIT != 0 && WASM_ENABLE_LAZY_JIT != 0
+    printf("  --multi-tier-jit         Run the wasm app with multi-tier jit mode\n");
 #endif
 #if WASM_ENABLE_JIT != 0
     printf("  --size-level=n           Set LLVM JIT size level, default is 3\n");
@@ -402,15 +404,17 @@ main(int argc, char *argv[])
             }
             func_name = argv[0];
         }
+#if WASM_ENABLE_INTERP != 0
         else if (!strcmp(argv[0], "--interp")) {
             running_mode = Mode_Interp;
         }
+#endif
 #if WASM_ENABLE_FAST_JIT != 0
         else if (!strcmp(argv[0], "--fast-jit")) {
             running_mode = Mode_Fast_JIT;
         }
 #endif
-#if WASM_ENABLE_INTERP != 0 && WASM_ENABLE_JIT != 0
+#if WASM_ENABLE_JIT != 0
         else if (!strcmp(argv[0], "--llvm-jit")) {
             running_mode = Mode_LLVM_JIT;
         }

--- a/product-mini/platforms/windows/main.c
+++ b/product-mini/platforms/windows/main.c
@@ -39,6 +39,10 @@ print_help()
 #if WASM_ENABLE_JIT != 0 && WASM_ENABLE_FAST_JIT != 0 && WASM_ENABLE_LAZY_JIT != 0
     printf("  --multi-tier-jit       Choose to run iwasm in multi-tier jit mode\n");
 #endif
+#if WASM_ENABLE_JIT != 0
+    printf("  --size-level=n         Set LLVM JIT size level, default is 3\n");
+    printf("  --opt-level=n          Set LLVM JIT optimization level, default is 3\n");
+#endif
     printf("  --stack-size=n         Set maximum stack size in bytes, default is 64 KB\n");
     printf("  --heap-size=n          Set maximum heap size in bytes, default is 16 KB\n");
     printf("  --repl                 Start a very simple REPL (read-eval-print-loop) mode\n"
@@ -289,6 +293,28 @@ main(int argc, char *argv[])
 #if WASM_ENABLE_JIT != 0 && WASM_ENABLE_FAST_JIT != 0
         else if (!strcmp(argv[0], "--multi-tier-jit")) {
             init_args.running_mode = Mode_Multi_Tier_JIT;
+        }
+#endif
+#if WASM_ENABLE_JIT != 0
+        else if (!strncmp(argv[0], "--size-level=", 13)) {
+            if (argv[0][13] == '\0')
+                return print_help();
+            init_args.llvm_jit_size_level = atoi(argv[0] + 13);
+            if (init_args.llvm_jit_size_level < 1
+                || init_args.llvm_jit_size_level > 3) {
+                printf("LLVM JIT size level should in range [1,3]\n");
+                return 1;
+            }
+        }
+        else if (!strncmp(argv[0], "--opt-level=", 12)) {
+            if (argv[0][12] == '\0')
+                return print_help();
+            init_args.llvm_jit_opt_level = atoi(argv[0] + 12);
+            if (init_args.llvm_jit_opt_level < 1
+                || init_args.llvm_jit_opt_level > 3) {
+                printf("LLVM JIT opt level should in range [1,3]\n");
+                return 1;
+            }
         }
 #endif
 #if WASM_ENABLE_LOG != 0

--- a/product-mini/platforms/windows/main.c
+++ b/product-mini/platforms/windows/main.c
@@ -36,7 +36,7 @@ print_help()
 #if WASM_ENABLE_JIT != 0
     printf("  --llvm-jit             Choose to run iwasm in llvm jit mode\n");
 #endif
-#if WASM_ENABLE_JIT != 0 && WASM_ENABLE_FAST_JIT != 0
+#if WASM_ENABLE_JIT != 0 && WASM_ENABLE_FAST_JIT != 0 && WASM_ENABLE_LAZY_JIT != 0
     printf("  --multi-tier-jit       Choose to run iwasm in multi-tier jit mode\n");
 #endif
     printf("  --stack-size=n         Set maximum stack size in bytes, default is 64 KB\n");

--- a/product-mini/platforms/windows/main.c
+++ b/product-mini/platforms/windows/main.c
@@ -27,6 +27,18 @@ print_help()
     printf("  -v=n                   Set log verbose level (0 to 5, default is 2) larger\n"
            "                         level with more log\n");
 #endif
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_FAST_JIT != 0
+    printf("  --interp               Choose to run iwasm in interpreter mode\n");
+#endif
+#if WASM_ENABLE_FAST_JIT != 0
+    printf("  --fast-jit             Choose to run iwasm in fast jit mode\n");
+#endif
+#if WASM_ENABLE_JIT != 0
+    printf("  --llvm-jit             Choose to run iwasm in llvm jit mode\n");
+#endif
+#if WASM_ENABLE_JIT != 0 && WASM_ENABLE_FAST_JIT != 0
+    printf("  --multi-tier-jit       Choose to run iwasm in multi-tier jit mode\n");
+#endif
     printf("  --stack-size=n         Set maximum stack size in bytes, default is 64 KB\n");
     printf("  --heap-size=n          Set maximum heap size in bytes, default is 16 KB\n");
     printf("  --repl                 Start a very simple REPL (read-eval-print-loop) mode\n"
@@ -248,6 +260,8 @@ main(int argc, char *argv[])
     int instance_port = 0;
 #endif
 
+    memset(&init_args, 0, sizeof(RuntimeInitArgs));
+
     /* Process options. */
     for (argc--, argv++; argc > 0 && argv[0][0] == '-'; argc--, argv++) {
         if (!strcmp(argv[0], "-f") || !strcmp(argv[0], "--function")) {
@@ -257,6 +271,26 @@ main(int argc, char *argv[])
             }
             func_name = argv[0];
         }
+#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_FAST_JIT != 0
+        else if (!strcmp(argv[0], "--interp")) {
+            init_args.running_mode = Mode_Interp;
+        }
+#endif
+#if WASM_ENABLE_FAST_JIT != 0
+        else if (!strcmp(argv[0], "--fast-jit")) {
+            init_args.running_mode = Mode_Fast_JIT;
+        }
+#endif
+#if WASM_ENABLE_JIT != 0
+        else if (!strcmp(argv[0], "--llvm-jit")) {
+            init_args.running_mode = Mode_LLVM_JIT;
+        }
+#endif
+#if WASM_ENABLE_JIT != 0 && WASM_ENABLE_FAST_JIT != 0
+        else if (!strcmp(argv[0], "--multi-tier-jit")) {
+            init_args.running_mode = Mode_Multi_Tier_JIT;
+        }
+#endif
 #if WASM_ENABLE_LOG != 0
         else if (!strncmp(argv[0], "-v=", 3)) {
             log_verbose_level = atoi(argv[0] + 3);
@@ -354,8 +388,6 @@ main(int argc, char *argv[])
     wasm_file = argv[0];
     app_argc = argc;
     app_argv = argv;
-
-    memset(&init_args, 0, sizeof(RuntimeInitArgs));
 
 #if WASM_ENABLE_GLOBAL_HEAP_POOL != 0
     init_args.mem_alloc_type = Alloc_With_Pool;

--- a/product-mini/platforms/windows/main.c
+++ b/product-mini/platforms/windows/main.c
@@ -27,15 +27,17 @@ print_help()
     printf("  -v=n                   Set log verbose level (0 to 5, default is 2) larger\n"
            "                         level with more log\n");
 #endif
-    printf("  --interp               Choose to run iwasm in interpreter mode\n");
+#if WASM_ENABLE_INTERP != 0
+    printf("  --interp               Run the wasm app with interpreter mode\n");
+#endif
 #if WASM_ENABLE_FAST_JIT != 0
-    printf("  --fast-jit             Choose to run iwasm in fast jit mode\n");
+    printf("  --fast-jit             Run the wasm app with fast jit mode\n");
 #endif
 #if WASM_ENABLE_JIT != 0
-    printf("  --llvm-jit             Choose to run iwasm in llvm jit mode\n");
+    printf("  --llvm-jit             Run the wasm app with llvm jit mode\n");
 #endif
 #if WASM_ENABLE_JIT != 0 && WASM_ENABLE_FAST_JIT != 0 && WASM_ENABLE_LAZY_JIT != 0
-    printf("  --multi-tier-jit       Choose to run iwasm in multi-tier jit mode\n");
+    printf("  --multi-tier-jit       Run the wasm app with multi-tier jit mode\n");
 #endif
 #if WASM_ENABLE_JIT != 0
     printf("  --size-level=n         Set LLVM JIT size level, default is 3\n");
@@ -272,9 +274,11 @@ main(int argc, char *argv[])
             }
             func_name = argv[0];
         }
+#if WASM_ENABLE_INTERP != 0
         else if (!strcmp(argv[0], "--interp")) {
             running_mode = Mode_Interp;
         }
+#endif
 #if WASM_ENABLE_FAST_JIT != 0
         else if (!strcmp(argv[0], "--fast-jit")) {
             running_mode = Mode_Fast_JIT;

--- a/product-mini/platforms/windows/main.c
+++ b/product-mini/platforms/windows/main.c
@@ -27,9 +27,7 @@ print_help()
     printf("  -v=n                   Set log verbose level (0 to 5, default is 2) larger\n"
            "                         level with more log\n");
 #endif
-#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_FAST_JIT != 0
     printf("  --interp               Choose to run iwasm in interpreter mode\n");
-#endif
 #if WASM_ENABLE_FAST_JIT != 0
     printf("  --fast-jit             Choose to run iwasm in fast jit mode\n");
 #endif
@@ -246,6 +244,7 @@ main(int argc, char *argv[])
     uint32 stack_size = 64 * 1024, heap_size = 16 * 1024;
     wasm_module_t wasm_module = NULL;
     wasm_module_inst_t wasm_module_inst = NULL;
+    RunningMode running_mode = 0;
     RuntimeInitArgs init_args;
     char error_buf[128] = { 0 };
 #if WASM_ENABLE_LOG != 0
@@ -264,8 +263,6 @@ main(int argc, char *argv[])
     int instance_port = 0;
 #endif
 
-    memset(&init_args, 0, sizeof(RuntimeInitArgs));
-
     /* Process options. */
     for (argc--, argv++; argc > 0 && argv[0][0] == '-'; argc--, argv++) {
         if (!strcmp(argv[0], "-f") || !strcmp(argv[0], "--function")) {
@@ -275,24 +272,22 @@ main(int argc, char *argv[])
             }
             func_name = argv[0];
         }
-#if WASM_ENABLE_JIT != 0 || WASM_ENABLE_FAST_JIT != 0
         else if (!strcmp(argv[0], "--interp")) {
-            init_args.running_mode = Mode_Interp;
+            running_mode = Mode_Interp;
         }
-#endif
 #if WASM_ENABLE_FAST_JIT != 0
         else if (!strcmp(argv[0], "--fast-jit")) {
-            init_args.running_mode = Mode_Fast_JIT;
+            running_mode = Mode_Fast_JIT;
         }
 #endif
 #if WASM_ENABLE_JIT != 0
         else if (!strcmp(argv[0], "--llvm-jit")) {
-            init_args.running_mode = Mode_LLVM_JIT;
+            running_mode = Mode_LLVM_JIT;
         }
 #endif
 #if WASM_ENABLE_JIT != 0 && WASM_ENABLE_FAST_JIT != 0
         else if (!strcmp(argv[0], "--multi-tier-jit")) {
-            init_args.running_mode = Mode_Multi_Tier_JIT;
+            running_mode = Mode_Multi_Tier_JIT;
         }
 #endif
 #if WASM_ENABLE_JIT != 0
@@ -300,20 +295,30 @@ main(int argc, char *argv[])
             if (argv[0][13] == '\0')
                 return print_help();
             init_args.llvm_jit_size_level = atoi(argv[0] + 13);
-            if (init_args.llvm_jit_size_level < 1
-                || init_args.llvm_jit_size_level > 3) {
-                printf("LLVM JIT size level should in range [1,3]\n");
-                return 1;
+            if (init_args.llvm_jit_size_level < 1) {
+                printf("LLVM JIT size level shouldn't be smaller than 1, "
+                       "setting it to 1\n");
+                init_args.llvm_jit_size_level = 1;
+            }
+            else if (init_args.llvm_jit_size_level > 3) {
+                printf("LLVM JIT size level shouldn't be greater than 3, "
+                       "setting it to 3\n");
+                init_args.llvm_jit_size_level = 3;
             }
         }
         else if (!strncmp(argv[0], "--opt-level=", 12)) {
             if (argv[0][12] == '\0')
                 return print_help();
             init_args.llvm_jit_opt_level = atoi(argv[0] + 12);
-            if (init_args.llvm_jit_opt_level < 1
-                || init_args.llvm_jit_opt_level > 3) {
-                printf("LLVM JIT opt level should in range [1,3]\n");
-                return 1;
+            if (init_args.llvm_jit_opt_level < 1) {
+                printf("LLVM JIT opt level shouldn't be smaller than 1, "
+                       "setting it to 1\n");
+                init_args.llvm_jit_opt_level = 1;
+            }
+            else if (init_args.llvm_jit_opt_level > 3) {
+                printf("LLVM JIT opt level shouldn't be greater than 3, "
+                       "setting it to 3\n");
+                init_args.llvm_jit_opt_level = 3;
             }
         }
 #endif
@@ -415,6 +420,9 @@ main(int argc, char *argv[])
     app_argc = argc;
     app_argv = argv;
 
+    memset(&init_args, 0, sizeof(RuntimeInitArgs));
+
+    init_args.running_mode = running_mode;
 #if WASM_ENABLE_GLOBAL_HEAP_POOL != 0
     init_args.mem_alloc_type = Alloc_With_Pool;
     init_args.mem_alloc_option.pool.heap_buf = global_heap_buf;


### PR DESCRIPTION
 Subtasks:
- CLI options: four options for running mode for iwasm and APIs to set the runtime running mode
- APIs to set the module instance running mode
- CLI options: two options for LLVM JIT

This is draft pr, subtasks three in one.