### PR TITLE
core/iwasm: posix.c: fix POLL{RD,WR}NORM in uClibc

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -2655,8 +2655,8 @@ wasmtime_ssp_poll_oneoff(
                     pfds[i] = (struct pollfd){
                         .fd = fd_number(fos[i]),
                         .events = s->u.type == __WASI_EVENTTYPE_FD_READ
-                                      ? POLLRDNORM
-                                      : POLLWRNORM,
+                                      ? POLLIN
+                                      : POLLOUT,
                     };
                 }
                 else {
@@ -2767,7 +2767,7 @@ wasmtime_ssp_poll_oneoff(
                             __WASI_EVENT_FD_READWRITE_HANGUP,
                     };
                 }
-                else if ((pfds[i].revents & (POLLRDNORM | POLLWRNORM)) != 0) {
+                else if ((pfds[i].revents & (POLLIN | POLLOUT)) != 0) {
                     // Read or write possible.
                     out[(*nevents)++] = (__wasi_event_t){
                         .userdata = in[i].userdata,


### PR DESCRIPTION
Not defined in uClibc, so replace them with the equivalent POLL{OUT,IN}.

https://www.man7.org/linux/man-pages/man2/poll.2.html

POLLWRNORM
       Equivalent to POLLOUT.

POLLRDNORM
       Equivalent to POLLIN.