### PR TITLE
User can provide a different vprintf() at runtime

### DIFF
--- a/core/shared/platform/darwin/platform_init.c
+++ b/core/shared/platform/darwin/platform_init.c
@@ -16,28 +16,24 @@ bh_platform_destroy()
 {}
 
 int
-os_printf(const char *format, ...)
-{
-    int ret = 0;
-    va_list ap;
-
-    va_start(ap, format);
-#ifndef BH_VPRINTF
-    ret += vprintf(format, ap);
-#else
-    ret += BH_VPRINTF(format, ap);
-#endif
-    va_end(ap);
-
-    return ret;
-}
-
-int
 os_vprintf(const char *format, va_list ap)
 {
 #ifndef BH_VPRINTF
-    return vprintf(format, ap);
+    return ptr_vprintf(format, ap);
 #else
     return BH_VPRINTF(format, ap);
 #endif
+}
+
+int
+os_printf(const char *format, ...)
+{
+    int ret;
+    va_list ap;
+
+    va_start(ap, format);
+    ret = os_vprintf(format, ap);
+    va_end(ap);
+
+    return ret;
 }

--- a/core/shared/platform/esp-idf/espidf_platform.c
+++ b/core/shared/platform/esp-idf/espidf_platform.c
@@ -17,22 +17,26 @@ bh_platform_destroy()
 {}
 
 int
-os_printf(const char *format, ...)
+os_vprintf(const char *format, va_list ap)
 {
-    int ret = 0;
-    va_list ap;
-
-    va_start(ap, format);
-    ret += vprintf(format, ap);
-    va_end(ap);
-
-    return ret;
+#ifndef BH_VPRINTF
+    return ptr_vprintf(format, ap);
+#else
+    return BH_VPRINTF(format, ap);
+#endif
 }
 
 int
-os_vprintf(const char *format, va_list ap)
+os_printf(const char *format, ...)
 {
-    return vprintf(format, ap);
+    int ret;
+    va_list ap;
+
+    va_start(ap, format);
+    ret = os_vprintf(format, ap);
+    va_end(ap);
+
+    return ret;
 }
 
 uint64

--- a/core/shared/platform/freebsd/platform_init.c
+++ b/core/shared/platform/freebsd/platform_init.c
@@ -16,28 +16,24 @@ bh_platform_destroy()
 {}
 
 int
-os_printf(const char *format, ...)
-{
-    int ret = 0;
-    va_list ap;
-
-    va_start(ap, format);
-#ifndef BH_VPRINTF
-    ret += vprintf(format, ap);
-#else
-    ret += BH_VPRINTF(format, ap);
-#endif
-    va_end(ap);
-
-    return ret;
-}
-
-int
 os_vprintf(const char *format, va_list ap)
 {
 #ifndef BH_VPRINTF
-    return vprintf(format, ap);
+    return ptr_vprintf(format, ap);
 #else
     return BH_VPRINTF(format, ap);
 #endif
+}
+
+int
+os_printf(const char *format, ...)
+{
+    int ret;
+    va_list ap;
+
+    va_start(ap, format);
+    ret = os_vprintf(format, ap);
+    va_end(ap);
+
+    return ret;
 }

--- a/core/shared/platform/include/platform_common.h
+++ b/core/shared/platform/include/platform_common.h
@@ -61,6 +61,9 @@ BH_VPRINTF(const char *format, va_list ap);
 #endif
 #endif
 
+extern int
+(*ptr_vprintf)(const char*,va_list);
+
 #ifndef NULL
 #define NULL (void *)0
 #endif

--- a/core/shared/platform/include/platform_common.h
+++ b/core/shared/platform/include/platform_common.h
@@ -61,8 +61,7 @@ BH_VPRINTF(const char *format, va_list ap);
 #endif
 #endif
 
-extern int
-(*ptr_vprintf)(const char*,va_list);
+extern int (*ptr_vprintf)(const char *, va_list);
 
 #ifndef NULL
 #define NULL (void *)0

--- a/core/shared/platform/linux/platform_init.c
+++ b/core/shared/platform/linux/platform_init.c
@@ -16,28 +16,24 @@ bh_platform_destroy()
 {}
 
 int
