### PR TITLE
Fix bh_assert on 64-bit platforms

### DIFF
--- a/core/shared/utils/bh_assert.c
+++ b/core/shared/utils/bh_assert.c
@@ -6,7 +6,7 @@
 #include "bh_assert.h"
 
 void
-bh_assert_internal(int v, const char *file_name, int line_number,
+bh_assert_internal(int64 v, const char *file_name, int line_number,
                    const char *expr_string)
 {
     if (v)

--- a/core/shared/utils/bh_assert.h
+++ b/core/shared/utils/bh_assert.h
@@ -14,10 +14,10 @@ extern "C" {
 
 #if BH_DEBUG != 0
 void
-bh_assert_internal(int v, const char *file_name, int line_number,
+bh_assert_internal(int64 v, const char *file_name, int line_number,
                    const char *expr_string);
 #define bh_assert(expr) \
-    bh_assert_internal((int)(uintptr_t)(expr), __FILE__, __LINE__, #expr)
+    bh_assert_internal((int64)(uintptr_t)(expr), __FILE__, __LINE__, #expr)
 #else
 #define bh_assert(expr) (void)0
 #endif /* end of BH_DEBUG */


### PR DESCRIPTION
In some cases (for me, every time I use memory sanitizer) the memory address of some of the variables has 4 least significant bytes set to zero. Because we cast the pointer to int, we look only at 4 (at least on my system, but I guess on many other systems too) least significant bytes; the assertion fails because 4 least significant bytes are 0.

I change bh_assert implementation so it casts to int64_t and it works well with 64-bit architectures.