### PR TITLE
Do not fetch the next instruction when proc_exit is propagated

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -194,11 +194,9 @@ runtime_signal_handler(void *sig_addr)
         else if (exec_env_tls->exce_check_guard_page <= (uint8 *)sig_addr
                  && (uint8 *)sig_addr
                         < exec_env_tls->exce_check_guard_page + page_size) {
-            bh_assert(wasm_get_exception(module_inst)
-#if WASM_ENABLE_THREAD_MGR != 0
-                      || wasm_cluster_is_thread_terminated(exec_env_tls)
+#if WASM_ENABLE_THREAD_MGR == 0
+            bh_assert(wasm_get_exception(module_inst));
 #endif
-            );
             os_longjmp(jmpbuf_node->jmpbuf, 1);
         }
     }

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -194,7 +194,6 @@ runtime_signal_handler(void *sig_addr)
         else if (exec_env_tls->exce_check_guard_page <= (uint8 *)sig_addr
                  && (uint8 *)sig_addr
                         < exec_env_tls->exce_check_guard_page + page_size) {
-            bh_assert(wasm_get_exception(module_inst));
             os_longjmp(jmpbuf_node->jmpbuf, 1);
         }
     }

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -194,6 +194,11 @@ runtime_signal_handler(void *sig_addr)
         else if (exec_env_tls->exce_check_guard_page <= (uint8 *)sig_addr
                  && (uint8 *)sig_addr
                         < exec_env_tls->exce_check_guard_page + page_size) {
+            bh_assert(wasm_get_exception(module_inst)
+#if WASM_ENABLE_THREAD_MGR != 0
+                      || wasm_cluster_is_thread_terminated(exec_env_tls)
+#endif
+            );
             os_longjmp(jmpbuf_node->jmpbuf, 1);
         }
     }
@@ -249,7 +254,11 @@ runtime_exception_handler(EXCEPTION_POINTERS *exce_info)
             else if (exec_env_tls->exce_check_guard_page <= (uint8 *)sig_addr
                      && (uint8 *)sig_addr
                             < exec_env_tls->exce_check_guard_page + page_size) {
-                bh_assert(wasm_get_exception(module_inst));
+                bh_assert(wasm_get_exception(module_inst)
+#if WASM_ENABLE_THREAD_MGR != 0
+                          || wasm_cluster_is_thread_terminated(exec_env_tls)
+#endif
+                );
                 if (module_inst->module_type == Wasm_Module_Bytecode) {
                     return EXCEPTION_CONTINUE_SEARCH;
                 }

--- a/core/iwasm/compilation/aot_emit_function.c
+++ b/core/iwasm/compilation/aot_emit_function.c
@@ -1003,7 +1003,7 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     /* Insert suspend check point */
     if (comp_ctx->enable_thread_mgr) {
         if (!check_suspend_flags(comp_ctx, func_ctx))
-            return false;
+            goto fail;
     }
 #endif
 
@@ -1657,7 +1657,7 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     /* Insert suspend check point */
     if (comp_ctx->enable_thread_mgr) {
         if (!check_suspend_flags(comp_ctx, func_ctx))
-            return false;
+            goto fail;
     }
 #endif
 

--- a/core/iwasm/compilation/aot_emit_function.c
+++ b/core/iwasm/compilation/aot_emit_function.c
@@ -857,14 +857,6 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                 goto fail;
             }
 
-#if WASM_ENABLE_THREAD_MGR != 0
-            /* Insert suspend check point */
-            if (comp_ctx->enable_thread_mgr) {
-                if (!check_suspend_flags(comp_ctx, func_ctx))
-                    return false;
-            }
-#endif
-
             /* Check whether there was exception thrown when executing
                the function */
             if (!check_exception_thrown(comp_ctx, func_ctx)) {
@@ -1004,6 +996,14 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     if (comp_ctx->enable_aux_stack_frame) {
         if (!call_aot_free_frame_func(comp_ctx, func_ctx))
             goto fail;
+    }
+#endif
+
+#if WASM_ENABLE_THREAD_MGR != 0
+    /* Insert suspend check point */
+    if (comp_ctx->enable_thread_mgr) {
+        if (!check_suspend_flags(comp_ctx, func_ctx))
+            return false;
     }
 #endif
 
@@ -1650,6 +1650,14 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     if (comp_ctx->enable_aux_stack_frame) {
         if (!call_aot_free_frame_func(comp_ctx, func_ctx))
             goto fail;
+    }
+#endif
+
+#if WASM_ENABLE_THREAD_MGR != 0
+    /* Insert suspend check point */
+    if (comp_ctx->enable_thread_mgr) {
+        if (!check_suspend_flags(comp_ctx, func_ctx))
+            return false;
     }
 #endif
 

--- a/core/iwasm/compilation/aot_emit_function.c
+++ b/core/iwasm/compilation/aot_emit_function.c
@@ -857,6 +857,14 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                 goto fail;
             }
 
