### PR TITLE
Remove a file test outside of the specs and improve CI reporting.

### DIFF
--- a/samples/file/src/main.c
+++ b/samples/file/src/main.c
@@ -20,7 +20,7 @@ main(int argc, char *argv_main[])
     static char global_heap_buf[512 * 1024];
     char *buffer, error_buf[128];
     const char *wasm_path = NULL, *wasi_dir = NULL;
-    int opt;
+    int opt, main_result = 1;
 
     wasm_module_t module = NULL;
     wasm_module_inst_t module_inst = NULL;
@@ -91,7 +91,7 @@ main(int argc, char *argv_main[])
     }
 
     if (wasm_application_execute_main(module_inst, 0, NULL)) {
-        printf("Main wasm function successfully finished.\n");
+        main_result = wasm_runtime_get_wasi_exit_code(module_inst);
     }
     else {
         printf("call wasm function main failed. error: %s\n",
@@ -109,5 +109,5 @@ fail:
     if (buffer)
         BH_FREE(buffer);
     wasm_runtime_destroy();
-    return 0;
+    return main_result;
 }

--- a/samples/file/wasm-app/main.c
+++ b/samples/file/wasm-app/main.c
@@ -99,8 +99,32 @@ main(int argc, char **argv)
     assert(ftell(file) == strlen(FILE_TEXT));
     printf("[Test] Reading at specified offset passed.\n");
 
+    // Test: moving at the start of the file (fseek)
+    printf("Move at the start of the file (fseek)..\n");
+    printf("File current offset: %ld\n", ftell(file));
+    fseek(file, 0, SEEK_SET);
+    printf("File current offset: %ld\n", ftell(file));
+    assert(ftell(file) == 0);
+
+    // Test: moving at the end of the file (fseek)
+    printf("Move at the end of the file (fseek)..\n");
+    printf("File current offset: %ld\n", ftell(file));
+    fseek(file, 0, SEEK_END);
+    printf("File current offset: %ld\n", ftell(file));
+    assert(ftell(file) == strlen(FILE_TEXT));
+    int end_position = ftell(file) / 2;
+
+    // Test: moving at the middle of the file (fseek)
+    printf("Move at the middle of the file (fseek)..\n");
+    printf("File current offset: %ld\n", ftell(file));
+    fseek(file, 0, SEEK_SET);
+    fseek(file, end_position, SEEK_CUR);
+    printf("File current offset: %ld\n", ftell(file));
+    assert(ftell(file) == end_position);
+
     // Test: allocate more space to the file (posix_fallocate)
     printf("Allocate more space to the file (posix_fallocate)..\n");
+    fseek(file, 0, SEEK_END);
     posix_fallocate(fileno(file), ftell(file), ADDITIONAL_SPACE);
     printf("File current offset: %ld\n", ftell(file));
     printf("Moving to the end..\n");
@@ -120,7 +144,7 @@ main(int argc, char **argv)
     assert(ftell(file) == strlen(text) + 2 * ADDITIONAL_SPACE);
     printf("[Test] Extension of the file size passed.\n");
 
-    // Test: allocate more space to the file (fseek)
+    // Test: allocate more space to the file (fseek, from the start)
     printf("Allocate more space to the file (fseek) from the start..\n");
     printf("File current offset: %ld\n", ftell(file));
     fseek(file, 3 * ADDITIONAL_SPACE, SEEK_SET);
@@ -128,15 +152,7 @@ main(int argc, char **argv)
     assert(ftell(file) == 3 * ADDITIONAL_SPACE);
     printf("[Test] Extension of the file size passed.\n");
 
-    // Test: allocate more space to the file (fseek)
-    printf("Allocate more space to the file (fseek) from the end..\n");
-    printf("File current offset: %ld\n", ftell(file));
-    fseek(file, ADDITIONAL_SPACE, SEEK_END);
-    printf("File current offset: %ld\n", ftell(file));
-    assert(ftell(file) == 4 * ADDITIONAL_SPACE);
-    printf("[Test] Extension of the file size passed.\n");
-
-    // Test: allocate more space to the file (fseek)
+    // Test: allocate more space to the file (fseek, from the middle)
     printf("Allocate more space to the file (fseek) from the middle..\n");
     fseek(file, 3 * ADDITIONAL_SPACE, SEEK_SET);
     printf("File current offset: %ld\n", ftell(file));


### PR DESCRIPTION
Remove the test in the sample of file interaction that tries to extend the file at the end because this is not supported by the specifications of fseek.

Add a couple of other tests related to fseek (moving around, without extending the length of the file).

The runtime now propagates the WASI exit code, so the CI will indicate when a test fails.