### PR TITLE
sgx-ra: disable the building of samples

### DIFF
--- a/core/iwasm/libraries/lib-rats/lib_rats.cmake
+++ b/core/iwasm/libraries/lib-rats/lib_rats.cmake
@@ -23,7 +23,7 @@ include(FetchContent)
 set(RATS_BUILD_MODE "sgx"
     CACHE INTERNAL "Select build mode for librats(host|occlum|sgx｜wasm)")
 set(RATS_INSTALL_PATH  "${CMAKE_BINARY_DIR}/librats" CACHE INTERNAL "")
-set(BUILD_SAMPLES OFF)
+set(BUILD_SAMPLES OFF CACHE BOOL "Disable de compilation of the librats samples" FORCE)
 
 FetchContent_Declare(
     librats


### PR DESCRIPTION
Dear developers,

This PR is a follow-up to my upgrade for the remote attestation with Ubuntu 20.04 and librats (#2441).

When integrating librats as a dependency using `add_subdirectory()`, the `BUILD_SAMPLES` option from the librats's CMakeLists isn't correctly overridden from the parent CMakeLists on the first run of `cmake`. It requires two runs of the command to reflect the changes. The root cause is the way regular and cache variables are handled in CMake.

I propose to set `BUILD_SAMPLES` as a cache variable in the parent CMakeLists before invoking `add_subdirectory()`. This ensures that the setting is applied on the first run.

Cheers!