### PR TITLE
Avoid re-installing if Tensorflow is already installed for WASI-NN

### DIFF
--- a/build-scripts/runtime_lib.cmake
+++ b/build-scripts/runtime_lib.cmake
@@ -101,26 +101,6 @@ if (WAMR_BUILD_LIB_PTHREAD_SEMAPHORE EQUAL 1)
 endif ()
 
 if (WAMR_BUILD_WASI_NN EQUAL 1)
-    if (NOT EXISTS "${WAMR_ROOT_DIR}/core/deps/tensorflow-src")
-        execute_process(COMMAND ${WAMR_ROOT_DIR}/core/deps/install_tensorflow.sh
-                        RESULT_VARIABLE TENSORFLOW_RESULT
-        )
-    else ()
-        message("Tensorflow is already downloaded.")
-    endif()
-    set(TENSORFLOW_SOURCE_DIR "${WAMR_ROOT_DIR}/core/deps/tensorflow-src")
-
-    if (WASI_NN_ENABLE_GPU EQUAL 1)
-        # Tensorflow specific:
-        # * https://www.tensorflow.org/lite/guide/build_cmake#available_options_to_build_tensorflow_lite
-        set (TFLITE_ENABLE_GPU ON)
-    endif ()
-
-    include_directories (${CMAKE_CURRENT_BINARY_DIR}/flatbuffers/include)
-    include_directories (${TENSORFLOW_SOURCE_DIR})
-    add_subdirectory(
-        "${TENSORFLOW_SOURCE_DIR}/tensorflow/lite"
-        "${CMAKE_CURRENT_BINARY_DIR}/tensorflow-lite" EXCLUDE_FROM_ALL)
     include (${IWASM_DIR}/libraries/wasi-nn/wasi_nn.cmake)
 endif ()
 

--- a/core/iwasm/libraries/wasi-nn/cmake/Findtensorflow-lite.cmake
+++ b/core/iwasm/libraries/wasi-nn/cmake/Findtensorflow-lite.cmake
@@ -1,0 +1,41 @@
+# Copyright (C) 2019 Intel Corporation. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+
+find_library(TENSORFLOW_LITE 
+     NAMES tensorflow-lite
+     HINTS ${CMAKE_LIBRARY_PATH}
+)
+find_path(TENSORFLOW_LITE_INCLUDE_DIR
+     NAMES tensorflow/lite/interpreter.h
+     HINTS ${CMAKE_LIBRARY_PATH}../include
+)
+find_path(FLATBUFFER_INCLUDE_DIR
+     NAMES flatbuffers/flatbuffers.h
+     HINTS ${CMAKE_LIBRARY_PATH}../include
+)
+include_directories (${TENSORFLOW_LITE_INCLUDE_DIR})
+include_directories (${FLATBUFFER_INCLUDE_DIR})
+
+if(NOT EXISTS ${TENSORFLOW_LITE})
+    if (NOT EXISTS "${WAMR_ROOT_DIR}/core/deps/tensorflow-src")
+        execute_process(COMMAND ${WAMR_ROOT_DIR}/core/deps/install_tensorflow.sh
+                        RESULT_VARIABLE TENSORFLOW_RESULT
+        )
+    else ()
+        message("Tensorflow is already downloaded.")
+    endif()
+    set(TENSORFLOW_SOURCE_DIR "${WAMR_ROOT_DIR}/core/deps/tensorflow-src")
+    include_directories (${CMAKE_CURRENT_BINARY_DIR}/flatbuffers/include)
+    include_directories (${TENSORFLOW_SOURCE_DIR})
+    add_subdirectory(
+        "${TENSORFLOW_SOURCE_DIR}/tensorflow/lite"
+        "${CMAKE_CURRENT_BINARY_DIR}/tensorflow-lite" EXCLUDE_FROM_ALL) 
+
+    if (WASI_NN_ENABLE_GPU EQUAL 1)
+    # Tensorflow specific:
+    # * https://www.tensorflow.org/lite/guide/build_cmake#available_options_to_build_tensorflow_lite
+    set (TFLITE_ENABLE_GPU ON)
+    endif ()
+endif()
+

--- a/core/iwasm/libraries/wasi-nn/cmake/Findtensorflow-lite.cmake
+++ b/core/iwasm/libraries/wasi-nn/cmake/Findtensorflow-lite.cmake
@@ -6,16 +6,6 @@ find_library(TENSORFLOW_LITE
      NAMES tensorflow-lite
      HINTS ${CMAKE_LIBRARY_PATH}
 )
