### PR TITLE
more precise trigger paths for github actions

### DIFF
--- a/.github/workflows/compilation_on_android_ubuntu.yml
+++ b/.github/workflows/compilation_on_android_ubuntu.yml
@@ -10,7 +10,8 @@ on:
       - opened
       - synchronize
     paths:
-      - ".github/**"
+      - ".github/workflows/build_llvm_libraries.yml"
+      - ".github/workflows/compilation_on_android_ubuntu.yml"
       - "build-scripts/**"
       - "core/**"
       - "!core/deps/**"
@@ -26,7 +27,8 @@ on:
       - main
       - "dev/**"
     paths:
-      - ".github/**"
+      - ".github/workflows/build_llvm_libraries.yml"
+      - ".github/workflows/compilation_on_android_ubuntu.yml"
       - "build-scripts/**"
       - "core/**"
       - "!core/deps/**"

--- a/.github/workflows/compilation_on_macos.yml
+++ b/.github/workflows/compilation_on_macos.yml
@@ -10,7 +10,8 @@ on:
       - opened
       - synchronize
     paths:
-      - ".github/**"
+      - ".github/workflows/build_llvm_libraries.yml"
+      - ".github/workflows/compilation_on_macos.yml"
       - "build-scripts/**"
       - "core/**"
       - "!core/deps/**"
@@ -26,7 +27,8 @@ on:
       - main
       - "dev/**"
     paths:
-      - ".github/**"
+      - ".github/workflows/build_llvm_libraries.yml"
+      - ".github/workflows/compilation_on_macos.yml"
       - "build-scripts/**"
       - "core/**"
       - "!core/deps/**"

--- a/.github/workflows/compilation_on_nuttx.yml
+++ b/.github/workflows/compilation_on_nuttx.yml
@@ -10,7 +10,7 @@ on:
       - opened
       - synchronize
     paths:
-      - ".github/**"
+      - ".github/workflows/compilation_on_nuttx.yml"
       - "build-scripts/**"
       - "core/**"
       - "!core/deps/**"
@@ -26,7 +26,7 @@ on:
       - main
       - "dev/**"
     paths:
-      - ".github/**"
+      - ".github/workflows/compilation_on_nuttx.yml"
       - "build-scripts/**"
       - "core/**"
       - "!core/deps/**"

--- a/.github/workflows/compilation_on_sgx.yml
+++ b/.github/workflows/compilation_on_sgx.yml
@@ -10,7 +10,8 @@ on:
       - opened
       - synchronize
     paths:
-      - ".github/**"
+      - ".github/workflows/build_llvm_libraries.yml"
+      - ".github/workflows/compilation_on_sgx.yml"
       - "build-scripts/**"
       - "core/**"
       - "!core/deps/**"
@@ -26,7 +27,8 @@ on:
       - main
       - "dev/**"
     paths:
-      - ".github/**"
+      - ".github/workflows/build_llvm_libraries.yml"
+      - ".github/workflows/compilation_on_sgx.yml"
       - "build-scripts/**"
       - "core/**"
       - "!core/deps/**"

--- a/.github/workflows/compilation_on_windows.yml
+++ b/.github/workflows/compilation_on_windows.yml
@@ -10,7 +10,7 @@ on:
       - opened
       - synchronize
     paths:
-      - ".github/**"
+      - ".github/workflows/compilation_on_windows.yml"
       - "build-scripts/**"
       - "core/**"
       - "!core/deps/**"
@@ -26,7 +26,7 @@ on:
       - main
       - "dev/**"
     paths:
-      - ".github/**"
+      - ".github/workflows/compilation_on_windows.yml"
       - "build-scripts/**"
       - "core/**"
       - "!core/deps/**"


### PR DESCRIPTION
As mentioned in https://github.com/bytecodealliance/wasm-micro-runtime/issues/2131, modify workflows to avoid unnecessary triggering
