### PR TITLE
core/iwasm/compilation: constify a bit

### DIFF
--- a/core/iwasm/compilation/aot_emit_variable.c
+++ b/core/iwasm/compilation/aot_emit_variable.c
@@ -112,7 +112,7 @@ static bool
 compile_global(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                uint32 global_idx, bool is_set, bool is_aux_stack)
 {
-    AOTCompData *comp_data = comp_ctx->comp_data;
+    const AOTCompData *comp_data = comp_ctx->comp_data;
     uint32 import_global_count = comp_data->import_global_count;
     uint32 global_base_offset;
     uint32 global_offset;

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -15,7 +15,7 @@
 #endif
 
 LLVMTypeRef
-wasm_type_to_llvm_type(AOTLLVMTypes *llvm_types, uint8 wasm_type)
+wasm_type_to_llvm_type(const AOTLLVMTypes *llvm_types, uint8 wasm_type)
 {
     switch (wasm_type) {
         case VALUE_TYPE_I32:
@@ -42,8 +42,8 @@ wasm_type_to_llvm_type(AOTLLVMTypes *llvm_types, uint8 wasm_type)
  * Add LLVM function
  */
 static LLVMValueRef
-aot_add_llvm_func(AOTCompContext *comp_ctx, LLVMModuleRef module,
-                  AOTFuncType *aot_func_type, uint32 func_index,
+aot_add_llvm_func(const AOTCompContext *comp_ctx, LLVMModuleRef module,
+                  const AOTFuncType *aot_func_type, uint32 func_index,
                   LLVMTypeRef *p_func_type)
 {
     LLVMValueRef func = NULL;
@@ -177,8 +177,9 @@ free_block_memory(AOTBlock *block)
  * Create first AOTBlock, or function block for the function
  */
 static AOTBlock *
-aot_create_func_block(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
-                      AOTFunc *func, AOTFuncType *aot_func_type)
+aot_create_func_block(const AOTCompContext *comp_ctx,
+                      const AOTFuncContext *func_ctx, const AOTFunc *func,
+                      const AOTFuncType *aot_func_type)
 {
     AOTBlock *aot_block;
     uint32 param_count = aot_func_type->param_count,
@@ -266,7 +267,8 @@ create_argv_buf(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 }
 
 static bool
-create_native_stack_bound(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
+create_native_stack_bound(const AOTCompContext *comp_ctx,
+                          AOTFuncContext *func_ctx)
 {
     LLVMValueRef stack_bound_offset = I32_FOUR, stack_bound_addr;
 
@@ -288,7 +290,8 @@ create_native_stack_bound(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 }
 
 static bool
-create_native_stack_top_min(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
+create_native_stack_top_min(const AOTCompContext *comp_ctx,
+                            AOTFuncContext *func_ctx)
 {
     LLVMValueRef offset = I32_NINE;
 
@@ -303,7 +306,7 @@ create_native_stack_top_min(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 }
 
 static bool
-create_aux_stack_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
+create_aux_stack_info(const AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 {
     LLVMValueRef aux_stack_bound_offset = I32_SIX, aux_stack_bound_addr;
     LLVMValueRef aux_stack_bottom_offset = I32_SEVEN, aux_stack_bottom_addr;
@@ -355,7 +358,7 @@ create_aux_stack_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 }
 
 static bool
-create_native_symbol(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
+create_native_symbol(const AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 {
     LLVMValueRef native_symbol_offset = I32_EIGHT, native_symbol_addr;
 
@@ -384,8 +387,9 @@ create_native_symbol(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 }
 
 static bool
-create_local_variables(AOTCompData *comp_data, AOTCompContext *comp_ctx,
-                       AOTFuncContext *func_ctx, AOTFunc *func)
+create_local_variables(const AOTCompData *comp_data,
+                       const AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+                       const AOTFunc *func)
 {
     AOTFuncType *aot_func_type = comp_data->func_types[func->func_type_index];
     char local_name[32];
@@ -475,7 +479,7 @@ create_local_variables(AOTCompData *comp_data, AOTCompContext *comp_ctx,
 }
 
 static bool
-create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+create_memory_info(const AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                    LLVMTypeRef int8_ptr_type, uint32 func_index)
 {
     LLVMValueRef offset, mem_info_base;
@@ -807,7 +811,7 @@ create_memory_info(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 }
 
 static bool
-create_cur_exception(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
+create_cur_exception(const AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 {
     LLVMValueRef offset;
 
@@ -823,7 +827,8 @@ create_cur_exception(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 }
 
 static bool
-create_func_type_indexes(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
+create_func_type_indexes(const AOTCompContext *comp_ctx,
+                         AOTFuncContext *func_ctx)
 {
     LLVMValueRef offset, func_type_indexes_ptr;
     LLVMTypeRef int32_ptr_type;
@@ -861,7 +866,7 @@ create_func_type_indexes(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 }
 
 static bool
-create_func_ptrs(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
+create_func_ptrs(const AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 {
     LLVMValueRef offset;
 
@@ -903,7 +908,7 @@ create_func_ptrs(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
  * Create function compiler context
  */
 static AOTFuncContext *
-aot_create_func_context(AOTCompData *comp_data, AOTCompContext *comp_ctx,
+aot_create_func_context(const AOTCompData *comp_data, AOTCompContext *comp_ctx,
                         AOTFunc *func, uint32 func_index)
 {
     AOTFuncContext *func_ctx;
@@ -1059,7 +1064,7 @@ aot_destroy_func_contexts(AOTFuncContext **func_ctxes, uint32 count)
  * Create function compiler contexts
  */
 static AOTFuncContext **
-aot_create_func_contexts(AOTCompData *comp_data, AOTCompContext *comp_ctx)
+aot_create_func_contexts(const AOTCompData *comp_data, AOTCompContext *comp_ctx)
 {
     AOTFuncContext **func_ctxes;
     uint64 size;
@@ -1536,7 +1541,7 @@ aot_compiler_destroy(void)
 }
 
 AOTCompContext *
-aot_create_comp_context(AOTCompData *comp_data, aot_comp_option_t option)
+aot_create_comp_context(const AOTCompData *comp_data, aot_comp_option_t option)
 {
     AOTCompContext *comp_ctx, *ret = NULL;
     LLVMTargetRef target;

--- a/core/iwasm/compilation/aot_llvm.h
+++ b/core/iwasm/compilation/aot_llvm.h
@@ -275,7 +275,7 @@ typedef struct AOTLLVMConsts {
  * Compiler context
  */
 typedef struct AOTCompContext {
-    AOTCompData *comp_data;
+    const AOTCompData *comp_data;
 
     /* LLVM variables required to emit LLVM IR */
     LLVMContextRef context;
@@ -425,7 +425,7 @@ void
 aot_compiler_destroy(void);
 
 AOTCompContext *
-aot_create_comp_context(AOTCompData *comp_data, aot_comp_option_t option);
+aot_create_comp_context(const AOTCompData *comp_data, aot_comp_option_t option);
 
 void
 aot_destroy_comp_context(AOTCompContext *comp_ctx);
@@ -464,7 +464,7 @@ void
 aot_block_destroy(AOTBlock *block);
 
 LLVMTypeRef
-wasm_type_to_llvm_type(AOTLLVMTypes *llvm_types, uint8 wasm_type);
+wasm_type_to_llvm_type(const AOTLLVMTypes *llvm_types, uint8 wasm_type);
 
 bool
 aot_checked_addr_list_add(AOTFuncContext *func_ctx, uint32 local_idx,


### PR DESCRIPTION
just to make the code a bit easier to read.