### PR TITLE
Increase stack size in the example app

### DIFF
--- a/samples/wasi-threads/wasm-apps/wasi_thread_start.h
+++ b/samples/wasi-threads/wasm-apps/wasi_thread_start.h
@@ -5,7 +5,7 @@
 #ifndef WASI_THREAD_START_H
 #define WASI_THREAD_START_H
 
-#define STACK_SIZE 1024
+#define STACK_SIZE 32 * 1024 // same as the main stack
 
 typedef struct {
     void *stack;


### PR DESCRIPTION
This is to avoid memory corruption.