### PR TITLE
Update Zephyr docs to remove unsupported west subcommand

### DIFF
--- a/product-mini/README.md
+++ b/product-mini/README.md
@@ -248,7 +248,7 @@ WAMR provides some features which can be easily configured by passing options to
 
 ## Zephyr
 
-You need to prepare Zephyr first as described here https://docs.zephyrproject.org/latest/getting_started/index.html#get-zephyr-and-install-python-dependencies.
+You need to prepare Zephyr first as described [here](https://docs.zephyrproject.org/latest/getting_started/index.html#get-zephyr-and-install-python-dependencies).
 
 After that you need to point the `ZEPHYR_BASE` variable to e.g. `~/zephyrproject/zephyr`. Also, it is important that you have `west` available for subsequent actions.
 
@@ -258,14 +258,7 @@ cd <wamr_root_dir>/product-mini/platforms/zephyr/simple
 ./build_and_run.sh x86
 ```
 
-If you want to use the Espressif toolchain (esp32 or esp32c3), you can most conveniently install it with `west`:
-
-``` Bash
-cd $ZEPHYR_BASE
-west espressif install
-```
-
-After that set `ESPRESSIF_TOOLCHAIN_PATH` according to the output, for example `~/.espressif/tools/zephyr`.
+The [Zephyr SDK](https://github.com/zephyrproject-rtos/sdk-ng) provides toolchains for all supported targets. Follow the instructions in the [documentation](https://docs.zephyrproject.org/latest/develop/getting_started/index.html#install-zephyr-sdk) to ensure it is installed and configured correctly.
 
 Note:
 WAMR provides some features which can be easily configured by passing options to cmake, please see [WAMR vmcore cmake building configurations](../doc/build_wamr.md#wamr-vmcore-cmake-building-configurations) for details. Currently in Zephyr, interpreter, AOT and builtin libc are enabled by default.


### PR DESCRIPTION
Removes the `west espressif install` command which is no longer supported.

https://github.com/zephyrproject-rtos/hal_espressif/pull/130

Also adds a reference to the Zephyr SDK, which will install the necessary toolchains for all supported targets.