### PR TITLE
wamrc enhancement: more user friendly logic for printing help info

### DIFF
--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -2745,7 +2745,8 @@ aot_create_comp_context(const AOTCompData *comp_data, aot_comp_option_t option)
             goto fail;
         }
 
-        /* If only to create target machine for querying information, early stop */
+        /* If only to create target machine for querying information, early stop
+         */
         if ((arch && !strcmp(arch, "help")) || (abi && !strcmp(abi, "help"))
             || (cpu && !strcmp(cpu, "help"))
             || (features && !strcmp(features, "+help"))) {

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -2746,11 +2746,10 @@ aot_create_comp_context(const AOTCompData *comp_data, aot_comp_option_t option)
         }
 
         /* If only create target machine for querying information, early stop */
-        if ((arch != NULL && !strcmp(arch, "help"))
-            || (abi != NULL && !strcmp(abi, "help"))
-            || (cpu != NULL && !strcmp(cpu, "help"))
-            || (features != NULL && !strcmp(features, "+help"))) {
-            aot_set_last_error(
+        if ((arch && !strcmp(arch, "help")) || (abi && !strcmp(abi, "help"))
+            || (cpu && !strcmp(cpu, "help"))
+            || (features && !strcmp(features, "+help"))) {
+            LOG_DEBUG(
                 "create LLVM target machine only for printing help infos.");
             goto fail;
         }

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -2745,12 +2745,12 @@ aot_create_comp_context(const AOTCompData *comp_data, aot_comp_option_t option)
             goto fail;
         }
 
-        /* If only create target machine for querying information, early stop */
+        /* If only to create target machine for querying information, early stop */
         if ((arch && !strcmp(arch, "help")) || (abi && !strcmp(abi, "help"))
             || (cpu && !strcmp(cpu, "help"))
             || (features && !strcmp(features, "+help"))) {
             LOG_DEBUG(
-                "create LLVM target machine only for printing help infos.");
+                "create LLVM target machine only for printing help info.");
             goto fail;
         }
     }

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -2744,6 +2744,16 @@ aot_create_comp_context(const AOTCompData *comp_data, aot_comp_option_t option)
             aot_set_last_error("create LLVM target machine failed.");
             goto fail;
         }
+
+        /* If only create target machine for querying information, early stop */
+        if ((arch != NULL && !strcmp(arch, "help"))
+            || (abi != NULL && !strcmp(abi, "help"))
+            || (cpu != NULL && !strcmp(cpu, "help"))
+            || (features != NULL && !strcmp(features, "+help"))) {
+            aot_set_last_error(
+                "create LLVM target machine only for printing help infos.");
+            goto fail;
+        }
     }
 
     triple = LLVMGetTargetMachineTriple(comp_ctx->target_machine);

--- a/wamr-compiler/main.c
+++ b/wamr-compiler/main.c
@@ -298,9 +298,9 @@ resolve_segue_flags(char *str_flags)
     return segue_flags;
 }
 
-/* When print help infos for target/cpu/target-abi/cpu-features, load this dummy
+/* When print help info for target/cpu/target-abi/cpu-features, load this dummy
  * wasm file content rather than from an input file, the dummy wasm file content
- * is: (module) */
+ * is: magic header + version number */
 static unsigned char dummy_wasm_file[8] = { 0x00, 0x61, 0x73, 0x6D,
                                             0x01, 0x00, 0x00, 0x00 };
 

--- a/wamr-compiler/main.c
+++ b/wamr-compiler/main.c
@@ -536,13 +536,7 @@ main(int argc, char *argv[])
             PRINT_HELP_AND_EXIT();
     }
 
-    /* Normal usage, generate output file */
     if (!use_dummy_wasm && (argc == 0 || !out_file_name))
-        PRINT_HELP_AND_EXIT();
-
-    /* When use wamrc to print architecture related help info, use dummy_wasm
-     * and don't generate anything */
-    if (use_dummy_wasm && out_file_name)
         PRINT_HELP_AND_EXIT();
 
     if (!size_level_set) {

--- a/wamr-compiler/main.c
+++ b/wamr-compiler/main.c
@@ -193,11 +193,8 @@ print_help()
     printf("Examples: wamrc -o test.aot test.wasm\n");
     printf("          wamrc --target=i386 -o test.aot test.wasm\n");
     printf("          wamrc --target=i386 --format=object -o test.o test.wasm\n");
-    printf("Usage for print architecture-related help infos: wamrc [--target/--cpu/--target-abi]=help\n");
-    printf("                                                 wamrc [--cpu-features]=+help\n");
-    printf("Examples: wamrc --target-abi=help\n");
+    printf("          wamrc --target-abi=help\n");
     printf("          wamrc --target=x86_64 --cpu=help\n");
-    printf("          wamrc --target=x86_64 --cpu=alderlake --cpu-features=+help\n");
 }
 /* clang-format on */
 

--- a/wamr-compiler/main.c
+++ b/wamr-compiler/main.c
@@ -193,6 +193,11 @@ print_help()
     printf("Examples: wamrc -o test.aot test.wasm\n");
     printf("          wamrc --target=i386 -o test.aot test.wasm\n");
     printf("          wamrc --target=i386 --format=object -o test.o test.wasm\n");
+    printf("Usage for print architecture-related help infos: wamrc [--target/--cpu/--target-abi]=help\n");
+    printf("                                                 wamrc [--cpu-features]=+help\n");
+    printf("Examples: wamrc --target-abi=help\n");
+    printf("          wamrc --target=x86_64 --cpu=help\n");
+    printf("          wamrc --target=x86_64 --cpu=alderlake --cpu-features=+help\n");
 }
 /* clang-format on */
 
