### PR TITLE
Update Docker image for latest version of external libraries & tools

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,8 +10,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Asian/Shanghai
 
 # hadolint ignore=DL3008
-RUN apt-get update
-RUN apt upgrade -y \
+RUN apt-get update \
+  && apt-get upgrade -y \
   && apt-get install -y apt-transport-https apt-utils build-essential \
   ca-certificates ccache cmake curl g++-multilib git gnupg \
   libgcc-12-dev lib32gcc-12-dev lsb-release \
@@ -93,15 +93,18 @@ WORKDIR /tmp
 #  && ./llvm.sh ${LLVM_VER} all
 
 # Workaround due to https://github.com/llvm/llvm-project/issues/62475
+# hadolint ignore=DL3008
 RUN set -ex \
     && echo "deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-${LLVM_VER} main" > /etc/apt/sources.list.d/apt.llvm.org.list \
     && wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
-    && apt update \
+    && apt-get update \
     && apt-get install -y \
     clang-${LLVM_VER} lldb-${LLVM_VER} lld-${LLVM_VER} clangd-${LLVM_VER} clang-tidy-${LLVM_VER} clang-format-${LLVM_VER} clang-tools-${LLVM_VER} \
     llvm-${LLVM_VER}-dev lld-${LLVM_VER} lldb-${LLVM_VER} llvm-${LLVM_VER}-tools libomp-${LLVM_VER}-dev libc++-${LLVM_VER}-dev libc++abi-${LLVM_VER}-dev \
     libclang-common-${LLVM_VER}-dev libclang-${LLVM_VER}-dev libclang-cpp${LLVM_VER}-dev libunwind-${LLVM_VER}-dev \
-    libclang-rt-${LLVM_VER}-dev libpolly-${LLVM_VER}-dev
+    libclang-rt-${LLVM_VER}-dev libpolly-${LLVM_VER}-dev --no-install-recommends \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
 
 #
 # [Optional]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,20 +1,21 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.195.0/containers/cpp/.devcontainer/base.Dockerfile
-# [Choice] Debian / Ubuntu version (use Debian 11/9, Ubuntu 18.04/21.04 on local arm64/Apple Silicon): debian-11, debian-10, debian-9, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
-ARG VARIANT=ubuntu-20.04
-FROM mcr.microsoft.com/vscode/devcontainers/cpp:0-${VARIANT}
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/cpp/.devcontainer/base.Dockerfile
+# [Choice] Debian / Ubuntu version (use Debian 12/11/9, Ubuntu 18.04/21.04 on local arm64/Apple Silicon): debian-12, debian-11, debian-10, debian-9, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
+ARG VARIANT=debian-12
+FROM mcr.microsoft.com/vscode/devcontainers/cpp:${VARIANT}
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Asian/Shanghai
 
 # hadolint ignore=DL3008
-RUN apt-get update \
+RUN apt-get update
+RUN apt upgrade -y \
   && apt-get install -y apt-transport-https apt-utils build-essential \
-  ca-certificates ccache curl g++-multilib git gnupg \
-  libgcc-9-dev lib32gcc-9-dev lsb-release \
-  ninja-build ocaml ocamlbuild python2.7 \
+  ca-certificates ccache cmake curl g++-multilib git gnupg \
+  libgcc-12-dev lib32gcc-12-dev lsb-release \
+  ninja-build ocaml ocamlbuild \
   software-properties-common tree tzdata \
   unzip valgrind vim wget zip --no-install-recommends \
   && apt-get clean -y \
@@ -22,32 +23,32 @@ RUN apt-get update \
 
 #
 # binaryen
-ARG BINARYEN_VER=111
+ARG BINARYEN_VER=114
 WORKDIR /opt
 RUN wget -c --progress=dot:giga https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VER}/binaryen-version_${BINARYEN_VER}-x86_64-linux.tar.gz \
   && tar xf binaryen-version_${BINARYEN_VER}-x86_64-linux.tar.gz \
