### PR TITLE
Update to Node >=16 in extension release process

### DIFF
--- a/.github/workflows/build_wamr_vscode_ext.yml
+++ b/.github/workflows/build_wamr_vscode_ext.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node.js 14.x
+      - name: Use Node.js 16.x
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
 
       - name: set vscode extension to correct version
         run: |


### PR DESCRIPTION
Since building the extension now depends on node >=16 (see [this](https://github.com/bytecodealliance/wasm-micro-runtime/pull/2292#issuecomment-1596761347)), build_wamr_vscode_ext.yml will fail on the next release without this change.