### PR TITLE
Fix compilation error for WAMRC with GC enabled

### DIFF
--- a/core/iwasm/compilation/aot.c
+++ b/core/iwasm/compilation/aot.c
@@ -234,6 +234,7 @@ static AOTFuncType **
 aot_create_func_types(const WASMModule *module)
 {
     AOTFuncType **func_types;
+    WASMFuncType *func_type;
     uint64 size;
     uint32 i;
 
@@ -249,9 +250,9 @@ aot_create_func_types(const WASMModule *module)
 
     /* Create each function type */
     for (i = 0; i < module->type_count; i++) {
-        size = offsetof(AOTFuncType, types)
-               + (uint64)module->types[i]->param_count
-               + (uint64)module->types[i]->result_count;
+        func_type = (WASMFuncType *)module->types[i];
+        size = offsetof(AOTFuncType, types) + func_type->param_count
+               + func_type->result_count;
         if (size >= UINT32_MAX
             || !(func_types[i] = wasm_runtime_malloc((uint32)size))) {
             aot_set_last_error("allocate memory failed.");
@@ -296,7 +297,7 @@ aot_create_import_funcs(const WASMModule *module)
         import_funcs[i].call_conv_wasm_c_api = false;
         /* Resolve function type index */
         for (j = 0; j < module->type_count; j++)
-            if (import_func->func_type == module->types[j]) {
+            if (import_func->func_type == (WASMFuncType *)module->types[j]) {
                 import_funcs[i].func_type_index = j;
                 break;
             }
@@ -345,7 +346,7 @@ aot_create_funcs(const WASMModule *module)
 
         /* Resolve function type index */
         for (j = 0; j < module->type_count; j++)
-            if (func->func_type == module->types[j]) {
+            if (func->func_type == (WASMFuncType *)module->types[j]) {
                 funcs[i]->func_type_index = j;
                 break;
             }

--- a/core/iwasm/compilation/aot_emit_function.c
+++ b/core/iwasm/compilation/aot_emit_function.c
@@ -1210,9 +1210,9 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
        are equal (the type index of call_indirect opcode and callee func),
        we don't need to check whether the whole function types are equal,
        including param types and result types. */
-    type_idx = wasm_get_smallest_type_idx(comp_ctx->comp_data->func_types,
-                                          comp_ctx->comp_data->func_type_count,
-                                          type_idx);
+    type_idx = wasm_get_smallest_type_idx(
+        (WASMTypePtr *)comp_ctx->comp_data->func_types,
+        comp_ctx->comp_data->func_type_count, type_idx);
     ftype_idx_const = I32_CONST(type_idx);
     CHECK_LLVM_CONST(ftype_idx_const);
 

--- a/core/iwasm/include/gc_export.h
+++ b/core/iwasm/include/gc_export.h
@@ -36,7 +36,7 @@ typedef enum wasm_value_type_enum {
 
 typedef int32_t wasm_heap_type_t;
 
-enum wasm_heap_type_enum {
+typedef enum wasm_heap_type_enum {
     HEAP_TYPE_FUNC = -0x10,
     HEAP_TYPE_EXTERN = -0x11,
     HEAP_TYPE_ANY = -0x12,

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -3445,7 +3445,7 @@ llvm_jit_invoke_native(WASMExecEnv *exec_env, uint32 func_idx, uint32 argc,
     WASMModule *module;
     uint32 *func_type_indexes;
     uint32 func_type_idx;
-    WASMFuncType *func_type;
+    WASMType *func_type;
     void *func_ptr;
     WASMFunctionImport *import_func;
     CApiFuncImport *c_api_func_import = NULL;
@@ -3492,20 +3492,21 @@ llvm_jit_invoke_native(WASMExecEnv *exec_env, uint32 func_idx, uint32 argc,
     attachment = import_func->attachment;
     if (import_func->call_conv_wasm_c_api) {
         ret = wasm_runtime_invoke_c_api_native(
-            (WASMModuleInstanceCommon *)module_inst, func_ptr, func_type, argc,
-            argv, c_api_func_import->with_env_arg, c_api_func_import->env_arg);
+            (WASMModuleInstanceCommon *)module_inst, func_ptr,
+            (WASMFuncType *)func_type, argc, argv,
+            c_api_func_import->with_env_arg, c_api_func_import->env_arg);
     }
     else if (!import_func->call_conv_raw) {
         signature = import_func->signature;
-        ret =
-            wasm_runtime_invoke_native(exec_env, func_ptr, func_type, signature,
-                                       attachment, argv, argc, argv);
+        ret = wasm_runtime_invoke_native(exec_env, func_ptr,
+                                         (WASMFuncType *)func_type, signature,
+                                         attachment, argv, argc, argv);
     }
     else {
         signature = import_func->signature;
-        ret = wasm_runtime_invoke_native_raw(exec_env, func_ptr, func_type,
-                                             signature, attachment, argv, argc,
-                                             argv);
+        ret = wasm_runtime_invoke_native_raw(
+            exec_env, func_ptr, (WASMFuncType *)func_type, signature,
+            attachment, argv, argc, argv);
     }
 
 fail:
@@ -3674,7 +3675,7 @@ llvm_jit_table_copy(WASMModuleInstance *module_inst, uint32 src_tbl_idx,
 
 void
 llvm_jit_table_fill(WASMModuleInstance *module_inst, uint32 tbl_idx,
-                    uint32 length, uint32 val, uint32 data_offset)
+                    uint32 length, table_elem_type_t val, uint32 data_offset)
 {
     WASMTableInstance *tbl_inst;
 
@@ -3700,7 +3701,7 @@ llvm_jit_table_fill(WASMModuleInstance *module_inst, uint32 tbl_idx,
 
 uint32
 llvm_jit_table_grow(WASMModuleInstance *module_inst, uint32 tbl_idx,
-                    uint32 inc_size, uint32 init_val)
+                    uint32 inc_size, table_elem_type_t init_val)
 {
     WASMTableInstance *tbl_inst;
     uint32 i, orig_size, total_size;

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -664,11 +664,11 @@ llvm_jit_table_copy(WASMModuleInstance *module_inst, uint32 src_tbl_idx,
 
 void
 llvm_jit_table_fill(WASMModuleInstance *module_inst, uint32 tbl_idx,
-                    uint32 length, uint32 val, uint32 data_offset);
+                    uint32 length, table_elem_type_t val, uint32 data_offset);
 
 uint32
 llvm_jit_table_grow(WASMModuleInstance *module_inst, uint32 tbl_idx,
-                    uint32 inc_entries, uint32 init_val);
+                    uint32 inc_entries, table_elem_type_t init_val);
 #endif
 
 #if WASM_ENABLE_DUMP_CALL_STACK != 0 || WASM_ENABLE_PERF_PROFILING != 0

--- a/product-mini/platforms/nuttx/wamr.mk
+++ b/product-mini/platforms/nuttx/wamr.mk
@@ -261,7 +261,7 @@ endif
 
 ifeq ($(CONFIG_INTERPRETERS_WAMR_GC),y)
 CFLAGS += -DWASM_ENABLE_GC=1
-CSRCS += gc_type.c gc_object.c
+CSRCS += gc_type.c gc_object.c gc_common.c
 VPATH += $(IWASM_ROOT)/common/gc
 else
 CFLAGS += -DWASM_ENABLE_GC=0

--- a/wamr-compiler/CMakeLists.txt
+++ b/wamr-compiler/CMakeLists.txt
@@ -45,6 +45,7 @@ add_definitions(-DWASM_ENABLE_DUMP_CALL_STACK=1)
 add_definitions(-DWASM_ENABLE_PERF_PROFILING=1)
 add_definitions(-DWASM_ENABLE_LOAD_CUSTOM_SECTION=1)
 add_definitions(-DWASM_ENABLE_LIB_WASI_THREADS=1)
+add_definitions(-DWASM_ENABLE_GC=1)
 
 if (WAMR_BUILD_LLVM_LEGACY_PM EQUAL 1)
   add_definitions(-DWASM_ENABLE_LLVM_LEGACY_PM=1)
@@ -213,6 +214,7 @@ endif()
 include (${IWASM_DIR}/libraries/lib-pthread/lib_pthread.cmake)
 include (${IWASM_DIR}/libraries/lib-wasi-threads/lib_wasi_threads.cmake)
 include (${IWASM_DIR}/common/iwasm_common.cmake)
+include (${IWASM_DIR}/common/gc/iwasm_gc.cmake)
 include (${IWASM_DIR}/interpreter/iwasm_interp.cmake)
 include (${IWASM_DIR}/aot/iwasm_aot.cmake)
 include (${IWASM_DIR}/compilation/iwasm_compl.cmake)
@@ -269,7 +271,8 @@ add_library (vmlib
              ${LIB_WASI_THREADS_SOURCE}
              ${IWASM_COMMON_SOURCE}
              ${IWASM_INTERP_SOURCE}
-             ${IWASM_AOT_SOURCE})
+             ${IWASM_AOT_SOURCE}
+             ${IWASM_GC_SOURCE})
 
 add_library (aotclib ${IWASM_COMPL_SOURCE})
 


### PR DESCRIPTION
* Correct typedef for wasm_heap_type_enum in gc_export.h, it shouldn't be a variable definition
* Fix missing source in build role of NuttX
* Fix compilation error for WAMRC with GC enabled

Note: Only build pass, but dont' have actual function now