### PR TITLE
Fix const qualifiers with -Wcast-qual warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 include (${WAMR_ROOT_DIR}/build-scripts/runtime_lib.cmake)
 
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security -Wshadow -Wno-unused-parameter")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wcast-qual -Wformat-security -Wshadow -Wno-unused-parameter")
 # set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wconversion -Wsign-conversion")
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wformat -Wformat-security -Wno-unused")

--- a/core/iwasm/aot/aot_reloc.h
+++ b/core/iwasm/aot/aot_reloc.h
@@ -174,16 +174,16 @@ uint32
 get_plt_table_size();
 
 void
-init_plt_table(uint8 *plt);
+init_plt_table(const uint8 *plt);
 
 void
 get_current_target(char *target_buf, uint32 target_buf_size);
 
 bool
 apply_relocation(AOTModule *module,
-                 uint8 *target_section_addr, uint32 target_section_size,
+                 const uint8 *target_section_addr, uint32 target_section_size,
                  uint64 reloc_offset, int64 reloc_addend,
-                 uint32 reloc_type, void *symbol_addr, int32 symbol_index,
+                 uint32 reloc_type, const void *symbol_addr, int32 symbol_index,
                  char *error_buf, uint32 error_buf_size);
 /* clang-format off */
 

--- a/core/iwasm/aot/aot_runtime.h
+++ b/core/iwasm/aot/aot_runtime.h
@@ -197,11 +197,11 @@ typedef struct AOTModule {
     uint32 retain_func_index;
 
     /* AOTed code */
-    void *code;
+    const void *code;
     uint32 code_size;
 
     /* literal for AOTed code */
-    uint8 *literal;
+    const uint8 *literal;
     uint32 literal_size;
 
 #if defined(BH_PLATFORM_WINDOWS)

--- a/core/iwasm/aot/arch/aot_reloc_aarch64.c
+++ b/core/iwasm/aot/arch/aot_reloc_aarch64.c
@@ -88,7 +88,7 @@ get_plt_item_size()
 }
 
 void
