### PR TITLE
Fix result arity check on select_t opcode

### DIFF
--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -8066,7 +8066,8 @@ re_scan:
                 uint8 vec_len, ref_type;
 
                 read_leb_uint32(p, p_end, vec_len);
-                if (!vec_len) {
+                if (vec_len != 1) {
+                    /* typed select must have exactly one result */
                     set_error_buf(error_buf, error_buf_size,
                                   "invalid result arity");
                     goto fail;

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -6235,7 +6235,8 @@ re_scan:
                 uint8 vec_len, ref_type;
 
                 read_leb_uint32(p, p_end, vec_len);
-                if (!vec_len) {
+                if (vec_len != 1) {
+                    /* typed select must have exactly one result */
                     set_error_buf(error_buf, error_buf_size,
                                   "invalid result arity");
                     goto fail;

--- a/tests/wamr-test-suites/spec-test-script/ignore_cases.patch
+++ b/tests/wamr-test-suites/spec-test-script/ignore_cases.patch
@@ -343,26 +343,6 @@ index adb5cb7..590f626 100644
    (func $g (param $x i32) (result i32)
      (i32.add (local.get $x) (i32.const 1))
    )
-diff --git a/test/core/select.wast b/test/core/select.wast
-index 046e6fe..b677023 100644
---- a/test/core/select.wast
-+++ b/test/core/select.wast
-@@ -324,6 +324,7 @@
-   (module (func $arity-0 (select (result) (nop) (nop) (i32.const 1))))
-   "invalid result arity"
- )
-+(;
- (assert_invalid
-   (module (func $arity-2 (result i32 i32)
-     (select (result i32 i32)
-@@ -334,6 +335,7 @@
-   ))
-   "invalid result arity"
- )
-+;)
- 
- 
- (assert_invalid
 diff --git a/test/core/table_copy.wast b/test/core/table_copy.wast
 index 380e84e..f37e745 100644
 --- a/test/core/table_copy.wast


### PR DESCRIPTION
Typed select must have exactly one result. Reported in issue #2402.