### PR TITLE
VSCode-Extension: download lldb built for ubuntu 20.04

### DIFF
--- a/test-tools/wamr-ide/VSCode-Extension/src/utilities/lldbUtilities.ts
+++ b/test-tools/wamr-ide/VSCode-Extension/src/utilities/lldbUtilities.ts
@@ -18,7 +18,7 @@ const LLDB_RESOURCE_DIR = 'resource/debug';
 const LLDB_OS_DOWNLOAD_URL_SUFFIX_MAP: Partial<
     Record<NodeJS.Platform, string>
 > = {
-    linux: 'x86_64-ubuntu-22.04',
+    linux: 'x86_64-ubuntu-20.04',
     darwin: 'universal-macos-latest',
 };
 


### PR DESCRIPTION
This should allow users to use the vscode extension on ubuntu 20.04.

After https://github.com/bytecodealliance/wasm-micro-runtime/pull/2132 , our lldb binary for 20.04 works on ubuntu 22.04 as well.

On the other hand, lldb for 22.04 has no chance to work on ubuntu 20.04. (because of glibc version requirement.)