### PR TITLE
aot: avoid possible relocations around "stack_sizes" for indirect mode

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -1843,6 +1843,13 @@ get_data_section_addr(AOTModule *module, const char *section_name,
     return NULL;
 }
 
+const void *
+aot_get_data_section_addr(AOTModule *module, const char *section_name,
+                          uint32 *p_data_size)
+{
+    return get_data_section_addr(module, section_name, p_data_size);
+}
+
 static void *
 resolve_target_sym(const char *symbol, int32 *p_index)
 {

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -39,10 +39,10 @@ bh_static_assert(offsetof(AOTModuleInstance, func_type_indexes)
                  == 6 * sizeof(uint64));
 bh_static_assert(offsetof(AOTModuleInstance, cur_exception)
                  == 13 * sizeof(uint64));
-bh_static_assert(offsetof(AOTModuleInstance, aot_stack_sizes)
-                 == 13 * sizeof(uint64) + 128 + 11 * sizeof(uint64));
 bh_static_assert(offsetof(AOTModuleInstance, global_table_data)
-                 == 13 * sizeof(uint64) + 128 + 12 * sizeof(uint64));
+                 == 13 * sizeof(uint64) + 128 + 11 * sizeof(uint64));
+
+bh_static_assert(offsetof(AOTModuleInstanceExtra, stack_sizes) == 0);
 
 static void
 set_error_buf(char *error_buf, uint32 error_buf_size, const char *string)
