### PR TITLE
nuttx: Remove fdopendir

### DIFF
--- a/core/shared/platform/nuttx/nuttx_platform.c
+++ b/core/shared/platform/nuttx/nuttx_platform.c
@@ -144,10 +144,3 @@ utimensat(int fd, const char *path, const struct timespec ts[2], int flag)
 }
 
 #endif /* !defined(AT_FDCWD) */
-
-DIR *
-fdopendir(int fd)
-{
-    errno = ENOSYS;
-    return NULL;
-}


### PR DESCRIPTION
Since newer version of nuttx implemented fdopendir, the compiler report multiple definition of it.