### PR TITLE
Fix wamrc build issues with LLVM 13 and LLVM 16

### DIFF
--- a/core/iwasm/compilation/aot_llvm_extra.cpp
+++ b/core/iwasm/compilation/aot_llvm_extra.cpp
@@ -235,7 +235,11 @@ aot_apply_llvm_new_pass_manager(AOTCompContext *comp_ctx, LLVMModuleRef module)
     PTO.SLPVectorization = true;
     PTO.LoopUnrolling = true;
 
-    Optional<PGOOptions> PGO = None;
+#if LLVM_VERSION_MAJOR >= 16
+    Optional<PGOOptions> PGO = std::nullopt;
+#else
+    Optional<PGOOptions> PGO = llvm::None;
+#endif
     if (comp_ctx->enable_llvm_pgo) {
         /* Disable static counter allocation for value profiler,
            it will be allocated by runtime */

--- a/core/iwasm/compilation/aot_llvm_extra2.cpp
+++ b/core/iwasm/compilation/aot_llvm_extra2.cpp
@@ -23,7 +23,11 @@ convert(LLVMRelocMode reloc_mode)
 {
     switch (reloc_mode) {
         case LLVMRelocDefault:
+#if LLVM_VERSION_MAJOR >= 16
+            return std::nullopt;
+#else
             return llvm::None;
+#endif
         case LLVMRelocStatic:
             return llvm::Reloc::Static;
         case LLVMRelocPIC:
@@ -38,7 +42,11 @@ convert(LLVMRelocMode reloc_mode)
             return llvm::Reloc::ROPI_RWPI;
     }
     bh_assert(0);
+#if LLVM_VERSION_MAJOR >= 16
+    return std::nullopt;
+#else
     return llvm::None;
+#endif
 }
 
 static llvm::CodeGenOpt::Level
@@ -64,10 +72,18 @@ convert(LLVMCodeModel code_model, bool *jit)
     *jit = false;
     switch (code_model) {
         case LLVMCodeModelDefault:
+#if LLVM_VERSION_MAJOR >= 16
+            return std::nullopt;
+#else
             return llvm::None;
+#endif
         case LLVMCodeModelJITDefault:
             *jit = true;
+#if LLVM_VERSION_MAJOR >= 16
+            return std::nullopt;
+#else
             return llvm::None;
+#endif
         case LLVMCodeModelTiny:
             return llvm::CodeModel::Tiny;
         case LLVMCodeModelSmall:
@@ -80,7 +96,11 @@ convert(LLVMCodeModel code_model, bool *jit)
             return llvm::CodeModel::Large;
     }
     bh_assert(0);
+#if LLVM_VERSION_MAJOR >= 16
+    return std::nullopt;
+#else
     return llvm::None;
+#endif
 }
 
 LLVMTargetMachineRef

--- a/core/iwasm/compilation/aot_orc_extra2.cpp
+++ b/core/iwasm/compilation/aot_orc_extra2.cpp
@@ -112,10 +112,16 @@ MyCompiler::operator()(llvm::Module &M)
         PM.run(M);
     }
 
+#if LLVM_VERSION_MAJOR > 13
     auto ObjBuffer = std::make_unique<llvm::SmallVectorMemoryBuffer>(
         std::move(ObjBufferSV),
         M.getModuleIdentifier() + "-jitted-objectbuffer",
         /*RequiresNullTerminator=*/false);
+#else
+    auto ObjBuffer = std::make_unique<llvm::SmallVectorMemoryBuffer>(
+        std::move(ObjBufferSV),
+        M.getModuleIdentifier() + "-jitted-objectbuffer");
+#endif
 
     return std::move(ObjBuffer);
 }


### PR DESCRIPTION
Fix some build errors when building wamrc with LLVM-13, reported in #2311
Fix some build warnings when building warc with LLVM-16:
  core/iwasm/compilation/aot_llvm_extra2.cpp:26:26: warning:
  ‘llvm::None’ is deprecated: Use std::nullopt instead. [-Wdeprecated-declarations]
     26 |             return llvm::None;
Fix compile warning:
  core/iwasm/compilation/aot_llvm.c:413:9: warning:
  ‘update_top_block’ may be used uninitialized in this function [-Wmaybe-uninitialized]
    413 |         LLVMPositionBuilderAtEnd(b, update_top_block);