### PR TITLE
Auto-check wrgsbase in cmake script

### DIFF
--- a/build-scripts/config_common.cmake
+++ b/build-scripts/config_common.cmake
@@ -395,6 +395,27 @@ endif ()
 if (WAMR_DISABLE_WRITE_GS_BASE EQUAL 1)
   add_definitions (-DWASM_DISABLE_WRITE_GS_BASE=1)
   message ("     Write linear memory base addr to x86 GS register disabled")
+elseif (WAMR_BUILD_TARGET STREQUAL "X86_64" AND WAMR_BUILD_PLATFORM STREQUAL "linux")
+  set (TEST_WRGSBASE_SOURCE "${CMAKE_BINARY_DIR}/test_wrgsbase.c")
+  file (WRITE "${TEST_WRGSBASE_SOURCE}" "
+  #include <stdio.h>
+  #include <stdint.h>
+  int main() {
+      uint64_t value;
+      asm volatile (\"wrgsbase %0\" : : \"r\"(value));
+      printf(\"WRGSBASE instruction is available.\\n\");
+      return 0;
+  }")
+  # Try to compile the test program
+  try_run (WRGSBASE_SUPPORTED
+    ${CMAKE_BINARY_DIR}/test_wrgsbase_build
+    ${CMAKE_BINARY_DIR}/test_wrgsbase
+    SOURCES ${TEST_WRGSBASE_SOURCE}
+    CMAKE_FLAGS -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+  )
+  if (NOT WRGSBASE_SUPPORTED)
+    add_definitions (-DWASM_DISABLE_WRITE_GS_BASE=1)
+  endif ()
 endif ()
 if (WAMR_CONFIGUABLE_BOUNDS_CHECKS EQUAL 1)
   add_definitions (-DWASM_CONFIGURABLE_BOUNDS_CHECKS=1)

--- a/build-scripts/config_common.cmake
+++ b/build-scripts/config_common.cmake
@@ -395,7 +395,8 @@ endif ()
 if (WAMR_DISABLE_WRITE_GS_BASE EQUAL 1)
   add_definitions (-DWASM_DISABLE_WRITE_GS_BASE=1)
   message ("     Write linear memory base addr to x86 GS register disabled")
-elseif (WAMR_BUILD_TARGET STREQUAL "X86_64" AND WAMR_BUILD_PLATFORM STREQUAL "linux")
+elseif (WAMR_BUILD_TARGET STREQUAL "X86_64"
+        AND WAMR_BUILD_PLATFORM STREQUAL "linux")
   set (TEST_WRGSBASE_SOURCE "${CMAKE_BINARY_DIR}/test_wrgsbase.c")
   file (WRITE "${TEST_WRGSBASE_SOURCE}" "
   #include <stdio.h>
@@ -406,15 +407,17 @@ elseif (WAMR_BUILD_TARGET STREQUAL "X86_64" AND WAMR_BUILD_PLATFORM STREQUAL "li
       printf(\"WRGSBASE instruction is available.\\n\");
       return 0;
   }")
-  # Try to compile the test program
-  try_run (WRGSBASE_SUPPORTED
-    ${CMAKE_BINARY_DIR}/test_wrgsbase_build
+  # Try to compile and run the test program
+  try_run (TEST_WRGSBASE_RESULT
+    TEST_WRGSBASE_COMPILED
     ${CMAKE_BINARY_DIR}/test_wrgsbase
     SOURCES ${TEST_WRGSBASE_SOURCE}
     CMAKE_FLAGS -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
   )
-  if (NOT WRGSBASE_SUPPORTED)
+  #message("${TEST_WRGSBASE_COMPILED}, ${TEST_WRGSBASE_RESULT}")
+  if (NOT TEST_WRGSBASE_RESULT EQUAL 0)
     add_definitions (-DWASM_DISABLE_WRITE_GS_BASE=1)
+    message ("     Write linear memory base addr to x86 GS register disabled")
   endif ()
 endif ()
 if (WAMR_CONFIGUABLE_BOUNDS_CHECKS EQUAL 1)


### PR DESCRIPTION
Auto-check whether `WRGSBASE` instruction is supported in linux x86-64 in the
cmake script. And if not, disable writing x86 GS register.