### PR TITLE
Make a workaround when `fstat()` return NOT_SUPPORT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,9 @@ project (iwasm)
 
 set (CMAKE_VERBOSE_MAKEFILE OFF)
 
-string (TOLOWER ${CMAKE_HOST_SYSTEM_NAME} WAMR_BUILD_PLATFORM)
+if (NOT DEFINED WAMR_BUILD_PLATFORM)
+  string (TOLOWER ${CMAKE_HOST_SYSTEM_NAME} WAMR_BUILD_PLATFORM)
+endif ()
 
 # Reset default linker flags
 set (CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
@@ -135,23 +137,26 @@ include (${SHARED_DIR}/utils/uncommon/shared_uncommon.cmake)
 
 # STATIC LIBRARY
 add_library(iwasm_static STATIC ${WAMR_RUNTIME_LIB_SOURCE})
-if (WAMR_BUILD_WASM_CACHE EQUAL 1)
-  target_link_libraries(iwasm_static PUBLIC boringssl_crypto)
-endif ()
 set_target_properties (iwasm_static PROPERTIES OUTPUT_NAME vmlib)
+target_include_directories(iwasm_static INTERFACE ${WAMR_ROOT_DIR}/core/iwasm/include)
+target_link_libraries (iwasm_static INTERFACE ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl -lpthread)
+if (WAMR_BUILD_WASM_CACHE EQUAL 1)
+  target_link_libraries(iwasm_static INTERFACE boringssl_crypto)
+endif ()
 
 install (TARGETS iwasm_static ARCHIVE DESTINATION lib)
 
 # SHARED LIBRARY
 add_library (iwasm_shared SHARED ${WAMR_RUNTIME_LIB_SOURCE})
 set_target_properties (iwasm_shared PROPERTIES OUTPUT_NAME iwasm)
-target_link_libraries (iwasm_shared ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl -lpthread)
+target_include_directories(iwasm_shared INTERFACE ${WAMR_ROOT_DIR}/core/iwasm/include)
+target_link_libraries (iwasm_shared INTERFACE ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl -lpthread)
 if (WAMR_BUILD_WASM_CACHE EQUAL 1)
-  target_link_libraries(iwasm_shared boringssl_crypto)
+  target_link_libraries(iwasm_shared INTERFACE boringssl_crypto)
 endif ()
 
 if (MINGW)
-target_link_libraries (iwasm_shared -lWs2_32)
+  target_link_libraries (iwasm_shared -lWs2_32)
 endif ()
 
 install (TARGETS iwasm_shared LIBRARY DESTINATION lib)

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -685,9 +685,20 @@ fd_table_insert_existing(struct fd_table *ft, __wasi_fd_t in, int out)
     struct fd_object *fo;
     __wasi_errno_t error;
 
-    if (fd_determine_type_rights(out, &type, &rights_base, &rights_inheriting)
-        != 0)
+    error =
+        fd_determine_type_rights(out, &type, &rights_base, &rights_inheriting);
+    if (error != 0) {
+#ifdef BH_PLATFORM_EGO
+        /**
+         * since it is an already opened file and we can assume the opened file
+         * has all necessary rights no matter how to get
+         */
+        if (error != __WASI_ENOTSUP)
+            return false;
+#else
         return false;
+#endif
+    }
 
     error = fd_object_new(type, &fo);
     if (error != 0)

--- a/core/shared/platform/ego/platform_init.c
+++ b/core/shared/platform/ego/platform_init.c
@@ -1,0 +1,6 @@
+/*
+ * Copyright (C) 2019 Intel Corporation.  All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#include "../linux/platform_init.c"

--- a/core/shared/platform/ego/platform_internal.h
+++ b/core/shared/platform/ego/platform_internal.h
@@ -1,0 +1,6 @@
+/*
+ * Copyright (C) 2019 Intel Corporation.  All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#include "../linux/platform_internal.h"

--- a/core/shared/platform/ego/shared_platform.cmake
+++ b/core/shared/platform/ego/shared_platform.cmake
@@ -1,0 +1,20 @@
+# Copyright (C) 2019 Intel Corporation.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set (PLATFORM_SHARED_DIR ${CMAKE_CURRENT_LIST_DIR})
+
+add_definitions(-DBH_PLATFORM_EGO)
+
+include_directories(${PLATFORM_SHARED_DIR})
+include_directories(${PLATFORM_SHARED_DIR}/../include)
+
+include (${CMAKE_CURRENT_LIST_DIR}/../common/posix/platform_api_posix.cmake)
+
+set (PLATFORM_SHARED_SOURCE
+  ${PLATFORM_COMMON_POSIX_SOURCE}
+  ${CMAKE_CURRENT_LIST_DIR}/platform_init.c
+)
+
+LIST (APPEND RUNTIME_LIB_HEADER_LIST
+  ${CMAKE_CURRENT_LIST_DIR}/platform_internal.h
+)


### PR DESCRIPTION
The problem was found by a Golang + WAMR(as CGO) wrapped by EGO in a SGX Enclave.

`fstat()` in EGO returns dummy values.

FYI:

- EGO use a `mount` configuration to define mount points that apply the host file system presented to the encalve.

- EGo has a different programming model: The entire application runs inside the enclave. Manual ECALLs/OCALLs by application code are neither required nor possible.