### PR TITLE
Fixed the undef error about WAMR_BUILD_MEMORY_PROFILING

### DIFF
--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -276,7 +276,7 @@ WASM_DEFINE_VEC_OWN(store, wasm_store_delete)
 WASM_DEFINE_VEC_OWN(valtype, wasm_valtype_delete)
 
 #ifndef NDEBUG
-#if WAMR_BUILD_MEMORY_PROFILING != 0
+#if WASM_ENABLE_MEMORY_PROFILING != 0
 #define WASM_C_DUMP_PROC_MEM() LOG_PROC_MEM()
 #else
 #define WASM_C_DUMP_PROC_MEM() (void)0


### PR DESCRIPTION
WAMR has an error when built the latest code. The problem is WAMR_BUILD_MEMORY_PROFILING is undefined.

```
 wamr/core/iwasm/common/wasm_c_api.c:279:5: error: "WAMR_BUILD_MEMORY_PROFILING" is not defined, evaluates to 0 [-Werror=undef]
  #if WAMR_BUILD_MEMORY_PROFILING != 0
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~
 cc1: all warnings being treated as errors
```