### PR TITLE
Fix module_malloc/module_free issues

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -932,7 +932,7 @@ execute_post_instantiate_functions(AOTModuleInstance *module_inst,
 #ifdef OS_ENABLE_HW_BOUND_CHECK
     WASMExecEnv *exec_env_tls = NULL;
 #endif
-    WASMExecEnv *exec_env = NULL;
+    WASMExecEnv *exec_env = NULL, *exec_env_created = NULL;
     bool ret = false;
 
 #if WASM_ENABLE_LIBC_WASI != 0
@@ -990,11 +990,29 @@ execute_post_instantiate_functions(AOTModuleInstance *module_inst,
         exec_env->module_inst = (WASMModuleInstanceCommon *)module_inst;
     }
     else {
-        if (!(exec_env =
-                  wasm_exec_env_create((WASMModuleInstanceCommon *)module_inst,
-                                       module_inst->default_wasm_stack_size))) {
-            aot_set_exception(module_inst, "allocate memory failed");
-            return false;
+/* Try using the existing exec_env */
+#ifdef OS_ENABLE_HW_BOUND_CHECK
+        exec_env = exec_env_tls;
+#endif
+#if WASM_ENABLE_THREAD_MGR != 0
+        if (!exec_env)
+            exec_env = wasm_clusters_search_exec_env(
+                (WASMModuleInstanceCommon *)module_inst);
+#endif
+        if (!exec_env) {
+            if (!(exec_env = exec_env_created = wasm_exec_env_create(
+                      (WASMModuleInstanceCommon *)module_inst,
+                      module_inst->default_wasm_stack_size))) {
+                aot_set_exception(module_inst, "allocate memory failed");
+                return false;
+            }
+        }
+        else {
+            /* Temporarily replace exec_env's module inst with current
+               module inst to ensure that the exec_env's module inst
+               is the correct one. */
+            module_inst_main = exec_env->module_inst;
+            exec_env->module_inst = (WASMModuleInstanceCommon *)module_inst;
         }
     }
 
@@ -1033,11 +1051,17 @@ execute_post_instantiate_functions(AOTModuleInstance *module_inst,
     ret = true;
 
 fail:
-    if (is_sub_inst)
+    if (is_sub_inst) {
         /* Restore the parent exec_env's module inst */
         exec_env_main->module_inst = module_inst_main;
-    else
-        wasm_exec_env_destroy(exec_env);
+    }
+    else {
+        if (module_inst_main)
+            /* Restore the existing exec_env's module inst */
+            exec_env->module_inst = module_inst_main;
+        if (exec_env_created)
+            wasm_exec_env_destroy(exec_env_created);
+    }
 
     return ret;
 }
@@ -1650,7 +1674,7 @@ execute_malloc_function(AOTModuleInstance *module_inst, WASMExecEnv *exec_env,
         ret = aot_call_function(exec_env, retain_func, 1, argv);
 
     if (module_inst_old)
-        /* Restore the module inst */
+        /* Restore the existing exec_env's module inst */
         exec_env->module_inst = module_inst_old;
 
     if (exec_env_created)
@@ -1714,7 +1738,7 @@ execute_free_function(AOTModuleInstance *module_inst, WASMExecEnv *exec_env,
     ret = aot_call_function(exec_env, free_func, 1, argv);
 
     if (module_inst_old)
-        /* Restore the module inst */
+        /* Restore the existing exec_env's module inst */
         exec_env->module_inst = module_inst_old;
 
     if (exec_env_created)

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -990,7 +990,7 @@ execute_post_instantiate_functions(AOTModuleInstance *module_inst,
         exec_env->module_inst = (WASMModuleInstanceCommon *)module_inst;
     }
     else {
-/* Try using the existing exec_env */
+        /* Try using the existing exec_env */
 #ifdef OS_ENABLE_HW_BOUND_CHECK
         exec_env = exec_env_tls;
 #endif

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1123,6 +1123,8 @@ execute_malloc_function(WASMModuleInstance *module_inst, WASMExecEnv *exec_env,
 #ifdef OS_ENABLE_HW_BOUND_CHECK
     WASMExecEnv *exec_env_tls = wasm_runtime_get_exec_env_tls();
 #endif
+    WASMExecEnv *exec_env_created = NULL;
+    WASMModuleInstanceCommon *module_inst_old = NULL;
     uint32 argv[2], argc;
     bool ret;
 
@@ -1151,19 +1153,43 @@ execute_malloc_function(WASMModuleInstance *module_inst, WASMExecEnv *exec_env,
                   == (WASMModuleInstanceCommon *)module_inst);
     }
     else {
-        if (!(exec_env =
-                  wasm_exec_env_create((WASMModuleInstanceCommon *)module_inst,
-                                       module_inst->default_wasm_stack_size))) {
-            wasm_set_exception(module_inst, "allocate memory failed");
-            return false;
+        /* Try using the existing exec_env */
+#ifdef OS_ENABLE_HW_BOUND_CHECK
+        exec_env = exec_env_tls;
+#endif
+#if WASM_ENABLE_THREAD_MGR != 0
+        if (!exec_env)
+            exec_env = wasm_clusters_search_exec_env(
+                (WASMModuleInstanceCommon *)module_inst);
+#endif
+        if (!exec_env) {
+            if (!(exec_env = exec_env_created = wasm_exec_env_create(
+                      (WASMModuleInstanceCommon *)module_inst,
+                      module_inst->default_wasm_stack_size))) {
+                wasm_set_exception(module_inst, "allocate memory failed");
+                return false;
+            }
+        }
+        else {
+            /* Temporarily replace exec_env's module inst with current
+               module inst to ensure that the exec_env's module inst
+               is the correct one. */
+            module_inst_old = exec_env->module_inst;
+            exec_env->module_inst = (WASMModuleInstanceCommon *)module_inst;
         }
     }
 
     ret = wasm_call_function(exec_env, malloc_func, argc, argv);
 
-    if (retain_func && ret) {
+    if (retain_func && ret)
         ret = wasm_call_function(exec_env, retain_func, 1, argv);
-    }
+
+    if (module_inst_old)
+        /* Restore the module inst */
+        exec_env->module_inst = module_inst_old;
+
+    if (exec_env_created)
+        wasm_exec_env_destroy(exec_env_created);
 
     if (ret)
         *p_result = argv[0];
@@ -1177,7 +1203,10 @@ execute_free_function(WASMModuleInstance *module_inst, WASMExecEnv *exec_env,
 #ifdef OS_ENABLE_HW_BOUND_CHECK
     WASMExecEnv *exec_env_tls = wasm_runtime_get_exec_env_tls();
 #endif
+    WASMExecEnv *exec_env_created = NULL;
+    WASMModuleInstanceCommon *module_inst_old = NULL;
     uint32 argv[2];
+    bool ret;
 
     argv[0] = offset;
 
@@ -1191,15 +1220,42 @@ execute_free_function(WASMModuleInstance *module_inst, WASMExecEnv *exec_env,
                   == (WASMModuleInstanceCommon *)module_inst);
     }
     else {
-        if (!(exec_env =
-                  wasm_exec_env_create((WASMModuleInstanceCommon *)module_inst,
-                                       module_inst->default_wasm_stack_size))) {
-            wasm_set_exception(module_inst, "allocate memory failed");
-            return false;
+        /* Try using the existing exec_env */
+#ifdef OS_ENABLE_HW_BOUND_CHECK
+        exec_env = exec_env_tls;
+#endif
+#if WASM_ENABLE_THREAD_MGR != 0
+        if (!exec_env)
+            exec_env = wasm_clusters_search_exec_env(
+                (WASMModuleInstanceCommon *)module_inst);
+#endif
+        if (!exec_env) {
+            if (!(exec_env = exec_env_created = wasm_exec_env_create(
+                      (WASMModuleInstanceCommon *)module_inst,
+                      module_inst->default_wasm_stack_size))) {
+                wasm_set_exception(module_inst, "allocate memory failed");
+                return false;
+            }
+        }
+        else {
+            /* Temporarily replace exec_env's module inst with current
+               module inst to ensure that the exec_env's module inst
+               is the correct one. */
+            module_inst_old = exec_env->module_inst;
+            exec_env->module_inst = (WASMModuleInstanceCommon *)module_inst;
         }
     }
 
-    return wasm_call_function(exec_env, free_func, 1, argv);
+    ret = wasm_call_function(exec_env, free_func, 1, argv);
+
+    if (module_inst_old)
+        /* Restore the module inst */
+        exec_env->module_inst = module_inst_old;
+
+    if (exec_env_created)
+        wasm_exec_env_destroy(exec_env_created);
+
+    return ret;
 }
 
 #if WASM_ENABLE_MULTI_MODULE != 0

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1016,7 +1016,7 @@ execute_post_instantiate_functions(WASMModuleInstance *module_inst,
 #ifdef OS_ENABLE_HW_BOUND_CHECK
     WASMExecEnv *exec_env_tls = NULL;
 #endif
-    WASMExecEnv *exec_env = NULL;
+    WASMExecEnv *exec_env = NULL, *exec_env_created = NULL;
     bool ret = false;
 
 #if WASM_ENABLE_LIBC_WASI != 0
@@ -1074,11 +1074,29 @@ execute_post_instantiate_functions(WASMModuleInstance *module_inst,
         exec_env->module_inst = (WASMModuleInstanceCommon *)module_inst;
     }
     else {
-        if (!(exec_env =
-                  wasm_exec_env_create((WASMModuleInstanceCommon *)module_inst,
-                                       module_inst->default_wasm_stack_size))) {
-            wasm_set_exception(module_inst, "allocate memory failed");
-            return false;
+        /* Try using the existing exec_env */
+#ifdef OS_ENABLE_HW_BOUND_CHECK
+        exec_env = exec_env_tls;
+#endif
+#if WASM_ENABLE_THREAD_MGR != 0
+        if (!exec_env)
+            exec_env = wasm_clusters_search_exec_env(
+                (WASMModuleInstanceCommon *)module_inst);
+#endif
+        if (!exec_env) {
+            if (!(exec_env = exec_env_created = wasm_exec_env_create(
+                      (WASMModuleInstanceCommon *)module_inst,
+                      module_inst->default_wasm_stack_size))) {
+                wasm_set_exception(module_inst, "allocate memory failed");
+                return false;
+            }
+        }
+        else {
+            /* Temporarily replace exec_env's module inst with current
+               module inst to ensure that the exec_env's module inst
+               is the correct one. */
+            module_inst_main = exec_env->module_inst;
+            exec_env->module_inst = (WASMModuleInstanceCommon *)module_inst;
         }
     }
 
@@ -1105,11 +1123,17 @@ execute_post_instantiate_functions(WASMModuleInstance *module_inst,
     ret = true;
 
 fail:
-    if (is_sub_inst)
+    if (is_sub_inst) {
         /* Restore the parent exec_env's module inst */
         exec_env_main->module_inst = module_inst_main;
-    else
-        wasm_exec_env_destroy(exec_env);
+    }
+    else {
+        if (module_inst_main)
+            /* Restore the existing exec_env's module inst */
+            exec_env->module_inst = module_inst_main;
+        if (exec_env_created)
+            wasm_exec_env_destroy(exec_env_created);
+    }
 
     return ret;
 }
@@ -1185,7 +1209,7 @@ execute_malloc_function(WASMModuleInstance *module_inst, WASMExecEnv *exec_env,
         ret = wasm_call_function(exec_env, retain_func, 1, argv);
 
     if (module_inst_old)
-        /* Restore the module inst */
+        /* Restore the existing exec_env's module inst */
         exec_env->module_inst = module_inst_old;
 
     if (exec_env_created)
@@ -1249,7 +1273,7 @@ execute_free_function(WASMModuleInstance *module_inst, WASMExecEnv *exec_env,
     ret = wasm_call_function(exec_env, free_func, 1, argv);
 
     if (module_inst_old)
-        /* Restore the module inst */
+        /* Restore the existing exec_env's module inst */
         exec_env->module_inst = module_inst_old;
 
     if (exec_env_created)


### PR DESCRIPTION
Try using existing exec_env to execute wasm app's malloc/free func and
execute post instantiation functions. Create a new exec_env only when
no existing exec_env was found.