### PR TITLE
Fix few wasm-c-api python binding issues

### DIFF
--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -1905,7 +1905,7 @@ wasm_trap_new_internal(wasm_store_t *store,
     }
 
     /* fill in message */
-    if (strlen(error_info) > 0) {
+    if (error_info && strlen(error_info) > 0) {
         if (!(trap->message = malloc_internal(sizeof(wasm_byte_vec_t)))) {
             goto failed;
         }

--- a/language-bindings/python/wasm-c-api/tests/test_basic.py
+++ b/language-bindings/python/wasm-c-api/tests/test_basic.py
@@ -1183,8 +1183,9 @@ class BasicTestSuite(unittest.TestCase):
             self._wasm_store, module, imports, create_null_pointer(wasm_trap_t)
         )
 
-        wasm_instance_delete(instance)
         wasm_module_delete(module)
+
+        self.assertIsNullPointer(instance)
 
     def test_wasm_instance_new_pos(self):
         binary = load_module_file(MODULE_BINARY)
@@ -1227,8 +1228,9 @@ class BasicTestSuite(unittest.TestCase):
             create_null_pointer(wasm_trap_t),
         )
 
-        wasm_instance_delete(instance)
         wasm_module_delete(module)
+
+        self.assertIsNullPointer(instance)
 
     # test those APIs in advanced:
     # wasm_instance_delete


### PR DESCRIPTION
```
$ cd /path/to/language-bindings/python/
$ python -m pip install -e .
$ cd wasm-c-api
$ python -m unittest tests/test_basic.py
$ python -m unittest tests/test_advanced.py
```