### PR TITLE
aot/jit: set module layout

### DIFF
--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -2165,6 +2165,7 @@ aot_create_comp_context(const AOTCompData *comp_data, aot_comp_option_t option)
         aot_set_last_error("create LLVM target data layout failed.");
         goto fail;
     }
+    LLVMSetModuleDataLayout(comp_ctx->module, target_data_ref);
     comp_ctx->pointer_size = LLVMPointerSize(target_data_ref);
     LLVMDisposeTargetData(target_data_ref);
 


### PR DESCRIPTION
LLVM 15 and later sometimes performs wrong optimizations without this.