### PR TITLE
fix go language binding build on macos arm64

### DIFF
--- a/language-bindings/go/build.sh
+++ b/language-bindings/go/build.sh
@@ -7,6 +7,12 @@ PLATFORM=$(uname -s | tr A-Z a-z)
 CUR_DIR=$PWD
 WAMR_DIR=$PWD/../..
 WAMR_GO_DIR=$PWD/wamr
+ARCH=$(uname -m)
+if [ ${ARCH} = "arm64" ]; then
+    ARCH="aarch64"
+elif [ ${ARCH} = "x86_64" ]; then
+    ARCH="amd64"
+fi
 
 cp -a ${WAMR_DIR}/core/iwasm/include/*.h ${WAMR_GO_DIR}/packaged/include
 
@@ -15,7 +21,7 @@ cmake ${WAMR_DIR}/product-mini/platforms/${PLATFORM} \
     -DWAMR_BUILD_LIB_PTHREAD=1 -DWAMR_BUILD_DUMP_CALL_STACK=1 \
     -DWAMR_BUILD_MEMORY_PROFILING=1
 make -j ${nproc}
-cp -a libvmlib.a ${WAMR_GO_DIR}/packaged/lib/${PLATFORM}-amd64
+cp -a libvmlib.a ${WAMR_GO_DIR}/packaged/lib/${PLATFORM}-${ARCH}
 
 cd ${WAMR_GO_DIR}
 go test

--- a/language-bindings/go/go.sum
+++ b/language-bindings/go/go.sum
@@ -5,6 +5,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/language-bindings/go/wamr/packaged/lib/darwin-aarch64/dummy.go
+++ b/language-bindings/go/wamr/packaged/lib/darwin-aarch64/dummy.go
@@ -1,0 +1,6 @@
+/*
+ * Copyright (C) 2019 Intel Corporation.  All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+package darwin_aarch64


### PR DESCRIPTION
Also a question in the meantime, are there any plans to support exposing host functions in the Go binding as in the Python implementation?