### PR TITLE
Fix build failure when using clang

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
@@ -113,7 +113,7 @@ so we have to handle this case specially */
 #if defined(__clang__)
 /* Clang provides stdatomic.h since 3.6.0
 See https://releases.llvm.org/3.6.0/tools/clang/docs/ReleaseNotes.html */
-#if __clang_major__ > 3 || (__clang_minor__ == 3 && __clang_minor__ >= 6)
+#if __clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 6)
 #define CONFIG_HAS_STD_ATOMIC 1
 #else
 #define CONFIG_HAS_STD_ATOMIC 0

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
@@ -113,7 +113,7 @@ so we have to handle this case specially */
 #if defined(__clang__)
 /* Clang provides stdatomic.h since 3.6.0
 See https://releases.llvm.org/3.6.0/tools/clang/docs/ReleaseNotes.html */
-#if __clang_major__ >= 3 || (__clang_minor__ == 3 && __clang_minor__ >= 6)
+#if __clang_major__ > 3 || (__clang_minor__ == 3 && __clang_minor__ >= 6)
 #define CONFIG_HAS_STD_ATOMIC 1
 #else
 #define CONFIG_HAS_STD_ATOMIC 0

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
@@ -108,11 +108,15 @@
 #endif
 
 #if !defined(BH_PLATFORM_LINUX_SGX)
+/* Clang's __GNUC_PREREQ macro has a different meaning than GCC one,
+so we have to handle this case specially */
 #if defined(__clang__)
 /* Clang provides stdatomic.h since 3.6.0
 See https://releases.llvm.org/3.6.0/tools/clang/docs/ReleaseNotes.html */
 #if __clang_major__ >= 3 || (__clang_minor__ == 3 && __clang_minor__ >= 6)
 #define CONFIG_HAS_STD_ATOMIC 1
+#else
+#define CONFIG_HAS_STD_ATOMIC 0
 #endif
 #elif defined(__GNUC_PREREQ)
 /* Even though older versions of GCC support C11, atomics were

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
@@ -108,7 +108,13 @@
 #endif
 
 #if !defined(BH_PLATFORM_LINUX_SGX)
-#if defined(__GNUC_PREREQ)
+#if defined(__clang__)
+/* Clang provides stdatomic.h since 3.6.0
+See https://releases.llvm.org/3.6.0/tools/clang/docs/ReleaseNotes.html */
+#if __clang_major__ >= 3 || (__clang_minor__ == 3 && __clang_minor__ >= 6)
+#define CONFIG_HAS_STD_ATOMIC 1
+#endif
+#elif defined(__GNUC_PREREQ)
 /* Even though older versions of GCC support C11, atomics were
 not implemented until 4.9. See
 https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58016 */


### PR DESCRIPTION
After some investigation, I found that #1928 will cause clang to fail to compile.

Fix #1949