### PR TITLE
Runtime memory allocation in managed heap when user import alloc/free

### DIFF
--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -2256,10 +2256,7 @@ wasm_module_malloc(WASMModuleInstance *module_inst, uint32 size,
         return 0;
     }
 
-    if (memory->heap_handle) {
-        addr = mem_allocator_malloc(memory->heap_handle, size);
-    }
-    else if (module_inst->e->malloc_function && module_inst->e->free_function) {
+    if (module_inst->e->malloc_function && module_inst->e->free_function) {
         if (!execute_malloc_function(
                 module_inst, module_inst->e->malloc_function,
                 module_inst->e->retain_function, size, &offset)) {
@@ -2269,6 +2266,9 @@ wasm_module_malloc(WASMModuleInstance *module_inst, uint32 size,
            the default memory may be changed while memory growing */
         memory = wasm_get_default_memory(module_inst);
         addr = offset ? memory->memory_data + offset : NULL;
+    }
+    else if (memory->heap_handle) {
+        addr = mem_allocator_malloc(memory->heap_handle, size);
     }
 
     if (!addr) {


### PR DESCRIPTION
In our case, we want to use managed heap provided by wamr for "wasm runtime data", such as loaded wasm code, resolved wasm module etc. And our case also use external allocate/free in assembly script for the data in wasm heap.  However, the current wamr seems only support to allocate runtime data in system heap by using os_malloc/os_free when wasm heap is controlled by external allocate/free..

So we made this change, expecting it could satisfy our cases and help improve wamr. 