@@ -296,6 +301,12 @@ resolve_segue_flags(char *str_flags)
     return segue_flags;
 }
 
+/* When print help infos for target/cpu/target-abi/cpu-features, load this dummy
+ * wasm file content rather than from an input file, the dummy wasm file content
+ * is: (module) */
+static unsigned char dummy_wasm_file[8] = { 0x00, 0x61, 0x73, 0x6D,
+                                            0x01, 0x00, 0x00, 0x00 };
+
 int
 main(int argc, char *argv[])
 {
@@ -309,7 +320,7 @@ main(int argc, char *argv[])
     AOTCompOption option = { 0 };
     char error_buf[128];
     int log_verbose_level = 2;
-    bool sgx_mode = false, size_level_set = false;
+    bool sgx_mode = false, size_level_set = false, use_dummy_wasm = false;
     int exit_status = EXIT_FAILURE;
 #if BH_HAS_DLFCN
     const char *native_lib_list[8] = { NULL };
@@ -342,21 +353,33 @@ main(int argc, char *argv[])
             if (argv[0][9] == '\0')
                 PRINT_HELP_AND_EXIT();
             option.target_arch = argv[0] + 9;
+            if (!strcmp(option.target_arch, "help")) {
+                use_dummy_wasm = true;
+            }
         }
         else if (!strncmp(argv[0], "--target-abi=", 13)) {
             if (argv[0][13] == '\0')
                 PRINT_HELP_AND_EXIT();
             option.target_abi = argv[0] + 13;
+            if (!strcmp(option.target_abi, "help")) {
+                use_dummy_wasm = true;
+            }
         }
         else if (!strncmp(argv[0], "--cpu=", 6)) {
             if (argv[0][6] == '\0')
                 PRINT_HELP_AND_EXIT();
             option.target_cpu = argv[0] + 6;
+            if (!strcmp(option.target_cpu, "help")) {
+                use_dummy_wasm = true;
+            }
         }
         else if (!strncmp(argv[0], "--cpu-features=", 15)) {
             if (argv[0][15] == '\0')
                 PRINT_HELP_AND_EXIT();
             option.cpu_features = argv[0] + 15;
+            if (!strcmp(option.cpu_features, "+help")) {
+                use_dummy_wasm = true;
+            }
         }
         else if (!strncmp(argv[0], "--opt-level=", 12)) {
             if (argv[0][12] == '\0')
@@ -516,7 +539,13 @@ main(int argc, char *argv[])
             PRINT_HELP_AND_EXIT();
     }
 
-    if (argc == 0 || !out_file_name)
+    /* Normal usage, generate output file */
+    if (!use_dummy_wasm && (argc == 0 || !out_file_name))
+        PRINT_HELP_AND_EXIT();
+
+    /* When use wamrc to print architecture related help info, use dummy_wasm
+     * and don't generate anything */
+    if (use_dummy_wasm && out_file_name)
         PRINT_HELP_AND_EXIT();
 
     if (!size_level_set) {
@@ -544,11 +573,13 @@ main(int argc, char *argv[])
         option.is_sgx_platform = true;
     }
 
-    wasm_file_name = argv[0];
+    if (!use_dummy_wasm) {
+        wasm_file_name = argv[0];
 
-    if (!strcmp(wasm_file_name, out_file_name)) {
-        printf("Error: input file and output file are the same");
-        return -1;
+        if (!strcmp(wasm_file_name, out_file_name)) {
+            printf("Error: input file and output file are the same");
+            return -1;
+        }
     }
 
     memset(&init_args, 0, sizeof(RuntimeInitArgs));
@@ -574,10 +605,17 @@ main(int argc, char *argv[])
 
     bh_print_time("Begin to load wasm file");
 
-    /* load WASM byte buffer from WASM bin file */
-    if (!(wasm_file =
-              (uint8 *)bh_read_file_to_buffer(wasm_file_name, &wasm_file_size)))
-        goto fail1;
+    if (use_dummy_wasm) {
+        /* load WASM byte buffer from dummy buffer */
+        wasm_file_size = sizeof(dummy_wasm_file);
+        wasm_file = dummy_wasm_file;
+    }
+    else {
+        /* load WASM byte buffer from WASM bin file */
+        if (!(wasm_file = (uint8 *)bh_read_file_to_buffer(wasm_file_name,
+                                                          &wasm_file_size)))
+            goto fail1;
+    }
 
     if (get_package_type(wasm_file, wasm_file_size) != Wasm_Module_Bytecode) {
         printf("Invalid file type: expected wasm file but got other\n");
@@ -659,7 +697,9 @@ fail3:
 
 fail2:
     /* free the file buffer */
-    wasm_runtime_free(wasm_file);
+    if (!use_dummy_wasm) {
+        wasm_runtime_free(wasm_file);
+    }
 
 fail1:
 #if BH_HAS_DLFCN


### PR DESCRIPTION
The printed usage message in print_help() may need to be further polished.

After this update, the wamrc can be used to 
1. either compile wasm file to aot file like before 
2. or be used to print target-machine-related help info.

But not at the same time

Under the current modification, the target-abi and arch-related info needs to be queried independently, can't query --target-abi and --arch at the same time. Usage for how to query target-machine-related help info:

```shell
./wamrc --target-abi=help
./wamrc --target=help
# Like before, if want to query cpu/cpu-features, have to clearly choose what target/cpu are using
./wamrc --target=x86_64 --cpu=help
./wamrc --target=x86_64 --cpu=help --cpu-features=+help
```

Maybe there is a more natural or user-friendly method, any suggestions? Any input would be appreciated