### PR TITLE
Fix sanitizer pointer overflow warning when perform pointer arithmetic

### DIFF
--- a/core/shared/mem-alloc/ems/ems_kfc.c
+++ b/core/shared/mem-alloc/ems/ems_kfc.c
@@ -153,7 +153,7 @@ static void
 adjust_ptr(uint8 **p_ptr, intptr_t offset)
 {
     if (*p_ptr)
-        *p_ptr += offset;
+        *p_ptr = (uint8 *)((intptr_t)(*p_ptr) + offset);
 }
 
 int


### PR DESCRIPTION
Convert the pointer to intptr_t to perform arithmetic to avoid the warning.