+#if WASM_ENABLE_THREAD_MGR != 0
+            /* Insert suspend check point */
+            if (comp_ctx->enable_thread_mgr) {
+                if (!check_suspend_flags(comp_ctx, func_ctx))
+                    return false;
+            }
+#endif
+
             /* Check whether there was exception thrown when executing
                the function */
             if (!check_exception_thrown(comp_ctx, func_ctx)) {

--- a/core/iwasm/compilation/aot_emit_memory.c
+++ b/core/iwasm/compilation/aot_emit_memory.c
@@ -7,6 +7,7 @@
 #include "aot_emit_exception.h"
 #include "../aot/aot_runtime.h"
 #include "aot_intrinsic.h"
+#include "aot_emit_control.h"
 
 #define BUILD_ICMP(op, left, right, res, name)                                \
     do {                                                                      \
@@ -1343,6 +1344,14 @@ aot_compile_op_atomic_wait(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         aot_set_last_error("llvm build call failed.");
         return false;
     }
+
+#if WASM_ENABLE_THREAD_MGR != 0
+    /* Insert suspend check point */
+    if (comp_ctx->enable_thread_mgr) {
+        if (!check_suspend_flags(comp_ctx, func_ctx))
+            return false;
+    }
+#endif
 
     BUILD_ICMP(LLVMIntSGT, ret_value, I32_ZERO, cmp, "atomic_wait_ret");
 

--- a/core/iwasm/compilation/aot_emit_memory.c
+++ b/core/iwasm/compilation/aot_emit_memory.c
@@ -1353,7 +1353,7 @@ aot_compile_op_atomic_wait(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     }
 #endif
 
-    BUILD_ICMP(LLVMIntSGT, ret_value, I32_ZERO, cmp, "atomic_wait_ret");
+    BUILD_ICMP(LLVMIntNE, ret_value, I32_NEG_ONE, cmp, "atomic_wait_ret");
 
     ADD_BASIC_BLOCK(wait_fail, "atomic_wait_fail");
     ADD_BASIC_BLOCK(wait_success, "wait_success");

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -3419,6 +3419,10 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         ret = wasm_runtime_atomic_wait(
                             (WASMModuleInstanceCommon *)module, maddr,
                             (uint64)expect, timeout, false);
+
+#if WASM_ENABLE_THREAD_MGR != 0
+                        CHECK_SUSPEND_FLAGS();
+#endif
                         if (ret == (uint32)-1)
                             goto got_exception;
 
@@ -3439,6 +3443,10 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         ret = wasm_runtime_atomic_wait(
                             (WASMModuleInstanceCommon *)module, maddr, expect,
                             timeout, true);
+
+#if WASM_ENABLE_THREAD_MGR != 0
+                        CHECK_SUSPEND_FLAGS();
+#endif
                         if (ret == (uint32)-1)
                             goto got_exception;
 
@@ -3894,10 +3902,10 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
             PUSH_CSP(LABEL_TYPE_FUNCTION, 0, cell_num, frame_ip_end - 1);
 
             wasm_exec_env_set_cur_frame(exec_env, frame);
-#if WASM_ENABLE_THREAD_MGR != 0
-            CHECK_SUSPEND_FLAGS();
-#endif
         }
+#if WASM_ENABLE_THREAD_MGR != 0
+        CHECK_SUSPEND_FLAGS();
+#endif
         HANDLE_OP_END();
     }
 

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -3263,6 +3263,10 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         ret = wasm_runtime_atomic_wait(
                             (WASMModuleInstanceCommon *)module, maddr,
                             (uint64)expect, timeout, false);
+
+#if WASM_ENABLE_THREAD_MGR != 0
+                        CHECK_SUSPEND_FLAGS();
+#endif
                         if (ret == (uint32)-1)
                             goto got_exception;
 
@@ -3283,6 +3287,10 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         ret = wasm_runtime_atomic_wait(
                             (WASMModuleInstanceCommon *)module, maddr, expect,
                             timeout, true);
+
+#if WASM_ENABLE_THREAD_MGR != 0
+                        CHECK_SUSPEND_FLAGS();
+#endif
                         if (ret == (uint32)-1)
                             goto got_exception;
 
@@ -3826,6 +3834,9 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
             wasm_exec_env_set_cur_frame(exec_env, (WASMRuntimeFrame *)frame);
         }
+#if WASM_ENABLE_THREAD_MGR != 0
+        CHECK_SUSPEND_FLAGS();
+#endif
         HANDLE_OP_END();
     }
 

--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -225,7 +225,9 @@ wasm_cluster_create(WASMExecEnv *exec_env)
     /* Prepare the aux stack top and size for every thread */
     if (!wasm_exec_env_get_aux_stack(exec_env, &aux_stack_start,
                                      &aux_stack_size)) {
+#if WASM_ENABLE_LIB_WASI_THREADS == 0
         LOG_VERBOSE("No aux stack info for this module, can't create thread");
+#endif
 
         /* If the module don't have aux stack info, don't throw error here,
             but remain stack_tops and stack_segment_occupied as NULL */

--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -1136,9 +1136,10 @@ set_exception_visitor(void *node, void *user_data)
         bh_memcpy_s(curr_wasm_inst->cur_exception,
                     sizeof(curr_wasm_inst->cur_exception),
                     wasm_inst->cur_exception, sizeof(wasm_inst->cur_exception));
-        /* Terminate the thread so it can exit from dead loops */
-        set_thread_cancel_flags(curr_exec_env);
     }
