### PR TITLE
Enable AOT static PGO for 32-bit targets

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -2543,6 +2543,8 @@ load_relocation_section(const uint8 *buf, const uint8 *buf_end,
 
         module->got_item_count = got_item_count;
     }
+#else
+    (void)got_item_count;
 #endif /* defined(BUILD_TARGET_X86_64) || defined(BUILD_TARGET_AMD_64) */
 
     buf = symbol_buf_end;

--- a/core/iwasm/aot/aot_runtime.h
+++ b/core/iwasm/aot/aot_runtime.h
@@ -339,15 +339,31 @@ typedef struct ValueProfNode {
     struct ValueProfNode *next;
 } ValueProfNode;
 
+/* The profiling data of data sections created by aot compiler and
+   used when profiling, the width of pointer can be 8 bytes (64-bit)
+   or 4 bytes (32-bit) */
 typedef struct LLVMProfileData {
     uint64 func_md5;
     uint64 func_hash;
-    intptr_t offset_counters;
+    uint64 offset_counters;
     uintptr_t func_ptr;
     ValueProfNode **values;
     uint32 num_counters;
     uint16 num_value_sites[2];
 } LLVMProfileData;
+
+/* The profiling data for writting to the output file, the width of
+   pointer is 8 bytes suppose we always use wamrc and llvm-profdata
+   with 64-bit mode */
+typedef struct LLVMProfileData_64 {
+    uint64 func_md5;
+    uint64 func_hash;
+    uint64 offset_counters;
+    uint64 func_ptr;
+    uint64 values;
+    uint32 num_counters;
+    uint16 num_value_sites[2];
+} LLVMProfileData_64;
 #endif /* end of WASM_ENABLE_STATIC_PGO != 0 */
 
 /**

--- a/core/iwasm/aot/arch/aot_reloc_x86_32.c
+++ b/core/iwasm/aot/arch/aot_reloc_x86_32.c
@@ -8,6 +8,9 @@
 #define R_386_32 1    /* Direct 32 bit  */
 #define R_386_PC32 2  /* PC relative 32 bit */
 #define R_386_PLT32 4 /* 32-bit address ProcedureLinkageTable */
+#define R_386_TLS_GD_32                      \
+    24 /*  Direct 32 bit for general dynamic \
+           thread local data */
 
 #if !defined(_WIN32) && !defined(_WIN32_)
 /* clang-format off */
@@ -110,6 +113,9 @@ apply_relocation(AOTModule *module, uint8 *target_section_addr,
 {
     switch (reloc_type) {
         case R_386_32:
+#if WASM_ENABLE_STATIC_PGO != 0
+        case R_386_TLS_GD_32:
+#endif
         {
             intptr_t value;
 

--- a/core/iwasm/compilation/aot_llvm_extra.cpp
+++ b/core/iwasm/compilation/aot_llvm_extra.cpp
@@ -234,10 +234,16 @@ aot_apply_llvm_new_pass_manager(AOTCompContext *comp_ctx, LLVMModuleRef module)
     PTO.LoopUnrolling = true;
 
     Optional<PGOOptions> PGO = None;
-    if (comp_ctx->enable_llvm_pgo)
+    if (comp_ctx->enable_llvm_pgo) {
+        /* Disable static counter allocation for value profiler,
+           it will be allocated by runtime */
+        const char *argv[] = { "", "-vp-static-alloc=false" };
+        cl::ParseCommandLineOptions(2, argv);
         PGO = PGOOptions("", "", "", PGOOptions::IRInstr);
-    else if (comp_ctx->use_prof_file)
+    }
+    else if (comp_ctx->use_prof_file) {
         PGO = PGOOptions(comp_ctx->use_prof_file, "", "", PGOOptions::IRUse);
+    }
 
 #ifdef DEBUG_PASS
     PassInstrumentationCallbacks PIC;


### PR DESCRIPTION
x86-32 target was tested with benchmark coremark, dhrystone, sightglass and polybench.