### PR TITLE
Fix typo for IP address buffer

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -228,22 +228,22 @@ wasi_addr_to_bh_sockaddr(const __wasi_addr_t *wasi_addr,
                          bh_sockaddr_t *sockaddr)
 {
     if (wasi_addr->kind == IPv4) {
-        sockaddr->addr_bufer.ipv4 = (wasi_addr->addr.ip4.addr.n0 << 24)
-                                    | (wasi_addr->addr.ip4.addr.n1 << 16)
-                                    | (wasi_addr->addr.ip4.addr.n2 << 8)
-                                    | wasi_addr->addr.ip4.addr.n3;
+        sockaddr->addr_buffer.ipv4 = (wasi_addr->addr.ip4.addr.n0 << 24)
+                                     | (wasi_addr->addr.ip4.addr.n1 << 16)
+                                     | (wasi_addr->addr.ip4.addr.n2 << 8)
+                                     | wasi_addr->addr.ip4.addr.n3;
         sockaddr->is_ipv4 = true;
         sockaddr->port = wasi_addr->addr.ip4.port;
     }
     else {
-        sockaddr->addr_bufer.ipv6[0] = wasi_addr->addr.ip6.addr.n0;
-        sockaddr->addr_bufer.ipv6[1] = wasi_addr->addr.ip6.addr.n1;
-        sockaddr->addr_bufer.ipv6[2] = wasi_addr->addr.ip6.addr.n2;
-        sockaddr->addr_bufer.ipv6[3] = wasi_addr->addr.ip6.addr.n3;
-        sockaddr->addr_bufer.ipv6[4] = wasi_addr->addr.ip6.addr.h0;
-        sockaddr->addr_bufer.ipv6[5] = wasi_addr->addr.ip6.addr.h1;
-        sockaddr->addr_bufer.ipv6[6] = wasi_addr->addr.ip6.addr.h2;
-        sockaddr->addr_bufer.ipv6[7] = wasi_addr->addr.ip6.addr.h3;
+        sockaddr->addr_buffer.ipv6[0] = wasi_addr->addr.ip6.addr.n0;
+        sockaddr->addr_buffer.ipv6[1] = wasi_addr->addr.ip6.addr.n1;
+        sockaddr->addr_buffer.ipv6[2] = wasi_addr->addr.ip6.addr.n2;
+        sockaddr->addr_buffer.ipv6[3] = wasi_addr->addr.ip6.addr.n3;
+        sockaddr->addr_buffer.ipv6[4] = wasi_addr->addr.ip6.addr.h0;
+        sockaddr->addr_buffer.ipv6[5] = wasi_addr->addr.ip6.addr.h1;
+        sockaddr->addr_buffer.ipv6[6] = wasi_addr->addr.ip6.addr.h2;
+        sockaddr->addr_buffer.ipv6[7] = wasi_addr->addr.ip6.addr.h3;
         sockaddr->is_ipv4 = false;
         sockaddr->port = wasi_addr->addr.ip6.port;
     }
@@ -258,24 +258,24 @@ bh_sockaddr_to_wasi_addr(const bh_sockaddr_t *sockaddr,
         wasi_addr->kind = IPv4;
         wasi_addr->addr.ip4.port = sockaddr->port;
         wasi_addr->addr.ip4.addr.n0 =
-            (sockaddr->addr_bufer.ipv4 & 0xFF000000) >> 24;
+            (sockaddr->addr_buffer.ipv4 & 0xFF000000) >> 24;
         wasi_addr->addr.ip4.addr.n1 =
-            (sockaddr->addr_bufer.ipv4 & 0x00FF0000) >> 16;
+            (sockaddr->addr_buffer.ipv4 & 0x00FF0000) >> 16;
         wasi_addr->addr.ip4.addr.n2 =
-            (sockaddr->addr_bufer.ipv4 & 0x0000FF00) >> 8;
-        wasi_addr->addr.ip4.addr.n3 = (sockaddr->addr_bufer.ipv4 & 0x000000FF);
+            (sockaddr->addr_buffer.ipv4 & 0x0000FF00) >> 8;
+        wasi_addr->addr.ip4.addr.n3 = (sockaddr->addr_buffer.ipv4 & 0x000000FF);
     }
     else {
         wasi_addr->kind = IPv6;
         wasi_addr->addr.ip6.port = sockaddr->port;
-        wasi_addr->addr.ip6.addr.n0 = sockaddr->addr_bufer.ipv6[0];
-        wasi_addr->addr.ip6.addr.n1 = sockaddr->addr_bufer.ipv6[1];
-        wasi_addr->addr.ip6.addr.n2 = sockaddr->addr_bufer.ipv6[2];
-        wasi_addr->addr.ip6.addr.n3 = sockaddr->addr_bufer.ipv6[3];
-        wasi_addr->addr.ip6.addr.h0 = sockaddr->addr_bufer.ipv6[4];
-        wasi_addr->addr.ip6.addr.h1 = sockaddr->addr_bufer.ipv6[5];
-        wasi_addr->addr.ip6.addr.h2 = sockaddr->addr_bufer.ipv6[6];
-        wasi_addr->addr.ip6.addr.h3 = sockaddr->addr_bufer.ipv6[7];
+        wasi_addr->addr.ip6.addr.n0 = sockaddr->addr_buffer.ipv6[0];
+        wasi_addr->addr.ip6.addr.n1 = sockaddr->addr_buffer.ipv6[1];
+        wasi_addr->addr.ip6.addr.n2 = sockaddr->addr_buffer.ipv6[2];
+        wasi_addr->addr.ip6.addr.n3 = sockaddr->addr_buffer.ipv6[3];
+        wasi_addr->addr.ip6.addr.h0 = sockaddr->addr_buffer.ipv6[4];
+        wasi_addr->addr.ip6.addr.h1 = sockaddr->addr_buffer.ipv6[5];
+        wasi_addr->addr.ip6.addr.h2 = sockaddr->addr_buffer.ipv6[6];
+        wasi_addr->addr.ip6.addr.h3 = sockaddr->addr_buffer.ipv6[7];
     }
 }
 