@@ -1212,7 +1212,7 @@ aot_instantiate(AOTModule *module, bool is_sub_inst, WASMExecEnv *exec_env_main,
 #endif
     module_inst->default_wasm_stack_size = stack_size;
 
-    module_inst->aot_stack_sizes =
+    ((AOTModuleInstanceExtra *)module_inst->e)->stack_sizes =
         aot_get_data_section_addr(module, AOT_STACK_SIZES_SECTION_NAME, NULL);
 
 #if WASM_ENABLE_PERF_PROFILING != 0

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -39,8 +39,10 @@ bh_static_assert(offsetof(AOTModuleInstance, func_type_indexes)
                  == 6 * sizeof(uint64));
 bh_static_assert(offsetof(AOTModuleInstance, cur_exception)
                  == 13 * sizeof(uint64));
-bh_static_assert(offsetof(AOTModuleInstance, global_table_data)
+bh_static_assert(offsetof(AOTModuleInstance, aot_stack_sizes)
                  == 13 * sizeof(uint64) + 128 + 11 * sizeof(uint64));
+bh_static_assert(offsetof(AOTModuleInstance, global_table_data)
+                 == 13 * sizeof(uint64) + 128 + 12 * sizeof(uint64));
 
 static void
 set_error_buf(char *error_buf, uint32 error_buf_size, const char *string)
@@ -1209,6 +1211,9 @@ aot_instantiate(AOTModule *module, bool is_sub_inst, WASMExecEnv *exec_env_main,
         stack_size = 48 * 1024;
 #endif
     module_inst->default_wasm_stack_size = stack_size;
+
+    module_inst->aot_stack_sizes =
+        aot_get_data_section_addr(module, AOT_STACK_SIZES_SECTION_NAME, NULL);
 
 #if WASM_ENABLE_PERF_PROFILING != 0
     total_size = (uint64)sizeof(AOTFuncPerfProfInfo)

--- a/core/iwasm/aot/aot_runtime.h
+++ b/core/iwasm/aot/aot_runtime.h
@@ -88,7 +88,7 @@ typedef struct AOTFunctionInstance {
 } AOTFunctionInstance;
 
 typedef struct AOTModuleInstanceExtra {
-    const uint32 *stack_sizes;
+    DefPointer(const uint32 *, stack_sizes);
     CApiFuncImport *c_api_func_imports;
 } AOTModuleInstanceExtra;
 

--- a/core/iwasm/aot/aot_runtime.h
+++ b/core/iwasm/aot/aot_runtime.h
@@ -88,6 +88,7 @@ typedef struct AOTFunctionInstance {
 } AOTFunctionInstance;
 
 typedef struct AOTModuleInstanceExtra {
+    const uint32 *stack_sizes;
     CApiFuncImport *c_api_func_imports;
 } AOTModuleInstanceExtra;
 

--- a/core/iwasm/aot/aot_runtime.h
+++ b/core/iwasm/aot/aot_runtime.h
@@ -633,6 +633,10 @@ aot_dump_perf_profiling(const AOTModuleInstance *module_inst);
 const uint8 *
 aot_get_custom_section(const AOTModule *module, const char *name, uint32 *len);
 
+const void *
+aot_get_data_section_addr(AOTModule *module, const char *section_name,
+                          uint32 *p_data_size);
+
 #if WASM_ENABLE_STATIC_PGO != 0
 void
 llvm_profile_instrument_target(uint64 target_value, void *data,

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -7,6 +7,7 @@
 #include "aot_llvm_extra2.h"
 #include "aot_compiler.h"
 #include "aot_emit_exception.h"
+#include "aot_emit_table.h"
 #include "../aot/aot_runtime.h"
 #include "../aot/aot_intrinsic.h"
 
@@ -230,6 +231,17 @@ aot_estimate_stack_usage_for_function_call(const AOTCompContext *comp_ctx,
     return size;
 }
 
+static uint32
+get_inst_extra_offset(AOTCompContext *comp_ctx)
+{
+    const AOTCompData *comp_data = comp_ctx->comp_data;
+    uint32 table_count = comp_data->import_table_count + comp_data->table_count;
+    uint64 offset = get_tbl_inst_offset(comp_ctx, NULL, table_count);
+    bh_assert(offset <= UINT_MAX);
+    offset = align_uint(offset, 8);
+    return offset;
+}
+
 /*
  * a "precheck" function performs a few things before calling wrapped_func.
  *
@@ -329,8 +341,9 @@ aot_add_precheck_function(AOTCompContext *comp_ctx, LLVMModuleRef module,
      */
     LLVMValueRef stack_sizes;
     if (comp_ctx->is_indirect_mode) {
-        LLVMValueRef offset =
-            I32_CONST(offsetof(AOTModuleInstance, aot_stack_sizes));
+        uint32 offset_u32 = get_inst_extra_offset(comp_ctx);
+        offset_u32 += offsetof(AOTModuleInstanceExtra, stack_sizes);
+        LLVMValueRef offset = I32_CONST(offset_u32);
         if (!offset) {
             goto fail;
         }

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -341,13 +341,17 @@ aot_add_precheck_function(AOTCompContext *comp_ctx, LLVMModuleRef module,
      */
     LLVMValueRef stack_sizes;
     if (comp_ctx->is_indirect_mode) {
-        uint32 offset_u32 = get_inst_extra_offset(comp_ctx);
+        uint32 offset_u32;
+        LLVMValueRef offset;
+        LLVMValueRef stack_sizes_p;
+
+        offset_u32 = get_inst_extra_offset(comp_ctx);
         offset_u32 += offsetof(AOTModuleInstanceExtra, stack_sizes);
-        LLVMValueRef offset = I32_CONST(offset_u32);
+        offset = I32_CONST(offset_u32);
         if (!offset) {
             goto fail;
         }
-        LLVMValueRef stack_sizes_p =
+        stack_sizes_p =
             LLVMBuildInBoundsGEP2(b, INT8_TYPE, func_ctx->aot_inst, &offset, 1,
                                   "aot_inst_stack_sizes_p");
         if (!stack_sizes_p) {

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -318,9 +318,6 @@ struct WASMModuleInstance {
     uint32 default_wasm_stack_size;
     uint32 reserved[3];
 
-    /* AOT */
-    DefPointer(const uint32 *, aot_stack_sizes);
-
     /*
      * +------------------------------+ <-- memories
      * | WASMMemoryInstance[mem_count], mem_count is always 1 for LLVM JIT/AOT

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -318,6 +318,9 @@ struct WASMModuleInstance {
     uint32 default_wasm_stack_size;
     uint32 reserved[3];
 
+    /* AOT */
+    DefPointer(const uint32 *, aot_stack_sizes);
+
     /*
      * +------------------------------+ <-- memories
      * | WASMMemoryInstance[mem_count], mem_count is always 1 for LLVM JIT/AOT


### PR DESCRIPTION
Fixes https://github.com/bytecodealliance/wasm-micro-runtime/issues/2316

Lightly tested on riscv64 qemu.