### PR TITLE
Add --enable-gc option to WAMRC

### DIFF
--- a/core/iwasm/compilation/aot.h
+++ b/core/iwasm/compilation/aot.h
@@ -277,7 +277,7 @@ typedef struct AOTNativeSymbol {
 } AOTNativeSymbol;
 
 AOTCompData *
-aot_create_comp_data(WASMModule *module);
+aot_create_comp_data(WASMModule *module, bool gc_enabled);
 
 void
 aot_destroy_comp_data(AOTCompData *comp_data);

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -1657,6 +1657,9 @@ aot_create_comp_context(AOTCompData *comp_data, aot_comp_option_t option)
     if (option->enable_stack_estimation)
         comp_ctx->enable_stack_estimation = true;
 
+    if (option->enable_gc)
+        comp_ctx->enable_gc = true;
+
     comp_ctx->opt_level = option->opt_level;
     comp_ctx->size_level = option->size_level;
 

--- a/core/iwasm/compilation/aot_llvm.h
+++ b/core/iwasm/compilation/aot_llvm.h
@@ -346,6 +346,9 @@ typedef struct AOTCompContext {
     /* Whether optimize the JITed code */
     bool optimize;
 
+    /* Enable GC */
+    bool enable_gc;
+
     uint32 opt_level;
     uint32 size_level;
 
@@ -410,6 +413,7 @@ typedef struct AOTCompOption {
     bool disable_llvm_intrinsics;
     bool disable_llvm_lto;
     bool enable_stack_estimation;
+    bool enable_gc;
     uint32 opt_level;
     uint32 size_level;
     uint32 output_format;

--- a/core/iwasm/include/aot_export.h
+++ b/core/iwasm/include/aot_export.h
@@ -20,7 +20,7 @@ struct AOTCompContext;
 typedef struct AOTCompContext *aot_comp_context_t;
 
 aot_comp_data_t
-aot_create_comp_data(void *wasm_module);
+aot_create_comp_data(void *wasm_module, bool gc_enabled);
 
 void
 aot_destroy_comp_data(aot_comp_data_t comp_data);
@@ -56,6 +56,7 @@ typedef struct AOTCompOption {
     bool disable_llvm_intrinsics;
     bool disable_llvm_lto;
     bool enable_stack_estimation;
+    bool enable_gc;
     uint32_t opt_level;
     uint32_t size_level;
     uint32_t output_format;

--- a/core/iwasm/interpreter/wasm.h
+++ b/core/iwasm/interpreter/wasm.h
@@ -979,7 +979,7 @@ wasm_string_equal(const char *s1, const char *s2)
  * Return the byte size of value type.
  */
 inline static uint32
-wasm_value_type_size(uint8 value_type)
+wasm_value_type_size_ex(uint8 value_type, bool gc_enabled)
 {
     if (value_type == VALUE_TYPE_VOID)
         return 0;
@@ -992,19 +992,31 @@ wasm_value_type_size(uint8 value_type)
     else if (value_type == VALUE_TYPE_V128)
         return sizeof(int64) * 2;
 #endif
-#if WASM_ENABLE_GC != 0
     else if (value_type >= (uint8)REF_TYPE_NULLREF /* 0x65 */
-             && value_type <= (uint8)REF_TYPE_FUNCREF /* 0x70 */)
+             && value_type <= (uint8)REF_TYPE_FUNCREF /* 0x70 */ && gc_enabled)
         return sizeof(uintptr_t);
-#elif WASM_ENABLE_REF_TYPES != 0
     else if (value_type == VALUE_TYPE_FUNCREF
              || value_type == VALUE_TYPE_EXTERNREF)
         return sizeof(uint32);
-#endif
     else {
         bh_assert(0);
     }
     return 0;
+}
+
+/**
+ * Return the byte size of value type.
+ */
+inline static uint32
+wasm_value_type_size(uint8 value_type)
+{
+    return wasm_value_type_size_ex(value_type,
+#if WASM_ENABLE_GC != 0
+                                   true
+#else
+                                   false
+#endif
+    );
 }
 
 inline static uint16

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -4112,6 +4112,13 @@ init_llvm_jit_functions_stage1(WASMModule *module, char *error_buf,
     AOTCompOption option = { 0 };
     char *aot_last_error;
     uint64 size;
+    bool gc_enabled =
+#if WASM_ENABLE_GC != 0
+        true
+#else
+        false
+#endif
+        ;
 
     if (module->function_count == 0)
         return true;
@@ -4138,7 +4145,7 @@ init_llvm_jit_functions_stage1(WASMModule *module, char *error_buf,
         (bool *)((uint8 *)module->func_ptrs
                  + sizeof(void *) * module->function_count);
 
-    module->comp_data = aot_create_comp_data(module);
+    module->comp_data = aot_create_comp_data(module, gc_enabled);
     if (!module->comp_data) {
         aot_last_error = aot_get_last_error();
         bh_assert(aot_last_error != NULL);

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -1839,6 +1839,13 @@ init_llvm_jit_functions_stage1(WASMModule *module, char *error_buf,
     AOTCompOption option = { 0 };
     char *aot_last_error;
     uint64 size;
+    bool gc_enabled =
+#if WASM_ENABLE_GC != 0
+        true
+#else
+        false
+#endif
+        ;
 
     if (module->function_count == 0)
         return true;
@@ -1865,7 +1872,7 @@ init_llvm_jit_functions_stage1(WASMModule *module, char *error_buf,
         (bool *)((uint8 *)module->func_ptrs
                  + sizeof(void *) * module->function_count);
 
-    module->comp_data = aot_create_comp_data(module);
+    module->comp_data = aot_create_comp_data(module, gc_enabled);
     if (!module->comp_data) {
         aot_last_error = aot_get_last_error();
         bh_assert(aot_last_error != NULL);

--- a/wamr-compiler/CMakeLists.txt
+++ b/wamr-compiler/CMakeLists.txt
@@ -46,6 +46,12 @@ add_definitions(-DWASM_ENABLE_PERF_PROFILING=1)
 add_definitions(-DWASM_ENABLE_LOAD_CUSTOM_SECTION=1)
 add_definitions(-DWASM_ENABLE_LIB_WASI_THREADS=1)
 
+if (WAMR_BUILD_GC_BINARYEN EQUAL 1)
+  add_definitions (-DWASM_ENABLE_GC_BINARYEN=1)
+else ()
+  add_definitions (-DWASM_ENABLE_GC=1)
+endif ()
+
 if (WAMR_BUILD_LLVM_LEGACY_PM EQUAL 1)
   add_definitions(-DWASM_ENABLE_LLVM_LEGACY_PM=1)
 endif()
@@ -213,6 +219,7 @@ endif()
 include (${IWASM_DIR}/libraries/lib-pthread/lib_pthread.cmake)
 include (${IWASM_DIR}/libraries/lib-wasi-threads/lib_wasi_threads.cmake)
 include (${IWASM_DIR}/common/iwasm_common.cmake)
+include (${IWASM_DIR}/common/gc/iwasm_gc.cmake)
 include (${IWASM_DIR}/interpreter/iwasm_interp.cmake)
 include (${IWASM_DIR}/aot/iwasm_aot.cmake)
 include (${IWASM_DIR}/compilation/iwasm_compl.cmake)
@@ -269,7 +276,8 @@ add_library (vmlib
              ${LIB_WASI_THREADS_SOURCE}
              ${IWASM_COMMON_SOURCE}
              ${IWASM_INTERP_SOURCE}
-             ${IWASM_AOT_SOURCE})
+             ${IWASM_AOT_SOURCE}
+             ${IWASM_GC_SOURCE})
 
 add_library (aotclib ${IWASM_COMPL_SOURCE})
 

--- a/wamr-compiler/main.c
+++ b/wamr-compiler/main.c
@@ -57,12 +57,14 @@ print_help()
     printf("  --disable-simd            Disable the post-MVP 128-bit SIMD feature:\n");
     printf("                              currently 128-bit SIMD is supported for x86-64 and aarch64 targets,\n");
     printf("                              and by default it is enabled in them and disabled in other targets\n");
-    printf("  --disable-ref-types       Disable the MVP reference types feature\n");
+    printf("  --disable-ref-types       Disable the MVP reference types feature, it will be disabled forcibly if\n");
+    printf("                              GC is enabled\n");
     printf("  --disable-aux-stack-check Disable auxiliary stack overflow/underflow check\n");
     printf("  --enable-dump-call-stack  Enable stack trace feature\n");
     printf("  --enable-perf-profiling   Enable function performance profiling\n");
     printf("  --enable-memory-profiling Enable memory usage profiling\n");
     printf("  --enable-indirect-mode    Enalbe call function through symbol table but not direct call\n");
+    printf("  --enable-gc               Enalbe GC (Garbage Collection) feature\n");
     printf("  --disable-llvm-intrinsics Disable the LLVM built-in intrinsics\n");
     printf("  --disable-llvm-lto        Disable the LLVM link time optimization\n");
     printf("  --emit-custom-sections=<section names>\n");
@@ -153,6 +155,7 @@ main(int argc, char *argv[])
     option.enable_aux_stack_check = true;
     option.enable_bulk_memory = true;
     option.enable_ref_types = true;
+    option.enable_gc = false;
 
     /* Process options */
     for (argc--, argv++; argc > 0 && argv[0][0] == '-'; argc--, argv++) {
@@ -266,6 +269,9 @@ main(int argc, char *argv[])
         else if (!strcmp(argv[0], "--enable-indirect-mode")) {
             option.is_indirect_mode = true;
         }
+        else if (!strcmp(argv[0], "--enable-gc")) {
+            option.enable_gc = true;
+        }
         else if (!strcmp(argv[0], "--disable-llvm-intrinsics")) {
             option.disable_llvm_intrinsics = true;
         }
@@ -325,6 +331,10 @@ main(int argc, char *argv[])
         option.is_sgx_platform = true;
     }
 
+    if (option.enable_gc) {
+        option.enable_ref_types = false;
+    }
+
     wasm_file_name = argv[0];
 
     if (!strcmp(wasm_file_name, out_file_name)) {
@@ -366,7 +376,7 @@ main(int argc, char *argv[])
         goto fail2;
     }
 
-    if (!(comp_data = aot_create_comp_data(wasm_module))) {
+    if (!(comp_data = aot_create_comp_data(wasm_module, option.enable_gc))) {
         printf("%s\n", aot_get_last_error());
         goto fail3;
     }


### PR DESCRIPTION
The runtime instance memory layout changed with GC enabled. With this patch GC enabled for WAMRC, but keep compatible for iwasm wether it enabled GC or not for non-GC wasm module.

It may waste some memory for iwasm without GC support since the GC relative fileds are always here, let's do optimization until   
AOT fully support GC.