-find_path(TENSORFLOW_LITE_INCLUDE_DIR
-     NAMES tensorflow/lite/interpreter.h
-     HINTS ${CMAKE_LIBRARY_PATH}../include
-)
-find_path(FLATBUFFER_INCLUDE_DIR
-     NAMES flatbuffers/flatbuffers.h
-     HINTS ${CMAKE_LIBRARY_PATH}../include
-)
-include_directories (${TENSORFLOW_LITE_INCLUDE_DIR})
-include_directories (${FLATBUFFER_INCLUDE_DIR})
 
 if(NOT EXISTS ${TENSORFLOW_LITE})
     if (NOT EXISTS "${WAMR_ROOT_DIR}/core/deps/tensorflow-src")
@@ -37,5 +27,16 @@ if(NOT EXISTS ${TENSORFLOW_LITE})
     # * https://www.tensorflow.org/lite/guide/build_cmake#available_options_to_build_tensorflow_lite
     set (TFLITE_ENABLE_GPU ON)
     endif ()
+else()
+    find_path(TENSORFLOW_LITE_INCLUDE_DIR
+    NAMES tensorflow/lite/interpreter.h
+    HINTS ${CMAKE_LIBRARY_PATH}../include
+    )
+    find_path(FLATBUFFER_INCLUDE_DIR
+    NAMES flatbuffers/flatbuffers.h
+    HINTS ${CMAKE_LIBRARY_PATH}../include
+    )
+    include_directories (${TENSORFLOW_LITE_INCLUDE_DIR})
+    include_directories (${FLATBUFFER_INCLUDE_DIR})    
 endif()
 

--- a/core/iwasm/libraries/wasi-nn/cmake/Findtensorflow_lite.cmake
+++ b/core/iwasm/libraries/wasi-nn/cmake/Findtensorflow_lite.cmake
@@ -4,7 +4,6 @@
 
 find_library(TENSORFLOW_LITE 
      NAMES tensorflow-lite
-     HINTS ${CMAKE_LIBRARY_PATH}
 )
 
 if(NOT EXISTS ${TENSORFLOW_LITE})
@@ -32,11 +31,9 @@ if(NOT EXISTS ${TENSORFLOW_LITE})
 else()
     find_path(TENSORFLOW_LITE_INCLUDE_DIR
     NAMES tensorflow/lite/interpreter.h
-    HINTS ${CMAKE_LIBRARY_PATH}../include
     )
     find_path(FLATBUFFER_INCLUDE_DIR
     NAMES flatbuffers/flatbuffers.h
-    HINTS ${CMAKE_LIBRARY_PATH}../include
     )
     include_directories (${TENSORFLOW_LITE_INCLUDE_DIR})
     include_directories (${FLATBUFFER_INCLUDE_DIR})    

--- a/core/iwasm/libraries/wasi-nn/cmake/Findtensorflow_lite.cmake
+++ b/core/iwasm/libraries/wasi-nn/cmake/Findtensorflow_lite.cmake
@@ -16,17 +16,19 @@ if(NOT EXISTS ${TENSORFLOW_LITE})
         message("Tensorflow is already downloaded.")
     endif()
     set(TENSORFLOW_SOURCE_DIR "${WAMR_ROOT_DIR}/core/deps/tensorflow-src")
-    include_directories (${CMAKE_CURRENT_BINARY_DIR}/flatbuffers/include)
-    include_directories (${TENSORFLOW_SOURCE_DIR})
-    add_subdirectory(
-        "${TENSORFLOW_SOURCE_DIR}/tensorflow/lite"
-        "${CMAKE_CURRENT_BINARY_DIR}/tensorflow-lite" EXCLUDE_FROM_ALL) 
 
     if (WASI_NN_ENABLE_GPU EQUAL 1)
     # Tensorflow specific:
     # * https://www.tensorflow.org/lite/guide/build_cmake#available_options_to_build_tensorflow_lite
     set (TFLITE_ENABLE_GPU ON)
     endif ()
