### PR TITLE
Upgrade SGX-RA integration for 0.1.2 and Ubuntu 20.04

### DIFF
--- a/core/iwasm/libraries/lib-rats/lib_rats.cmake
+++ b/core/iwasm/libraries/lib-rats/lib_rats.cmake
@@ -23,6 +23,7 @@ include(FetchContent)
 set(RATS_BUILD_MODE "sgx"
     CACHE INTERNAL "Select build mode for librats(host|occlum|sgx｜wasm)")
 set(RATS_INSTALL_PATH  "${CMAKE_BINARY_DIR}/librats" CACHE INTERNAL "")
+set(BUILD_SAMPLES OFF)
 
 FetchContent_Declare(
     librats
@@ -34,7 +35,16 @@ if (NOT librats_POPULATED)
     message("-- Fetching librats ..")
     FetchContent_Populate(librats)
     include_directories("${librats_SOURCE_DIR}/include")
+    
+    # Prevent the propagation of the CMAKE_C_FLAGS of WAMR into librats
+    set(SAVED_CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
+    set(CMAKE_C_FLAGS "")
+
+    # Import the building scripts of librats
     add_subdirectory(${librats_SOURCE_DIR} ${librats_BINARY_DIR} EXCLUDE_FROM_ALL)
+
+    # Restore the CMAKE_C_FLAGS of WAMR
+    set(CMAKE_C_FLAGS ${SAVED_CMAKE_C_FLAGS})
 
 endif()
 

--- a/product-mini/platforms/linux-sgx/enclave-sample/Makefile
+++ b/product-mini/platforms/linux-sgx/enclave-sample/Makefile
@@ -143,10 +143,10 @@ else
 endif
 
 ifeq ($(WAMR_BUILD_LIB_RATS), 1)
-	Rats_Lib_Link_Dirs := -L$(LIB_RATS_INSTALL_DIR) -L$(LIB_RATS_INSTALL_DIR)/attesters -L$(LIB_RATS_INSTALL_DIR)/verifiers -L$(SGX_SSL)/lib64
+	Rats_Lib_Link_Dirs := -L$(LIB_RATS_INSTALL_DIR) -L$(LIB_RATS_INSTALL_DIR)/attesters -L$(LIB_RATS_INSTALL_DIR)/verifiers -L$(SGX_SSL)/lib64 -L$(VMLIB_BUILD_DIR)/external/libcbor/src/libcbor/lib -L$(LIB_RATS_INSTALL_DIR)/crypto_wrappers
 	Rats_Lib_W_Link_libs := -lattester_nullattester -lattester_sgx_ecdsa -lattester_sgx_la \
-						-lverifier_nullverifier -lverifier_sgx_ecdsa -lverifier_sgx_la -lverifier_sgx_ecdsa_qve \
-						-lrats_lib -lsgx_tsgxssl
+						-lverifier_nullverifier -lverifier_sgx_la -lverifier_sgx_ecdsa_qve -lcbor \
+						-lrats_lib -lsgx_tsgxssl -lcrypto_wrapper_nullcrypto -lcrypto_wrapper_openssl
 	Rats_Lib_NW_Link_libs := -lsgx_dcap_tvl -lsgx_tsgxssl_crypto
 endif
 


### PR DESCRIPTION
Dear developers,

I started facing issues with SGX-RA integration, which relies on `librats`. I have reported these issues in a dedicated [GitHub issue](https://github.com/bytecodealliance/wasm-micro-runtime/issues/2441).

After investigations, I realized that the structure of `librats` evolved, and the building scripts in this repository were no longer aligned properly. By this PR, I propose to fix what's broken and upgrade the setup for Ubuntu 20.04 (was 18.04).

To have a working remote attestation workflow, `librats` developers also need to accept a connected PR ([here](https://github.com/inclavare-containers/librats/pull/82)), as a bug prevents the SGX quote verification from operating correctly. Hopefully, they will be reactive.

Cheers,
Jämes