-init_plt_table(uint8 *plt)
+init_plt_table(const uint8 *plt)
 {
     uint32 i, num = sizeof(target_sym_map) / sizeof(SymbolMap);
     for (i = 0; i < num; i++) {
@@ -136,16 +136,16 @@ check_reloc_offset(uint32 target_section_size, uint64 reloc_offset,
 }
 
 bool
-apply_relocation(AOTModule *module, uint8 *target_section_addr,
+apply_relocation(AOTModule *module, const uint8 *target_section_addr,
                  uint32 target_section_size, uint64 reloc_offset,
-                 int64 reloc_addend, uint32 reloc_type, void *symbol_addr,
+                 int64 reloc_addend, uint32 reloc_type, const void *symbol_addr,
                  int32 symbol_index, char *error_buf, uint32 error_buf_size)
 {
     switch (reloc_type) {
         case R_AARCH64_CALL26:
         case R_AARCH64_JUMP26:
         {
-            void *S, *P = (void *)(target_section_addr + reloc_offset);
+            const void *S, *P = (void *)(target_section_addr + reloc_offset);
             int64 X, A, initial_addend;
             int32 insn, imm26;
 
@@ -179,7 +179,7 @@ apply_relocation(AOTModule *module, uint8 *target_section_addr,
                  * beyond of the +-128MB space. Apply relocation with
                  * the PLT which branch to the target symbol address.
                  */
-                S = plt = (uint8 *)module->code + module->code_size
+                S = plt = (const uint8 *)module->code + module->code_size
                           - get_plt_table_size()
                           + get_plt_item_size() * symbol_index;
             }

--- a/core/iwasm/aot/arch/aot_reloc_arc.c
+++ b/core/iwasm/aot/arch/aot_reloc_arc.c
@@ -278,7 +278,7 @@ get_plt_table_size()
 }
 
 void
-init_plt_table(uint8 *plt)
+init_plt_table(const uint8 *plt)
 {
     (void)plt;
 }
@@ -304,7 +304,7 @@ middle_endian_convert(uint32 insn)
 }
 
 bool
-apply_relocation(AOTModule *module, uint8 *target_section_addr,
+apply_relocation(AOTModule *module, const uint8 *target_section_addr,
                  uint32 target_section_size, uint64 reloc_offset,
                  int64 reloc_addend, uint32 reloc_type, void *symbol_addr,
                  int32 symbol_index, char *error_buf, uint32 error_buf_size)

--- a/core/iwasm/aot/arch/aot_reloc_arm.c
+++ b/core/iwasm/aot/arch/aot_reloc_arm.c
@@ -265,9 +265,9 @@ check_reloc_offset(uint32 target_section_size, uint64 reloc_offset,
 }
 
 bool
-apply_relocation(AOTModule *module, uint8 *target_section_addr,
+apply_relocation(AOTModule *module, const uint8 *target_section_addr,
                  uint32 target_section_size, uint64 reloc_offset,
-                 int64 reloc_addend, uint32 reloc_type, void *symbol_addr,
+                 int64 reloc_addend, uint32 reloc_type, const void *symbol_addr,
                  int32 symbol_index, char *error_buf, uint32 error_buf_size)
 {
     switch (reloc_type) {

--- a/core/iwasm/aot/arch/aot_reloc_mips.c
+++ b/core/iwasm/aot/arch/aot_reloc_mips.c
@@ -46,9 +46,9 @@ get_plt_table_size()
 }
 
 bool
-apply_relocation(AOTModule *module, uint8 *target_section_addr,
+apply_relocation(AOTModule *module, const uint8 *target_section_addr,
                  uint32 target_section_size, uint64 reloc_offset,
-                 int64 reloc_addend, uint32 reloc_type, void *symbol_addr,
+                 int64 reloc_addend, uint32 reloc_type, const void *symbol_addr,
                  int32 symbol_index, char *error_buf, uint32 error_buf_size)
 {
     switch (reloc_type) {

--- a/core/iwasm/aot/arch/aot_reloc_riscv.c
+++ b/core/iwasm/aot/arch/aot_reloc_riscv.c
@@ -300,9 +300,9 @@ check_reloc_offset(uint32 target_section_size, uint64 reloc_offset,
 }
 
 bool
-apply_relocation(AOTModule *module, uint8 *target_section_addr,
+apply_relocation(AOTModule *module, const uint8 *target_section_addr,
                  uint32 target_section_size, uint64 reloc_offset,
-                 int64 reloc_addend, uint32 reloc_type, void *symbol_addr,
+                 int64 reloc_addend, uint32 reloc_type, const void *symbol_addr,
                  int32 symbol_index, char *error_buf, uint32 error_buf_size)
 {
     int32 val, imm_hi, imm_lo, insn;

--- a/core/iwasm/aot/arch/aot_reloc_thumb.c
+++ b/core/iwasm/aot/arch/aot_reloc_thumb.c
@@ -284,9 +284,9 @@ check_reloc_offset(uint32 target_section_size, uint64 reloc_offset,
 }
 
 bool
-apply_relocation(AOTModule *module, uint8 *target_section_addr,
+apply_relocation(AOTModule *module, const uint8 *target_section_addr,
                  uint32 target_section_size, uint64 reloc_offset,
-                 int64 reloc_addend, uint32 reloc_type, void *symbol_addr,
+                 int64 reloc_addend, uint32 reloc_type, const void *symbol_addr,
                  int32 symbol_index, char *error_buf, uint32 error_buf_size)
 {
     switch (reloc_type) {

--- a/core/iwasm/aot/arch/aot_reloc_x86_32.c
+++ b/core/iwasm/aot/arch/aot_reloc_x86_32.c
@@ -120,9 +120,9 @@ check_reloc_offset(uint32 target_section_size, uint64 reloc_offset,
 }
 
 bool
-apply_relocation(AOTModule *module, uint8 *target_section_addr,
+apply_relocation(AOTModule *module, const uint8 *target_section_addr,
                  uint32 target_section_size, uint64 reloc_offset,
-                 int64 reloc_addend, uint32 reloc_type, void *symbol_addr,
+                 int64 reloc_addend, uint32 reloc_type, const void *symbol_addr,
                  int32 symbol_index, char *error_buf, uint32 error_buf_size)
 {
     switch (reloc_type) {

--- a/core/iwasm/aot/arch/aot_reloc_xtensa.c
+++ b/core/iwasm/aot/arch/aot_reloc_xtensa.c
@@ -208,9 +208,9 @@ typedef union {
 } l32r_insn_t;
 
 bool
-apply_relocation(AOTModule *module, uint8 *target_section_addr,
+apply_relocation(AOTModule *module, const uint8 *target_section_addr,
                  uint32 target_section_size, uint64 reloc_offset,
-                 int64 reloc_addend, uint32 reloc_type, void *symbol_addr,
+                 int64 reloc_addend, uint32 reloc_type, const void *symbol_addr,
                  int32 symbol_index, char *error_buf, uint32 error_buf_size)
 {
     switch (reloc_type) {

--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -1599,19 +1599,19 @@ rt_val_to_wasm_val(const uint8 *data, uint8 val_type_rt, wasm_val_t *out)
     switch (val_type_rt) {
         case VALUE_TYPE_I32:
             out->kind = WASM_I32;
-            out->of.i32 = *((int32 *)data);
+            out->of.i32 = *((const int32 *)data);
             break;
         case VALUE_TYPE_F32:
             out->kind = WASM_F32;
-            out->of.f32 = *((float32 *)data);
+            out->of.f32 = *((const float32 *)data);
             break;
         case VALUE_TYPE_I64:
             out->kind = WASM_I64;
-            out->of.i64 = *((int64 *)data);
+            out->of.i64 = *((const int64 *)data);
             break;
         case VALUE_TYPE_F64:
             out->kind = WASM_F64;
-            out->of.f64 = *((float64 *)data);
+            out->of.f64 = *((const float64 *)data);
             break;
 #if WASM_ENABLE_REF_TYPES != 0
         case VALUE_TYPE_EXTERNREF:
@@ -1633,7 +1633,7 @@ rt_val_to_wasm_val(const uint8 *data, uint8 val_type_rt, wasm_val_t *out)
 }
 
 bool
-wasm_val_to_rt_val(WASMModuleInstanceCommon *inst_comm_rt, uint8 val_type_rt,
+wasm_val_to_rt_val(const WASMModuleInstanceCommon *inst_comm_rt, uint8 val_type_rt,
                    const wasm_val_t *v, uint8 *data)
 {
     bool ret = true;
@@ -1673,7 +1673,7 @@ wasm_val_to_rt_val(WASMModuleInstanceCommon *inst_comm_rt, uint8 val_type_rt,
 
 wasm_ref_t *
 wasm_ref_new_internal(wasm_store_t *store, enum wasm_reference_kind kind,
-                      uint32 ref_idx_rt, WASMModuleInstanceCommon *inst_comm_rt)
+                      uint32 ref_idx_rt, const WASMModuleInstanceCommon *inst_comm_rt)
 {
     wasm_ref_t *ref;
 
@@ -1890,7 +1890,7 @@ wasm_frame_func_offset(const wasm_frame_t *frame)
 
 static wasm_trap_t *
 wasm_trap_new_internal(wasm_store_t *store,
-                       WASMModuleInstanceCommon *inst_comm_rt,
+                       const WASMModuleInstanceCommon *inst_comm_rt,
                        const char *error_info)
 {
     wasm_trap_t *trap;
@@ -2057,7 +2057,7 @@ failed:
 
 wasm_foreign_t *
 wasm_foreign_new_internal(wasm_store_t *store, uint32 foreign_idx_rt,
-                          WASMModuleInstanceCommon *inst_comm_rt)
+                          const WASMModuleInstanceCommon *inst_comm_rt)
 {
     wasm_foreign_t *foreign = NULL;
 
@@ -2959,7 +2959,7 @@ wasm_func_new_with_env(wasm_store_t *store, const wasm_functype_t *type,
 
 wasm_func_t *
 wasm_func_new_internal(wasm_store_t *store, uint16 func_idx_rt,
-                       WASMModuleInstanceCommon *inst_comm_rt)
+                       const WASMModuleInstanceCommon *inst_comm_rt)
 {
     wasm_func_t *func = NULL;
     WASMType *type_rt = NULL;
@@ -2980,9 +2980,9 @@ wasm_func_new_internal(wasm_store_t *store, uint16 func_idx_rt,
 #if WASM_ENABLE_INTERP != 0
     if (inst_comm_rt->module_type == Wasm_Module_Bytecode) {
         bh_assert(func_idx_rt
-                  < ((WASMModuleInstance *)inst_comm_rt)->e->function_count);
-        WASMFunctionInstance *func_interp =
-            ((WASMModuleInstance *)inst_comm_rt)->e->functions + func_idx_rt;
+                  < ((const WASMModuleInstance *)inst_comm_rt)->e->function_count);
+        const WASMFunctionInstance *func_interp =
+            ((const WASMModuleInstance *)inst_comm_rt)->e->functions + func_idx_rt;
         type_rt = func_interp->is_import_func
                       ? func_interp->u.func_import->func_type
                       : func_interp->u.func->func_type;
@@ -2993,8 +2993,8 @@ wasm_func_new_internal(wasm_store_t *store, uint16 func_idx_rt,
     if (inst_comm_rt->module_type == Wasm_Module_AoT) {
         /* use same index to trace the function type in AOTFuncType **func_types
          */
-        AOTModule *module_aot =
-            (AOTModule *)((AOTModuleInstance *)inst_comm_rt)->module;
+        const AOTModule *module_aot =
+            (const AOTModule *)((const AOTModuleInstance *)inst_comm_rt)->module;
         if (func_idx_rt < module_aot->import_func_count) {
             type_rt = (module_aot->import_funcs + func_idx_rt)->func_type;
         }
@@ -3185,28 +3185,28 @@ argv_to_results(const uint32 *argv, const wasm_valtype_vec_t *result_defs,
             case WASM_I32:
             {
                 result->kind = WASM_I32;
-                result->of.i32 = *(int32 *)(argv + argv_i);
+                result->of.i32 = *(const int32 *)(argv + argv_i);
                 argv_i += 1;
                 break;
             }
             case WASM_I64:
             {
                 result->kind = WASM_I64;
-                result->of.i64 = *(int64 *)(argv + argv_i);
+                result->of.i64 = *(const int64 *)(argv + argv_i);
                 argv_i += 2;
                 break;
             }
             case WASM_F32:
             {
                 result->kind = WASM_F32;
-                result->of.f32 = *(float32 *)(argv + argv_i);
+                result->of.f32 = *(const float32 *)(argv + argv_i);
                 argv_i += 1;
                 break;
             }
             case WASM_F64:
             {
                 result->kind = WASM_F64;
-                result->of.f64 = *(float64 *)(argv + argv_i);
+                result->of.f64 = *(const float64 *)(argv + argv_i);
                 argv_i += 2;
                 break;
             }
@@ -3263,7 +3263,7 @@ wasm_func_call(const wasm_func_t *func, const wasm_val_vec_t *params,
 
 #if WASM_ENABLE_INTERP != 0
     if (func->inst_comm_rt->module_type == Wasm_Module_Bytecode) {
-        func_comm_rt = ((WASMModuleInstance *)func->inst_comm_rt)->e->functions
+        func_comm_rt = ((const WASMModuleInstance *)func->inst_comm_rt)->e->functions
                        + func->func_idx_rt;
     }
 #endif
@@ -3271,13 +3271,13 @@ wasm_func_call(const wasm_func_t *func, const wasm_val_vec_t *params,
 #if WASM_ENABLE_AOT != 0
     if (func->inst_comm_rt->module_type == Wasm_Module_AoT) {
         if (!(func_comm_rt = func->func_comm_rt)) {
-            AOTModuleInstance *inst_aot =
-                (AOTModuleInstance *)func->inst_comm_rt;
-            AOTModule *module_aot = (AOTModule *)inst_aot->module;
+            const AOTModuleInstance *inst_aot =
+                (const AOTModuleInstance *)func->inst_comm_rt;
+            const AOTModule *module_aot = (const AOTModule *)inst_aot->module;
             uint32 export_i = 0, export_func_j = 0;
 
             for (; export_i < module_aot->export_count; ++export_i) {
-                AOTExport *export = module_aot->exports + export_i;
+                const AOTExport *export = module_aot->exports + export_i;
                 if (export->kind == EXPORT_KIND_FUNC) {
                     if (export->index == func->func_idx_rt) {
                         func_comm_rt =
@@ -3327,16 +3327,17 @@ wasm_func_call(const wasm_func_t *func, const wasm_val_vec_t *params,
     }
 #endif
     if (!exec_env) {
-        exec_env = wasm_runtime_get_exec_env_singleton(func->inst_comm_rt);
+        exec_env = wasm_runtime_get_exec_env_singleton(
+            (WASMModuleInstanceCommon *)func->inst_comm_rt);
     }
     if (!exec_env) {
         goto failed;
     }
 
-    wasm_runtime_set_exception(func->inst_comm_rt, NULL);
+    wasm_runtime_set_exception((WASMModuleInstanceCommon *)func->inst_comm_rt, NULL);
     if (!wasm_runtime_call_wasm(exec_env, func_comm_rt, argc, argv)) {
-        if (wasm_runtime_get_exception(func->inst_comm_rt)) {
-            LOG_DEBUG(wasm_runtime_get_exception(func->inst_comm_rt));
+        if (wasm_runtime_get_exception((WASMModuleInstanceCommon *)func->inst_comm_rt)) {
+            LOG_DEBUG(wasm_runtime_get_exception((WASMModuleInstanceCommon *)func->inst_comm_rt));
             goto failed;
         }
     }
@@ -3361,7 +3362,7 @@ failed:
 
     return wasm_trap_new_internal(
         func->store, func->inst_comm_rt,
-        wasm_runtime_get_exception(func->inst_comm_rt));
+        wasm_runtime_get_exception((WASMModuleInstanceCommon *)func->inst_comm_rt));
 }
 
 size_t
@@ -3519,7 +3520,7 @@ interp_global_set(const WASMModuleInstance *inst_interp, uint16 global_idx_rt,
     uint8 *data = inst_interp->global_data + global_interp->data_offset;
 #endif
 
-    return wasm_val_to_rt_val((WASMModuleInstanceCommon *)inst_interp,
+    return wasm_val_to_rt_val((const WASMModuleInstanceCommon *)inst_interp,
                               val_type_rt, v, data);
 }
 
@@ -3566,7 +3567,7 @@ aot_global_set(const AOTModuleInstance *inst_aot, uint16 global_idx_rt,
     }
 
     data = (void *)(inst_aot->global_data + data_offset);
-    return wasm_val_to_rt_val((WASMModuleInstanceCommon *)inst_aot, val_type_rt,
+    return wasm_val_to_rt_val((const WASMModuleInstanceCommon *)inst_aot, val_type_rt,
                               v, data);
 }
 
@@ -3606,7 +3607,7 @@ wasm_global_set(wasm_global_t *global, const wasm_val_t *v)
 
 #if WASM_ENABLE_INTERP != 0
     if (global->inst_comm_rt->module_type == Wasm_Module_Bytecode) {
-        (void)interp_global_set((WASMModuleInstance *)global->inst_comm_rt,
+        (void)interp_global_set((const WASMModuleInstance *)global->inst_comm_rt,
                                 global->global_idx_rt, v);
         return;
     }
@@ -3614,7 +3615,7 @@ wasm_global_set(wasm_global_t *global, const wasm_val_t *v)
 
 #if WASM_ENABLE_AOT != 0
     if (global->inst_comm_rt->module_type == Wasm_Module_AoT) {
-        (void)aot_global_set((AOTModuleInstance *)global->inst_comm_rt,
+        (void)aot_global_set((const AOTModuleInstance *)global->inst_comm_rt,
                              global->global_idx_rt, v);
         return;
     }
@@ -3642,7 +3643,7 @@ wasm_global_get(const wasm_global_t *global, wasm_val_t *out)
 
 #if WASM_ENABLE_INTERP != 0
     if (global->inst_comm_rt->module_type == Wasm_Module_Bytecode) {
-        (void)interp_global_get((WASMModuleInstance *)global->inst_comm_rt,
+        (void)interp_global_get((const WASMModuleInstance *)global->inst_comm_rt,
                                 global->global_idx_rt, out);
         return;
     }
@@ -3650,7 +3651,7 @@ wasm_global_get(const wasm_global_t *global, wasm_val_t *out)
 
 #if WASM_ENABLE_AOT != 0
     if (global->inst_comm_rt->module_type == Wasm_Module_AoT) {
-        (void)aot_global_get((AOTModuleInstance *)global->inst_comm_rt,
+        (void)aot_global_get((const AOTModuleInstance *)global->inst_comm_rt,
                              global->global_idx_rt, out);
         return;
     }
@@ -3665,7 +3666,7 @@ wasm_global_get(const wasm_global_t *global, wasm_val_t *out)
 
 wasm_global_t *
 wasm_global_new_internal(wasm_store_t *store, uint16 global_idx_rt,
-                         WASMModuleInstanceCommon *inst_comm_rt)
+                         const WASMModuleInstanceCommon *inst_comm_rt)
 {
     wasm_global_t *global = NULL;
     uint8 val_type_rt = 0;
@@ -3688,8 +3689,8 @@ wasm_global_new_internal(wasm_store_t *store, uint16 global_idx_rt,
 
 #if WASM_ENABLE_INTERP != 0
     if (inst_comm_rt->module_type == Wasm_Module_Bytecode) {
-        WASMGlobalInstance *global_interp =
-            ((WASMModuleInstance *)inst_comm_rt)->e->globals + global_idx_rt;
+        const WASMGlobalInstance *global_interp =
+            ((const WASMModuleInstance *)inst_comm_rt)->e->globals + global_idx_rt;
         val_type_rt = global_interp->type;
         is_mutable = global_interp->is_mutable;
         init = true;
@@ -3698,19 +3699,19 @@ wasm_global_new_internal(wasm_store_t *store, uint16 global_idx_rt,
 
 #if WASM_ENABLE_AOT != 0
     if (inst_comm_rt->module_type == Wasm_Module_AoT) {
-        AOTModuleInstance *inst_aot = (AOTModuleInstance *)inst_comm_rt;
-        AOTModule *module_aot = (AOTModule *)inst_aot->module;
+        const AOTModuleInstance *inst_aot = (const AOTModuleInstance *)inst_comm_rt;
+        const AOTModule *module_aot = (const AOTModule *)inst_aot->module;
 
         init = true;
 
         if (global_idx_rt < module_aot->import_global_count) {
-            AOTImportGlobal *global_import_aot =
+            const AOTImportGlobal *global_import_aot =
                 module_aot->import_globals + global_idx_rt;
             val_type_rt = global_import_aot->type;
             is_mutable = global_import_aot->is_mutable;
         }
         else {
-            AOTGlobal *global_aot =
+            const AOTGlobal *global_aot =
                 module_aot->globals
                 + (global_idx_rt - module_aot->import_global_count);
             val_type_rt = global_aot->type;
@@ -3739,14 +3740,14 @@ wasm_global_new_internal(wasm_store_t *store, uint16 global_idx_rt,
 
 #if WASM_ENABLE_INTERP != 0
     if (inst_comm_rt->module_type == Wasm_Module_Bytecode) {
-        interp_global_get((WASMModuleInstance *)inst_comm_rt, global_idx_rt,
+        interp_global_get((const WASMModuleInstance *)inst_comm_rt, global_idx_rt,
                           global->init);
     }
 #endif
 
 #if WASM_ENABLE_AOT != 0
     if (inst_comm_rt->module_type == Wasm_Module_AoT) {
-        aot_global_get((AOTModuleInstance *)inst_comm_rt, global_idx_rt,
+        aot_global_get((const AOTModuleInstance *)inst_comm_rt, global_idx_rt,
                        global->init);
     }
 #endif
@@ -3792,7 +3793,7 @@ wasm_table_new_basic(wasm_store_t *store, const wasm_tabletype_t *type)
 
 wasm_table_t *
 wasm_table_new_internal(wasm_store_t *store, uint16 table_idx_rt,
-                        WASMModuleInstanceCommon *inst_comm_rt)
+                        const WASMModuleInstanceCommon *inst_comm_rt)
 {
     wasm_table_t *table = NULL;
     uint8 val_type_rt = 0;
@@ -3899,8 +3900,8 @@ wasm_table_get(const wasm_table_t *table, wasm_table_size_t index)
 
 #if WASM_ENABLE_INTERP != 0
     if (table->inst_comm_rt->module_type == Wasm_Module_Bytecode) {
-        WASMTableInstance *table_interp =
-            ((WASMModuleInstance *)table->inst_comm_rt)
+        const WASMTableInstance *table_interp =
+            ((const WASMModuleInstance *)table->inst_comm_rt)
                 ->tables[table->table_idx_rt];
         if (index >= table_interp->cur_size) {
             return NULL;
@@ -3911,8 +3912,8 @@ wasm_table_get(const wasm_table_t *table, wasm_table_size_t index)
 
 #if WASM_ENABLE_AOT != 0
     if (table->inst_comm_rt->module_type == Wasm_Module_AoT) {
-        AOTModuleInstance *inst_aot = (AOTModuleInstance *)table->inst_comm_rt;
-        AOTTableInstance *table_aot = inst_aot->tables[table->table_idx_rt];
+        const AOTModuleInstance *inst_aot = (const AOTModuleInstance *)table->inst_comm_rt;
+        const AOTTableInstance *table_aot = inst_aot->tables[table->table_idx_rt];
         if (index >= table_aot->cur_size) {
             return NULL;
         }
@@ -3968,31 +3969,31 @@ wasm_table_set(wasm_table_t *table, wasm_table_size_t index,
 
 #if WASM_ENABLE_INTERP != 0
     if (table->inst_comm_rt->module_type == Wasm_Module_Bytecode) {
-        WASMTableInstance *table_interp =
-            ((WASMModuleInstance *)table->inst_comm_rt)
+        const WASMTableInstance *table_interp =
+            ((const WASMModuleInstance *)table->inst_comm_rt)
                 ->tables[table->table_idx_rt];
 
         if (index >= table_interp->cur_size) {
             return false;
         }
 
-        p_ref_idx = table_interp->elems + index;
+        p_ref_idx = (uint32 *)table_interp->elems + index;
         function_count =
-            ((WASMModuleInstance *)table->inst_comm_rt)->e->function_count;
+            ((const WASMModuleInstance *)table->inst_comm_rt)->e->function_count;
     }
 #endif
 
 #if WASM_ENABLE_AOT != 0
     if (table->inst_comm_rt->module_type == Wasm_Module_AoT) {
-        AOTModuleInstance *inst_aot = (AOTModuleInstance *)table->inst_comm_rt;
-        AOTModule *module_aot = (AOTModule *)inst_aot->module;
-        AOTTableInstance *table_aot = inst_aot->tables[table->table_idx_rt];
+        const AOTModuleInstance *inst_aot = (const AOTModuleInstance *)table->inst_comm_rt;
+        const AOTModule *module_aot = (const AOTModule *)inst_aot->module;
+        const AOTTableInstance *table_aot = inst_aot->tables[table->table_idx_rt];
 
         if (index >= table_aot->cur_size) {
             return false;
         }
 
-        p_ref_idx = table_aot->elems + index;
+        p_ref_idx = (uint32 *)table_aot->elems + index;
         function_count = module_aot->func_count;
     }
 #endif
@@ -4038,8 +4039,8 @@ wasm_table_size(const wasm_table_t *table)
 
 #if WASM_ENABLE_INTERP != 0
     if (table->inst_comm_rt->module_type == Wasm_Module_Bytecode) {
-        WASMTableInstance *table_interp =
-            ((WASMModuleInstance *)table->inst_comm_rt)
+        const WASMTableInstance *table_interp =
+            ((const WASMModuleInstance *)table->inst_comm_rt)
                 ->tables[table->table_idx_rt];
         return table_interp->cur_size;
     }
@@ -4047,16 +4048,16 @@ wasm_table_size(const wasm_table_t *table)
 
 #if WASM_ENABLE_AOT != 0
     if (table->inst_comm_rt->module_type == Wasm_Module_AoT) {
-        AOTModuleInstance *inst_aot = (AOTModuleInstance *)table->inst_comm_rt;
-        AOTModule *module_aot = (AOTModule *)inst_aot->module;
+        const AOTModuleInstance *inst_aot = (const AOTModuleInstance *)table->inst_comm_rt;
+        const AOTModule *module_aot = (const AOTModule *)inst_aot->module;
 
         if (table->table_idx_rt < module_aot->import_table_count) {
-            AOTImportTable *table_aot =
+            const AOTImportTable *table_aot =
                 module_aot->import_tables + table->table_idx_rt;
             return table_aot->table_init_size;
         }
         else {
-            AOTTable *table_aot =
+            const AOTTable *table_aot =
                 module_aot->tables
                 + (table->table_idx_rt - module_aot->import_table_count);
             return table_aot->table_init_size;
@@ -4131,7 +4132,7 @@ wasm_memory_copy(const wasm_memory_t *src)
 
 wasm_memory_t *
 wasm_memory_new_internal(wasm_store_t *store, uint16 memory_idx_rt,
-                         WASMModuleInstanceCommon *inst_comm_rt)
+                         const WASMModuleInstanceCommon *inst_comm_rt)
 {
     wasm_memory_t *memory = NULL;
     uint32 min_pages = 0, max_pages = 0;
@@ -4152,8 +4153,8 @@ wasm_memory_new_internal(wasm_store_t *store, uint16 memory_idx_rt,
 
 #if WASM_ENABLE_INTERP != 0
     if (inst_comm_rt->module_type == Wasm_Module_Bytecode) {
-        WASMMemoryInstance *memory_interp =
-            ((WASMModuleInstance *)inst_comm_rt)->memories[memory_idx_rt];
+        const WASMMemoryInstance *memory_interp =
+            ((const WASMModuleInstance *)inst_comm_rt)->memories[memory_idx_rt];
         min_pages = memory_interp->cur_page_count;
         max_pages = memory_interp->max_page_count;
         init_flag = true;
@@ -4162,8 +4163,8 @@ wasm_memory_new_internal(wasm_store_t *store, uint16 memory_idx_rt,
 
 #if WASM_ENABLE_AOT != 0
     if (inst_comm_rt->module_type == Wasm_Module_AoT) {
-        AOTModuleInstance *inst_aot = (AOTModuleInstance *)inst_comm_rt;
-        AOTModule *module_aot = (AOTModule *)inst_aot->module;
+        const AOTModuleInstance *inst_aot = (const AOTModuleInstance *)inst_comm_rt;
+        const AOTModule *module_aot = (const AOTModule *)inst_aot->module;
 
         if (memory_idx_rt < module_aot->import_memory_count) {
             min_pages = module_aot->import_memories->mem_init_page_count;
@@ -4225,7 +4226,7 @@ wasm_memory_type(const wasm_memory_t *memory)
 byte_t *
 wasm_memory_data(wasm_memory_t *memory)
 {
-    WASMModuleInstanceCommon *module_inst_comm;
+    const WASMModuleInstanceCommon *module_inst_comm;
 
     if (!memory || !memory->inst_comm_rt) {
         return NULL;
@@ -4234,9 +4235,9 @@ wasm_memory_data(wasm_memory_t *memory)
     module_inst_comm = memory->inst_comm_rt;
 #if WASM_ENABLE_INTERP != 0
     if (module_inst_comm->module_type == Wasm_Module_Bytecode) {
-        WASMModuleInstance *module_inst =
-            (WASMModuleInstance *)module_inst_comm;
-        WASMMemoryInstance *memory_inst =
+        const WASMModuleInstance *module_inst =
+            (const WASMModuleInstance *)module_inst_comm;
+        const WASMMemoryInstance *memory_inst =
             module_inst->memories[memory->memory_idx_rt];
         return (byte_t *)memory_inst->memory_data;
     }
@@ -4244,9 +4245,9 @@ wasm_memory_data(wasm_memory_t *memory)
 
 #if WASM_ENABLE_AOT != 0
     if (module_inst_comm->module_type == Wasm_Module_AoT) {
-        AOTModuleInstance *module_inst = (AOTModuleInstance *)module_inst_comm;
-        AOTMemoryInstance *memory_inst =
-            ((AOTMemoryInstance **)
+        const AOTModuleInstance *module_inst = (const AOTModuleInstance *)module_inst_comm;
+        const AOTMemoryInstance *memory_inst =
+            ((const AOTMemoryInstance * const *)
                  module_inst->memories)[memory->memory_idx_rt];
         return (byte_t *)memory_inst->memory_data;
     }
@@ -4262,7 +4263,7 @@ wasm_memory_data(wasm_memory_t *memory)
 size_t
 wasm_memory_data_size(const wasm_memory_t *memory)
 {
-    WASMModuleInstanceCommon *module_inst_comm;
+    const WASMModuleInstanceCommon *module_inst_comm;
 
     if (!memory || !memory->inst_comm_rt) {
         return 0;
@@ -4271,9 +4272,9 @@ wasm_memory_data_size(const wasm_memory_t *memory)
     module_inst_comm = memory->inst_comm_rt;
 #if WASM_ENABLE_INTERP != 0
     if (module_inst_comm->module_type == Wasm_Module_Bytecode) {
-        WASMModuleInstance *module_inst =
-            (WASMModuleInstance *)module_inst_comm;
-        WASMMemoryInstance *memory_inst =
+        const WASMModuleInstance *module_inst =
+            (const WASMModuleInstance *)module_inst_comm;
+        const WASMMemoryInstance *memory_inst =
             module_inst->memories[memory->memory_idx_rt];
         return (size_t)memory_inst->cur_page_count
                * memory_inst->num_bytes_per_page;
@@ -4282,9 +4283,9 @@ wasm_memory_data_size(const wasm_memory_t *memory)
 
 #if WASM_ENABLE_AOT != 0
     if (module_inst_comm->module_type == Wasm_Module_AoT) {
-        AOTModuleInstance *module_inst = (AOTModuleInstance *)module_inst_comm;
-        AOTMemoryInstance *memory_inst =
-            ((AOTMemoryInstance **)
+        const AOTModuleInstance *module_inst = (const AOTModuleInstance *)module_inst_comm;
+        const AOTMemoryInstance *memory_inst =
+            ((const AOTMemoryInstance * const *)
                  module_inst->memories)[memory->memory_idx_rt];
         return (size_t)memory_inst->cur_page_count
                * memory_inst->num_bytes_per_page;
@@ -4301,7 +4302,7 @@ wasm_memory_data_size(const wasm_memory_t *memory)
 wasm_memory_pages_t
 wasm_memory_size(const wasm_memory_t *memory)
 {
-    WASMModuleInstanceCommon *module_inst_comm;
+    const WASMModuleInstanceCommon *module_inst_comm;
 
     if (!memory || !memory->inst_comm_rt) {
         return 0;
@@ -4310,9 +4311,9 @@ wasm_memory_size(const wasm_memory_t *memory)
     module_inst_comm = memory->inst_comm_rt;
 #if WASM_ENABLE_INTERP != 0
     if (module_inst_comm->module_type == Wasm_Module_Bytecode) {
-        WASMModuleInstance *module_inst =
-            (WASMModuleInstance *)module_inst_comm;
-        WASMMemoryInstance *memory_inst =
+        const WASMModuleInstance *module_inst =
+            (const WASMModuleInstance *)module_inst_comm;
+        const WASMMemoryInstance *memory_inst =
             module_inst->memories[memory->memory_idx_rt];
         return memory_inst->cur_page_count;
     }
@@ -4320,9 +4321,9 @@ wasm_memory_size(const wasm_memory_t *memory)
 
 #if WASM_ENABLE_AOT != 0
     if (module_inst_comm->module_type == Wasm_Module_AoT) {
-        AOTModuleInstance *module_inst = (AOTModuleInstance *)module_inst_comm;
-        AOTMemoryInstance *memory_inst =
-            ((AOTMemoryInstance **)
+        const AOTModuleInstance *module_inst = (const AOTModuleInstance *)module_inst_comm;
+        const AOTMemoryInstance *memory_inst =
+            ((const AOTMemoryInstance * const *)
                  module_inst->memories)[memory->memory_idx_rt];
         return memory_inst->cur_page_count;
     }
@@ -4461,7 +4462,7 @@ interp_process_export(wasm_store_t *store,
                 wasm_func_t *func;
                 if (!(func = wasm_func_new_internal(
                           store, export->index,
-                          (WASMModuleInstanceCommon *)inst_interp))) {
+                          (const WASMModuleInstanceCommon *)inst_interp))) {
                     goto failed;
                 }
 
@@ -4473,7 +4474,7 @@ interp_process_export(wasm_store_t *store,
                 wasm_global_t *global;
                 if (!(global = wasm_global_new_internal(
                           store, export->index,
-                          (WASMModuleInstanceCommon *)inst_interp))) {
+                          (const WASMModuleInstanceCommon *)inst_interp))) {
                     goto failed;
                 }
 
@@ -4485,7 +4486,7 @@ interp_process_export(wasm_store_t *store,
                 wasm_table_t *table;
                 if (!(table = wasm_table_new_internal(
                           store, export->index,
-                          (WASMModuleInstanceCommon *)inst_interp))) {
+                          (const WASMModuleInstanceCommon *)inst_interp))) {
                     goto failed;
                 }
 
@@ -4497,7 +4498,7 @@ interp_process_export(wasm_store_t *store,
                 wasm_memory_t *memory;
                 if (!(memory = wasm_memory_new_internal(
                           store, export->index,
-                          (WASMModuleInstanceCommon *)inst_interp))) {
+                          (const WASMModuleInstanceCommon *)inst_interp))) {
                     goto failed;
                 }
 
@@ -4629,7 +4630,7 @@ aot_process_export(wasm_store_t *store, const AOTModuleInstance *inst_aot,
                 wasm_func_t *func = NULL;
                 if (!(func = wasm_func_new_internal(
                           store, export->index,
-                          (WASMModuleInstanceCommon *)inst_aot))) {
+                          (const WASMModuleInstanceCommon *)inst_aot))) {
                     goto failed;
                 }
 
@@ -4641,7 +4642,7 @@ aot_process_export(wasm_store_t *store, const AOTModuleInstance *inst_aot,
                 wasm_global_t *global = NULL;
                 if (!(global = wasm_global_new_internal(
                           store, export->index,
-                          (WASMModuleInstanceCommon *)inst_aot))) {
+                          (const WASMModuleInstanceCommon *)inst_aot))) {
                     goto failed;
                 }
 
@@ -4653,7 +4654,7 @@ aot_process_export(wasm_store_t *store, const AOTModuleInstance *inst_aot,
                 wasm_table_t *table;
                 if (!(table = wasm_table_new_internal(
                           store, export->index,
-                          (WASMModuleInstanceCommon *)inst_aot))) {
+                          (const WASMModuleInstanceCommon *)inst_aot))) {
                     goto failed;
                 }
 
@@ -4665,7 +4666,7 @@ aot_process_export(wasm_store_t *store, const AOTModuleInstance *inst_aot,
                 wasm_memory_t *memory;
                 if (!(memory = wasm_memory_new_internal(
                           store, export->index,
-                          (WASMModuleInstanceCommon *)inst_aot))) {
+                          (const WASMModuleInstanceCommon *)inst_aot))) {
                     goto failed;
                 }
 
@@ -4944,14 +4945,14 @@ wasm_instance_new_with_args(wasm_store_t *store, const wasm_module_t *module,
     /* build the exports list */
 #if WASM_ENABLE_INTERP != 0
     if (instance->inst_comm_rt->module_type == Wasm_Module_Bytecode) {
-        uint32 export_cnt = ((WASMModuleInstance *)instance->inst_comm_rt)
+        uint32 export_cnt = ((const WASMModuleInstance *)instance->inst_comm_rt)
                                 ->module->export_count;
 
         INIT_VEC(instance->exports, wasm_extern_vec_new_uninitialized,
                  export_cnt);
 
         if (!interp_process_export(store,
-                                   (WASMModuleInstance *)instance->inst_comm_rt,
+                                   (const WASMModuleInstance *)instance->inst_comm_rt,
                                    instance->exports)) {
             snprintf(sub_error_buf, sizeof(sub_error_buf),
                      "Interpreter failed to process exports");

--- a/core/iwasm/common/wasm_c_api_internal.h
+++ b/core/iwasm/common/wasm_c_api_internal.h
@@ -105,7 +105,7 @@ struct wasm_ref_t {
     enum wasm_reference_kind kind;
     struct wasm_host_info host_info;
     uint32 ref_idx_rt;
-    WASMModuleInstanceCommon *inst_comm_rt;
+    const WASMModuleInstanceCommon *inst_comm_rt;
 };
 
 struct wasm_trap_t {
@@ -145,7 +145,7 @@ struct wasm_func_t {
      * of interpreter mode and aot mode
      */
     uint16 func_idx_rt;
-    WASMModuleInstanceCommon *inst_comm_rt;
+    const WASMModuleInstanceCommon *inst_comm_rt;
     WASMFunctionInstanceCommon *func_comm_rt;
 };
 
@@ -163,7 +163,7 @@ struct wasm_global_t {
      * of interpreter mode and aot mode
      */
     uint16 global_idx_rt;
-    WASMModuleInstanceCommon *inst_comm_rt;
+    const WASMModuleInstanceCommon *inst_comm_rt;
 };
 
 struct wasm_memory_t {
@@ -179,7 +179,7 @@ struct wasm_memory_t {
      * of interpreter mode and aot mode
      */
     uint16 memory_idx_rt;
-    WASMModuleInstanceCommon *inst_comm_rt;
+    const WASMModuleInstanceCommon *inst_comm_rt;
 };
 
 struct wasm_table_t {
@@ -195,7 +195,7 @@ struct wasm_table_t {
      * of interpreter mode and aot mode
      */
     uint16 table_idx_rt;
-    WASMModuleInstanceCommon *inst_comm_rt;
+    const WASMModuleInstanceCommon *inst_comm_rt;
 };
 
 struct wasm_extern_t {
@@ -217,25 +217,25 @@ struct wasm_instance_t {
 wasm_ref_t *
 wasm_ref_new_internal(wasm_store_t *store, enum wasm_reference_kind kind,
                       uint32 obj_idx_rt,
-                      WASMModuleInstanceCommon *inst_comm_rt);
+                      const WASMModuleInstanceCommon *inst_comm_rt);
 
 wasm_foreign_t *
 wasm_foreign_new_internal(wasm_store_t *store, uint32 foreign_idx_rt,
-                          WASMModuleInstanceCommon *inst_comm_rt);
+                          const WASMModuleInstanceCommon *inst_comm_rt);
 
 wasm_func_t *
 wasm_func_new_internal(wasm_store_t *store, uint16 func_idx_rt,
-                       WASMModuleInstanceCommon *inst_comm_rt);
+                       const WASMModuleInstanceCommon *inst_comm_rt);
 
 wasm_global_t *
 wasm_global_new_internal(wasm_store_t *store, uint16 global_idx_rt,
-                         WASMModuleInstanceCommon *inst_comm_rt);
+                         const WASMModuleInstanceCommon *inst_comm_rt);
 
 wasm_memory_t *
 wasm_memory_new_internal(wasm_store_t *store, uint16 memory_idx_rt,
-                         WASMModuleInstanceCommon *inst_comm_rt);
+                         const WASMModuleInstanceCommon *inst_comm_rt);
 
 wasm_table_t *
 wasm_table_new_internal(wasm_store_t *store, uint16 table_idx_rt,
-                        WASMModuleInstanceCommon *inst_comm_rt);
+                        const WASMModuleInstanceCommon *inst_comm_rt);
 #endif /* _WASM_C_API_INTERNAL_H */

--- a/core/iwasm/common/wasm_memory.c
+++ b/core/iwasm/common/wasm_memory.c
@@ -89,7 +89,7 @@ wasm_memory_init_with_allocator(void *_malloc_func, void *_realloc_func,
 #endif
 
 static inline bool
-is_bounds_checks_enabled(WASMModuleInstanceCommon *module_inst)
+is_bounds_checks_enabled(const WASMModuleInstanceCommon *module_inst)
 {
 #if WASM_CONFIGUABLE_BOUNDS_CHECKS != 0
     return wasm_runtime_is_bounds_checks_enabled(module_inst);
@@ -337,11 +337,11 @@ fail:
 
 bool
 wasm_runtime_validate_native_addr(WASMModuleInstanceCommon *module_inst_comm,
-                                  void *native_ptr, uint32 size)
+                                  const void *native_ptr, uint32 size)
 {
     WASMModuleInstance *module_inst = (WASMModuleInstance *)module_inst_comm;
-    WASMMemoryInstance *memory_inst;
-    uint8 *addr = (uint8 *)native_ptr;
+    WASMMemoryInstance *memory_inst = NULL;
+    const uint8 *addr = (const uint8 *)native_ptr;
 
     bh_assert(module_inst_comm->module_type == Wasm_Module_Bytecode
               || module_inst_comm->module_type == Wasm_Module_AoT);

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -733,7 +733,7 @@ wasm_runtime_validate_app_str_addr(WASMModuleInstanceCommon *module_inst,
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_validate_native_addr(WASMModuleInstanceCommon *module_inst,
-                                  void *native_ptr, uint32 size);
+                                  const void *native_ptr, uint32 size);
 
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN void *
@@ -871,7 +871,8 @@ wasm_runtime_set_wasi_ns_lookup_pool(wasm_module_t module,
 #if WASM_ENABLE_REF_TYPES != 0
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN bool
-wasm_externref_obj2ref(WASMModuleInstanceCommon *module_inst, void *extern_obj,
+wasm_externref_obj2ref(WASMModuleInstanceCommon *module_inst,
+                       const void *extern_obj,
                        uint32 *p_externref_idx);
 
 /* See wasm_export.h for description */

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -77,7 +77,7 @@ typedef struct wasm_section_t {
     /* section type */
     int section_type;
     /* section body, not include type and size */
-    uint8_t *section_body;
+    const uint8_t *section_body;
     /* section body size */
     uint32_t section_body_size;
 } wasm_section_t, aot_section_t, *wasm_section_list_t, *aot_section_list_t;
@@ -1033,7 +1033,7 @@ wasm_runtime_validate_app_str_addr(wasm_module_inst_t module_inst,
  */
 WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_validate_native_addr(wasm_module_inst_t module_inst,
-                                  void *native_ptr, uint32_t size);
+                                  const void *native_ptr, uint32_t size);
 
 /**
  * Convert app address(relative address) to native address(absolute address)

--- a/core/iwasm/interpreter/wasm.h
+++ b/core/iwasm/interpreter/wasm.h
@@ -179,8 +179,8 @@ typedef struct WASMMemoryImport {
 } WASMMemoryImport;
 
 typedef struct WASMFunctionImport {
-    char *module_name;
-    char *field_name;
+    const char *module_name;
+    const char *field_name;
     /* function type */
     WASMType *func_type;
     /* native function pointer after linked */
@@ -253,10 +253,10 @@ struct WASMFunction {
     uint32 max_stack_cell_num;
     uint32 max_block_num;
     uint32 code_size;
-    uint8 *code;
+    const uint8 *code;
 #if WASM_ENABLE_FAST_INTERP != 0
     uint32 code_compiled_size;
-    uint8 *code_compiled;
+    const uint8 *code_compiled;
     uint8 *consts;
     uint32 const_cell_num;
 #endif
@@ -326,7 +326,7 @@ typedef struct WASMDataSeg {
 #if WASM_ENABLE_BULK_MEMORY != 0
     bool is_passive;
 #endif
-    uint8 *data;
+    const uint8 *data;
 } WASMDataSeg;
 
 typedef struct BlockAddr {
@@ -667,7 +667,7 @@ inline static uint32
 wasm_string_hash(const char *str)
 {
     unsigned h = (unsigned)strlen(str);
-    const uint8 *p = (uint8 *)str;
+    const uint8 *p = (const uint8 *)str;
     const uint8 *end = p + h;
 
     while (p != end)

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -2975,7 +2975,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     {
                         uint32 addr, segment;
                         uint64 bytes, offset, seg_len;
-                        uint8 *data;
+                        const uint8 *data;
 
                         segment = read_uint32(frame_ip);
 

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -3577,7 +3577,7 @@ wasm_loader_find_block_addr(WASMExecEnv *exec_env, BlockAddr *block_addr_cache,
 typedef struct BranchBlockPatch {
     struct BranchBlockPatch *next;
     uint8 patch_type;
-    uint8 *code_compiled;
+    const uint8 *code_compiled;
 } BranchBlockPatch;
 #endif
 
@@ -3590,7 +3590,7 @@ typedef struct BranchBlock {
     uint32 stack_cell_num;
 #if WASM_ENABLE_FAST_INTERP != 0
     uint16 dynamic_offset;
-    uint8 *code_compiled;
+    const uint8 *code_compiled;
     BranchBlockPatch *patch_list;
     /* This is used to save params frame_offset of of if block */
     int16 *param_frame_offsets;

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1060,7 +1060,7 @@ execute_post_instantiate_functions(WASMModuleInstance *module_inst,
 #if WASM_ENABLE_THREAD_MGR != 0
         if (!exec_env)
             exec_env = wasm_clusters_search_exec_env(
-                (WASMModuleInstanceCommon *)module_inst);
+                (const WASMModuleInstanceCommon *)module_inst);
 #endif
         if (!exec_env) {
             if (!(exec_env = exec_env_created = wasm_exec_env_create(
@@ -1167,7 +1167,7 @@ execute_malloc_function(WASMModuleInstance *module_inst, WASMExecEnv *exec_env,
 #if WASM_ENABLE_THREAD_MGR != 0
         if (!exec_env)
             exec_env = wasm_clusters_search_exec_env(
-                (WASMModuleInstanceCommon *)module_inst);
+                (const WASMModuleInstanceCommon *)module_inst);
 #endif
         if (!exec_env) {
             if (!(exec_env = exec_env_created = wasm_exec_env_create(
@@ -1234,7 +1234,7 @@ execute_free_function(WASMModuleInstance *module_inst, WASMExecEnv *exec_env,
 #if WASM_ENABLE_THREAD_MGR != 0
         if (!exec_env)
             exec_env = wasm_clusters_search_exec_env(
-                (WASMModuleInstanceCommon *)module_inst);
+                (const WASMModuleInstanceCommon *)module_inst);
 #endif
         if (!exec_env) {
             if (!(exec_env = exec_env_created = wasm_exec_env_create(

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -360,7 +360,7 @@ typedef struct WASMSubModInstNode {
  *
  * @return the code block of the function
  */
-static inline uint8 *
+static inline const uint8 *
 wasm_get_func_code(WASMFunctionInstance *func)
 {
 #if WASM_ENABLE_FAST_INTERP == 0
@@ -377,7 +377,7 @@ wasm_get_func_code(WASMFunctionInstance *func)
  *
  * @return the code block end of the function
  */
-static inline uint8 *
+static inline const uint8 *
 wasm_get_func_code_end(WASMFunctionInstance *func)
 {
 #if WASM_ENABLE_FAST_INTERP == 0

--- a/core/iwasm/libraries/libc-builtin/libc_builtin_wrapper.c
+++ b/core/iwasm/libraries/libc-builtin/libc_builtin_wrapper.c
@@ -517,7 +517,7 @@ memcmp_wrapper(wasm_exec_env_t exec_env, const void *s1, const void *s2,
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
 
     /* s2 has been checked by runtime */
-    if (!validate_native_addr((void *)s1, size))
+    if (!validate_native_addr((const void *)s1, size))
         return 0;
 
     return memcmp(s1, s2, size);
@@ -596,7 +596,7 @@ strncmp_wrapper(wasm_exec_env_t exec_env, const char *s1, const char *s2,
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
 
     /* s2 has been checked by runtime */
-    if (!validate_native_addr((void *)s1, size))
+    if (!validate_native_addr((const void *)s1, size))
         return 0;
 
     return strncmp(s1, s2, size);
@@ -746,7 +746,7 @@ memchr_wrapper(wasm_exec_env_t exec_env, const void *s, int32 c, uint32 n)
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     void *res;
 
-    if (!validate_native_addr((void *)s, n))
+    if (!validate_native_addr((const void *)s, n))
         return 0;
 
     res = memchr(s, c, n);

--- a/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
+++ b/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
@@ -424,7 +424,7 @@ wasi_fd_pwrite(wasm_exec_env_t exec_env, wasi_fd_t fd,
     total_size = sizeof(iovec_app_t) * (uint64)iovs_len;
     if (!validate_native_addr(nwritten_app, (uint32)sizeof(uint32))
         || total_size >= UINT32_MAX
-        || !validate_native_addr((void *)iovec_app, (uint32)total_size))
+        || !validate_native_addr((const void *)iovec_app, (uint32)total_size))
         return (wasi_errno_t)-1;
 
     total_size = sizeof(wasi_ciovec_t) * (uint64)iovs_len;
@@ -477,7 +477,7 @@ wasi_fd_read(wasm_exec_env_t exec_env, wasi_fd_t fd,
     total_size = sizeof(iovec_app_t) * (uint64)iovs_len;
     if (!validate_native_addr(nread_app, (uint32)sizeof(uint32))
         || total_size >= UINT32_MAX
-        || !validate_native_addr((void *)iovec_app, (uint32)total_size))
+        || !validate_native_addr((const void *)iovec_app, (uint32)total_size))
         return (wasi_errno_t)-1;
 
     total_size = sizeof(wasi_iovec_t) * (uint64)iovs_len;
@@ -644,7 +644,7 @@ wasi_fd_write(wasm_exec_env_t exec_env, wasi_fd_t fd,
     total_size = sizeof(iovec_app_t) * (uint64)iovs_len;
     if (!validate_native_addr(nwritten_app, (uint32)sizeof(uint32))
         || total_size >= UINT32_MAX
-        || !validate_native_addr((void *)iovec_app, (uint32)total_size))
+        || !validate_native_addr((const void *)iovec_app, (uint32)total_size))
         return (wasi_errno_t)-1;
 
     total_size = sizeof(wasi_ciovec_t) * (uint64)iovs_len;
@@ -1073,7 +1073,7 @@ wasi_poll_oneoff(wasm_exec_env_t exec_env, const wasi_subscription_t *in,
     if (!wasi_ctx)
         return (wasi_errno_t)-1;
 
-    if (!validate_native_addr((void *)in, sizeof(wasi_subscription_t))
+    if (!validate_native_addr((const void *)in, sizeof(wasi_subscription_t))
         || !validate_native_addr(out, sizeof(wasi_event_t))
         || !validate_native_addr(nevents_app, sizeof(uint32)))
         return (wasi_errno_t)-1;
@@ -1953,7 +1953,7 @@ allocate_iovec_app_buffer(wasm_module_inst_t module_inst,
 
     total_size = sizeof(iovec_app_t) * (uint64)data_len;
     if (total_size >= UINT32_MAX
-        || !validate_native_addr((void *)data, (uint32)total_size))
+        || !validate_native_addr((const void *)data, (uint32)total_size))
         return __WASI_EINVAL;
 
     for (total_size = 0, i = 0; i < data_len; i++, data++) {

--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -429,7 +429,7 @@ wasm_cluster_del_exec_env(WASMCluster *cluster, WASMExecEnv *exec_env)
 
 static WASMExecEnv *
 wasm_cluster_search_exec_env(WASMCluster *cluster,
-                             WASMModuleInstanceCommon *module_inst)
+                             const WASMModuleInstanceCommon *module_inst)
 {
     WASMExecEnv *node = NULL;
 
@@ -450,7 +450,7 @@ wasm_cluster_search_exec_env(WASMCluster *cluster,
 /* search the global cluster list to find if the given
    module instance have a corresponding exec_env */
 WASMExecEnv *
-wasm_clusters_search_exec_env(WASMModuleInstanceCommon *module_inst)
+wasm_clusters_search_exec_env(const WASMModuleInstanceCommon *module_inst)
 {
     WASMCluster *cluster = NULL;
     WASMExecEnv *exec_env = NULL;

--- a/core/iwasm/libraries/thread-mgr/thread_manager.h
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.h
@@ -136,7 +136,7 @@ bool
 wasm_cluster_del_exec_env(WASMCluster *cluster, WASMExecEnv *exec_env);
 
 WASMExecEnv *
-wasm_clusters_search_exec_env(WASMModuleInstanceCommon *module_inst);
+wasm_clusters_search_exec_env(const WASMModuleInstanceCommon *module_inst);
 
 void
 wasm_cluster_spread_exception(WASMExecEnv *exec_env, bool clear);

--- a/core/shared/platform/common/posix/posix_socket.c
+++ b/core/shared/platform/common/posix/posix_socket.c
@@ -50,7 +50,7 @@ sockaddr_to_bh_sockaddr(const struct sockaddr *sockaddr,
     switch (sockaddr->sa_family) {
         case AF_INET:
         {
-            struct sockaddr_in *addr = (struct sockaddr_in *)sockaddr;
+            const struct sockaddr_in *addr = (const struct sockaddr_in *)sockaddr;
 
             bh_sockaddr->port = ntohs(addr->sin_port);
             bh_sockaddr->addr_bufer.ipv4 = ntohl(addr->sin_addr.s_addr);
@@ -60,7 +60,7 @@ sockaddr_to_bh_sockaddr(const struct sockaddr *sockaddr,
 #ifdef IPPROTO_IPV6
         case AF_INET6:
         {
-            struct sockaddr_in6 *addr = (struct sockaddr_in6 *)sockaddr;
+            const struct sockaddr_in6 *addr = (const struct sockaddr_in6 *)sockaddr;
             size_t i;
 
             bh_sockaddr->port = ntohs(addr->sin6_port);

--- a/core/shared/utils/bh_common.c
+++ b/core/shared/utils/bh_common.c
@@ -6,10 +6,10 @@
 #include "bh_common.h"
 
 static char *
-align_ptr(char *src, unsigned int b)
+align_ptr(const char *src, unsigned int b)
 {
-    uintptr_t v = (uintptr_t)src;
-    uintptr_t m = b - 1;
+    const uintptr_t v = (const uintptr_t)src;
+    const uintptr_t m = b - 1;
     return (char *)((v + m) & ~m);
 }
 
@@ -20,7 +20,7 @@ int
 b_memcpy_wa(void *s1, unsigned int s1max, const void *s2, unsigned int n)
 {
     char *dest = (char *)s1;
-    char *src = (char *)s2;
+    const char *src = (const char *)s2;
 
     char *pa = align_ptr(src, 4);
     char *pb = align_ptr((src + n), 4);
@@ -29,7 +29,7 @@ b_memcpy_wa(void *s1, unsigned int s1max, const void *s2, unsigned int n)
     const char *p_byte_read;
 
     unsigned int *p;
-    char *ps;
+    const char *ps;
 
     if (pa > src) {
         pa -= 4;
@@ -76,7 +76,7 @@ int
 b_memcpy_s(void *s1, unsigned int s1max, const void *s2, unsigned int n)
 {
     char *dest = (char *)s1;
-    char *src = (char *)s2;
+    const char *src = (const char *)s2;
     if (n == 0) {
         return 0;
     }
@@ -96,7 +96,7 @@ int
 b_memmove_s(void *s1, unsigned int s1max, const void *s2, unsigned int n)
 {
     char *dest = (char *)s1;
-    char *src = (char *)s2;
+    const char *src = (const char *)s2;
     if (n == 0) {
         return 0;
     }


### PR DESCRIPTION
With help of `"-Wcast-qual"` warning, I tried to clean up some files regarding compiler logs. Please take a look them.