### PR TITLE
Remove unnecessary and extra zero length check in mem functions' macro

### DIFF
--- a/core/shared/utils/bh_common.c
+++ b/core/shared/utils/bh_common.c
@@ -31,6 +31,10 @@ b_memcpy_wa(void *s1, unsigned int s1max, const void *s2, unsigned int n)
     unsigned int *p;
     char *ps;
 
+    if (n == 0) {
+        return 0;
+    }
+
     if (pa > src) {
         pa -= 4;
     }

--- a/core/shared/utils/bh_common.h
+++ b/core/shared/utils/bh_common.h
@@ -12,25 +12,25 @@
 extern "C" {
 #endif
 
-#define bh_memcpy_s(dest, dlen, src, slen)                            \
-    do {                                                              \
-        int _ret = slen == 0 ? 0 : b_memcpy_s(dest, dlen, src, slen); \
-        (void)_ret;                                                   \
-        bh_assert(_ret == 0);                                         \
+#define bh_memcpy_s(dest, dlen, src, slen)            \
+    do {                                              \
+        int _ret = b_memcpy_s(dest, dlen, src, slen); \
+        (void)_ret;                                   \
+        bh_assert(_ret == 0);                         \
     } while (0)
 
-#define bh_memcpy_wa(dest, dlen, src, slen)                            \
-    do {                                                               \
-        int _ret = slen == 0 ? 0 : b_memcpy_wa(dest, dlen, src, slen); \
-        (void)_ret;                                                    \
-        bh_assert(_ret == 0);                                          \
+#define bh_memcpy_wa(dest, dlen, src, slen)            \
+    do {                                               \
+        int _ret = b_memcpy_wa(dest, dlen, src, slen); \
+        (void)_ret;                                    \
+        bh_assert(_ret == 0);                          \
     } while (0)
 
-#define bh_memmove_s(dest, dlen, src, slen)                            \
-    do {                                                               \
-        int _ret = slen == 0 ? 0 : b_memmove_s(dest, dlen, src, slen); \
-        (void)_ret;                                                    \
-        bh_assert(_ret == 0);                                          \
+#define bh_memmove_s(dest, dlen, src, slen)            \
+    do {                                               \
+        int _ret = b_memmove_s(dest, dlen, src, slen); \
+        (void)_ret;                                    \
+        bh_assert(_ret == 0);                          \
     } while (0)
 
 #define bh_strcat_s(dest, dlen, src)            \


### PR DESCRIPTION
In these 3 functions, no need to do extra check for length is equal zero or not because it was already done inside of these functions. 

PS : I added this check into `b_memcpy_wa` function which was missing.