### PR TITLE
Loosen the wasi abi compatibility check in loader

### DIFF
--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -4151,10 +4151,8 @@ check_wasi_abi_compatibility(const WASMModule *module,
 
     /* should have one at least */
     if (module->import_wasi_api && !start && !initialize) {
-        set_error_buf(
-            error_buf, error_buf_size,
-            "a module with WASI apis must be either a command or a reactor");
-        return false;
+        LOG_WARNING("warning: a module with WASI apis should be either "
+                    "a command or a reactor");
     }
 
     /*


### PR DESCRIPTION
Change an error to warning when checking wasi abi compatibility in loader, for rust case below:
#[no_mangle]
pub extern "C" fn main() {
    println!("foo");
}
compile it with `cargo build --target wasm32-wasi`, a wasm file is generated with wasi apis imported
and a "void main(void)" function exported.

Other runtime e.g. wasmtime allows to load it and execute the main function with `--invoke` option.