-os_printf(const char *format, ...)
-{
-    int ret = 0;
-    va_list ap;
-
-    va_start(ap, format);
-#ifndef BH_VPRINTF
-    ret += vprintf(format, ap);
-#else
-    ret += BH_VPRINTF(format, ap);
-#endif
-    va_end(ap);
-
-    return ret;
-}
-
-int
 os_vprintf(const char *format, va_list ap)
 {
 #ifndef BH_VPRINTF
-    return vprintf(format, ap);
+    return ptr_vprintf(format, ap);
 #else
     return BH_VPRINTF(format, ap);
 #endif
+}
+
+int
+os_printf(const char *format, ...)
+{
+    int ret;
+    va_list ap;
+
+    va_start(ap, format);
+    ret = os_vprintf(format, ap);
+    va_end(ap);
+
+    return ret;
 }

--- a/core/shared/platform/vxworks/platform_init.c
+++ b/core/shared/platform/vxworks/platform_init.c
@@ -16,28 +16,24 @@ bh_platform_destroy()
 {}
 
 int
-os_printf(const char *format, ...)
-{
-    int ret = 0;
-    va_list ap;
-
-    va_start(ap, format);
-#ifndef BH_VPRINTF
-    ret += vprintf(format, ap);
-#else
-    ret += BH_VPRINTF(format, ap);
-#endif
-    va_end(ap);
-
-    return ret;
-}
-
-int
 os_vprintf(const char *format, va_list ap)
 {
 #ifndef BH_VPRINTF
-    return vprintf(format, ap);
+    return ptr_vprintf(format, ap);
 #else
     return BH_VPRINTF(format, ap);
 #endif
+}
+
+int
+os_printf(const char *format, ...)
+{
+    int ret;
+    va_list ap;
+
+    va_start(ap, format);
+    ret = os_vprintf(format, ap);
+    va_end(ap);
+
+    return ret;
 }

--- a/core/shared/platform/windows/platform_init.c
+++ b/core/shared/platform/windows/platform_init.c
@@ -36,30 +36,26 @@ bh_platform_destroy()
 }
 
 int
-os_printf(const char *format, ...)
-{
-    int ret = 0;
-    va_list ap;
-
-    va_start(ap, format);
-#ifndef BH_VPRINTF
-    ret += vprintf(format, ap);
-#else
-    ret += BH_VPRINTF(format, ap);
-#endif
-    va_end(ap);
-
-    return ret;
-}
-
-int
 os_vprintf(const char *format, va_list ap)
 {
 #ifndef BH_VPRINTF
-    return vprintf(format, ap);
+    return ptr_vprintf(format, ap);
 #else
     return BH_VPRINTF(format, ap);
 #endif
+}
+
+int
+os_printf(const char *format, ...)
+{
+    int ret;
+    va_list ap;
+
+    va_start(ap, format);
+    ret = os_vprintf(format, ap);
+    va_end(ap);
+
+    return ret;
 }
 
 unsigned

--- a/core/shared/platform/zephyr/zephyr_platform.c
+++ b/core/shared/platform/zephyr/zephyr_platform.c
@@ -121,30 +121,26 @@ os_vprintf(const char *fmt, va_list ap)
 #endif
 
 int
-os_printf(const char *format, ...)
-{
-    int ret = 0;
-    va_list ap;
-
-    va_start(ap, format);
-#ifndef BH_VPRINTF
-    ret += vprintf(format, ap);
-#else
-    ret += BH_VPRINTF(format, ap);
-#endif
-    va_end(ap);
-
-    return ret;
-}
-
-int
 os_vprintf(const char *format, va_list ap)
 {
 #ifndef BH_VPRINTF
-    return vprintf(format, ap);
+    return ptr_vprintf(format, ap);
 #else
     return BH_VPRINTF(format, ap);
 #endif
+}
+
+int
+os_printf(const char *format, ...)
+{
+    int ret;
+    va_list ap;
+
+    va_start(ap, format);
+    ret = os_vprintf(format, ap);
+    va_end(ap);
+
+    return ret;
 }
 
 #if KERNEL_VERSION_NUMBER <= 0x020400 /* version 2.4.0 */

--- a/core/shared/utils/bh_log.c
+++ b/core/shared/utils/bh_log.c
@@ -11,9 +11,10 @@
  */
 static uint32 log_verbose_level = BH_LOG_LEVEL_WARNING;
 
-int (*ptr_vprintf)(const char*,va_list) = vprintf;
+int (*ptr_vprintf)(const char *, va_list) = vprintf;
 
-void bh_set_vprintf(int (*ptr)(const char*,va_list))
+void
+bh_set_vprintf(int (*ptr)(const char *, va_list))
 {
     ptr_vprintf = ptr;
 }

--- a/core/shared/utils/bh_log.c
+++ b/core/shared/utils/bh_log.c
@@ -4,8 +4,6 @@
  */
 
 #include "bh_log.h"
