### PR TITLE
Enable windows x86-32 AOT relocations

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -1997,7 +1997,7 @@ do_text_relocation(AOTModule *module, AOTRelocationGroup *group,
 #endif
         }
 #if defined(BH_PLATFORM_WINDOWS) && defined(BUILD_TARGET_X86_32)
-        /* AOT function name starts with '-' in windows x86-32 */
+        /* AOT function name starts with '_' in windows x86-32 */
         else if (!strncmp(symbol, "_" AOT_FUNC_PREFIX,
                           strlen("_" AOT_FUNC_PREFIX))) {
             p = symbol + strlen("_" AOT_FUNC_PREFIX);

--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -1996,6 +1996,20 @@ do_text_relocation(AOTModule *module, AOTRelocationGroup *group,
             symbol_addr = module->func_ptrs[func_index];
 #endif
         }
+#if defined(BH_PLATFORM_WINDOWS) && defined(BUILD_TARGET_X86_32)
+        /* AOT function name starts with '-' in windows x86-32 */
+        else if (!strncmp(symbol, "_" AOT_FUNC_PREFIX,
+                          strlen("_" AOT_FUNC_PREFIX))) {
+            p = symbol + strlen("_" AOT_FUNC_PREFIX);
+            if (*p == '\0'
+                || (func_index = (uint32)atoi(p)) > module->func_count) {
+                set_error_buf_v(error_buf, error_buf_size, "invalid symbol %s",
+                                symbol);
+                goto check_symbol_fail;
+            }
+            symbol_addr = module->func_ptrs[func_index];
+        }
+#endif
         else if (!strcmp(symbol, ".text")) {
             symbol_addr = module->code;
         }

--- a/core/iwasm/aot/arch/aot_reloc_x86_32.c
+++ b/core/iwasm/aot/arch/aot_reloc_x86_32.c
@@ -25,6 +25,7 @@ void __divdi3();
 void __udivdi3();
 void __moddi3();
 void __umoddi3();
+void __aulldiv();
 /* clang-format on */
 #else
 #pragma function(floor)

--- a/core/iwasm/aot/arch/aot_reloc_x86_32.c
+++ b/core/iwasm/aot/arch/aot_reloc_x86_32.c
@@ -5,12 +5,19 @@
 
 #include "aot_reloc.h"
 
+/* clang-format off */
+#if !defined(BH_PLATFORM_WINDOWS)
 #define R_386_32 1    /* Direct 32 bit  */
 #define R_386_PC32 2  /* PC relative 32 bit */
 #define R_386_PLT32 4 /* 32-bit address ProcedureLinkageTable */
-#define R_386_TLS_GD_32                      \
-    24 /*  Direct 32 bit for general dynamic \
-           thread local data */
+#define R_386_TLS_GD_32 24 /* Direct 32 bit for general dynamic
+                              thread local data */
+#else
+#define IMAGE_REL_I386_DIR32 6 /* The target's 32-bit VA */
+#define IMAGE_REL_I386_REL32 20 /* The 32-bit relative displacement
+                                   to the target */
+#endif
+/* clang-format on */
 
 #if !defined(_WIN32) && !defined(_WIN32_)
 /* clang-format off */
@@ -46,6 +53,12 @@ __umoddi3(uint64 a, uint64 b)
 {
     return a % b;
 }
+
+static uint64
+__aulldiv(uint64 a, uint64 b)
+{
+    return a / b;
+}
 #endif
 
 /* clang-format off */
@@ -55,7 +68,8 @@ static SymbolMap target_sym_map[] = {
     REG_SYM(__divdi3),
     REG_SYM(__udivdi3),
     REG_SYM(__moddi3),
-    REG_SYM(__umoddi3)
+    REG_SYM(__umoddi3),
+    REG_SYM(__aulldiv)
 };
 /* clang-format on */
 
@@ -112,9 +126,13 @@ apply_relocation(AOTModule *module, uint8 *target_section_addr,
                  int32 symbol_index, char *error_buf, uint32 error_buf_size)
 {
     switch (reloc_type) {
+#if !defined(BH_PLATFORM_WINDOWS)
         case R_386_32:
 #if WASM_ENABLE_STATIC_PGO != 0
         case R_386_TLS_GD_32:
+#endif
+#else
+        case IMAGE_REL_I386_DIR32:
 #endif
         {
             intptr_t value;
@@ -127,12 +145,16 @@ apply_relocation(AOTModule *module, uint8 *target_section_addr,
             break;
         }
 
+#if !defined(BH_PLATFORM_WINDOWS)
         /*
          * Handle R_386_PLT32 like R_386_PC32 since it should be able to reach
          * any 32 bit address
          */
         case R_386_PLT32:
         case R_386_PC32:
+#else
+        case IMAGE_REL_I386_REL32:
+#endif
         {
             int32 value;
 

--- a/core/iwasm/aot/arch/aot_reloc_x86_32.c
+++ b/core/iwasm/aot/arch/aot_reloc_x86_32.c
@@ -25,7 +25,6 @@ void __divdi3();
 void __udivdi3();
 void __moddi3();
 void __umoddi3();
-void __aulldiv();
 /* clang-format on */
 #else
 #pragma function(floor)
@@ -54,13 +53,13 @@ __umoddi3(uint64 a, uint64 b)
 {
     return a % b;
 }
+#endif
 
 static uint64
 __aulldiv(uint64 a, uint64 b)
 {
     return a / b;
 }
-#endif
 
 /* clang-format off */
 static SymbolMap target_sym_map[] = {


### PR DESCRIPTION
Implement relocation types IMAGE_REL_I386_DIR32 and IMAGE_REL_I386_REL32,
fix find symbol of AOT function, and implement symbol __aulldiv.