### PR TITLE
Add callback to handle memory.grow failures

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -1443,6 +1443,9 @@ aot_call_function(WASMExecEnv *exec_env, AOTFunctionInstance *function,
     /* set thread handle and stack boundary */
     wasm_exec_env_set_thread_info(exec_env);
 
+    /* set exec env so it can be later retrieved from instance */
+    ((AOTModuleInstanceExtra *)module_inst->e)->common.cur_exec_env = exec_env;
+
     if (ext_ret_count > 0) {
         uint32 cell_num = 0, i;
         uint8 *ext_ret_types = func_type->types + func_type->param_count + 1;

--- a/core/iwasm/common/wasm_memory.c
+++ b/core/iwasm/common/wasm_memory.c
@@ -700,11 +700,24 @@ wasm_enlarge_memory_internal(WASMModuleInstance *module, uint32 inc_page_count)
 #endif
 
 return_func:
-    if (!ret && enlarge_memory_error_cb)
+    if (!ret && enlarge_memory_error_cb) {
+        WASMExecEnv *exec_env = NULL;
+
+#if WASM_ENABLE_INTERP != 0
+        if (module->module_type == Wasm_Module_Bytecode)
+            exec_env =
+                ((WASMModuleInstanceExtra *)module->e)->common.cur_exec_env;
+#endif
+#if WASM_ENABLE_AOT != 0
+        if (module->module_type == Wasm_Module_AoT)
+            exec_env =
+                ((AOTModuleInstanceExtra *)module->e)->common.cur_exec_env;
+#endif
+
         enlarge_memory_error_cb(inc_page_count, total_size_old, 0,
-                                failure_reason, (wasm_module_inst_t)module,
-                                wasm_runtime_get_exec_env_singleton(
-                                    (WASMModuleInstanceCommon *)module));
+                                failure_reason,
+                                (WASMModuleInstanceCommon *)module, exec_env);
+    }
 
     return ret;
 }
@@ -793,11 +806,24 @@ wasm_enlarge_memory_internal(WASMModuleInstance *module, uint32 inc_page_count)
 #endif
 
 return_func:
-    if (!ret && enlarge_memory_error_cb)
+    if (!ret && enlarge_memory_error_cb) {
+        WASMExecEnv *exec_env = NULL;
+
+#if WASM_ENABLE_INTERP != 0
+        if (module->module_type == Wasm_Module_Bytecode)
+            exec_env =
+                ((WASMModuleInstanceExtra *)module->e)->common.cur_exec_env;
+#endif
+#if WASM_ENABLE_AOT != 0
+        if (module->module_type == Wasm_Module_AoT)
+            exec_env =
+                ((AOTModuleInstanceExtra *)module->e)->common.cur_exec_env;
+#endif
+
         enlarge_memory_error_cb(inc_page_count, total_size_old, 0,
-                                failure_reason, (wasm_module_inst_t)module,
-                                wasm_runtime_get_exec_env_singleton(
-                                    (WASMModuleInstanceCommon *)module));
+                                failure_reason,
+                                (WASMModuleInstanceCommon *)module, exec_env);
+    }
 
     return ret;
 }

--- a/core/iwasm/common/wasm_memory.h
+++ b/core/iwasm/common/wasm_memory.h
@@ -24,6 +24,9 @@ wasm_runtime_memory_destroy();
 unsigned
 wasm_runtime_memory_pool_size();
 
+void
+set_memory_grow_error_callback(const memory_grow_error_callback callback);
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/iwasm/common/wasm_memory.h
+++ b/core/iwasm/common/wasm_memory.h
@@ -25,7 +25,8 @@ unsigned
 wasm_runtime_memory_pool_size();
 
 void
-set_memory_grow_error_callback(const memory_grow_error_callback callback);
+wasm_runtime_set_enlarge_mem_error_callback(
+    const enlarge_memory_error_callback_t callback);
 
 #ifdef __cplusplus
 }

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -1439,13 +1439,22 @@ WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_is_import_global_linked(const char *module_name,
                                      const char *global_name);
 
-typedef void (*memory_grow_error_callback)(uint32_t inc_page_count);
+typedef enum {
+    INTERNAL_ERROR,
+    MAX_SIZE_REACHED,
+} enlarge_memory_error_reason_t;
+
+typedef void (*enlarge_memory_error_callback_t)(
+    uint32_t inc_page_count, uint64_t current_memory_size,
+    uint32_t memory_index, enlarge_memory_error_reason_t failure_reason,
+    wasm_module_inst_t instance, wasm_exec_env_t exec_env);
 
 /**
  * Setup callback invoked when memory.grow fails
  */
 WASM_RUNTIME_API_EXTERN void
-set_memory_grow_error_callback(const memory_grow_error_callback callback);
+wasm_runtime_set_enlarge_mem_error_callback(
+    const enlarge_memory_error_callback_t callback);
 
 /* clang-format on */
 

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -1439,6 +1439,14 @@ WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_is_import_global_linked(const char *module_name,
                                      const char *global_name);
 
+typedef void (*memory_grow_error_callback)(uint32_t inc_page_count);
+
+/**
+ * Setup callback invoked when memory.grow fails
+ */
+WASM_RUNTIME_API_EXTERN void
+set_memory_grow_error_callback(const memory_grow_error_callback callback);
+
 /* clang-format on */
 
 #ifdef __cplusplus

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -2400,6 +2400,9 @@ wasm_call_function(WASMExecEnv *exec_env, WASMFunctionInstance *function,
     /* set thread handle and stack boundary */
     wasm_exec_env_set_thread_info(exec_env);
 
+    /* set exec env so it can be later retrieved from instance */
+    module_inst->e->common.cur_exec_env = exec_env;
+
     interp_call_wasm(module_inst, exec_env, function, argc, argv);
     return !wasm_copy_exception(module_inst, NULL);
 }

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -213,6 +213,8 @@ typedef struct CApiFuncImport {
 /* The common part of WASMModuleInstanceExtra and AOTModuleInstanceExtra */
 typedef struct WASMModuleInstanceExtraCommon {
     CApiFuncImport *c_api_func_imports;
+    /* pointer to the exec env currently used */
+    WASMExecEnv *cur_exec_env;
 #if WASM_CONFIGUABLE_BOUNDS_CHECKS != 0
     /* Disable bounds checks or not */
     bool disable_bounds_checks;


### PR DESCRIPTION
When embedding WAMR, this PR allows to register a callback that is invoked when `memory.grow` fails.

In case of memory allocation failures, some languages allow to handle the error (e.g. by checking the return code of `malloc`/`calloc` in c), some others (e.g. Rust) just panic. For the latter, it is useful to have a callback function that would be called before the wasm execution crashes, allowing the embedder to detect and handle the `memory.grow` error. It comes in handy when using shared memory since shared memory forces the maximum linear memory size to be set at compilation time. Setting a value that is too low can lead to memory allocation failures (i.e. `memory.grow` failures).

It would be nice to capture the crash in Rust directly, but the feature is experimental (https://github.com/rust-lang/rust/issues/51540).