### PR TITLE
Add support for universal binaries on OSX

### DIFF
--- a/core/iwasm/common/arch/invokeNative_osx_universal.s
+++ b/core/iwasm/common/arch/invokeNative_osx_universal.s
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2019 Intel Corporation.  All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#if defined(__aarch64__)
+#if WASM_ENABLE_SIMD == 0
+#include "invokeNative_aarch64.s"
+#else
+#include "invokeNative_aarch64_simd.s"
+#endif
+#else
+#if WASM_ENABLE_SIMD == 0
+#include "invokeNative_em64.s"
+#else
+#include "invokeNative_em64_simd.s"
+#endif
+#endif

--- a/core/iwasm/common/iwasm_common.cmake
+++ b/core/iwasm/common/iwasm_common.cmake
@@ -14,6 +14,17 @@ if (WAMR_DISABLE_APP_ENTRY EQUAL 1)
   list(REMOVE_ITEM c_source_all "${IWASM_COMMON_DIR}/wasm_application.c")
 endif ()
 
+if (CMAKE_OSX_ARCHITECTURES)
+  string(TOLOWER "${CMAKE_OSX_ARCHITECTURES}" OSX_ARCHS)
+
+  list(FIND OSX_ARCHS arm64 OSX_AARCH64)
+  list(FIND OSX_ARCHS x86_64 OSX_X86_64)
+
+  if (NOT "${OSX_AARCH64}" STREQUAL "-1" AND NOT "${OSX_X86_64}" STREQUAL "-1")
+    set(OSX_UNIVERSAL_BUILD 1)
+  endif()
+endif()
+
 if (WAMR_BUILD_INVOKE_NATIVE_GENERAL EQUAL 1)
   # Use invokeNative C version instead of asm code version
   # if WAMR_BUILD_INVOKE_NATIVE_GENERAL is explicitly set.
@@ -24,6 +35,8 @@ if (WAMR_BUILD_INVOKE_NATIVE_GENERAL EQUAL 1)
   #   in arm and mips need to be 8-bytes aligned, and some arguments
   #   of x86_64 are passed by registers but not stack
   set (source_all ${c_source_all} ${IWASM_COMMON_DIR}/arch/invokeNative_general.c)
+elseif (OSX_UNIVERSAL_BUILD EQUAL 1)
+  set (source_all ${c_source_all} ${IWASM_COMMON_DIR}/arch/invokeNative_osx_universal.s)
 elseif (WAMR_BUILD_TARGET STREQUAL "X86_64" OR WAMR_BUILD_TARGET STREQUAL "AMD_64")
   if (NOT WAMR_BUILD_SIMD EQUAL 1)
     if (WAMR_BUILD_PLATFORM STREQUAL "windows")


### PR DESCRIPTION
When building for multiple architectures on OSX, it's necessary to use compiler macros to conditionally include architecture-specific code rather than conditionally including architecture-specific assembly files via cmake. See
https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary and
https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_ARCHITECTURES.html for more details.