### PR TITLE
Update compiler target for wasi-threads examples

### DIFF
--- a/.github/workflows/compilation_on_android_ubuntu.yml
+++ b/.github/workflows/compilation_on_android_ubuntu.yml
@@ -326,7 +326,7 @@ jobs:
 
       - name: build wasi-libc (needed for wasi-threads)
         run: |
-          git clone --branch wasi-sdk-17 https://github.com/WebAssembly/wasi-libc
+          git clone https://github.com/WebAssembly/wasi-libc
           cd wasi-libc
           make \
             AR=/opt/wasi-sdk/bin/llvm-ar \

--- a/.github/workflows/compilation_on_macos.yml
+++ b/.github/workflows/compilation_on_macos.yml
@@ -268,7 +268,7 @@ jobs:
 
       - name: build wasi-libc (needed for wasi-threads)
         run: |
-          git clone --branch wasi-sdk-17 https://github.com/WebAssembly/wasi-libc
+          git clone https://github.com/WebAssembly/wasi-libc
           cd wasi-libc
           make \
             AR=/opt/wasi-sdk/bin/llvm-ar \

--- a/.github/workflows/compilation_on_sgx.yml
+++ b/.github/workflows/compilation_on_sgx.yml
@@ -270,7 +270,7 @@ jobs:
 
       - name: build wasi-libc (needed for wasi-threads)
         run: |
-          git clone --branch wasi-sdk-17 https://github.com/WebAssembly/wasi-libc
+          git clone https://github.com/WebAssembly/wasi-libc
           cd wasi-libc
           make \
             AR=/opt/wasi-sdk/bin/llvm-ar \

--- a/samples/wasi-threads/wasm-apps/CMakeLists.txt
+++ b/samples/wasi-threads/wasm-apps/CMakeLists.txt
@@ -14,7 +14,7 @@ endif ()
 set (CMAKE_SYSROOT                  "${WASI_SYSROOT}")
 set (CMAKE_C_COMPILER               "${WASI_SDK_DIR}/bin/clang")
 set (CMAKE_ASM_COMPILER               "${WASI_SDK_DIR}/bin/clang")
-set (CMAKE_C_COMPILER_TARGET        "wasm32-wasi")
+set (CMAKE_C_COMPILER_TARGET        "wasm32-wasi-threads")
 
 function (compile_sample SOURCE_FILE)
   get_filename_component (FILE_NAME ${SOURCE_FILE} NAME_WLE)


### PR DESCRIPTION
The target was updated to wasm32-wasi-threads in wasi-libc (and most likely will stay like that for a while) https://github.com/WebAssembly/wasi-libc/pull/381