+
+    /* Terminate the thread so it can exit from dead loops */
+    set_thread_cancel_flags(curr_exec_env);
 }
 
 static void

--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -1136,10 +1136,10 @@ set_exception_visitor(void *node, void *user_data)
         bh_memcpy_s(curr_wasm_inst->cur_exception,
                     sizeof(curr_wasm_inst->cur_exception),
                     wasm_inst->cur_exception, sizeof(wasm_inst->cur_exception));
-    }
 
-    /* Terminate the thread so it can exit from dead loops */
-    set_thread_cancel_flags(curr_exec_env);
+        /* Terminate the thread so it can exit from dead loops */
+        set_thread_cancel_flags(curr_exec_env);
+    }
 }
 
 static void

--- a/samples/wasi-threads/README.md
+++ b/samples/wasi-threads/README.md
@@ -26,6 +26,7 @@ $ ./iwasm wasm-apps/exception_propagation.wasm
 ## Run samples in AOT mode
 ```shell
 $ ../../../wamr-compiler/build/wamrc \
+    --enable-multi-thread \
     -o wasm-apps/no_pthread.aot wasm-apps/no_pthread.wasm
 $ ./iwasm wasm-apps/no_pthread.aot
 ```

--- a/samples/wasi-threads/wasm-apps/thread_termination.c
+++ b/samples/wasi-threads/wasm-apps/thread_termination.c
@@ -15,8 +15,14 @@
 
 #include "wasi_thread_start.h"
 
-#define TEST_TERMINATION_BY_TRAP 0 // Otherwise test `proc_exit` termination
-#define TEST_TERMINATION_IN_MAIN_THREAD 1
+#define BUSY_WAIT 0
+#define ATOMIC_WAIT 1
+#define POLL_ONEOFF 2
+
+/* Change parameters here to modify the sample behavior */
+#define TEST_TERMINATION_BY_TRAP 0 /* Otherwise `proc_exit` termination */
+#define TEST_TERMINATION_IN_MAIN_THREAD 1 /* Otherwise in spawn thread */
+#define LONG_TASK_IMPL ATOMIC_WAIT
 
 #define TIMEOUT_SECONDS 10
 #define NUM_THREADS 3
@@ -30,23 +36,28 @@ typedef struct {
 void
 run_long_task()
 {
-    // Busy waiting to be interruptible by trap or `proc_exit`
+#if LONG_TASK_IMPL == BUSY_WAIT
     for (int i = 0; i < TIMEOUT_SECONDS; i++)
         sleep(1);
+#elif LONG_TASK_IMPL == ATOMIC_WAIT
+    __builtin_wasm_memory_atomic_wait32(0, 0, -1);
+#else
+    sleep(TIMEOUT_SECONDS);
+#endif
 }
 
 void
 start_job()
 {
     sem_post(&sem);
-    run_long_task(); // Wait to be interrupted
+    run_long_task(); /* Wait to be interrupted */
     assert(false && "Unreachable");
 }
 
 void
 terminate_process()
 {
-    // Wait for all other threads (including main thread) to be ready
+    /* Wait for all other threads (including main thread) to be ready */
     printf("Waiting before terminating\n");
     for (int i = 0; i < NUM_THREADS; i++)
         sem_wait(&sem);
@@ -55,7 +66,7 @@ terminate_process()
 #if TEST_TERMINATION_BY_TRAP == 1
     __builtin_trap();
 #else
-    __wasi_proc_exit(1);
+    __wasi_proc_exit(33);
 #endif
 }
 
@@ -86,14 +97,14 @@ main(int argc, char **argv)
     }
 
     for (i = 0; i < NUM_THREADS; i++) {
-        // No graceful memory free to simplify the example
+        /* No graceful memory free to simplify the example */
         if (!start_args_init(&data[i].base)) {
             printf("Failed to allocate thread's stack\n");
             return EXIT_FAILURE;
         }
     }
 
-// Create a thread that forces termination through trap or `proc_exit`
+/* Create a thread that forces termination through trap or `proc_exit` */
 #if TEST_TERMINATION_IN_MAIN_THREAD == 1
     data[0].throw_exception = false;
 #else
@@ -105,7 +116,7 @@ main(int argc, char **argv)
         return EXIT_FAILURE;
     }
 
-    // Create two additional threads to test exception propagation
+    /* Create two additional threads to test exception propagation */
     data[1].throw_exception = false;
     thread_id = __wasi_thread_spawn(&data[1]);
     if (thread_id < 0) {


### PR DESCRIPTION
Without the change in this PR, upon receiving the `proc_exit` exception propagation while on an `atomic.atomic` or `poll_oneoff`, the next instruction is fetched instead of stopping the executing.

That results in the exception being overridden (by an `unreachable` exception) when using the tests in https://github.com/WebAssembly/wasi-threads/tree/main/test/testsuite, causing the exit code to be wrong.
Continuation of #1929 #1951.