### PR TITLE
Expose wasm_runtime_call_indirect

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -4346,7 +4346,7 @@ fail:
                  || defined(BUILD_TARGET_RISCV64_LP64) */
 
 bool
-wasm_runtime_call_indirect(WASMExecEnv *exec_env, uint32 element_indices,
+wasm_runtime_call_indirect(WASMExecEnv *exec_env, uint32 element_index,
                            uint32 argc, uint32 argv[])
 {
     bool ret = false;
@@ -4362,11 +4362,11 @@ wasm_runtime_call_indirect(WASMExecEnv *exec_env, uint32 element_indices,
 
 #if WASM_ENABLE_INTERP != 0
     if (exec_env->module_inst->module_type == Wasm_Module_Bytecode)
-        ret = wasm_call_indirect(exec_env, 0, element_indices, argc, argv);
+        ret = wasm_call_indirect(exec_env, 0, element_index, argc, argv);
 #endif
 #if WASM_ENABLE_AOT != 0
     if (exec_env->module_inst->module_type == Wasm_Module_AoT)
-        ret = aot_call_indirect(exec_env, 0, element_indices, argc, argv);
+        ret = aot_call_indirect(exec_env, 0, element_index, argc, argv);
 #endif
 
     if (!ret && clear_wasi_proc_exit_exception(exec_env->module_inst)) {

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -617,7 +617,7 @@ wasm_runtime_call_wasm_v(WASMExecEnv *exec_env,
 
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN bool
-wasm_runtime_call_indirect(WASMExecEnv *exec_env, uint32 element_indices,
+wasm_runtime_call_indirect(WASMExecEnv *exec_env, uint32 element_index,
                            uint32 argc, uint32 argv[]);
 
 #if WASM_ENABLE_DEBUG_INTERP != 0

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -615,6 +615,11 @@ wasm_runtime_call_wasm_v(WASMExecEnv *exec_env,
                          uint32 num_results, wasm_val_t *results,
                          uint32 num_args, ...);
 
+/* See wasm_export.h for description */
+WASM_RUNTIME_API_EXTERN bool
+wasm_runtime_call_indirect(WASMExecEnv *exec_env, uint32 element_indices,
+                           uint32 argc, uint32 argv[]);
+
 #if WASM_ENABLE_DEBUG_INTERP != 0
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN uint32
@@ -625,27 +630,6 @@ wasm_runtime_start_debug_instance_with_port(WASMExecEnv *exec_env,
 WASM_RUNTIME_API_EXTERN uint32
 wasm_runtime_start_debug_instance(WASMExecEnv *exec_env);
 #endif
-
-/**
- * Call a function reference of a given WASM runtime instance with
- * arguments.
- *
- * @param exec_env the execution environment to call the function
- *   which must be created from wasm_create_exec_env()
- * @param element_indices the function ference indicies, usually
- *   prvovided by the caller of a registed native function
- * @param argc the number of arguments
- * @param argv the arguments.  If the function method has return value,
- *   the first (or first two in case 64-bit return value) element of
- *   argv stores the return value of the called WASM function after this
- *   function returns.
- *
- * @return true if success, false otherwise and exception will be thrown,
- *   the caller can call wasm_runtime_get_exception to get exception info.
- */
-bool
-wasm_runtime_call_indirect(WASMExecEnv *exec_env, uint32 element_indices,
-                           uint32 argc, uint32 argv[]);
 
 bool
 wasm_runtime_create_exec_env_singleton(WASMModuleInstanceCommon *module_inst);

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -806,7 +806,7 @@ wasm_runtime_call_wasm_v(wasm_exec_env_t exec_env,
  *
  * @param exec_env the execution environment to call the function
  *   which must be created from wasm_create_exec_env()
- * @param element_indices the function ference indicies, usually
+ * @param element_index the function reference index, usually
  *   prvovided by the caller of a registed native function
  * @param argc the number of arguments
  * @param argv the arguments.  If the function method has return value,
@@ -818,7 +818,7 @@ wasm_runtime_call_wasm_v(wasm_exec_env_t exec_env,
  *   the caller can call wasm_runtime_get_exception to get exception info.
  */
 WASM_RUNTIME_API_EXTERN bool
-wasm_runtime_call_indirect(wasm_exec_env_t exec_env, uint32_t element_indices,
+wasm_runtime_call_indirect(wasm_exec_env_t exec_env, uint32_t element_index,
                            uint32_t argc, uint32_t argv[]);
 
 /**

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -805,7 +805,7 @@ wasm_runtime_call_wasm_v(wasm_exec_env_t exec_env,
  * arguments.
  *
  * Note: this can be used to call a function which is not exported
- * by the module's explicitly. You might consider it as an abstraction
+ * by the module explicitly. You might consider it as an abstraction
  * violation.
  *
  * @param exec_env the execution environment to call the function

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -804,6 +804,10 @@ wasm_runtime_call_wasm_v(wasm_exec_env_t exec_env,
  * Call a function reference of a given WASM runtime instance with
  * arguments.
  *
+ * Note: this can be used to call a function which is not exported
+ * by the module's explicitly. You might consider it as an abstraction
+ * violation.
+ *
  * @param exec_env the execution environment to call the function
  *   which must be created from wasm_create_exec_env()
  * @param element_index the function reference index, usually

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -801,6 +801,27 @@ wasm_runtime_call_wasm_v(wasm_exec_env_t exec_env,
                          uint32_t num_args, ...);
 
 /**
+ * Call a function reference of a given WASM runtime instance with
+ * arguments.
+ *
+ * @param exec_env the execution environment to call the function
+ *   which must be created from wasm_create_exec_env()
+ * @param element_indices the function ference indicies, usually
+ *   prvovided by the caller of a registed native function
+ * @param argc the number of arguments
+ * @param argv the arguments.  If the function method has return value,
+ *   the first (or first two in case 64-bit return value) element of
+ *   argv stores the return value of the called WASM function after this
+ *   function returns.
+ *
+ * @return true if success, false otherwise and exception will be thrown,
+ *   the caller can call wasm_runtime_get_exception to get exception info.
+ */
+WASM_RUNTIME_API_EXTERN bool
+wasm_runtime_call_indirect(wasm_exec_env_t exec_env, uint32_t element_indices,
+                           uint32_t argc, uint32_t argv[]);
+
+/**
  * Find the unique main function from a WASM module instance
  * and execute that function.
  *

--- a/core/iwasm/libraries/lib-pthread/lib_pthread_wrapper.c
+++ b/core/iwasm/libraries/lib-pthread/lib_pthread_wrapper.c
@@ -46,10 +46,6 @@
     wasm_runtime_addr_native_to_app(module_inst, ptr)
 /* clang-format on */
 
-extern bool
-wasm_runtime_call_indirect(wasm_exec_env_t exec_env, uint32 element_indices,
-                           uint32 argc, uint32 argv[]);
-
 enum {
     T_THREAD,
     T_MUTEX,

--- a/core/iwasm/libraries/libc-emcc/libc_emcc_wrapper.c
+++ b/core/iwasm/libraries/libc-emcc/libc_emcc_wrapper.c
@@ -37,10 +37,6 @@
     wasm_runtime_module_free(module_inst, offset)
 /* clang-format on */
 
-extern bool
-wasm_runtime_call_indirect(wasm_exec_env_t exec_env, uint32 element_idx,
-                           uint32 argc, uint32 argv[]);
-
 static void
 invoke_viiii_wrapper(wasm_exec_env_t exec_env, uint32 elem_idx, int arg0,
                      int arg1, int arg2, int arg3)

--- a/samples/basic/src/native_impl.c
+++ b/samples/basic/src/native_impl.c
@@ -7,10 +7,6 @@
 #include "wasm_export.h"
 #include "math.h"
 
-extern bool
-wasm_runtime_call_indirect(wasm_exec_env_t exec_env, uint32_t element_indices,
-                           uint32_t argc, uint32_t argv[]);
-
 // The first parameter is not exec_env because it is invoked by native funtions
 void
 reverse(char *str, int len)


### PR DESCRIPTION
The function has been there for long.
While what it does looks a bit unsafe as it calls a function which is not wasm-wise exported explicitly, it's useful and widely used when implemention callback-taking APIs, including our pthread implementation. We even have a sample to use it.