### PR TITLE
Fix issues reported by Coverity

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -930,7 +930,7 @@ execute_post_instantiate_functions(AOTModuleInstance *module_inst,
     AOTFunctionInstance *call_ctors_func = NULL;
     WASMModuleInstanceCommon *module_inst_main = NULL;
 #ifdef OS_ENABLE_HW_BOUND_CHECK
-    WASMExecEnv *exec_env_tls = NULL;
+    WASMExecEnv *exec_env_tls = wasm_runtime_get_exec_env_tls();
 #endif
     WASMExecEnv *exec_env = NULL, *exec_env_created = NULL;
     bool ret = false;
@@ -976,7 +976,6 @@ execute_post_instantiate_functions(AOTModuleInstance *module_inst,
     if (is_sub_inst) {
         bh_assert(exec_env_main);
 #ifdef OS_ENABLE_HW_BOUND_CHECK
-        exec_env_tls = wasm_runtime_get_exec_env_tls();
         bh_assert(exec_env_tls == exec_env_main);
         (void)exec_env_tls;
 #endif

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1014,7 +1014,7 @@ execute_post_instantiate_functions(WASMModuleInstance *module_inst,
 #endif
     WASMModuleInstanceCommon *module_inst_main = NULL;
 #ifdef OS_ENABLE_HW_BOUND_CHECK
-    WASMExecEnv *exec_env_tls = NULL;
+    WASMExecEnv *exec_env_tls = wasm_runtime_get_exec_env_tls();
 #endif
     WASMExecEnv *exec_env = NULL, *exec_env_created = NULL;
     bool ret = false;
@@ -1060,7 +1060,6 @@ execute_post_instantiate_functions(WASMModuleInstance *module_inst,
     if (is_sub_inst) {
         bh_assert(exec_env_main);
 #ifdef OS_ENABLE_HW_BOUND_CHECK
-        exec_env_tls = wasm_runtime_get_exec_env_tls();
         bh_assert(exec_env_tls == exec_env_main);
         (void)exec_env_tls;
 #endif


### PR DESCRIPTION
Get exec_env_tls at the beginning of execute_post_instantiate_functions
to avoid it is uninitialized when is_sub_inst is false.