### PR TITLE
Add runtime inited checks in Enclave command handlings to improve security

### DIFF
--- a/core/iwasm/common/wasm_shared_memory.c
+++ b/core/iwasm/common/wasm_shared_memory.c
@@ -66,6 +66,7 @@ void
 wasm_shared_memory_destroy()
 {
     bh_hash_map_destroy(wait_map);
+    wait_map = NULL;
     os_mutex_destroy(&shared_memory_list_lock);
 }
 

--- a/core/iwasm/common/wasm_shared_memory.c
+++ b/core/iwasm/common/wasm_shared_memory.c
@@ -66,7 +66,6 @@ void
 wasm_shared_memory_destroy()
 {
     bh_hash_map_destroy(wait_map);
-    wait_map = NULL;
     os_mutex_destroy(&shared_memory_list_lock);
 }
 


### PR DESCRIPTION
As reported in https://github.com/bytecodealliance/wasm-micro-runtime/issues/2252#issuecomment-1634940219,
`wait_map` may be referred again after free in linux-sgx ecall command if it isn't set NULL.