-  && ln -sf /opt/binaryen-version_111 /opt/binaryen \
+  && ln -sf /opt/binaryen-version_${BINARYEN_VER} /opt/binaryen \
   && rm binaryen-version_${BINARYEN_VER}-x86_64-linux.tar.gz
 
 #
 # CMAKE (https://apt.kitware.com/)
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3008
-RUN wget --progress=dot:giga -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg > /dev/null \
-  && echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ bionic main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null \
-  && apt-get update \
-  && rm /usr/share/keyrings/kitware-archive-keyring.gpg \
-  && apt-get install -y kitware-archive-keyring --no-install-recommends \
-  && apt-get install -y cmake --no-install-recommends \
-  && apt-get clean -y \
-  && rm -rf /var/lib/apt/lists/*
+ARG CMAKE_VER=3.27.0
+RUN wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-Linux-x86_64.sh \
+      -q -O /tmp/cmake-install.sh \
+      && chmod u+x /tmp/cmake-install.sh \
+      && mkdir /opt/cmake-${CMAKE_VER} \
+      && /tmp/cmake-install.sh --skip-license --prefix=/opt/cmake-${CMAKE_VER} \
+      && rm /tmp/cmake-install.sh \
+      && ln -s /opt/cmake-${CMAKE_VER}/bin/* /usr/local/bin
 
 #
 # install emsdk
 WORKDIR /opt
 RUN git clone https://github.com/emscripten-core/emsdk.git
 
-ARG EMSDK_VER=3.0.0
+ARG EMSDK_VER=3.1.43
 WORKDIR /opt/emsdk
 RUN  git pull \
   && ./emsdk install ${EMSDK_VER} \
@@ -56,7 +57,7 @@ RUN  git pull \
 
 #
 # install wasi-sdk
-ARG WASI_SDK_VER=19
+ARG WASI_SDK_VER=20
 RUN wget -c --progress=dot:giga https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_SDK_VER}/wasi-sdk-${WASI_SDK_VER}.0-linux.tar.gz -P /opt \
   && tar xf /opt/wasi-sdk-${WASI_SDK_VER}.0-linux.tar.gz -C /opt \
   && ln -sf /opt/wasi-sdk-${WASI_SDK_VER}.0 /opt/wasi-sdk \
@@ -64,7 +65,7 @@ RUN wget -c --progress=dot:giga https://github.com/WebAssembly/wasi-sdk/releases
 
 #
 #install wabt
-ARG WABT_VER=1.0.29
+ARG WABT_VER=1.0.33
 RUN wget -c --progress=dot:giga https://github.com/WebAssembly/wabt/releases/download/${WABT_VER}/wabt-${WABT_VER}-ubuntu.tar.gz -P /opt \
   && tar xf /opt/wabt-${WABT_VER}-ubuntu.tar.gz -C /opt \
   && ln -sf /opt/wabt-${WABT_VER} /opt/wabt \
@@ -72,7 +73,7 @@ RUN wget -c --progress=dot:giga https://github.com/WebAssembly/wabt/releases/dow
 
 #
 # install bazelisk
-ARG BAZELISK_VER=1.12.0
+ARG BAZELISK_VER=1.17.0
 RUN mkdir /opt/bazelisk \
   && wget -c --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/download/v${BAZELISK_VER}/bazelisk-linux-amd64 -P /opt/bazelisk \
   && chmod a+x /opt/bazelisk/bazelisk-linux-amd64 \
@@ -80,16 +81,27 @@ RUN mkdir /opt/bazelisk \
 
 #
 # install clang+llvm
-ARG LLVM_VER=14
-RUN apt-get purge -y clang-10 llvm-10 && apt-get autoremove -y
+ARG LLVM_VER=16
+RUN apt-get purge -y clang-14 llvm-14 && apt-get autoremove -y
 WORKDIR /etc/apt/apt.conf.d
 RUN touch 99verfiy-peer.conf \
   && echo "Acquire { https::Verify-Peer false }" > 99verfiy-peer.conf
 
 WORKDIR /tmp
-RUN wget --progress=dot:giga https://apt.llvm.org/llvm.sh \
-  && chmod a+x ./llvm.sh \
-  && ./llvm.sh ${LLVM_VER} all
+#RUN wget --progress=dot:giga https://apt.llvm.org/llvm.sh \
+#  && chmod a+x ./llvm.sh \
+#  && ./llvm.sh ${LLVM_VER} all
+
+# Workaround due to https://github.com/llvm/llvm-project/issues/62475
+RUN set -ex \
+    && echo "deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-${LLVM_VER} main" > /etc/apt/sources.list.d/apt.llvm.org.list \
+    && wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
+    && apt update \
+    && apt-get install -y \
+    clang-${LLVM_VER} lldb-${LLVM_VER} lld-${LLVM_VER} clangd-${LLVM_VER} clang-tidy-${LLVM_VER} clang-format-${LLVM_VER} clang-tools-${LLVM_VER} \
+    llvm-${LLVM_VER}-dev lld-${LLVM_VER} lldb-${LLVM_VER} llvm-${LLVM_VER}-tools libomp-${LLVM_VER}-dev libc++-${LLVM_VER}-dev libc++abi-${LLVM_VER}-dev \
+    libclang-common-${LLVM_VER}-dev libclang-${LLVM_VER}-dev libclang-cpp${LLVM_VER}-dev libunwind-${LLVM_VER}-dev \
+    libclang-rt-${LLVM_VER}-dev libpolly-${LLVM_VER}-dev
 
 #
 # [Optional]
@@ -105,18 +117,19 @@ RUN apt-get update \
 #
 # Install required python packages
 # hadolint ignore=DL3013
-RUN python3 -m pip install --no-cache-dir --upgrade pip \
-  && pip3 install --no-cache-dir black nose pycparser pylint
+RUN python3 -m pip install --no-cache-dir --break-system-packages --upgrade pip \
+  && pip3 install --no-cache-dir --break-system-packages black nose pycparser pylint
 
 #
 # Install github-cli. It doens't work as a feature of devcontainer.json
+ARG GH_CLI_VER=2.32.0
 WORKDIR /tmp
-RUN wget -q https://github.com/cli/cli/releases/download/v2.20.2/gh_2.20.2_linux_amd64.deb \
-  && dpkg -i gh_2.20.2_linux_amd64.deb
+RUN wget -q https://github.com/cli/cli/releases/download/v${GH_CLI_VER}/gh_${GH_CLI_VER}_linux_amd64.deb \
+  && dpkg -i gh_${GH_CLI_VER}_linux_amd64.deb
 
 #
 # Install NodeJS
-RUN wget -qO- https://deb.nodesource.com/setup_19.x | bash -
+RUN wget -qO- https://deb.nodesource.com/setup_20.x | bash -
 # hadolint ignore=DL3008
 RUN apt-get install -y nodejs --no-install-recommends
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,20 +1,23 @@
 // Copyright (C) 2019 Intel Corporation.  All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.195.0/containers/cpp
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/cpp
 {
   "name": "WAMR-Dev",
   "build": {
     "dockerfile": "Dockerfile",
-    // Update 'VARIANT' to pick an Debian / Ubuntu OS version: debian-11, debian-10, debian-9, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
-    // Use Debian 11, Debian 9, Ubuntu 18.04 or Ubuntu 21.04 on local arm64/Apple Silicon
+    // Update 'VARIANT' to pick an Debian / Ubuntu OS version: debian-12, debian-11, debian-10, debian-9, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
+    // Use Debian 12, Debian 11, Debian 9, Ubuntu 18.04 or Ubuntu 21.04 on local arm64/Apple Silicon
     "args": {
-      "BINARYEN_VER": "111",
-      "EMSDK_VER": "3.0.0",
-      "LLVM_VER": "15",
-      "VARIANT": "ubuntu-20.04",
-      "WASI_SDK_VER": "19",
-      "WABT_VER": "1.0.31"
+      "BINARYEN_VER": "114",
+      "BAZELISK_VER": "1.17.0",
+      "CMAKE_VER": "3.27.0",
+      "EMSDK_VER": "3.1.43",
+      "GH_CLI_VER": "2.32.0",
+      "LLVM_VER": "16",
+      "VARIANT": "debian-12",
+      "WASI_SDK_VER": "20",
+      "WABT_VER": "1.0.33"
     }
   },
   "runArgs": [
@@ -34,7 +37,7 @@
         "llvm-vs-code-extensions.vscode-clangd",
         "ms-python.python",
         "ms-python.vscode-pylance",
-        "ms-vscode.cmake-tools",
+        "ms-vscode.cmake-tools"
       ]
     }
   },


### PR DESCRIPTION
Devcontainer seems to old to catch up the latest versions of dependencies. So, I updated the libraries & tools if WASM environment requires for Docker image.

**Impediments:**
- LLVM 16 could not be retrieved directly by using shell command that was provided before. So, I need to upgrade all tools manually but it is workaround and I just put LLVM issue URL as a comment in the script. 

**Improvements:**
- Use `Debian 12 (Bookworm)` as a base image instead of `Ubuntu 20.04`.
- `GCC9` upgraded to `GCC12`.
- `LLVM14` upgraded to `LLVM16`.
- `Clang10` upgraded to `Clang10`.
- `Binaryen111` upgraded to `Binaryen114`.
- `WASI-19` upgraded to `WASI-20`
- `WABT-1.0.29` upgraded to `WABT-1.0.33`
- `Bazelisk-1.12.0` upgraded to `Bazelisk-1.17.0`
- `GithubCLI-2.20.2` upgraded to `GithubCLI-2.32.0`
- `NodeJS-19.x` upgraded to `NodeJS-20.x`
- `EMSDK-3.0.0` upgraded to `EMSDK-3.1.43`

**Notes:**
`Python 2.7` was removed due to no support anymore and not found in the repository.