### PR TITLE
Stripping static and shared libraries of iwasm to reduce binary size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,8 +109,7 @@ set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Set the strip command based on the system (GNU or Clang)
 if (CMAKE_STRIP)
-    set(CMAKE_C_STRIP_FLAGS "${CMAKE_STRIP}")
-    set(CMAKE_CXX_STRIP_FLAGS "${CMAKE_STRIP}")
+    set (CMAKE_STRIP_FLAGS "--strip-all")
 endif ()
 
 include (${WAMR_ROOT_DIR}/build-scripts/runtime_lib.cmake)
@@ -148,11 +147,11 @@ endif ()
 install (TARGETS iwasm_static ARCHIVE DESTINATION lib)
 
 # If it's a Release build, strip the static library
-if (CMAKE_BUILD_TYPE STREQUAL "Release")
+if (CMAKE_STRIP AND CMAKE_BUILD_TYPE STREQUAL "Release")
   # Strip static library
-  message(STATUS "Stripping static library after build!")
-  add_custom_command(TARGET iwasm_static POST_BUILD
-      COMMAND ${CMAKE_STRIP} ${CMAKE_C_STRIP_FLAGS} $<TARGET_FILE:iwasm_static>
+  message (STATUS "Stripping static library after build!")
+  add_custom_command (TARGET iwasm_static POST_BUILD
+      COMMAND ${CMAKE_STRIP} ${CMAKE_STRIP_FLAGS} $<TARGET_FILE:iwasm_static>
   )
 endif ()
 
@@ -179,10 +178,10 @@ install (FILES
     DESTINATION include)
 
 # If it's a Release build, strip the shared library
-if (CMAKE_BUILD_TYPE STREQUAL "Release")
+if (CMAKE_STRIP AND CMAKE_BUILD_TYPE STREQUAL "Release")
   # Strip shared library
-  message(STATUS "Stripping shared library after build!")
-  add_custom_command(TARGET iwasm_shared POST_BUILD
-      COMMAND ${CMAKE_STRIP} ${CMAKE_C_STRIP_FLAGS} $<TARGET_FILE:iwasm_shared>
+  message (STATUS "Stripping shared library after build!")
+  add_custom_command (TARGET iwasm_shared POST_BUILD
+      COMMAND ${CMAKE_STRIP} ${CMAKE_STRIP_FLAGS} $<TARGET_FILE:iwasm_shared>
   )
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,12 @@ endif ()
 
 set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
+# Set the strip command based on the system (GNU or Clang)
+if (CMAKE_STRIP)
+    set(CMAKE_C_STRIP_FLAGS "${CMAKE_STRIP}")
+    set(CMAKE_CXX_STRIP_FLAGS "${CMAKE_STRIP}")
+endif ()
+
 include (${WAMR_ROOT_DIR}/build-scripts/runtime_lib.cmake)
 
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security -Wshadow -Wno-unused-parameter")
@@ -141,6 +147,15 @@ endif ()
 
 install (TARGETS iwasm_static ARCHIVE DESTINATION lib)
 
+# If it's a Release build, strip the static library
+if (CMAKE_BUILD_TYPE STREQUAL "Release")
+  # Strip static library
+  message(STATUS "Stripping static library after build!")
+  add_custom_command(TARGET iwasm_static POST_BUILD
+      COMMAND ${CMAKE_STRIP} ${CMAKE_C_STRIP_FLAGS} $<TARGET_FILE:iwasm_static>
+  )
+endif ()
+
 # SHARED LIBRARY
 add_library (iwasm_shared SHARED ${WAMR_RUNTIME_LIB_SOURCE})
 set_target_properties (iwasm_shared PROPERTIES OUTPUT_NAME iwasm)
@@ -162,3 +177,12 @@ install (FILES
     ${WAMR_ROOT_DIR}/core/iwasm/include/wasm_export.h
     ${WAMR_ROOT_DIR}/core/iwasm/include/lib_export.h
     DESTINATION include)
+
+# If it's a Release build, strip the shared library
+if (CMAKE_BUILD_TYPE STREQUAL "Release")
+  # Strip shared library
+  message(STATUS "Stripping shared library after build!")
+  add_custom_command(TARGET iwasm_shared POST_BUILD
+      COMMAND ${CMAKE_STRIP} ${CMAKE_C_STRIP_FLAGS} $<TARGET_FILE:iwasm_shared>
+  )
+endif ()


### PR DESCRIPTION
Reduce iwasm static and shared library size when build type is "Release". It remains as it is when build type was selected Debug.

Before stripping the shared and static library size:

> -rwxr-xr-x  1 546184 Aug  7 15:10 libiwasm.so
> -rw-r--r--  1 932658 Aug  7 15:10 libvmlib.a

After stripping the shared and static library size:

> -rwxr-xr-x  1 485536 Aug  7 15:09 libiwasm.so
> -rw-r--r--  1 489030 Aug  7 15:09 libvmlib.a