### PR TITLE
build_wamr_vscode_ext.yml: vsce publish only on the official repo

### DIFF
--- a/.github/workflows/build_wamr_vscode_ext.yml
+++ b/.github/workflows/build_wamr_vscode_ext.yml
@@ -37,6 +37,10 @@ jobs:
           rm -rf node_modules
           npm install
           vsce package
+        working-directory: test-tools/wamr-ide/VSCode-Extension
+
+      - name: publish wamr ide vscode extension to the vsce marketplace
+        run: |
           vsce publish -p ${{ secrets.TOKEN }}
         working-directory: test-tools/wamr-ide/VSCode-Extension
 

--- a/.github/workflows/build_wamr_vscode_ext.yml
+++ b/.github/workflows/build_wamr_vscode_ext.yml
@@ -32,8 +32,6 @@ jobs:
         working-directory: test-tools/wamr-ide/VSCode-Extension
 
       - name: generate wamr ide vscode extension
-        env:
-          credentials: ${{ secrets.TOKEN }}
         run: |
           npm install -g vsce
           rm -rf node_modules

--- a/.github/workflows/build_wamr_vscode_ext.yml
+++ b/.github/workflows/build_wamr_vscode_ext.yml
@@ -40,6 +40,7 @@ jobs:
         working-directory: test-tools/wamr-ide/VSCode-Extension
 
       - name: publish wamr ide vscode extension to the vsce marketplace
+        if: ${{ github.repository == 'bytecodealliance/wasm-micro-runtime' }}
         run: |
           vsce publish -p ${{ secrets.TOKEN }}
         working-directory: test-tools/wamr-ide/VSCode-Extension


### PR DESCRIPTION
This makes it simpler to test workflow files on a fork.
