### PR TITLE
aot: disable musttail for mips

### DIFF
--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -146,6 +146,13 @@ aot_target_precheck_can_use_musttail(const AOTCompContext *comp_ctx)
          */
         return false;
     }
+    if (!strcmp(comp_ctx->target_arch, "mips")) {
+        /*
+         * cf.
+         * https://github.com/bytecodealliance/wasm-micro-runtime/issues/2412
+         */
+        return false;
+    }
     /*
      * x86-64/i386: true
      *


### PR DESCRIPTION
While i'm not familiar with mips abi, it's reported that it (at least sometimes) doesn't work.
This fixes https://github.com/bytecodealliance/wasm-micro-runtime/issues/2412