### PR TITLE
build wasi-libc from source in WAMR CI 

### DIFF
--- a/.github/workflows/compilation_on_android_ubuntu.yml
+++ b/.github/workflows/compilation_on_android_ubuntu.yml
@@ -483,6 +483,16 @@ jobs:
           sudo tar -xzf wasi-sdk-*.tar.gz
           sudo mv wasi-sdk-20.0 wasi-sdk
 
+      # It is a temporary solution until new wasi-sdk that includes bug fixes is released 
+      - name: build wasi-libc from source
+        if: matrix.test_option == '$WASI_TEST_OPTIONS'
+        run: |
+          git clone https://github.com/WebAssembly/wasi-libc
+          cd wasi-libc
+          make -j AR=/opt/wasi-sdk/bin/llvm-ar NM=/opt/wasi-sdk/bin/llvm-nm CC=/opt/wasi-sdk/bin/clang THREAD_MODEL=posix
+          echo "SYSROOT_PATH=$PWD/sysroot" >> $GITHUB_ENV
+
+
       - name: set env variable(if llvm are used)
         if: matrix.running_mode == 'aot' || matrix.running_mode == 'jit' || matrix.running_mode == 'multi-tier-jit'
         run: echo "USE_LLVM=true" >> $GITHUB_ENV
@@ -518,7 +528,7 @@ jobs:
 
       - name: Build WASI thread tests
         if: matrix.test_option == '$WASI_TEST_OPTIONS'
-        run: bash build.sh
+        run: bash build.sh --sysroot "$SYSROOT_PATH"
         working-directory: ./core/iwasm/libraries/lib-wasi-threads/test/
 
       - name: build socket api tests

--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -548,6 +548,16 @@ jobs:
           sudo wget ${{ matrix.wasi_sdk_release }}
           sudo tar -xzf wasi-sdk-*.tar.gz
           sudo mv wasi-sdk-20.0 wasi-sdk
+
+      # It is a temporary solution until new wasi-sdk that includes bug fixes is released 
+      - name: build wasi-libc from source
+        if: matrix.test_option == '$WASI_TEST_OPTIONS'
+        run: |
+          git clone https://github.com/WebAssembly/wasi-libc
+          cd wasi-libc
+          make -j AR=/opt/wasi-sdk/bin/llvm-ar NM=/opt/wasi-sdk/bin/llvm-nm CC=/opt/wasi-sdk/bin/clang THREAD_MODEL=posix
+          echo "SYSROOT_PATH=$PWD/sysroot" >> $GITHUB_ENV
+
       - name: set env variable(if llvm are used)
         if: matrix.running_mode == 'aot' || matrix.running_mode == 'jit' || matrix.running_mode == 'multi-tier-jit'
         run: echo "USE_LLVM=true" >> $GITHUB_ENV
@@ -586,7 +596,7 @@ jobs:
 
       - name: Build WASI thread tests
         if: matrix.test_option == '$WASI_TEST_OPTIONS'
-        run: bash build.sh
+        run: bash build.sh --sysroot "$SYSROOT_PATH"
         working-directory: ./core/iwasm/libraries/lib-wasi-threads/test/
 
       - name: build socket api tests


### PR DESCRIPTION
We need to apply some bug fixes that were merged to wasi-libc because wasi-sdk 20 is about half a year old. 

Let's remove this code when wasi-sdk 21 is released.

Currently, #2411 is blocked on this PR 
