### PR TITLE
Set termination flags in debug mode

### DIFF
--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -988,12 +988,12 @@ static void
 set_thread_cancel_flags(WASMExecEnv *exec_env)
 {
     os_mutex_lock(&exec_env->wait_lock);
-    /* Set the termination flag */
+
 #if WASM_ENABLE_DEBUG_INTERP != 0
     wasm_cluster_thread_send_signal(exec_env, WAMR_SIG_TERM);
-#else
-    exec_env->suspend_flags.flags |= 0x01;
 #endif
+    exec_env->suspend_flags.flags |= 0x01;
+
     os_mutex_unlock(&exec_env->wait_lock);
 }
 


### PR DESCRIPTION
When using multiple threads, terminations flags are checked to stop the thread if a `proc_exit` or trap occurs. They have to be set also in debug mode.

Tested using [WASI thread tests](https://github.com/bytecodealliance/wasm-micro-runtime/tree/main/core/iwasm/libraries/lib-wasi-threads/test).