### PR TITLE
set_exception_visitor: remove the special case for wasi proc exit

### DIFF
--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -1260,12 +1260,8 @@ set_exception_visitor(void *node, void *user_data)
 
         exception_lock(wasm_inst);
         if (data->exception != NULL) {
-            /* Only spread non "wasi proc exit" exception */
-            if (strcmp(data->exception, "wasi proc exit")) {
-                snprintf(wasm_inst->cur_exception,
-                         sizeof(wasm_inst->cur_exception), "Exception: %s",
-                         data->exception);
-            }
+            snprintf(wasm_inst->cur_exception, sizeof(wasm_inst->cur_exception),
+                     "Exception: %s", data->exception);
         }
         else {
             wasm_inst->cur_exception[0] = '\0';


### PR DESCRIPTION
while wasi proc exit is not a real trap, what the runtime does on it is mostly same as real traps. that is, kill the siblings threads and represent the exit/trap as the result of the "process" to the user api. there seems no reason to distinuguish it from real traps here.

note that:

* the target thread either doesn't care the specific exception type or ignore wasi proc exit by themselves. (clear_wasi_proc_exit_exception)

* clear_wasi_proc_exit_exception only clears local exception.