### PR TITLE
nuttx: add a kconfig for wasi-threads

### DIFF
--- a/product-mini/platforms/nuttx/wamr.mk
+++ b/product-mini/platforms/nuttx/wamr.mk
@@ -265,6 +265,15 @@ else
 CFLAGS += -DWASM_ENABLE_THREAD_MGR=0
 endif
 
+ifeq ($(CONFIG_INTERPRETERS_WAMR_LIB_WASI_THREADS),y)
+CFLAGS += -DWASM_ENABLE_LIB_WASI_THREADS=1
+CSRCS += lib_wasi_threads_wrapper.c
+CSRCS += tid_allocator.c
+VPATH += $(IWASM_ROOT)/libraries/lib-wasi-threads
+else
+CFLAGS += -DWASM_ENABLE_LIB_WASI_THREADS=0
+endif
+
 ifeq ($(CONFIG_INTERPRETERS_WAMR_LIB_PTHREAD),y)
 CFLAGS += -DWASM_ENABLE_LIB_PTHREAD=1
 CSRCS += lib_pthread_wrapper.c


### PR DESCRIPTION
nuttx apps counterpart: https://github.com/apache/nuttx-apps/pull/1823
