### PR TITLE
Fix WAMR IDE Debugger Ignoring Launch Config

### DIFF
--- a/test-tools/wamr-ide/VSCode-Extension/package.json
+++ b/test-tools/wamr-ide/VSCode-Extension/package.json
@@ -6,7 +6,7 @@
     },
     "displayName": "WAMR-IDE",
     "description": "An Integrated Development Environment for WASM",
-    "version": "1.1.2",
+    "version": "1.2.1",
     "engines": {
         "vscode": "^1.59.0"
     },

--- a/test-tools/wamr-ide/VSCode-Extension/src/debugConfigurationProvider.ts
+++ b/test-tools/wamr-ide/VSCode-Extension/src/debugConfigurationProvider.ts
@@ -7,32 +7,29 @@ import * as vscode from 'vscode';
 import * as os from 'os';
 
 export class WasmDebugConfigurationProvider
-    implements vscode.DebugConfigurationProvider
-{
-    private wasmDebugConfig!: vscode.DebugConfiguration;
+    implements vscode.DebugConfigurationProvider {
+    private wasmDebugConfig = {
+        type: 'wamr-debug',
+        name: 'Attach',
+        request: 'attach',
+        stopOnEntry: true,
+        initCommands: os.platform() === 'win32' || os.platform() === 'darwin' ?
+            /* linux and windows has different debug configuration */
+            ['platform select remote-linux'] :
+            undefined,
+        attachCommands: [
+            /* default port 1234 */
+            'process connect -p wasm connect://127.0.0.1:1234',
+        ]
+    };
 
-    resolveDebugConfiguration(
+    public resolveDebugConfiguration(
         _: vscode.WorkspaceFolder | undefined,
         debugConfiguration: vscode.DebugConfiguration,
     ): vscode.ProviderResult<vscode.DebugConfiguration> {
-        const defaultConfig: vscode.DebugConfiguration = {
-            type: 'wamr-debug',
-            name: 'Attach',
-            request: 'attach',
-            stopOnEntry: true,
-            attachCommands: [
-                /* default port 1234 */
-                'process connect -p wasm connect://127.0.0.1:1234',
-            ]
-        };
-
-        /* linux and windows has different debug configuration */
-        if (os.platform() === 'win32' || os.platform() === 'darwin') {
-            defaultConfig.initCommands = ['platform select remote-linux'];
-        }
 
         this.wasmDebugConfig = {
-            ...defaultConfig,
+            ...this.wasmDebugConfig,
             ...debugConfiguration
         };
 

--- a/test-tools/wamr-ide/VSCode-Extension/src/extension.ts
+++ b/test-tools/wamr-ide/VSCode-Extension/src/extension.ts
@@ -171,7 +171,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
     /* register debug configuration */
     wasmDebugConfigProvider = new WasmDebugConfigurationProvider();
-    wasmDebugConfigProvider.setDebugConfig(currentPrjDir, 1234);
 
     vscode.debug.registerDebugConfigurationProvider(
         'wamr-debug',


### PR DESCRIPTION
The `DebugConfigurationProvider` was overwriting configurations provided in `launch.json`. In particular, this for example prevented from specifying a custom port for the debugger.

Example `launch.json`
```
{
    "configurations": [
        {
            "type": "wamr-debug",
            "request": "attach",
            "name": "Attach Debugger",
            "stopOnEntry": true,
            "attachCommands": [
                "process connect -p wasm connect://127.0.0.1:1237"
            ]
        }
    ]
}
```