### PR TITLE
Limit the minimal size of bh_hashmap

### DIFF
--- a/core/shared/utils/bh_hashmap.c
+++ b/core/shared/utils/bh_hashmap.c
@@ -33,6 +33,9 @@ bh_hash_map_create(uint32 size, bool use_lock, HashFunc hash_func,
     HashMap *map;
     uint64 total_size;
 
+    if (size < HASH_MAP_MIN_SIZE)
+        size = HASH_MAP_MIN_SIZE;
+
     if (size > HASH_MAP_MAX_SIZE) {
         LOG_ERROR("HashMap create failed: size is too large.\n");
         return NULL;

--- a/core/shared/utils/bh_hashmap.h
+++ b/core/shared/utils/bh_hashmap.h
@@ -12,6 +12,9 @@
 extern "C" {
 #endif
 
+/* Minimum initial size of hash map */
+#define HASH_MAP_MIN_SIZE 4
+
 /* Maximum initial size of hash map */
 #define HASH_MAP_MAX_SIZE 65536
 


### PR DESCRIPTION
Limit the minimal size of bh_hashmap to avoid creating hashmap with size 0,
and encounter `divide by zero` when calling bh_hash_map_find.

Reported by #2008.