### PR TITLE
Fix typo in test_wamr.sh

### DIFF
--- a/tests/wamr-test-suites/test_wamr.sh
+++ b/tests/wamr-test-suites/test_wamr.sh
@@ -824,7 +824,7 @@ function trigger()
                 collect_coverage llvm-jit
 
                 echo "work in orc jit lazy compilation mode"
-                BUILD_FLAGS="$ORC_EAGER_JIT_COMPILE_FLAGS $EXTRA_COMPILE_FLAGS"
+                BUILD_FLAGS="$ORC_LAZY_JIT_COMPILE_FLAGS $EXTRA_COMPILE_FLAGS"
                 build_iwasm_with_cfg $BUILD_FLAGS
                 for suite in "${TEST_CASE_ARR[@]}"; do
                     $suite"_test" jit


### PR DESCRIPTION
I will close this PR if it is done on purpose. 

Another question: can I split "jit" test type to "eager_jit" and "lazy_jit" so that the ci is more consistent (e.g. one test type would always mean that test bundle will run once. It's already true right now with jit being the only exception)