### PR TITLE
Fix wasm_cluster_create_thread issue

### DIFF
--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -583,6 +583,7 @@ thread_manager_start_routine(void *arg)
     /* Notify the parent thread to continue running */
     os_cond_signal(&exec_env->wait_cond);
     os_mutex_unlock(&exec_env->wait_lock);
+
     ret = exec_env->thread_start_routine(exec_env);
 
 #ifdef OS_ENABLE_HW_BOUND_CHECK
@@ -666,14 +667,16 @@ wasm_cluster_create_thread(WASMExecEnv *exec_env,
     new_exec_env->thread_start_routine = thread_routine;
     new_exec_env->thread_arg = arg;
 
+    os_mutex_lock(&new_exec_env->wait_lock);
+
     if (0
         != os_thread_create(&tid, thread_manager_start_routine,
                             (void *)new_exec_env,
                             APP_THREAD_STACK_SIZE_DEFAULT)) {
+        os_mutex_unlock(&new_exec_env->wait_lock);
         goto fail4;
     }
 
-    os_mutex_lock(&new_exec_env->wait_lock);
     /* Wait until the new_exec_env->handle is set to avoid it is
        illegally accessed after unlocking cluster->lock */
     os_cond_wait(&new_exec_env->wait_cond, &new_exec_env->wait_lock);


### PR DESCRIPTION
In wasm_cluster_create_thread, the new_exec_env is added into the cluster's
exec_env list before the thread is created, so other threads can access the
fields of new_exec_env once the cluster->lock is unlocked, while the
new_exec_env's handle is set later inside the thread routine. This may result
in the new_exec_env's handle may be invalidly accessed by other threads.