--- a/core/shared/platform/common/posix/posix_socket.c
+++ b/core/shared/platform/common/posix/posix_socket.c
@@ -53,7 +53,7 @@ sockaddr_to_bh_sockaddr(const struct sockaddr *sockaddr,
             struct sockaddr_in *addr = (struct sockaddr_in *)sockaddr;
 
             bh_sockaddr->port = ntohs(addr->sin_port);
-            bh_sockaddr->addr_bufer.ipv4 = ntohl(addr->sin_addr.s_addr);
+            bh_sockaddr->addr_buffer.ipv4 = ntohl(addr->sin_addr.s_addr);
             bh_sockaddr->is_ipv4 = true;
             return BHT_OK;
         }
@@ -65,12 +65,12 @@ sockaddr_to_bh_sockaddr(const struct sockaddr *sockaddr,
 
             bh_sockaddr->port = ntohs(addr->sin6_port);
 
-            for (i = 0; i < sizeof(bh_sockaddr->addr_bufer.ipv6)
-                                / sizeof(bh_sockaddr->addr_bufer.ipv6[0]);
+            for (i = 0; i < sizeof(bh_sockaddr->addr_buffer.ipv6)
+                                / sizeof(bh_sockaddr->addr_buffer.ipv6[0]);
                  i++) {
                 uint16 part_addr = addr->sin6_addr.s6_addr[i * 2]
                                    | (addr->sin6_addr.s6_addr[i * 2 + 1] << 8);
-                bh_sockaddr->addr_bufer.ipv6[i] = ntohs(part_addr);
+                bh_sockaddr->addr_buffer.ipv6[i] = ntohs(part_addr);
             }
 
             bh_sockaddr->is_ipv4 = false;
@@ -91,7 +91,7 @@ bh_sockaddr_to_sockaddr(const bh_sockaddr_t *bh_sockaddr,
         struct sockaddr_in *addr = (struct sockaddr_in *)sockaddr;
         addr->sin_port = htons(bh_sockaddr->port);
         addr->sin_family = AF_INET;
-        addr->sin_addr.s_addr = htonl(bh_sockaddr->addr_bufer.ipv4);
+        addr->sin_addr.s_addr = htonl(bh_sockaddr->addr_buffer.ipv4);
         *socklen = sizeof(*addr);
     }
 #ifdef IPPROTO_IPV6
@@ -101,10 +101,10 @@ bh_sockaddr_to_sockaddr(const bh_sockaddr_t *bh_sockaddr,
         addr->sin6_port = htons(bh_sockaddr->port);
         addr->sin6_family = AF_INET6;
 
-        for (i = 0; i < sizeof(bh_sockaddr->addr_bufer.ipv6)
-                            / sizeof(bh_sockaddr->addr_bufer.ipv6[0]);
+        for (i = 0; i < sizeof(bh_sockaddr->addr_buffer.ipv6)
+                            / sizeof(bh_sockaddr->addr_buffer.ipv6[0]);
              i++) {
-            uint16 part_addr = htons(bh_sockaddr->addr_bufer.ipv6[i]);
+            uint16 part_addr = htons(bh_sockaddr->addr_buffer.ipv6[i]);
             addr->sin6_addr.s6_addr[i * 2] = 0xff & part_addr;
             addr->sin6_addr.s6_addr[i * 2 + 1] = (0xff00 & part_addr) >> 8;
         }

--- a/core/shared/platform/esp-idf/espidf_socket.c
+++ b/core/shared/platform/esp-idf/espidf_socket.c
@@ -30,7 +30,7 @@ sockaddr_to_bh_sockaddr(const struct sockaddr *sockaddr, socklen_t socklen,
             assert(socklen >= sizeof(struct sockaddr_in));
 
             bh_sockaddr->port = ntohs(addr->sin_port);
-            bh_sockaddr->addr_bufer.ipv4 = ntohl(addr->sin_addr.s_addr);
+            bh_sockaddr->addr_buffer.ipv4 = ntohl(addr->sin_addr.s_addr);
             bh_sockaddr->is_ipv4 = true;
             return BHT_OK;
         }

--- a/core/shared/platform/include/platform_api_extension.h
+++ b/core/shared/platform/include/platform_api_extension.h
@@ -342,7 +342,7 @@ typedef union {
 } bh_ip_addr_buffer_t;
 
 typedef struct {
-    bh_ip_addr_buffer_t addr_bufer;
+    bh_ip_addr_buffer_t addr_buffer;
     uint16 port;
     bool is_ipv4;
 } bh_sockaddr_t;

--- a/core/shared/platform/linux-sgx/sgx_socket.c
+++ b/core/shared/platform/linux-sgx/sgx_socket.c
@@ -261,7 +261,7 @@ sockaddr_to_bh_sockaddr(const struct sockaddr *sockaddr, socklen_t socklen,
             assert(socklen >= sizeof(struct sockaddr_in));
 
             bh_sockaddr->port = ntohs(addr->sin_port);
-            bh_sockaddr->addr_bufer.ipv4 = ntohl(addr->sin_addr.s_addr);
+            bh_sockaddr->addr_buffer.ipv4 = ntohl(addr->sin_addr.s_addr);
             bh_sockaddr->is_ipv4 = true;
             return BHT_OK;
         }
@@ -279,7 +279,7 @@ bh_sockaddr_to_sockaddr(const bh_sockaddr_t *bh_sockaddr,
         struct sockaddr_in *addr = (struct sockaddr_in *)sockaddr;
         addr->sin_port = htons(bh_sockaddr->port);
         addr->sin_family = AF_INET;
-        addr->sin_addr.s_addr = htonl(bh_sockaddr->addr_bufer.ipv4);
+        addr->sin_addr.s_addr = htonl(bh_sockaddr->addr_buffer.ipv4);
         *socklen = sizeof(*addr);
         return BHT_OK;
     }


### PR DESCRIPTION
There is a typo for `bh_ip_addr_buffer_t` struct in buffer element. Small cosmetic fix.