### PR TITLE
Fixing use after free when dumping call stack

### DIFF
--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -687,8 +687,8 @@ wasm_store_delete(wasm_store_t *store)
         return;
     }
 
-    DEINIT_VEC(store->modules, wasm_module_vec_delete);
     DEINIT_VEC(store->instances, wasm_instance_vec_delete);
+    DEINIT_VEC(store->modules, wasm_module_vec_delete);
     if (store->foreigns) {
         bh_vector_destroy(store->foreigns);
         wasm_runtime_free(store->foreigns);


### PR DESCRIPTION
This line will eventually call `wasm_cluster_wait_for_all_except_self`:

```
DEINIT_VEC(store->instances, wasm_instance_vec_delete);
```

As the threads are joining they can call `wasm_interp_dump_call_stack` which tries to use the module frames but they are already freed by this line:

```
DEINIT_VEC(store->modules, wasm_module_vec_delete);
```

This PR swaps the order that these are deleted so module is deleted after the instances