### PR TITLE
aot_compile_op_call: remove a wrong optimization

### DIFF
--- a/core/iwasm/compilation/aot_emit_function.c
+++ b/core/iwasm/compilation/aot_emit_function.c
@@ -868,10 +868,6 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 #if LLVM_VERSION_MAJOR >= 14
         LLVMTypeRef llvm_func_type;
 #endif
-        bool recursive_call =
-            (func_ctx == func_ctxes[func_idx - import_func_count]) ? true
-                                                                   : false;
-
         if (comp_ctx->is_indirect_mode) {
             LLVMTypeRef func_ptr_type;
 
@@ -971,7 +967,7 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
         /* Check whether there was exception thrown when executing
            the function */
-        if (!tail_call && !recursive_call && comp_ctx->enable_bound_check
+        if (!tail_call && comp_ctx->enable_bound_check
             && !check_exception_thrown(comp_ctx, func_ctx))
             goto fail;
     }


### PR DESCRIPTION
Unlike a tail-call, the caller of an ordinary recursive call doesn't necessarily return immediately.