### PR TITLE
Fix URL in README.md

### DIFF
--- a/language-bindings/python/README.md
+++ b/language-bindings/python/README.md
@@ -30,5 +30,5 @@ import wamr.wasmcapi.ffi as ffi
 
 For more information:
 
-* [WAMR API](./wamr_api)
-* [WASM-C-API](./wasm_c_api)
+* [WAMR API](./wamr-api)
+* [WASM-C-API](./wasm-c-api)


### PR DESCRIPTION
Fix "WAMR API" and "WASM-C-API" URLs.