### PR TITLE
Fix several issues found

### DIFF
--- a/.github/workflows/compilation_on_android_ubuntu.yml
+++ b/.github/workflows/compilation_on_android_ubuntu.yml
@@ -367,7 +367,7 @@ jobs:
           git fetch https://github.com/WebAssembly/wasi-libc \
             8f5275796a82f8ecfd0833a4f3f444fa37ed4546
           git checkout FETCH_HEAD
-          make \
+          make -j \
             AR=/opt/wasi-sdk/bin/llvm-ar \
             NM=/opt/wasi-sdk/bin/llvm-nm \
             CC=/opt/wasi-sdk/bin/clang \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,4 +160,5 @@ install (TARGETS iwasm_shared LIBRARY DESTINATION lib)
 install (FILES
     ${WAMR_ROOT_DIR}/core/iwasm/include/wasm_c_api.h
     ${WAMR_ROOT_DIR}/core/iwasm/include/wasm_export.h
+    ${WAMR_ROOT_DIR}/core/iwasm/include/lib_export.h
     DESTINATION include)

--- a/core/iwasm/fast-jit/jit_frontend.c
+++ b/core/iwasm/fast-jit/jit_frontend.c
@@ -841,7 +841,7 @@ init_func_translation(JitCompContext *cc)
     cc->spill_cache_offset = wasm_interp_interp_frame_size(total_cell_num);
     /* Set spill cache size according to max local cell num, max stack cell
        num and virtual fixed register num */
-    cc->spill_cache_size = (max_locals + max_stacks) * 4 + sizeof(void *) * 5;
+    cc->spill_cache_size = (max_locals + max_stacks) * 4 + sizeof(void *) * 16;
     cc->total_frame_size = cc->spill_cache_offset + cc->spill_cache_size;
     cc->jitted_return_address_offset =
         offsetof(WASMInterpFrame, jitted_return_addr);

--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -896,6 +896,7 @@ void
 wasm_cluster_exit_thread(WASMExecEnv *exec_env, void *retval)
 {
     WASMCluster *cluster;
+    WASMModuleInstanceCommon *module_inst;
 
 #ifdef OS_ENABLE_HW_BOUND_CHECK
     if (exec_env->jmpbuf_stack_top) {
@@ -926,6 +927,8 @@ wasm_cluster_exit_thread(WASMExecEnv *exec_env, void *retval)
 
     os_mutex_lock(&cluster->lock);
 
+    module_inst = exec_env->module_inst;
+
     /* Free aux stack space */
     free_aux_stack(exec_env, exec_env->aux_stack_bottom.bottom);
     /* Remove exec_env */
@@ -933,7 +936,7 @@ wasm_cluster_exit_thread(WASMExecEnv *exec_env, void *retval)
     /* Destroy exec_env */
     wasm_exec_env_destroy_internal(exec_env);
     /* Routine exit, destroy instance */
-    wasm_runtime_deinstantiate_internal(exec_env->module_inst, true);
+    wasm_runtime_deinstantiate_internal(module_inst, true);
 
     os_mutex_unlock(&cluster->lock);
 

--- a/samples/socket-api/README.md
+++ b/samples/socket-api/README.md
@@ -121,7 +121,7 @@ Shuting down
 ```
 
 ```bash
-$ ./iwasm --addr-pool=127.0.0.1/15 --heap-size=10000000 timeout_client.wasm
+$ ./iwasm --addr-pool=127.0.0.1/15 timeout_client.wasm
 ```
 
 The output is:

--- a/samples/socket-api/wasm-src/CMakeLists.txt
+++ b/samples/socket-api/wasm-src/CMakeLists.txt
@@ -54,7 +54,9 @@ function(COMPILE_WITH_CLANG SOURCE_FILE)
   target_link_options(${MAIN_TARGET_NAME} PRIVATE
     LINKER:--export=__heap_base
     LINKER:--export=__data_end
-    LINKER:--shared-memory,--max-memory=196608
+    LINKER:--export=malloc
+    LINKER:--export=free
+    LINKER:--shared-memory,--max-memory=10485760
     LINKER:--no-check-features
     LINKER:--allow-undefined
   )

--- a/samples/wasm-c-api-imports/CMakeLists.txt
+++ b/samples/wasm-c-api-imports/CMakeLists.txt
@@ -56,10 +56,15 @@ if (NOT CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE Release)
 endif ()
 
-set(WAMR_BUILD_AOT 1)
-set(WAMR_BUILD_INTERP 0)
+if (NOT DEFINED WAMR_BUILD_AOT)
+  # Enable AOT by default.
+  set (WAMR_BUILD_AOT 1)
+endif ()
+if (NOT DEFINED WAMR_BUILD_INTERP)
+    # Disable Interpreter by default
+  set (WAMR_BUILD_INTERP 0)
+endif ()
 set(WAMR_BUILD_JIT 0)
-
 set(WAMR_BUILD_FAST_INTERP 1)
 set(WAMR_BUILD_LIB_PTHREAD 1)
 set(WAMR_BUILD_LIBC_BUILTIN 1)


### PR DESCRIPTION
- CMakeLists.txt: add lib_export.h to install list
- Fast JIT: enlarge spill cache size to enable run several standalone cases
                when hw bound check is disabled
- Thread manager: wasm_cluster_exit_thread may destroy an invalid
               exec_env->module_inst as exec_env was destroyed before
- samples/socket-api: failed to run timeout_client.wasm
- enhance CI build wasi-libc and sample/wasm-c-api-imports CMakeLlist.txt