### PR TITLE
Add test for validating linear memory size updates

### DIFF
--- a/core/iwasm/libraries/lib-wasi-threads/test/build.sh
+++ b/core/iwasm/libraries/lib-wasi-threads/test/build.sh
@@ -12,6 +12,12 @@ WAMR_DIR=../../../../..
 for test_c in *.c; do
     test_wasm="$(basename $test_c .c).wasm"
 
+    if [ $test_wasm = "linear_memory_size_update.wasm" ]; then
+        thread_start_file=""
+    else
+        thread_start_file=$WAMR_DIR/samples/wasi-threads/wasm-apps/wasi_thread_start.S
+    fi
+
     echo "Compiling $test_c to $test_wasm"
     $CC \
         -target wasm32-wasi-threads \
@@ -24,6 +30,6 @@ for test_c in *.c; do
         -Wl,--export=malloc \
         -Wl,--export=free \
         -I $WAMR_DIR/samples/wasi-threads/wasm-apps \
-        $WAMR_DIR/samples/wasi-threads/wasm-apps/wasi_thread_start.S \
+        $thread_start_file \
         $test_c -o $test_wasm
 done

--- a/core/iwasm/libraries/lib-wasi-threads/test/linear_memory_size_update.c
+++ b/core/iwasm/libraries/lib-wasi-threads/test/linear_memory_size_update.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2023 Amazon.com Inc. or its affiliates. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+#include <stdlib.h>
+#include <pthread.h>
+
+typedef enum {
+    APP_STARTED,
+    THREAD_STARTED,
+    MEMORY_ALLOCATED,
+} app_state_t;
+typedef struct {
+
+    pthread_cond_t cond;
+    pthread_mutex_t mutex;
+    app_state_t state;
+    char *data;
+} context_t;
+
+void
+context_init(context_t *ctx)
+{
+    pthread_cond_init(&ctx->cond, NULL);
+    pthread_mutex_init(&ctx->mutex, NULL);
+    ctx->state = APP_STARTED;
+    ctx->data = NULL;
+}
+
+void
+context_destroy(context_t *ctx)
+{
+    pthread_cond_destroy(&ctx->cond);
+    pthread_mutex_destroy(&ctx->mutex);
+    if (ctx->data) {
+        free(ctx->data);
+    }
+}
+
+void
+context_set_state(context_t *ctx, app_state_t state)
+{
+    pthread_mutex_lock(&ctx->mutex);
+    ctx->state = state;
+    pthread_mutex_unlock(&ctx->mutex);
+    pthread_cond_signal(&ctx->cond);
+}
+
+void
+context_wait_for_state(context_t *ctx, app_state_t state)
+{
+    pthread_mutex_lock(&ctx->mutex);
+    while (ctx->state != state) {
+        pthread_cond_wait(&ctx->cond, &ctx->mutex);
+    }
+    pthread_mutex_unlock(&ctx->mutex);
+}
+
+void *
+fnc(void *p)
+{
+    context_t *ctx = (context_t *)p;
+    context_set_state(ctx, THREAD_STARTED);
+
+    context_wait_for_state(ctx, MEMORY_ALLOCATED);
+
+    // trigger memory.copy
+    __builtin_memcpy(ctx->data + 512 * 1024, ctx->data + 1024, 1024);
+
+    return NULL;
+}
+
+int
+main()
+{
+    context_t ctx;
+    context_init(&ctx);
+
+    pthread_t th;
+    pthread_create(&th, NULL, fnc, &ctx);
+
+    context_wait_for_state(&ctx, THREAD_STARTED);
+
+    // trigger memory.grow
+    ctx.data = calloc(1024 * 1024, 1);
+
+    context_set_state(&ctx, MEMORY_ALLOCATED);
+
+    pthread_join(th, NULL);
+
+    context_destroy(&ctx);
+
+    return 0;
+}


### PR DESCRIPTION
When memory.grow operation is called, it updates a `linear_mem_size` variable in the `wasm_interp_call_func_bytecode()`; that update is not propagated to all the threads, therefore if the function already is running and want to access the memory that was added (after `memory.grow`) e.g. by calling `memory.copy` where we check boundaries, the `memory.copy` fails with: `Exception: out of bounds memory access` exception. 

It's only been tested on classic and fast interpreter. The issue couldn't be reproduced on AOT (the mechanisms are different there, I don't think it's an issue for AOT).

The current implementation is not optimal as it causes mutex lock for memory access operations. I'd suggest though merging that to have a working, bug-free solution for the upcoming release and we can optimize that in the future if needed.