### PR TITLE
Add retries for a flaky step

### DIFF
--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -279,7 +279,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install dependencies
-        run: apt update && apt install -y make g++-4.8 gcc-4.8 wget git
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: apt update && apt install -y make g++-4.8 gcc-4.8 wget git
+          on_retry_command: sudo rm -r /var/lib/apt/lists/*
 
       - name: Install cmake
         run: |


### PR DESCRIPTION
Adds more automated way for errors like this https://github.com/bytecodealliance/wasm-micro-runtime/actions/runs/5328561662

Thanks to @wenyongh  for retrying at night but it didn't help so proposing an automated solution 

Proposed dependency : https://github.com/nick-fields/retry