### PR TITLE
Clone the input binary during wasm_module_validate

### DIFF
--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -2290,8 +2290,10 @@ quit:
 bool
 wasm_module_validate(wasm_store_t *store, const wasm_byte_vec_t *binary)
 {
+    wasm_byte_vec_t local_binary = { 0 };
     struct WASMModuleCommon *module_rt;
     char error_buf[128] = { 0 };
+    bool ret;
 
     bh_assert(singleton_engine);
 
@@ -2300,15 +2302,26 @@ wasm_module_validate(wasm_store_t *store, const wasm_byte_vec_t *binary)
         return false;
     }
 
-    if ((module_rt = wasm_runtime_load((uint8 *)binary->data,
-                                       (uint32)binary->size, error_buf, 128))) {
+    /* make a copy of binary */
+    wasm_byte_vec_new_uninitialized(&local_binary, binary->size);
+    if (binary->size && !local_binary.data)
+        return false;
+
+    wasm_byte_vec_copy(&local_binary, binary);
+
+    module_rt = wasm_runtime_load((uint8 *)local_binary.data,
+                                  (uint32)local_binary.size, error_buf, 128);
+    wasm_byte_vec_delete(&local_binary);
+    if (module_rt) {
         wasm_runtime_unload(module_rt);
-        return true;
+        ret = true;
     }
     else {
+        ret = false;
         LOG_VERBOSE(error_buf);
-        return false;
     }
+
+    return ret;
 }
 
 static void

--- a/samples/wasm-c-api/src/hello.c
+++ b/samples/wasm-c-api/src/hello.c
@@ -65,6 +65,12 @@ int main(int argc, const char* argv[]) {
   }
   fclose(file);
 
+  if (!wasm_module_validate(store, &binary)) {
+    printf("> Error validate module!\n");
+    wasm_byte_vec_delete(&binary);
+    return 1;
+  }
+
   // Compile.
   printf("Compiling module...\n");
   own wasm_module_t* module = wasm_module_new(store, &binary);


### PR DESCRIPTION
since `wasm_runtime_unload` will release the incoming binary, we'd better make a copy of it.