### PR TITLE
Fixes a compile warn due to missing include.

### DIFF
--- a/core/shared/platform/android/platform_internal.h
+++ b/core/shared/platform/android/platform_internal.h
@@ -27,6 +27,7 @@
 #include <sched.h>
 #include <errno.h>
 #include <netinet/in.h>
+#include <sys/epoll.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/mman.h>


### PR DESCRIPTION
Compilation in strict mode fails with
`wasm_micro_runtime/core/shared/platform/android/platform_init.c:122:30: error: declaration of 'struct epoll_event' will not be visible outside of this function [-Werror,-Wvisibility]
epoll_pwait(int epfd, struct epoll_event *events, int maxevents, int timeout,
                             ^
1 error generated.
`