### PR TITLE
nuttx: Add missing pthread.h header

### DIFF
--- a/core/shared/platform/nuttx/platform_internal.h
+++ b/core/shared/platform/nuttx/platform_internal.h
@@ -14,6 +14,7 @@
 #include <inttypes.h>
 #include <limits.h>
 #include <poll.h>
+#include <pthread.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>


### PR DESCRIPTION
This PR intends to add the missing `pthread.h` header to the NuttX build to fix the following build error:

```bash
In file included from wamr/core/shared/utils/../platform/include/platform_common.h:13,
                 from wamr/core/shared/utils/bh_platform.h:9,
                 from wamr/core/iwasm/aot/aot_runtime.h:9,
                 from wamr/core/iwasm/aot/aot_loader.c:6:
wamr/core/shared/platform/nuttx/platform_internal.h:39:9: error: unknown type name 'pthread_t'
 typedef pthread_t korp_tid;
         ^~~~~~~~~
wamr/core/shared/platform/nuttx/platform_internal.h:40:9: error: unknown type name 'pthread_mutex_t'
 typedef pthread_mutex_t korp_mutex;
         ^~~~~~~~~~~~~~~
wamr/core/shared/platform/nuttx/platform_internal.h:41:9: error: unknown type name 'pthread_cond_t'
 typedef pthread_cond_t korp_cond;
         ^~~~~~~~~~~~~~
wamr/core/shared/platform/nuttx/platform_internal.h:42:9: error: unknown type name 'pthread_t'
 typedef pthread_t korp_thread;
         ^~~~~~~~~
In file included from wamr/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.h:18,
                 from wamr/core/iwasm/aot/../common/wasm_runtime_common.h:18,
                 from wamr/core/iwasm/aot/aot_runtime.h:10,
                 from wamr/core/iwasm/aot/aot_loader.c:6:
wamr/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/locking.h:52:5: error: unknown type name 'pthread_mutex_t'
     pthread_mutex_t object;
     ^~~~~~~~~~~~~~~
wamr/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/locking.h:87:5: error: unknown type name 'pthread_rwlock_t'
     pthread_rwlock_t object;
     ^~~~~~~~~~~~~~~~
wamr/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/locking.h:123:5: error: unknown type name 'pthread_cond_t'
     pthread_cond_t object;
     ^~~~~~~~~~~~~~
wamr/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/locking.h: In function 'cond_init_monotonic':
wamr/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/locking.h:135:5: error: unknown type name 'pthread_condattr_t'
     pthread_condattr_t attr;
     ^~~~~~~~~~~~~~~~~~
make[3]: *** [/home/nihei/Projects/NuttX/apps/Application.mk:157: aot_loader.c.home.nihei.Projects.NuttX.apps.interpreters.wamr.o] Error 1
```