-#include <stdio.h>
-#include <stdarg.h>
 
 /**
  * The verbose level of the log system.  Only those verbose logs whose
@@ -13,12 +11,16 @@
  */
 static uint32 log_verbose_level = BH_LOG_LEVEL_WARNING;
 
+#ifndef BH_PLATFORM_LINUX_SGX
 int (*ptr_vprintf)(const char *, va_list) = vprintf;
+#endif
 
 void
 bh_set_vprintf(int (*ptr)(const char *, va_list))
 {
+#ifndef BH_PLATFORM_LINUX_SGX
     ptr_vprintf = ptr;
+#endif
 }
 
 void

--- a/core/shared/utils/bh_log.c
+++ b/core/shared/utils/bh_log.c
@@ -11,6 +11,13 @@
  */
 static uint32 log_verbose_level = BH_LOG_LEVEL_WARNING;
 
+int (*ptr_vprintf)(const char*,va_list) = vprintf;
+
+void bh_set_vprintf(int (*ptr)(const char*,va_list))
+{
+    ptr_vprintf = ptr;
+}
+
 void
 bh_log_set_verbose_level(uint32 level)
 {

--- a/core/shared/utils/bh_log.c
+++ b/core/shared/utils/bh_log.c
@@ -4,6 +4,8 @@
  */
 
 #include "bh_log.h"
+#include <stdio.h>
+#include <stdarg.h>
 
 /**
  * The verbose level of the log system.  Only those verbose logs whose

--- a/core/shared/utils/bh_log.h
+++ b/core/shared/utils/bh_log.h
@@ -42,7 +42,7 @@ void
 bh_log(LogLevel log_level, const char *file, int line, const char *fmt, ...);
 
 void
-bh_set_vprintf(int (*ptr)(const char*,va_list));
+bh_set_vprintf(int (*ptr)(const char *, va_list));
 
 #ifdef BH_PLATFORM_NUTTX
 

--- a/core/shared/utils/bh_log.h
+++ b/core/shared/utils/bh_log.h
@@ -35,10 +35,8 @@ typedef enum {
     BH_LOG_LEVEL_VERBOSE = 4
 } LogLevel;
 
-#ifndef BH_PLATFORM_LINUX_SGX
 void
 bh_log_set_verbose_level(uint32 level);
-#endif
 
 void
 bh_log(LogLevel log_level, const char *file, int line, const char *fmt, ...);

--- a/core/shared/utils/bh_log.h
+++ b/core/shared/utils/bh_log.h
@@ -41,6 +41,9 @@ bh_log_set_verbose_level(uint32 level);
 void
 bh_log(LogLevel log_level, const char *file, int line, const char *fmt, ...);
 
+void
+bh_set_vprintf(int (*ptr)(const char*,va_list));
+
 #ifdef BH_PLATFORM_NUTTX
 
 #undef LOG_FATAL

--- a/core/shared/utils/bh_log.h
+++ b/core/shared/utils/bh_log.h
@@ -35,8 +35,10 @@ typedef enum {
     BH_LOG_LEVEL_VERBOSE = 4
 } LogLevel;
 
+#ifndef BH_PLATFORM_LINUX_SGX
 void
 bh_log_set_verbose_level(uint32 level);
+#endif
 
 void
 bh_log(LogLevel log_level, const char *file, int line, const char *fmt, ...);


### PR DESCRIPTION
I needed a better mechanism for printing WAMR's messages than defining `BH_VPRINTF` (not a good mechanism if you want to build the library once and dynamically link to it). So now there's a global called `ptr_vprintf` which by default is equal to `vprintf`, and in all the versions of `os_printf()` and `os_vprintf()` calls to `vprintf()` are now replaced by calls to `ptr_vprintf()`, which if the user does nothing is exactly the same.

However if the user calls `bh_set_vprintf(my_vprintf);` then all calls to `ptr_vprintf` are now calls to the user's function, which can allow for things such as logging to a buffer than can be displayed in the same program's GUI or logged to a file. So my change breaks nothing but adds the possibility to change at runtime whether `vprintf()` or another function is used by `os_printf()`.

I'm just not sure if `bh_log.[ch]` were the right files to put this, but there was no better non-platform specific file to put this in. Btw there's an `os_printf()` and `os_vprintf()` for every platform but they're all the same, you might want to consider grouping them into one. Also I haven't added this mechanism to platforms that just use `#define os_printf printf`, but if anything is to be done about this it would probably to make one `os_printf()` for all platforms.