### PR TITLE
Don't call start/initialize in child thread's instantiation

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -901,6 +901,19 @@ create_exports(AOTModuleInstance *module_inst, AOTModule *module,
     return create_export_funcs(module_inst, module, error_buf, error_buf_size);
 }
 
+#if WASM_ENABLE_LIBC_WASI != 0
+static bool
+execute_initialize_function(AOTModuleInstance *module_inst)
+{
+    AOTFunctionInstance *initialize =
+        aot_lookup_function(module_inst, "_initialize", NULL);
+
+    return !initialize
+           || aot_create_exec_env_and_call_function(module_inst, initialize, 0,
+                                                    NULL);
+}
+#endif
+
 static bool
 execute_post_inst_function(AOTModuleInstance *module_inst)
 {
@@ -1121,11 +1134,27 @@ aot_instantiate(AOTModule *module, bool is_sub_inst, uint32 stack_size,
     }
 #endif
 
-    /* Execute __post_instantiate function and start function*/
-    if (!execute_post_inst_function(module_inst)
-        || !execute_start_function(module_inst)) {
-        set_error_buf(error_buf, error_buf_size, module_inst->cur_exception);
-        goto fail;
+    if (!is_sub_inst) {
+        if (
+#if WASM_ENABLE_LIBC_WASI != 0
+            /*
+             * reactor instances may assume that _initialize will be called by
+             * the environment at most once, and that none of their other
+             * exports are accessed before that call.
+             *
+             * let the loader decide how to act if there is no _initialize
+             * in a reactor
+             */
+            !execute_initialize_function(module_inst) ||
+#endif
+            /* Execute __post_instantiate function */
+            !execute_post_inst_function(module_inst)
+            /* Execute the function in "start" section */
+            || !execute_start_function(module_inst)) {
+            set_error_buf(error_buf, error_buf_size,
+                          module_inst->cur_exception);
+            goto fail;
+        }
     }
 
 #if WASM_ENABLE_BULK_MEMORY != 0

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -1367,7 +1367,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
             HANDLE_OP(EXT_OP_BR_TABLE_CACHE)
             {
-                BrTableCache *node =
+                BrTableCache *node_cache =
                     bh_list_first_elem(module->module->br_table_cache_list);
                 BrTableCache *node_next;
 
@@ -1376,13 +1376,13 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 #endif
                 lidx = POP_I32();
 
-                while (node) {
-                    node_next = bh_list_elem_next(node);
-                    if (node->br_table_op_addr == frame_ip - 1) {
-                        depth = node->br_depths[lidx];
+                while (node_cache) {
+                    node_next = bh_list_elem_next(node_cache);
+                    if (node_cache->br_table_op_addr == frame_ip - 1) {
+                        depth = node_cache->br_depths[lidx];
                         goto label_pop_csp_n;
                     }
-                    node = node_next;
+                    node_cache = node_next;
                 }
                 bh_assert(0);
                 HANDLE_OP_END();

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1999,24 +1999,27 @@ wasm_instantiate(WASMModule *module, bool is_sub_inst, uint32 stack_size,
                 &module_inst->e->functions[module->start_function];
     }
 
-    if (
+    if (!is_sub_inst) {
+        if (
 #if WASM_ENABLE_LIBC_WASI != 0
-        /*
-         * reactor instances may assume that _initialize will be called by
-         * the environment at most once, and that none of their other
-         * exports are accessed before that call.
-         *
-         * let the loader decide how to act if there is no _initialize
-         * in a reactor
-         */
-        !execute_initialize_function(module_inst) ||
+            /*
+             * reactor instances may assume that _initialize will be called by
+             * the environment at most once, and that none of their other
+             * exports are accessed before that call.
+             *
+             * let the loader decide how to act if there is no _initialize
+             * in a reactor
+             */
+            !execute_initialize_function(module_inst) ||
 #endif
-        /* Execute __post_instantiate function */
-        !execute_post_inst_function(module_inst)
-        /* Execute the function in "start" section */
-        || !execute_start_function(module_inst)) {
-        set_error_buf(error_buf, error_buf_size, module_inst->cur_exception);
-        goto fail;
+            /* Execute __post_instantiate function */
+            !execute_post_inst_function(module_inst)
+            /* Execute the function in "start" section */
+            || !execute_start_function(module_inst)) {
+            set_error_buf(error_buf, error_buf_size,
+                          module_inst->cur_exception);
+            goto fail;
+        }
     }
 
 #if WASM_ENABLE_BULK_MEMORY != 0


### PR DESCRIPTION
The start/initialize functions of wasi module are to do some initialization work
during instantiation, which should be only called one time in the instantiation
of main instance. For example, they may initialize the data in linear memory,
if the data was changed later by main instance, and re-initialized again by
sub instance, unexpected behaviors may occur.

And clear a shadow warning in classic interpreter.