+
+    include_directories (${CMAKE_CURRENT_BINARY_DIR}/flatbuffers/include)
+    include_directories (${TENSORFLOW_SOURCE_DIR})
+    add_subdirectory(
+        "${TENSORFLOW_SOURCE_DIR}/tensorflow/lite"
+        "${CMAKE_CURRENT_BINARY_DIR}/tensorflow-lite" EXCLUDE_FROM_ALL) 
+
 else()
     find_path(TENSORFLOW_LITE_INCLUDE_DIR
     NAMES tensorflow/lite/interpreter.h

--- a/core/iwasm/libraries/wasi-nn/wasi_nn.cmake
+++ b/core/iwasm/libraries/wasi-nn/wasi_nn.cmake
@@ -1,6 +1,32 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+find_library(TENSORFLOW_LITE 
+    NAMES tensorflow-lite
+    HINTS ${CMAKE_LIBRARY_PATH})
+
+if(NOT EXISTS ${TENSORFLOW_LITE})
+    if (NOT EXISTS "${WAMR_ROOT_DIR}/core/deps/tensorflow-src")
+        execute_process(COMMAND ${WAMR_ROOT_DIR}/core/deps/install_tensorflow.sh
+                        RESULT_VARIABLE TENSORFLOW_RESULT
+        )
+    else ()
+        message("Tensorflow is already downloaded.")
+    endif()
+    set(TENSORFLOW_SOURCE_DIR "${WAMR_ROOT_DIR}/core/deps/tensorflow-src")
+    include_directories (${CMAKE_CURRENT_BINARY_DIR}/flatbuffers/include)
+    include_directories (${TENSORFLOW_SOURCE_DIR})
+    add_subdirectory(
+        "${TENSORFLOW_SOURCE_DIR}/tensorflow/lite"
+        "${CMAKE_CURRENT_BINARY_DIR}/tensorflow-lite" EXCLUDE_FROM_ALL)      
+endif()
+
+if (WASI_NN_ENABLE_GPU EQUAL 1)
+# Tensorflow specific:
+# * https://www.tensorflow.org/lite/guide/build_cmake#available_options_to_build_tensorflow_lite
+set (TFLITE_ENABLE_GPU ON)
+endif ()
+
 set (WASI_NN_DIR ${CMAKE_CURRENT_LIST_DIR})
 
 include_directories (${WASI_NN_DIR})

--- a/core/iwasm/libraries/wasi-nn/wasi_nn.cmake
+++ b/core/iwasm/libraries/wasi-nn/wasi_nn.cmake
@@ -4,7 +4,7 @@
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
 # Find tensorflow-lite
-find_package(tensorflow-lite REQUIRED)
+find_package(tensorflow_lite REQUIRED)
 
 set (WASI_NN_DIR ${CMAKE_CURRENT_LIST_DIR})
 

--- a/core/iwasm/libraries/wasi-nn/wasi_nn.cmake
+++ b/core/iwasm/libraries/wasi-nn/wasi_nn.cmake
@@ -1,31 +1,10 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-find_library(TENSORFLOW_LITE 
-    NAMES tensorflow-lite
-    HINTS ${CMAKE_LIBRARY_PATH})
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
-if(NOT EXISTS ${TENSORFLOW_LITE})
-    if (NOT EXISTS "${WAMR_ROOT_DIR}/core/deps/tensorflow-src")
-        execute_process(COMMAND ${WAMR_ROOT_DIR}/core/deps/install_tensorflow.sh
-                        RESULT_VARIABLE TENSORFLOW_RESULT
-        )
-    else ()
-        message("Tensorflow is already downloaded.")
-    endif()
-    set(TENSORFLOW_SOURCE_DIR "${WAMR_ROOT_DIR}/core/deps/tensorflow-src")
-    include_directories (${CMAKE_CURRENT_BINARY_DIR}/flatbuffers/include)
-    include_directories (${TENSORFLOW_SOURCE_DIR})
-    add_subdirectory(
-        "${TENSORFLOW_SOURCE_DIR}/tensorflow/lite"
-        "${CMAKE_CURRENT_BINARY_DIR}/tensorflow-lite" EXCLUDE_FROM_ALL)      
-endif()
-
-if (WASI_NN_ENABLE_GPU EQUAL 1)
-# Tensorflow specific:
-# * https://www.tensorflow.org/lite/guide/build_cmake#available_options_to_build_tensorflow_lite
-set (TFLITE_ENABLE_GPU ON)
-endif ()
+# Find tensorflow-lite
+find_package(tensorflow-lite REQUIRED)
 
 set (WASI_NN_DIR ${CMAKE_CURRENT_LIST_DIR})
 


### PR DESCRIPTION
Since the Tensorflow library is already installed in many cases(especially in the case of the embedded system), move the installation code to find_package.