### PR TITLE
Fix wasi-sockets tests

### DIFF
--- a/core/iwasm/libraries/lib-socket/test/nslookup.c
+++ b/core/iwasm/libraries/lib-socket/test/nslookup.c
@@ -46,6 +46,7 @@ test_nslookup_mt(void *params)
 {
     int *af = (int *)params;
     test_nslookup(*af);
+    return NULL;
 }
 
 int

--- a/tests/wamr-test-suites/wasi-test-script/run_wasi_tests.sh
+++ b/tests/wamr-test-suites/wasi-test-script/run_wasi_tests.sh
@@ -11,7 +11,9 @@ readonly TARGET=$2
 readonly WORK_DIR=$PWD
 readonly PLATFORM=$(uname -s | tr A-Z a-z)
 readonly WAMR_DIR="${WORK_DIR}/../../../.."
-readonly IWASM_CMD="${WORK_DIR}/../../../../product-mini/platforms/${PLATFORM}/build/iwasm"
+readonly IWASM_CMD="${WORK_DIR}/../../../../product-mini/platforms/${PLATFORM}/build/iwasm \
+    --allow-resolve=google-public-dns-a.google.com \
+    --addr-pool=::1/128,127.0.0.1/32"
 readonly WAMRC_CMD="${WORK_DIR}/../../../../wamr-compiler/build/wamrc"
 readonly C_TESTS="tests/c/testsuite/"
 readonly ASSEMBLYSCRIPT_TESTS="tests/assemblyscript/testsuite/"
@@ -35,12 +37,12 @@ run_aot_tests () {
 
         echo "Running $test_aot"
         expected=0
-        if [ -f ${test_json} ]; then 
+        if [ -f ${test_json} ]; then
             expected=$(jq .exit_code ${test_json})
         fi
-        
+
         ${IWASM_CMD} $test_aot
-        
+
         ret=${PIPESTATUS[0]}
 
         echo "expected=$expected, actual=$ret"
@@ -48,7 +50,7 @@ run_aot_tests () {
             exit_code=1
         fi
     done
-} 
+}
 
 if [[ $MODE != "aot" ]];then
     python3 -m venv wasi-env && source wasi-env/bin/activate
@@ -60,7 +62,7 @@ if [[ $MODE != "aot" ]];then
                     ${ASSEMBLYSCRIPT_TESTS} \
                     ${THREAD_PROPOSAL_TESTS} \
                     ${THREAD_INTERNAL_TESTS} \
-                    ${LIB_SOCKET_TESTS} \
+                    ${LIB_SOCKET_TESTS}
     exit_code=${PIPESTATUS[0]}
     deactivate
 else


### PR DESCRIPTION
Tests were failing because the right permissions were not provided to iwasm.
Also, test failures didn't trigger build failure due to typo - also fixed in this change

In addition to that, I fixed a few issues with the test itself:
* the `server_init_complete` was not reset early enough causing the client to occasionally assume the server started even though it didn't yet.
* set `SO_REUSEADDR` on the server socket so the port can be reused shortly after closing the previous socket
* defined receive-send-receive sequence from server to make sure server is alive at the time of sending messages from client
