### PR TITLE
Add more fixes for wasi libc on windows

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -3609,8 +3609,13 @@ wasmtime_ssp_sock_shutdown(
 __wasi_errno_t
 wasmtime_ssp_sched_yield(void)
 {
+#ifdef BH_PLATFORM_WINDOWS
+    if (!SwitchToThread())
+        return __WASI_EAGAIN;
+#else
     if (sched_yield() < 0)
         return convert_errno(errno);
+#endif
     return 0;
 }
 

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -86,7 +86,9 @@ convert_errno(int error)
         X(EDEADLK),
         X(EDESTADDRREQ),
         X(EDOM),
+#ifdef EDQUOT
         X(EDQUOT),
+#endif
         X(EEXIST),
         X(EFAULT),
         X(EFBIG),
@@ -103,7 +105,9 @@ convert_errno(int error)
         X(EMFILE),
         X(EMLINK),
         X(EMSGSIZE),
+#ifdef EMULTIHOP
         X(EMULTIHOP),
+#endif
         X(ENAMETOOLONG),
         X(ENETDOWN),
         X(ENETRESET),
@@ -142,7 +146,9 @@ convert_errno(int error)
         X(EROFS),
         X(ESPIPE),
         X(ESRCH),
+#ifdef ESTALE
         X(ESTALE),
+#endif
         X(ETIMEDOUT),
         X(ETXTBSY),
         X(EXDEV),

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -21,6 +21,18 @@
 #include "rights.h"
 #include "str.h"
 
+/* Some platforms (e.g. Windows) already define `min()` macro.
+ We're undefing it here to make sure the `min` call does exactly
+ what we want it to do. */
+#ifdef min
+#undef min
+#endif
+static inline size_t
+min(size_t a, size_t b)
+{
+    return a > b ? b : a;
+}
+
 #if 0 /* TODO: -std=gnu99 causes compile error, comment them first */
 // struct iovec must have the same layout as __wasi_iovec_t.
 static_assert(offsetof(struct iovec, iov_base) ==
@@ -3760,12 +3772,6 @@ addr_pool_insert(struct addr_pool *addr_pool, const char *addr, uint8 mask)
     }
     cur->next = next;
     return true;
-}
-
-static inline size_t
-min(size_t a, size_t b)
-{
-    return a > b ? b : a;
 }
 
 static void

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
@@ -47,7 +47,8 @@
 #define CONFIG_HAS_CLOCK_NANOSLEEP 0
 #endif
 
-#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(ESP_PLATFORM)
+#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(ESP_PLATFORM) \
+    && !defined(_WIN32)
 #define CONFIG_HAS_FDATASYNC 1
 #else
 #define CONFIG_HAS_FDATASYNC 0
@@ -65,13 +66,13 @@
 #endif
 #endif
 
-#if !defined(__APPLE__) && !defined(ESP_PLATFORM)
+#if !defined(__APPLE__) && !defined(ESP_PLATFORM) && !defined(_WIN32)
 #define CONFIG_HAS_POSIX_FALLOCATE 1
 #else
 #define CONFIG_HAS_POSIX_FALLOCATE 0
 #endif
 
-#if !defined(__APPLE__) && !defined(ESP_PLATFORM)
+#if !defined(__APPLE__) && !defined(ESP_PLATFORM) && !defined(_WIN32)
 #define CONFIG_HAS_PREADV 1
 #else
 #define CONFIG_HAS_PREADV 0
@@ -89,7 +90,7 @@
 #define CONFIG_HAS_PTHREAD_CONDATTR_SETCLOCK 0
 #endif
 
-#if !defined(__APPLE__) && !defined(ESP_PLATFORM)
+#if !defined(__APPLE__) && !defined(ESP_PLATFORM) && !defined(_WIN32)
 #define CONFIG_HAS_PWRITEV 1
 #else
 #define CONFIG_HAS_PWRITEV 0


### PR DESCRIPTION
* disable translations of errno codes that aren't defined on Windows
* undef `min()` macro if it is defined to not conflict with the `min()` function we define
* implement `shed_yield` wasi call
* disable some of the features in the config for windows by default