### PR TITLE
Fix Enclave Interfaces of WAMR SGX version; Set pointer to NULL after free, otherwise cause UAF/DF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,6 @@ wamr-sdk/out/
 wamr-sdk/runtime/build_runtime_sdk/
 test-tools/host-tool/bin/
 product-mini/app-samples/hello-world/test.wasm
-product-mini/platforms/linux-sgx/enclave-sample/App/
-product-mini/platforms/linux-sgx/enclave-sample/Enclave/
 product-mini/platforms/linux-sgx/enclave-sample/iwasm
 
 build_out
@@ -40,3 +38,11 @@ samples/workload/include/**
 !samples/workload/include/.gitkeep
 
 # core/iwasm/libraries/wasi-threads
+
+*_u.c
+*_u.h
+*_t.c
+*_t.h
+*.o
+product-mini/app-samples/hello-world/iwasm
+product-mini/app-samples/hello-world/test_wasm.h

--- a/core/iwasm/common/wasm_shared_memory.c
+++ b/core/iwasm/common/wasm_shared_memory.c
@@ -66,6 +66,7 @@ void
 wasm_shared_memory_destroy()
 {
     bh_hash_map_destroy(wait_map);
+    wait_map = NULL;
     os_mutex_destroy(&shared_memory_list_lock);
 }
 

--- a/product-mini/platforms/linux-sgx/enclave-sample/Enclave/Enclave.edl
+++ b/product-mini/platforms/linux-sgx/enclave-sample/Enclave/Enclave.edl
@@ -20,11 +20,71 @@ enclave {
 
     trusted {
         /* define ECALLs here. */
-        public void ecall_handle_command(unsigned cmd,
-                                         [in, out, size=cmd_buf_size]uint8_t *cmd_buf,
-                                         unsigned cmd_buf_size);
-        public void ecall_iwasm_main([user_check]uint8_t *wasm_file_buf,
-                                     uint32_t wasm_file_size);
+      public bool ecall_handle_cmd_init_runtime(uint32_t max_thread_num);
+      public void ecall_handle_cmd_destroy_runtime();
+      public bool ecall_handle_cmd_load_module(
+        [in, size=wasm_file_size] char *wasm_file,
+        uint32_t wasm_file_size,
+        [out, size=error_buf_size] char *error_buf,
+        uint32_t error_buf_size,
+        [out] uint16_t *enclave_module_idx
+      );
+      public bool ecall_handle_cmd_unload_module(uint16_t enclave_module_idx);
+      public bool ecall_handle_cmd_instantiate_module(
+        uint16_t enclave_module_idx,
+        uint32_t stack_size,
+        uint32_t heap_size,
+        [out, size=error_buf_size] char *error_buf,
+        uint32_t error_buf_size,
+        [out] uint16_t *module_inst_idx
+      );
+      public bool ecall_handle_cmd_deinstantiate_module(uint16_t wasm_module_inst_idx);
+      public bool ecall_handle_cmd_get_exception(
+        uint16_t wasm_module_inst_idx,
+        [out, size=exception_size] char *exception,
+        uint32_t exception_size
+      );
+      public bool ecall_handle_cmd_exec_app_main(
+        uint16_t wasm_module_inst_idx,
+        [in, count=app_argc] char **u_app_argv,
+        uint32_t app_argc
+      );
+      public bool ecall_handle_cmd_exec_app_func(
+        uint16_t wasm_module_inst_idx,
+        [in, string] const char *func_name,
+        [in, count=app_argc] char **u_app_argv,
+        uint32_t app_argc
+      );
+      public void ecall_handle_cmd_set_log_level(int log_level);
+      public bool ecall_handle_cmd_set_wasi_args(
+        uint16_t enclave_module_idx,
+        [in, count=dir_list_size] const char **dir_list,
+        uint32_t dir_list_size,
+        [in, count=env_list_size] const char **env_list,
+        uint32_t env_list_size,
+        int stdinfd,
+        int stdoutfd,
+        int stderrfd,
+        [in, count=wasi_argc] char **wasi_argv,
+        uint32_t wasi_argc,
+        [in, count=addr_pool_list_size] const char **addr_pool_list,
+        uint32_t addr_pool_list_size
+      );
+      public void ecall_handle_cmd_get_version(
+        [out] uint32_t *major,
+        [out] uint32_t *minor,
+        [out] uint32_t *patch
+      );
+      public uint32_t ecall_handle_cmd_get_pgo_prof_buf_size(uint16_t wasm_module_inst_idx);
+      public uint32_t ecall_handle_cmd_get_pgo_prof_buf_data(
+        uint16_t wasm_module_inst_idx,
+        [out, size=len] char *buf,
+        uint32_t len
+      );
+      public void ecall_iwasm_main(
+        [in, size=wasm_file_size] uint8_t *wasm_file_buf,
+        uint32_t wasm_file_size
+      );
     };
 
     untrusted {

--- a/product-mini/platforms/linux-sgx/enclave-sample/Makefile
+++ b/product-mini/platforms/linux-sgx/enclave-sample/Makefile
@@ -129,6 +129,7 @@ Enclave_Include_Paths := -IEnclave -I$(WAMR_ROOT)/core/iwasm/include \
                          -I$(WAMR_ROOT)/core/shared/platform/linux-sgx \
                          -I$(SGX_SDK)/include \
                          -I$(SGX_SDK)/include/tlibc \
+                         -I$(SGX_SDK)/include/libcxx \
                          -I$(SGX_SDK)/include/stlport
 
 ifeq ($(WAMR_BUILD_LIB_RATS), 1)
@@ -208,6 +209,7 @@ ifeq ($(WAMR_BUILD_LIB_RATS), 1)
 	@echo "librats build success"
 endif
 
+App/Enclave_u.h: App/Enclave_u.c
 App/Enclave_u.c: $(SGX_EDGER8R) Enclave/Enclave.edl librats
 	@cd App && $(SGX_EDGER8R) --untrusted ../Enclave/Enclave.edl $(Enclave_Edl_Search_Path)
 	@echo "GEN  =>  $@"
@@ -216,6 +218,7 @@ App/Enclave_u.o: App/Enclave_u.c
 	@$(CC) $(App_C_Flags) -c $< -o $@
 	@echo "CC   <=  $<"
 
+App/%.o: App/Enclave_u.h
 App/%.o: App/%.cpp
 	@$(CXX) $(App_Cpp_Flags) -c $< -o $@
 	@echo "CXX  <=  $<"
@@ -230,6 +233,7 @@ $(App_Name): App/Enclave_u.o $(App_Cpp_Objects) libvmlib_untrusted.a
 
 
 ######## Enclave Objects ########
+Enclave/Enclave_t.h: Enclave/Enclave_t.c
 Enclave/Enclave_t.c: $(SGX_EDGER8R) Enclave/Enclave.edl librats
 	@cd Enclave && $(SGX_EDGER8R) --trusted ../Enclave/Enclave.edl $(Enclave_Edl_Search_Path)
 	@echo "GEN  =>  $@"
@@ -238,6 +242,7 @@ Enclave/Enclave_t.o: Enclave/Enclave_t.c
 	@$(CC) $(Enclave_C_Flags) -c $< -o $@
 	@echo "CC   <=  $<"
 
+Enclave/%.o: Enclave/Enclave_t.h
 Enclave/%.o: Enclave/%.cpp
 	@$(CXX) $(Enclave_Cpp_Flags) -c $< -o $@
 	@echo "CXX  <=  $<"


### PR DESCRIPTION
1. Fix Enclave Interfaces of WAMR SGX version
2. Set pointer to NULL after free, otherwise cause UAF/DF