### PR TITLE
unifdef -U WASMTIME_SSP_STATIC_CURFDS

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/include/wasmtime_ssp.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/include/wasmtime_ssp.h
@@ -598,17 +598,13 @@ typedef struct __wasi_addr_info_hints_t {
 #endif
 
 __wasi_errno_t wasmtime_ssp_args_get(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct argv_environ_values *arg_environ,
-#endif
     char **argv,
     char *argv_buf
 ) WASMTIME_SSP_SYSCALL_NAME(args_get) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_args_sizes_get(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct argv_environ_values *arg_environ,
-#endif
     size_t *argc,
     size_t *argv_buf_size
 ) WASMTIME_SSP_SYSCALL_NAME(args_sizes_get) __attribute__((__warn_unused_result__));
@@ -625,57 +621,43 @@ __wasi_errno_t wasmtime_ssp_clock_time_get(
 ) WASMTIME_SSP_SYSCALL_NAME(clock_time_get) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_environ_get(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct argv_environ_values *arg_environ,
-#endif
     char **environ,
     char *environ_buf
 ) WASMTIME_SSP_SYSCALL_NAME(environ_get) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_environ_sizes_get(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct argv_environ_values *arg_environ,
-#endif
     size_t *environ_count,
     size_t *environ_buf_size
 ) WASMTIME_SSP_SYSCALL_NAME(environ_sizes_get) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_fd_prestat_get(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_prestats *prestats,
-#endif
     __wasi_fd_t fd,
     __wasi_prestat_t *buf
 ) WASMTIME_SSP_SYSCALL_NAME(fd_prestat_get) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_fd_prestat_dir_name(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_prestats *prestats,
-#endif
     __wasi_fd_t fd,
     char *path,
     size_t path_len
 ) WASMTIME_SSP_SYSCALL_NAME(fd_prestat_dir_name) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_fd_close(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
     struct fd_prestats *prestats,
-#endif
     __wasi_fd_t fd
 ) WASMTIME_SSP_SYSCALL_NAME(fd_close) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_fd_datasync(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd
 ) WASMTIME_SSP_SYSCALL_NAME(fd_datasync) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_fd_pread(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd,
     const __wasi_iovec_t *iovs,
     size_t iovs_len,
@@ -684,9 +666,7 @@ __wasi_errno_t wasmtime_ssp_fd_pread(
 ) WASMTIME_SSP_SYSCALL_NAME(fd_pread) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_fd_pwrite(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd,
     const __wasi_ciovec_t *iovs,
     size_t iovs_len,
@@ -695,9 +675,7 @@ __wasi_errno_t wasmtime_ssp_fd_pwrite(
 ) WASMTIME_SSP_SYSCALL_NAME(fd_pwrite) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_fd_read(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd,
     const __wasi_iovec_t *iovs,
     size_t iovs_len,
@@ -705,18 +683,14 @@ __wasi_errno_t wasmtime_ssp_fd_read(
 ) WASMTIME_SSP_SYSCALL_NAME(fd_read) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_fd_renumber(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
     struct fd_prestats *prestats,
-#endif
     __wasi_fd_t from,
     __wasi_fd_t to
 ) WASMTIME_SSP_SYSCALL_NAME(fd_renumber) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_fd_seek(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd,
     __wasi_filedelta_t offset,
     __wasi_whence_t whence,
@@ -724,49 +698,37 @@ __wasi_errno_t wasmtime_ssp_fd_seek(
 ) WASMTIME_SSP_SYSCALL_NAME(fd_seek) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_fd_tell(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd,
     __wasi_filesize_t *newoffset
 ) WASMTIME_SSP_SYSCALL_NAME(fd_tell) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_fd_fdstat_get(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd,
     __wasi_fdstat_t *buf
 ) WASMTIME_SSP_SYSCALL_NAME(fd_fdstat_get) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_fd_fdstat_set_flags(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd,
     __wasi_fdflags_t flags
 ) WASMTIME_SSP_SYSCALL_NAME(fd_fdstat_set_flags) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_fd_fdstat_set_rights(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd,
     __wasi_rights_t fs_rights_base,
     __wasi_rights_t fs_rights_inheriting
 ) WASMTIME_SSP_SYSCALL_NAME(fd_fdstat_set_rights) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_fd_sync(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd
 ) WASMTIME_SSP_SYSCALL_NAME(fd_sync) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_fd_write(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd,
     const __wasi_ciovec_t *iovs,
     size_t iovs_len,
@@ -774,9 +736,7 @@ __wasi_errno_t wasmtime_ssp_fd_write(
 ) WASMTIME_SSP_SYSCALL_NAME(fd_write) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_fd_advise(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd,
     __wasi_filesize_t offset,
     __wasi_filesize_t len,
@@ -784,28 +744,22 @@ __wasi_errno_t wasmtime_ssp_fd_advise(
 ) WASMTIME_SSP_SYSCALL_NAME(fd_advise) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_fd_allocate(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd,
     __wasi_filesize_t offset,
     __wasi_filesize_t len
 ) WASMTIME_SSP_SYSCALL_NAME(fd_allocate) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_path_create_directory(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd,
     const char *path,
     size_t path_len
 ) WASMTIME_SSP_SYSCALL_NAME(path_create_directory) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_path_link(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
     struct fd_prestats *prestats,
-#endif
     __wasi_fd_t old_fd,
     __wasi_lookupflags_t old_flags,
     const char *old_path,
@@ -816,9 +770,7 @@ __wasi_errno_t wasmtime_ssp_path_link(
 ) WASMTIME_SSP_SYSCALL_NAME(path_link) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_path_open(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t dirfd,
     __wasi_lookupflags_t dirflags,
     const char *path,
@@ -831,9 +783,7 @@ __wasi_errno_t wasmtime_ssp_path_open(
 ) WASMTIME_SSP_SYSCALL_NAME(path_open) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_fd_readdir(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd,
     void *buf,
     size_t buf_len,
@@ -842,9 +792,7 @@ __wasi_errno_t wasmtime_ssp_fd_readdir(
 ) WASMTIME_SSP_SYSCALL_NAME(fd_readdir) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_path_readlink(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd,
     const char *path,
     size_t path_len,
@@ -854,9 +802,7 @@ __wasi_errno_t wasmtime_ssp_path_readlink(
 ) WASMTIME_SSP_SYSCALL_NAME(path_readlink) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_path_rename(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t old_fd,
     const char *old_path,
     size_t old_path_len,
@@ -866,17 +812,13 @@ __wasi_errno_t wasmtime_ssp_path_rename(
 ) WASMTIME_SSP_SYSCALL_NAME(path_rename) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_fd_filestat_get(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd,
     __wasi_filestat_t *buf
 ) WASMTIME_SSP_SYSCALL_NAME(fd_filestat_get) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_fd_filestat_set_times(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd,
     __wasi_timestamp_t st_atim,
     __wasi_timestamp_t st_mtim,
@@ -884,17 +826,13 @@ __wasi_errno_t wasmtime_ssp_fd_filestat_set_times(
 ) WASMTIME_SSP_SYSCALL_NAME(fd_filestat_set_times) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_fd_filestat_set_size(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd,
     __wasi_filesize_t st_size
 ) WASMTIME_SSP_SYSCALL_NAME(fd_filestat_set_size) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_path_filestat_get(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd,
     __wasi_lookupflags_t flags,
     const char *path,
@@ -903,9 +841,7 @@ __wasi_errno_t wasmtime_ssp_path_filestat_get(
 ) WASMTIME_SSP_SYSCALL_NAME(path_filestat_get) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_path_filestat_set_times(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd,
     __wasi_lookupflags_t flags,
     const char *path,
@@ -916,10 +852,8 @@ __wasi_errno_t wasmtime_ssp_path_filestat_set_times(
 ) WASMTIME_SSP_SYSCALL_NAME(path_filestat_set_times) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_path_symlink(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
     struct fd_prestats *prestats,
-#endif
     const char *old_path,
     size_t old_path_len,
     __wasi_fd_t fd,
@@ -928,27 +862,21 @@ __wasi_errno_t wasmtime_ssp_path_symlink(
 ) WASMTIME_SSP_SYSCALL_NAME(path_symlink) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_path_unlink_file(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd,
     const char *path,
     size_t path_len
 ) WASMTIME_SSP_SYSCALL_NAME(path_unlink_file) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_path_remove_directory(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd,
     const char *path,
     size_t path_len
 ) WASMTIME_SSP_SYSCALL_NAME(path_remove_directory) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_poll_oneoff(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     const __wasi_subscription_t *in,
     __wasi_event_t *out,
     size_t nsubscriptions,
@@ -962,50 +890,38 @@ __wasi_errno_t wasmtime_ssp_random_get(
 
 __wasi_errno_t
 wasi_ssp_sock_accept(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_fdflags_t flags, __wasi_fd_t *fd_new
 ) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t
 wasi_ssp_sock_addr_local(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_addr_t *addr
 ) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t
 wasi_ssp_sock_addr_remote(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_addr_t *addr
 ) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t
 wasi_ssp_sock_open(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t poolfd, __wasi_address_family_t af, __wasi_sock_type_t socktype,
     __wasi_fd_t *sockfd
 ) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t
 wasi_ssp_sock_bind(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds, struct addr_pool *addr_pool,
-#endif
     __wasi_fd_t fd, __wasi_addr_t *addr
 ) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t
 wasi_ssp_sock_addr_resolve(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds, char **ns_lookup_list,
-#endif
     const char *host, const char* service,
     __wasi_addr_info_hints_t *hints, __wasi_addr_info_t *addr_info,
     __wasi_size_t addr_info_size, __wasi_size_t *max_info_size
@@ -1013,88 +929,66 @@ wasi_ssp_sock_addr_resolve(
 
 __wasi_errno_t
 wasi_ssp_sock_connect(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds, struct addr_pool *addr_pool,
-#endif
     __wasi_fd_t fd, __wasi_addr_t *addr
 ) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t
 wasi_ssp_sock_get_recv_buf_size(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_size_t *size
 ) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t
 wasi_ssp_sock_get_reuse_addr(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, uint8_t *reuse
 ) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t
 wasi_ssp_sock_get_reuse_port(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, uint8_t *reuse
 ) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t
 wasi_ssp_sock_get_send_buf_size(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_size_t *size
 ) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t
 wasi_ssp_sock_set_recv_buf_size(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_size_t size
 ) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t
 wasi_ssp_sock_set_reuse_addr(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, uint8_t reuse
 ) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t
 wasi_ssp_sock_set_reuse_port(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, uint8_t reuse
 ) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t
 wasi_ssp_sock_set_send_buf_size(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_size_t size
 ) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t
 wasi_ssp_sock_listen(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_size_t backlog
 ) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_recv(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     void *buf,
     size_t buf_len,
@@ -1102,9 +996,7 @@ __wasi_errno_t wasmtime_ssp_sock_recv(
 ) WASMTIME_SSP_SYSCALL_NAME(sock_recv) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_recv_from(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     void *buf,
     size_t buf_len,
@@ -1114,9 +1006,7 @@ __wasi_errno_t wasmtime_ssp_sock_recv_from(
 ) WASMTIME_SSP_SYSCALL_NAME(sock_recv_from) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_send(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     const void *buf,
     size_t buf_len,
@@ -1124,9 +1014,7 @@ __wasi_errno_t wasmtime_ssp_sock_send(
 ) WASMTIME_SSP_SYSCALL_NAME(sock_send) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_send_to(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds, struct addr_pool *addr_pool,
-#endif
     __wasi_fd_t sock,
     const void *buf,
     size_t buf_len,
@@ -1136,317 +1024,239 @@ __wasi_errno_t wasmtime_ssp_sock_send_to(
 ) WASMTIME_SSP_SYSCALL_NAME(sock_send_to) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_shutdown(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock
 ) WASMTIME_SSP_SYSCALL_NAME(sock_shutdown) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_recv_timeout(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     uint64_t timeout_us
 ) WASMTIME_SSP_SYSCALL_NAME(sock_set_recv_timeout) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_get_recv_timeout(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     uint64_t *timeout_us
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_recv_timeout) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_send_timeout(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     uint64_t timeout_us
 ) WASMTIME_SSP_SYSCALL_NAME(sock_set_send_timeout) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_get_send_timeout(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     uint64_t *timeout_us
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_send_timeout) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_send_buf_size(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     size_t bufsiz
 ) WASMTIME_SSP_SYSCALL_NAME(sock_set_send_buf_size) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_get_send_buf_size(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     size_t *bufsiz
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_send_buf_size) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_recv_buf_size(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     size_t bufsiz
 ) WASMTIME_SSP_SYSCALL_NAME(sock_set_recv_buf_size) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_get_recv_buf_size(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     size_t *bufsiz
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_recv_buf_size) __attribute__((__warn_unused_result__));
 
 
 __wasi_errno_t wasmtime_ssp_sock_set_keep_alive(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     bool is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_set_keep_alive) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_get_keep_alive(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     bool *is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_keep_alive) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_reuse_addr(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     bool is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_set_reuse_addr) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_get_reuse_addr(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     bool *is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_reuse_addr) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_reuse_port(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     bool is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_set_reuse_port) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_get_reuse_port(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     bool *is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_reuse_port) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_linger(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     bool is_enabled,
     int linger_s
 ) WASMTIME_SSP_SYSCALL_NAME(sock_set_linger) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_get_linger(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock, bool *is_enabled, int *linger_s
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_linger) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_broadcast(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     bool is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_set_broadcast) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_get_broadcast(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     bool *is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_broadcast) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_tcp_no_delay(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     bool is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_set_tcp_no_delay) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_get_tcp_no_delay(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     bool *is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_tcp_no_delay) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_tcp_quick_ack(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     bool is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_set_tcp_quick_ack) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_get_tcp_quick_ack(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     bool *is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_tcp_quick_ack) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_tcp_keep_idle(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     uint32_t time_s
 ) WASMTIME_SSP_SYSCALL_NAME(sock_set_tcp_keep_idle) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_get_tcp_keep_idle(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     uint32_t *time_s
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_tcp_keep_idle) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_tcp_keep_intvl(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     uint32_t time_s
 ) WASMTIME_SSP_SYSCALL_NAME(sock_set_tcp_keep_intvl) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_get_tcp_keep_intvl(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     uint32_t *time_s
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_tcp_keep_intvl) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_tcp_fastopen_connect(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     bool is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_set_tcp_fastopen_connect) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_get_tcp_fastopen_connect(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     bool *is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_tcp_fastopen_connect) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_ip_multicast_loop(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     bool ipv6,
     bool is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_set_ip_multicast_loop) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_get_ip_multicast_loop(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     bool ipv6,
     bool *is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_ip_multicast_loop) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_ip_add_membership(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     __wasi_addr_ip_t *imr_multiaddr,
     uint32_t imr_interface
 ) WASMTIME_SSP_SYSCALL_NAME(sock_set_ip_add_membership) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_ip_drop_membership(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     __wasi_addr_ip_t *imr_multiaddr,
     uint32_t imr_interface
 ) WASMTIME_SSP_SYSCALL_NAME(sock_set_ip_drop_membership) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_ip_ttl(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     uint8_t ttl_s
 ) WASMTIME_SSP_SYSCALL_NAME(sock_set_ip_ttl) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_get_ip_ttl(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     uint8_t *ttl_s
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_ip_ttl) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_ip_multicast_ttl(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     uint8_t ttl_s
 ) WASMTIME_SSP_SYSCALL_NAME(sock_set_ip_multicast_ttl) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_get_ip_multicast_ttl(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     uint8_t *ttl_s
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_ip_multicast_ttl) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_set_ipv6_only(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     bool is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_set_ipv6_only) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_sock_get_ipv6_only(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock,
     bool *is_enabled
 ) WASMTIME_SSP_SYSCALL_NAME(sock_get_ipv6_only) __attribute__((__warn_unused_result__));

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -55,7 +55,6 @@ static_assert(sizeof(struct iovec) == sizeof(__wasi_ciovec_t),
               "Size mismatch");
 #endif
 
-
 // Converts a POSIX error code to a CloudABI error code.
 static __wasi_errno_t
 convert_errno(int error)
@@ -774,9 +773,8 @@ fd_table_insert_fd(struct fd_table *ft, int in, __wasi_filetype_t type,
 }
 
 __wasi_errno_t
-wasmtime_ssp_fd_prestat_get(
-    struct fd_prestats *prestats,
-    __wasi_fd_t fd, __wasi_prestat_t *buf)
+wasmtime_ssp_fd_prestat_get(struct fd_prestats *prestats, __wasi_fd_t fd,
+                            __wasi_prestat_t *buf)
 {
     rwlock_rdlock(&prestats->lock);
     struct fd_prestat *prestat;
@@ -798,9 +796,8 @@ wasmtime_ssp_fd_prestat_get(
 }
 
 __wasi_errno_t
-wasmtime_ssp_fd_prestat_dir_name(
-    struct fd_prestats *prestats,
-    __wasi_fd_t fd, char *path, size_t path_len)
+wasmtime_ssp_fd_prestat_dir_name(struct fd_prestats *prestats, __wasi_fd_t fd,
+                                 char *path, size_t path_len)
 {
     rwlock_rdlock(&prestats->lock);
     struct fd_prestat *prestat;
@@ -822,9 +819,8 @@ wasmtime_ssp_fd_prestat_dir_name(
 }
 
 __wasi_errno_t
-wasmtime_ssp_fd_close(
-    struct fd_table *curfds, struct fd_prestats *prestats,
-    __wasi_fd_t fd)
+wasmtime_ssp_fd_close(struct fd_table *curfds, struct fd_prestats *prestats,
+                      __wasi_fd_t fd)
 {
     // Don't allow closing a pre-opened resource.
     // TODO: Eventually, we do want to permit this, once libpreopen in
@@ -896,9 +892,7 @@ fd_object_get(struct fd_table *curfds, struct fd_object **fo, __wasi_fd_t fd,
 }
 
 __wasi_errno_t
-wasmtime_ssp_fd_datasync(
-    struct fd_table *curfds,
-    __wasi_fd_t fd)
+wasmtime_ssp_fd_datasync(struct fd_table *curfds, __wasi_fd_t fd)
 {
     struct fd_object *fo;
     __wasi_errno_t error =
@@ -918,10 +912,9 @@ wasmtime_ssp_fd_datasync(
 }
 
 __wasi_errno_t
-wasmtime_ssp_fd_pread(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, const __wasi_iovec_t *iov, size_t iovcnt,
-    __wasi_filesize_t offset, size_t *nread)
+wasmtime_ssp_fd_pread(struct fd_table *curfds, __wasi_fd_t fd,
+                      const __wasi_iovec_t *iov, size_t iovcnt,
+                      __wasi_filesize_t offset, size_t *nread)
 {
     if (iovcnt == 0)
         return __WASI_EINVAL;
@@ -990,10 +983,9 @@ wasmtime_ssp_fd_pread(
 }
 
 __wasi_errno_t
-wasmtime_ssp_fd_pwrite(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, const __wasi_ciovec_t *iov, size_t iovcnt,
-    __wasi_filesize_t offset, size_t *nwritten)
+wasmtime_ssp_fd_pwrite(struct fd_table *curfds, __wasi_fd_t fd,
+                       const __wasi_ciovec_t *iov, size_t iovcnt,
+                       __wasi_filesize_t offset, size_t *nwritten)
 {
     if (iovcnt == 0)
         return __WASI_EINVAL;
@@ -1042,9 +1034,8 @@ wasmtime_ssp_fd_pwrite(
 }
 
 __wasi_errno_t
-wasmtime_ssp_fd_read(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, const __wasi_iovec_t *iov, size_t iovcnt, size_t *nread)
+wasmtime_ssp_fd_read(struct fd_table *curfds, __wasi_fd_t fd,
+                     const __wasi_iovec_t *iov, size_t iovcnt, size_t *nread)
 {
     struct fd_object *fo;
     __wasi_errno_t error =
@@ -1061,9 +1052,8 @@ wasmtime_ssp_fd_read(
 }
 
 __wasi_errno_t
-wasmtime_ssp_fd_renumber(
-    struct fd_table *curfds, struct fd_prestats *prestats,
-    __wasi_fd_t from, __wasi_fd_t to)
+wasmtime_ssp_fd_renumber(struct fd_table *curfds, struct fd_prestats *prestats,
+                         __wasi_fd_t from, __wasi_fd_t to)
 {
     // Don't allow renumbering over a pre-opened resource.
     // TODO: Eventually, we do want to permit this, once libpreopen in
@@ -1113,10 +1103,9 @@ wasmtime_ssp_fd_renumber(
 }
 
 __wasi_errno_t
-wasmtime_ssp_fd_seek(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, __wasi_filedelta_t offset, __wasi_whence_t whence,
-    __wasi_filesize_t *newoffset)
+wasmtime_ssp_fd_seek(struct fd_table *curfds, __wasi_fd_t fd,
+                     __wasi_filedelta_t offset, __wasi_whence_t whence,
+                     __wasi_filesize_t *newoffset)
 {
     int nwhence;
     switch (whence) {
@@ -1152,9 +1141,8 @@ wasmtime_ssp_fd_seek(
 }
 
 __wasi_errno_t
-wasmtime_ssp_fd_tell(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, __wasi_filesize_t *newoffset)
+wasmtime_ssp_fd_tell(struct fd_table *curfds, __wasi_fd_t fd,
+                     __wasi_filesize_t *newoffset)
 {
     struct fd_object *fo;
     __wasi_errno_t error =
@@ -1171,9 +1159,8 @@ wasmtime_ssp_fd_tell(
 }
 
 __wasi_errno_t
-wasmtime_ssp_fd_fdstat_get(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, __wasi_fdstat_t *buf)
+wasmtime_ssp_fd_fdstat_get(struct fd_table *curfds, __wasi_fd_t fd,
+                           __wasi_fdstat_t *buf)
 {
     struct fd_table *ft = curfds;
     rwlock_rdlock(&ft->lock);
@@ -1221,9 +1208,8 @@ wasmtime_ssp_fd_fdstat_get(
 }
 
 __wasi_errno_t
-wasmtime_ssp_fd_fdstat_set_flags(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, __wasi_fdflags_t fs_flags)
+wasmtime_ssp_fd_fdstat_set_flags(struct fd_table *curfds, __wasi_fd_t fd,
+                                 __wasi_fdflags_t fs_flags)
 {
     int noflags = 0;
     if ((fs_flags & __WASI_FDFLAG_APPEND) != 0)
@@ -1259,10 +1245,9 @@ wasmtime_ssp_fd_fdstat_set_flags(
 }
 
 __wasi_errno_t
-wasmtime_ssp_fd_fdstat_set_rights(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, __wasi_rights_t fs_rights_base,
-    __wasi_rights_t fs_rights_inheriting)
+wasmtime_ssp_fd_fdstat_set_rights(struct fd_table *curfds, __wasi_fd_t fd,
+                                  __wasi_rights_t fs_rights_base,
+                                  __wasi_rights_t fs_rights_inheriting)
 {
     struct fd_table *ft = curfds;
     rwlock_wrlock(&ft->lock);
@@ -1282,9 +1267,7 @@ wasmtime_ssp_fd_fdstat_set_rights(
 }
 
 __wasi_errno_t
-wasmtime_ssp_fd_sync(
-    struct fd_table *curfds,
-    __wasi_fd_t fd)
+wasmtime_ssp_fd_sync(struct fd_table *curfds, __wasi_fd_t fd)
 {
     struct fd_object *fo;
     __wasi_errno_t error =
@@ -1300,9 +1283,9 @@ wasmtime_ssp_fd_sync(
 }
 
 __wasi_errno_t
-wasmtime_ssp_fd_write(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, const __wasi_ciovec_t *iov, size_t iovcnt, size_t *nwritten)
+wasmtime_ssp_fd_write(struct fd_table *curfds, __wasi_fd_t fd,
+                      const __wasi_ciovec_t *iov, size_t iovcnt,
+                      size_t *nwritten)
 {
     struct fd_object *fo;
     __wasi_errno_t error =
@@ -1341,10 +1324,9 @@ wasmtime_ssp_fd_write(
 }
 
 __wasi_errno_t
-wasmtime_ssp_fd_advise(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, __wasi_filesize_t offset, __wasi_filesize_t len,
-    __wasi_advice_t advice)
+wasmtime_ssp_fd_advise(struct fd_table *curfds, __wasi_fd_t fd,
+                       __wasi_filesize_t offset, __wasi_filesize_t len,
+                       __wasi_advice_t advice)
 {
 #ifdef POSIX_FADV_NORMAL
     int nadvice;
@@ -1408,9 +1390,8 @@ wasmtime_ssp_fd_advise(
 }
 
 __wasi_errno_t
-wasmtime_ssp_fd_allocate(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, __wasi_filesize_t offset, __wasi_filesize_t len)
+wasmtime_ssp_fd_allocate(struct fd_table *curfds, __wasi_fd_t fd,
+                         __wasi_filesize_t offset, __wasi_filesize_t len)
 {
     struct fd_object *fo;
     __wasi_errno_t error =
@@ -1747,9 +1728,8 @@ path_put(struct path_access *pa) UNLOCKS(pa->fd_object->refcount)
 }
 
 __wasi_errno_t
-wasmtime_ssp_path_create_directory(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, const char *path, size_t pathlen)
+wasmtime_ssp_path_create_directory(struct fd_table *curfds, __wasi_fd_t fd,
+                                   const char *path, size_t pathlen)
 {
     struct path_access pa;
     __wasi_errno_t error =
@@ -1793,11 +1773,11 @@ validate_path(const char *path, struct fd_prestats *pt)
 }
 
 __wasi_errno_t
-wasmtime_ssp_path_link(
-    struct fd_table *curfds, struct fd_prestats *prestats,
-    __wasi_fd_t old_fd, __wasi_lookupflags_t old_flags, const char *old_path,
-    size_t old_path_len, __wasi_fd_t new_fd, const char *new_path,
-    size_t new_path_len)
+wasmtime_ssp_path_link(struct fd_table *curfds, struct fd_prestats *prestats,
+                       __wasi_fd_t old_fd, __wasi_lookupflags_t old_flags,
+                       const char *old_path, size_t old_path_len,
+                       __wasi_fd_t new_fd, const char *new_path,
+                       size_t new_path_len)
 {
     struct path_access old_pa;
     __wasi_errno_t error =
@@ -1850,12 +1830,12 @@ wasmtime_ssp_path_link(
 }
 
 __wasi_errno_t
-wasmtime_ssp_path_open(
-    struct fd_table *curfds,
-    __wasi_fd_t dirfd, __wasi_lookupflags_t dirflags, const char *path,
-    size_t pathlen, __wasi_oflags_t oflags, __wasi_rights_t fs_rights_base,
-    __wasi_rights_t fs_rights_inheriting, __wasi_fdflags_t fs_flags,
-    __wasi_fd_t *fd)
+wasmtime_ssp_path_open(struct fd_table *curfds, __wasi_fd_t dirfd,
+                       __wasi_lookupflags_t dirflags, const char *path,
+                       size_t pathlen, __wasi_oflags_t oflags,
+                       __wasi_rights_t fs_rights_base,
+                       __wasi_rights_t fs_rights_inheriting,
+                       __wasi_fdflags_t fs_flags, __wasi_fd_t *fd)
 {
     // Rights that should be installed on the new file descriptor.
     __wasi_rights_t rights_base = fs_rights_base;
@@ -2002,10 +1982,9 @@ fd_readdir_put(void *buf, size_t bufsize, size_t *bufused, const void *elem,
 }
 
 __wasi_errno_t
-wasmtime_ssp_fd_readdir(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, void *buf, size_t nbyte, __wasi_dircookie_t cookie,
-    size_t *bufused)
+wasmtime_ssp_fd_readdir(struct fd_table *curfds, __wasi_fd_t fd, void *buf,
+                        size_t nbyte, __wasi_dircookie_t cookie,
+                        size_t *bufused)
 {
     struct fd_object *fo;
     __wasi_errno_t error =
@@ -2099,10 +2078,9 @@ wasmtime_ssp_fd_readdir(
 }
 
 __wasi_errno_t
-wasmtime_ssp_path_readlink(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, const char *path, size_t pathlen, char *buf, size_t bufsize,
-    size_t *bufused)
+wasmtime_ssp_path_readlink(struct fd_table *curfds, __wasi_fd_t fd,
+                           const char *path, size_t pathlen, char *buf,
+                           size_t bufsize, size_t *bufused)
 {
     struct path_access pa;
     __wasi_errno_t error = path_get_nofollow(
@@ -2123,10 +2101,10 @@ wasmtime_ssp_path_readlink(
 }
 
 __wasi_errno_t
-wasmtime_ssp_path_rename(
-    struct fd_table *curfds,
-    __wasi_fd_t old_fd, const char *old_path, size_t old_path_len,
-    __wasi_fd_t new_fd, const char *new_path, size_t new_path_len)
+wasmtime_ssp_path_rename(struct fd_table *curfds, __wasi_fd_t old_fd,
+                         const char *old_path, size_t old_path_len,
+                         __wasi_fd_t new_fd, const char *new_path,
+                         size_t new_path_len)
 {
     struct path_access old_pa;
     __wasi_errno_t error =
@@ -2168,9 +2146,8 @@ convert_stat(const struct stat *in, __wasi_filestat_t *out)
 }
 
 __wasi_errno_t
-wasmtime_ssp_fd_filestat_get(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, __wasi_filestat_t *buf)
+wasmtime_ssp_fd_filestat_get(struct fd_table *curfds, __wasi_fd_t fd,
+                             __wasi_filestat_t *buf)
 {
     struct fd_object *fo;
     __wasi_errno_t error =
@@ -2239,9 +2216,8 @@ convert_utimens_arguments(__wasi_timestamp_t st_atim,
 }
 
 __wasi_errno_t
-wasmtime_ssp_fd_filestat_set_size(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, __wasi_filesize_t st_size)
+wasmtime_ssp_fd_filestat_set_size(struct fd_table *curfds, __wasi_fd_t fd,
+                                  __wasi_filesize_t st_size)
 {
     struct fd_object *fo;
     __wasi_errno_t error =
@@ -2257,10 +2233,10 @@ wasmtime_ssp_fd_filestat_set_size(
 }
 
 __wasi_errno_t
-wasmtime_ssp_fd_filestat_set_times(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, __wasi_timestamp_t st_atim, __wasi_timestamp_t st_mtim,
-    __wasi_fstflags_t fstflags)
+wasmtime_ssp_fd_filestat_set_times(struct fd_table *curfds, __wasi_fd_t fd,
+                                   __wasi_timestamp_t st_atim,
+                                   __wasi_timestamp_t st_mtim,
+                                   __wasi_fstflags_t fstflags)
 {
     if ((fstflags
          & ~(__WASI_FILESTAT_SET_ATIM | __WASI_FILESTAT_SET_ATIM_NOW
@@ -2285,10 +2261,9 @@ wasmtime_ssp_fd_filestat_set_times(
 }
 
 __wasi_errno_t
-wasmtime_ssp_path_filestat_get(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, __wasi_lookupflags_t flags, const char *path,
-    size_t pathlen, __wasi_filestat_t *buf)
+wasmtime_ssp_path_filestat_get(struct fd_table *curfds, __wasi_fd_t fd,
+                               __wasi_lookupflags_t flags, const char *path,
+                               size_t pathlen, __wasi_filestat_t *buf)
 {
     struct path_access pa;
     __wasi_errno_t error = path_get(curfds, &pa, fd, flags, path, pathlen,
@@ -2323,11 +2298,12 @@ wasmtime_ssp_path_filestat_get(
 }
 
 __wasi_errno_t
-wasmtime_ssp_path_filestat_set_times(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, __wasi_lookupflags_t flags, const char *path,
-    size_t pathlen, __wasi_timestamp_t st_atim, __wasi_timestamp_t st_mtim,
-    __wasi_fstflags_t fstflags)
+wasmtime_ssp_path_filestat_set_times(struct fd_table *curfds, __wasi_fd_t fd,
+                                     __wasi_lookupflags_t flags,
+                                     const char *path, size_t pathlen,
+                                     __wasi_timestamp_t st_atim,
+                                     __wasi_timestamp_t st_mtim,
+                                     __wasi_fstflags_t fstflags)
 {
     if (((fstflags
           & ~(__WASI_FILESTAT_SET_ATIM | __WASI_FILESTAT_SET_ATIM_NOW
@@ -2360,10 +2336,10 @@ wasmtime_ssp_path_filestat_set_times(
 }
 
 __wasi_errno_t
-wasmtime_ssp_path_symlink(
-    struct fd_table *curfds, struct fd_prestats *prestats,
-    const char *old_path, size_t old_path_len, __wasi_fd_t fd,
-    const char *new_path, size_t new_path_len)
+wasmtime_ssp_path_symlink(struct fd_table *curfds, struct fd_prestats *prestats,
+                          const char *old_path, size_t old_path_len,
+                          __wasi_fd_t fd, const char *new_path,
+                          size_t new_path_len)
 {
     char *target = str_nullterminate(old_path, old_path_len);
     if (target == NULL)
@@ -2395,9 +2371,8 @@ wasmtime_ssp_path_symlink(
 }
 
 __wasi_errno_t
-wasmtime_ssp_path_unlink_file(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, const char *path, size_t pathlen)
+wasmtime_ssp_path_unlink_file(struct fd_table *curfds, __wasi_fd_t fd,
+                              const char *path, size_t pathlen)
 {
     struct path_access pa;
     __wasi_errno_t error = path_get_nofollow(
@@ -2430,9 +2405,8 @@ wasmtime_ssp_path_unlink_file(
 }
 
 __wasi_errno_t
-wasmtime_ssp_path_remove_directory(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, const char *path, size_t pathlen)
+wasmtime_ssp_path_remove_directory(struct fd_table *curfds, __wasi_fd_t fd,
+                                   const char *path, size_t pathlen)
 {
     struct path_access pa;
     __wasi_errno_t error =
@@ -2457,10 +2431,10 @@ wasmtime_ssp_path_remove_directory(
 }
 
 __wasi_errno_t
-wasmtime_ssp_poll_oneoff(
-    struct fd_table *curfds,
-    const __wasi_subscription_t *in, __wasi_event_t *out, size_t nsubscriptions,
-    size_t *nevents) NO_LOCK_ANALYSIS
+wasmtime_ssp_poll_oneoff(struct fd_table *curfds,
+                         const __wasi_subscription_t *in, __wasi_event_t *out,
+                         size_t nsubscriptions,
+                         size_t *nevents) NO_LOCK_ANALYSIS
 {
     // Sleeping.
     if (nsubscriptions == 1 && in[0].u.type == __WASI_EVENTTYPE_CLOCK) {
@@ -2719,9 +2693,8 @@ wasmtime_ssp_random_get(void *buf, size_t nbyte)
 }
 
 __wasi_errno_t
-wasi_ssp_sock_accept(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, __wasi_fdflags_t flags, __wasi_fd_t *fd_new)
+wasi_ssp_sock_accept(struct fd_table *curfds, __wasi_fd_t fd,
+                     __wasi_fdflags_t flags, __wasi_fd_t *fd_new)
 {
     __wasi_filetype_t wasi_type;
     __wasi_rights_t max_base, max_inheriting;
@@ -2765,9 +2738,8 @@ fail:
 }
 
 __wasi_errno_t
-wasi_ssp_sock_addr_local(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, __wasi_addr_t *addr)
+wasi_ssp_sock_addr_local(struct fd_table *curfds, __wasi_fd_t fd,
+                         __wasi_addr_t *addr)
 {
     struct fd_object *fo;
     bh_sockaddr_t bh_addr;
@@ -2790,9 +2762,8 @@ wasi_ssp_sock_addr_local(
 }
 
 __wasi_errno_t
-wasi_ssp_sock_addr_remote(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, __wasi_addr_t *addr)
+wasi_ssp_sock_addr_remote(struct fd_table *curfds, __wasi_fd_t fd,
+                          __wasi_addr_t *addr)
 {
     struct fd_object *fo;
     bh_sockaddr_t bh_addr;
@@ -2844,9 +2815,8 @@ wasi_addr_to_string(const __wasi_addr_t *addr, char *buf, size_t buflen)
 }
 
 __wasi_errno_t
-wasi_ssp_sock_bind(
-    struct fd_table *curfds, struct addr_pool *addr_pool,
-    __wasi_fd_t fd, __wasi_addr_t *addr)
+wasi_ssp_sock_bind(struct fd_table *curfds, struct addr_pool *addr_pool,
+                   __wasi_fd_t fd, __wasi_addr_t *addr)
 {
     char buf[48] = { 0 };
     struct fd_object *fo;
@@ -2876,11 +2846,12 @@ wasi_ssp_sock_bind(
 }
 
 __wasi_errno_t
-wasi_ssp_sock_addr_resolve(
-    struct fd_table *curfds, char **ns_lookup_list,
-    const char *host, const char *service, __wasi_addr_info_hints_t *hints,
-    __wasi_addr_info_t *addr_info, __wasi_size_t addr_info_size,
-    __wasi_size_t *max_info_size)
+wasi_ssp_sock_addr_resolve(struct fd_table *curfds, char **ns_lookup_list,
+                           const char *host, const char *service,
+                           __wasi_addr_info_hints_t *hints,
+                           __wasi_addr_info_t *addr_info,
+                           __wasi_size_t addr_info_size,
+                           __wasi_size_t *max_info_size)
 {
     bh_addr_info_t *wamr_addr_info =
         wasm_runtime_malloc(addr_info_size * sizeof(bh_addr_info_t));
@@ -2927,9 +2898,8 @@ wasi_ssp_sock_addr_resolve(
 }
 
 __wasi_errno_t
-wasi_ssp_sock_connect(
-    struct fd_table *curfds, struct addr_pool *addr_pool,
-    __wasi_fd_t fd, __wasi_addr_t *addr)
+wasi_ssp_sock_connect(struct fd_table *curfds, struct addr_pool *addr_pool,
+                      __wasi_fd_t fd, __wasi_addr_t *addr)
 {
     char buf[48] = { 0 };
     struct fd_object *fo;
@@ -2960,9 +2930,8 @@ wasi_ssp_sock_connect(
 }
 
 __wasi_errno_t
-wasi_ssp_sock_get_recv_buf_size(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, __wasi_size_t *size)
+wasi_ssp_sock_get_recv_buf_size(struct fd_table *curfds, __wasi_fd_t fd,
+                                __wasi_size_t *size)
 {
     struct fd_object *fo;
     int ret;
@@ -2985,9 +2954,8 @@ wasi_ssp_sock_get_recv_buf_size(
 }
 
 __wasi_errno_t
-wasi_ssp_sock_get_reuse_addr(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, uint8_t *reuse)
+wasi_ssp_sock_get_reuse_addr(struct fd_table *curfds, __wasi_fd_t fd,
+                             uint8_t *reuse)
 {
 
     struct fd_object *fo;
@@ -3011,9 +2979,8 @@ wasi_ssp_sock_get_reuse_addr(
 }
 
 __wasi_errno_t
-wasi_ssp_sock_get_reuse_port(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, uint8_t *reuse)
+wasi_ssp_sock_get_reuse_port(struct fd_table *curfds, __wasi_fd_t fd,
+                             uint8_t *reuse)
 {
     struct fd_object *fo;
     int ret;
@@ -3043,9 +3010,8 @@ wasi_ssp_sock_get_reuse_port(
 }
 
 __wasi_errno_t
-wasi_ssp_sock_get_send_buf_size(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, __wasi_size_t *size)
+wasi_ssp_sock_get_send_buf_size(struct fd_table *curfds, __wasi_fd_t fd,
+                                __wasi_size_t *size)
 {
     struct fd_object *fo;
     int ret;
@@ -3068,9 +3034,8 @@ wasi_ssp_sock_get_send_buf_size(
 }
 
 __wasi_errno_t
-wasi_ssp_sock_listen(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, __wasi_size_t backlog)
+wasi_ssp_sock_listen(struct fd_table *curfds, __wasi_fd_t fd,
+                     __wasi_size_t backlog)
 {
     struct fd_object *fo;
     int ret;
@@ -3089,10 +3054,9 @@ wasi_ssp_sock_listen(
 }
 
 __wasi_errno_t
-wasi_ssp_sock_open(
-    struct fd_table *curfds,
-    __wasi_fd_t poolfd, __wasi_address_family_t af, __wasi_sock_type_t socktype,
-    __wasi_fd_t *sockfd)
+wasi_ssp_sock_open(struct fd_table *curfds, __wasi_fd_t poolfd,
+                   __wasi_address_family_t af, __wasi_sock_type_t socktype,
+                   __wasi_fd_t *sockfd)
 {
     bh_socket_t sock;
     bool is_tcp = SOCKET_DGRAM == socktype ? false : true;
@@ -3134,9 +3098,8 @@ wasi_ssp_sock_open(
 }
 
 __wasi_errno_t
-wasi_ssp_sock_set_recv_buf_size(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, __wasi_size_t size)
+wasi_ssp_sock_set_recv_buf_size(struct fd_table *curfds, __wasi_fd_t fd,
+                                __wasi_size_t size)
 {
     struct fd_object *fo;
     int ret;
@@ -3157,9 +3120,8 @@ wasi_ssp_sock_set_recv_buf_size(
 }
 
 __wasi_errno_t
-wasi_ssp_sock_set_reuse_addr(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, uint8_t reuse)
+wasi_ssp_sock_set_reuse_addr(struct fd_table *curfds, __wasi_fd_t fd,
+                             uint8_t reuse)
 {
     struct fd_object *fo;
     int ret;
@@ -3180,9 +3142,8 @@ wasi_ssp_sock_set_reuse_addr(
 }
 
 __wasi_errno_t
-wasi_ssp_sock_set_reuse_port(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, uint8_t reuse)
+wasi_ssp_sock_set_reuse_port(struct fd_table *curfds, __wasi_fd_t fd,
+                             uint8_t reuse)
 {
     struct fd_object *fo;
     int ret;
@@ -3209,9 +3170,8 @@ wasi_ssp_sock_set_reuse_port(
 }
 
 __wasi_errno_t
-wasi_ssp_sock_set_send_buf_size(
-    struct fd_table *curfds,
-    __wasi_fd_t fd, __wasi_size_t size)
+wasi_ssp_sock_set_send_buf_size(struct fd_table *curfds, __wasi_fd_t fd,
+                                __wasi_size_t size)
 {
     struct fd_object *fo;
     int ret;
@@ -3233,9 +3193,8 @@ wasi_ssp_sock_set_send_buf_size(
 }
 
 __wasi_errno_t
-wasmtime_ssp_sock_recv(
-    struct fd_table *curfds,
-    __wasi_fd_t sock, void *buf, size_t buf_len, size_t *recv_len)
+wasmtime_ssp_sock_recv(struct fd_table *curfds, __wasi_fd_t sock, void *buf,
+                       size_t buf_len, size_t *recv_len)
 {
     __wasi_addr_t src_addr;
 
@@ -3244,10 +3203,10 @@ wasmtime_ssp_sock_recv(
 }
 
 __wasi_errno_t
-wasmtime_ssp_sock_recv_from(
-    struct fd_table *curfds,
-    __wasi_fd_t sock, void *buf, size_t buf_len, __wasi_riflags_t ri_flags,
-    __wasi_addr_t *src_addr, size_t *recv_len)
+wasmtime_ssp_sock_recv_from(struct fd_table *curfds, __wasi_fd_t sock,
+                            void *buf, size_t buf_len,
+                            __wasi_riflags_t ri_flags, __wasi_addr_t *src_addr,
+                            size_t *recv_len)
 {
     struct fd_object *fo;
     __wasi_errno_t error;
@@ -3272,9 +3231,8 @@ wasmtime_ssp_sock_recv_from(
 }
 
 __wasi_errno_t
-wasmtime_ssp_sock_send(
-    struct fd_table *curfds,
-    __wasi_fd_t sock, const void *buf, size_t buf_len, size_t *sent_len)
+wasmtime_ssp_sock_send(struct fd_table *curfds, __wasi_fd_t sock,
+                       const void *buf, size_t buf_len, size_t *sent_len)
 {
     struct fd_object *fo;
     __wasi_errno_t error;
@@ -3296,10 +3254,10 @@ wasmtime_ssp_sock_send(
 }
 
 __wasi_errno_t
-wasmtime_ssp_sock_send_to(
-    struct fd_table *curfds, struct addr_pool *addr_pool,
-    __wasi_fd_t sock, const void *buf, size_t buf_len,
-    __wasi_siflags_t si_flags, const __wasi_addr_t *dest_addr, size_t *sent_len)
+wasmtime_ssp_sock_send_to(struct fd_table *curfds, struct addr_pool *addr_pool,
+                          __wasi_fd_t sock, const void *buf, size_t buf_len,
+                          __wasi_siflags_t si_flags,
+                          const __wasi_addr_t *dest_addr, size_t *sent_len)
 {
     char addr_buf[48] = { 0 };
     struct fd_object *fo;
@@ -3333,9 +3291,7 @@ wasmtime_ssp_sock_send_to(
 }
 
 __wasi_errno_t
-wasmtime_ssp_sock_shutdown(
-    struct fd_table *curfds,
-    __wasi_fd_t sock)
+wasmtime_ssp_sock_shutdown(struct fd_table *curfds, __wasi_fd_t sock)
 {
     struct fd_object *fo;
     __wasi_errno_t error;
@@ -3362,9 +3318,8 @@ wasmtime_ssp_sched_yield(void)
 }
 
 __wasi_errno_t
-wasmtime_ssp_args_get(
-    struct argv_environ_values *argv_environ,
-    char **argv, char *argv_buf)
+wasmtime_ssp_args_get(struct argv_environ_values *argv_environ, char **argv,
+                      char *argv_buf)
 {
     for (size_t i = 0; i < argv_environ->argc; ++i) {
         argv[i] =
@@ -3377,9 +3332,8 @@ wasmtime_ssp_args_get(
 }
 
 __wasi_errno_t
-wasmtime_ssp_args_sizes_get(
-    struct argv_environ_values *argv_environ,
-    size_t *argc, size_t *argv_buf_size)
+wasmtime_ssp_args_sizes_get(struct argv_environ_values *argv_environ,
+                            size_t *argc, size_t *argv_buf_size)
 {
     *argc = argv_environ->argc;
     *argv_buf_size = argv_environ->argv_buf_size;
@@ -3387,9 +3341,8 @@ wasmtime_ssp_args_sizes_get(
 }
 
 __wasi_errno_t
-wasmtime_ssp_environ_get(
-    struct argv_environ_values *argv_environ,
-    char **environ, char *environ_buf)
+wasmtime_ssp_environ_get(struct argv_environ_values *argv_environ,
+                         char **environ, char *environ_buf)
 {
     for (size_t i = 0; i < argv_environ->environ_count; ++i) {
         environ[i] =
@@ -3404,9 +3357,8 @@ wasmtime_ssp_environ_get(
 }
 
 __wasi_errno_t
-wasmtime_ssp_environ_sizes_get(
-    struct argv_environ_values *argv_environ,
-    size_t *environ_count, size_t *environ_buf_size)
+wasmtime_ssp_environ_sizes_get(struct argv_environ_values *argv_environ,
+                               size_t *environ_count, size_t *environ_buf_size)
 {
     *environ_count = argv_environ->environ_count;
     *environ_buf_size = argv_environ->environ_buf_size;
@@ -3690,9 +3642,8 @@ WASMTIME_SSP_PASSTHROUGH_SOCKET_OPTION(get_ipv6_only, bool *)
 #undef WASMTIME_SSP_PASSTHROUGH_SOCKET_OPTION
 
 __wasi_errno_t
-wasmtime_ssp_sock_set_linger(
-    struct fd_table *curfds,
-    __wasi_fd_t sock, bool is_enabled, int linger_s)
+wasmtime_ssp_sock_set_linger(struct fd_table *curfds, __wasi_fd_t sock,
+                             bool is_enabled, int linger_s)
 {
     struct fd_object *fo;
     __wasi_errno_t error;
@@ -3709,9 +3660,8 @@ wasmtime_ssp_sock_set_linger(
 }
 
 __wasi_errno_t
-wasmtime_ssp_sock_get_linger(
-    struct fd_table *curfds,
-    __wasi_fd_t sock, bool *is_enabled, int *linger_s)
+wasmtime_ssp_sock_get_linger(struct fd_table *curfds, __wasi_fd_t sock,
+                             bool *is_enabled, int *linger_s)
 {
     struct fd_object *fo;
     __wasi_errno_t error;
@@ -3729,9 +3679,10 @@ wasmtime_ssp_sock_get_linger(
 }
 
 __wasi_errno_t
-wasmtime_ssp_sock_set_ip_add_membership(
-    struct fd_table *curfds,
-    __wasi_fd_t sock, __wasi_addr_ip_t *imr_multiaddr, uint32_t imr_interface)
+wasmtime_ssp_sock_set_ip_add_membership(struct fd_table *curfds,
+                                        __wasi_fd_t sock,
+                                        __wasi_addr_ip_t *imr_multiaddr,
+                                        uint32_t imr_interface)
 {
     struct fd_object *fo;
     __wasi_errno_t error;
@@ -3753,9 +3704,10 @@ wasmtime_ssp_sock_set_ip_add_membership(
 }
 
 __wasi_errno_t
-wasmtime_ssp_sock_set_ip_drop_membership(
-    struct fd_table *curfds,
-    __wasi_fd_t sock, __wasi_addr_ip_t *imr_multiaddr, uint32_t imr_interface)
+wasmtime_ssp_sock_set_ip_drop_membership(struct fd_table *curfds,
+                                         __wasi_fd_t sock,
+                                         __wasi_addr_ip_t *imr_multiaddr,
+                                         uint32_t imr_interface)
 {
     struct fd_object *fo;
     __wasi_errno_t error;
@@ -3777,9 +3729,9 @@ wasmtime_ssp_sock_set_ip_drop_membership(
 }
 
 __wasi_errno_t
-wasmtime_ssp_sock_set_ip_multicast_loop(
-    struct fd_table *curfds,
-    __wasi_fd_t sock, bool ipv6, bool is_enabled)
+wasmtime_ssp_sock_set_ip_multicast_loop(struct fd_table *curfds,
+                                        __wasi_fd_t sock, bool ipv6,
+                                        bool is_enabled)
 {
     struct fd_object *fo;
     __wasi_errno_t error;
@@ -3796,9 +3748,9 @@ wasmtime_ssp_sock_set_ip_multicast_loop(
 }
 
 __wasi_errno_t
-wasmtime_ssp_sock_get_ip_multicast_loop(
-    struct fd_table *curfds,
-    __wasi_fd_t sock, bool ipv6, bool *is_enabled)
+wasmtime_ssp_sock_get_ip_multicast_loop(struct fd_table *curfds,
+                                        __wasi_fd_t sock, bool ipv6,
+                                        bool *is_enabled)
 {
     struct fd_object *fo;
     __wasi_errno_t error;

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -55,12 +55,6 @@ static_assert(sizeof(struct iovec) == sizeof(__wasi_ciovec_t),
               "Size mismatch");
 #endif
 
-#if defined(WASMTIME_SSP_STATIC_CURFDS)
-static __thread struct fd_table *curfds;
-static __thread struct fd_prestats *prestats;
-static __thread struct argv_environ_values *argv_environ;
-static __thread struct addr_pool *addr_pool;
-#endif
 
 // Converts a POSIX error code to a CloudABI error code.
 static __wasi_errno_t
@@ -340,9 +334,6 @@ fd_prestats_init(struct fd_prestats *pt)
     pt->prestats = NULL;
     pt->size = 0;
     pt->used = 0;
-#if defined(WASMTIME_SSP_STATIC_CURFDS)
-    prestats = pt;
-#endif
     return true;
 }
 
@@ -446,9 +437,6 @@ fd_table_init(struct fd_table *ft)
     ft->entries = NULL;
     ft->size = 0;
     ft->used = 0;
-#if defined(WASMTIME_SSP_STATIC_CURFDS)
-    curfds = ft;
-#endif
     return true;
 }
 
@@ -787,9 +775,7 @@ fd_table_insert_fd(struct fd_table *ft, int in, __wasi_filetype_t type,
 
 __wasi_errno_t
 wasmtime_ssp_fd_prestat_get(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_prestats *prestats,
-#endif
     __wasi_fd_t fd, __wasi_prestat_t *buf)
 {
     rwlock_rdlock(&prestats->lock);
@@ -813,9 +799,7 @@ wasmtime_ssp_fd_prestat_get(
 
 __wasi_errno_t
 wasmtime_ssp_fd_prestat_dir_name(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_prestats *prestats,
-#endif
     __wasi_fd_t fd, char *path, size_t path_len)
 {
     rwlock_rdlock(&prestats->lock);
@@ -839,9 +823,7 @@ wasmtime_ssp_fd_prestat_dir_name(
 
 __wasi_errno_t
 wasmtime_ssp_fd_close(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds, struct fd_prestats *prestats,
-#endif
     __wasi_fd_t fd)
 {
     // Don't allow closing a pre-opened resource.
@@ -915,9 +897,7 @@ fd_object_get(struct fd_table *curfds, struct fd_object **fo, __wasi_fd_t fd,
 
 __wasi_errno_t
 wasmtime_ssp_fd_datasync(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd)
 {
     struct fd_object *fo;
@@ -939,9 +919,7 @@ wasmtime_ssp_fd_datasync(
 
 __wasi_errno_t
 wasmtime_ssp_fd_pread(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, const __wasi_iovec_t *iov, size_t iovcnt,
     __wasi_filesize_t offset, size_t *nread)
 {
@@ -1013,9 +991,7 @@ wasmtime_ssp_fd_pread(
 
 __wasi_errno_t
 wasmtime_ssp_fd_pwrite(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, const __wasi_ciovec_t *iov, size_t iovcnt,
     __wasi_filesize_t offset, size_t *nwritten)
 {
@@ -1067,9 +1043,7 @@ wasmtime_ssp_fd_pwrite(
 
 __wasi_errno_t
 wasmtime_ssp_fd_read(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, const __wasi_iovec_t *iov, size_t iovcnt, size_t *nread)
 {
     struct fd_object *fo;
@@ -1088,9 +1062,7 @@ wasmtime_ssp_fd_read(
 
 __wasi_errno_t
 wasmtime_ssp_fd_renumber(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds, struct fd_prestats *prestats,
-#endif
     __wasi_fd_t from, __wasi_fd_t to)
 {
     // Don't allow renumbering over a pre-opened resource.
@@ -1142,9 +1114,7 @@ wasmtime_ssp_fd_renumber(
 
 __wasi_errno_t
 wasmtime_ssp_fd_seek(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_filedelta_t offset, __wasi_whence_t whence,
     __wasi_filesize_t *newoffset)
 {
@@ -1183,9 +1153,7 @@ wasmtime_ssp_fd_seek(
 
 __wasi_errno_t
 wasmtime_ssp_fd_tell(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_filesize_t *newoffset)
 {
     struct fd_object *fo;
@@ -1204,9 +1172,7 @@ wasmtime_ssp_fd_tell(
 
 __wasi_errno_t
 wasmtime_ssp_fd_fdstat_get(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_fdstat_t *buf)
 {
     struct fd_table *ft = curfds;
@@ -1256,9 +1222,7 @@ wasmtime_ssp_fd_fdstat_get(
 
 __wasi_errno_t
 wasmtime_ssp_fd_fdstat_set_flags(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_fdflags_t fs_flags)
 {
     int noflags = 0;
@@ -1296,9 +1260,7 @@ wasmtime_ssp_fd_fdstat_set_flags(
 
 __wasi_errno_t
 wasmtime_ssp_fd_fdstat_set_rights(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_rights_t fs_rights_base,
     __wasi_rights_t fs_rights_inheriting)
 {
@@ -1321,9 +1283,7 @@ wasmtime_ssp_fd_fdstat_set_rights(
 
 __wasi_errno_t
 wasmtime_ssp_fd_sync(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd)
 {
     struct fd_object *fo;
@@ -1341,9 +1301,7 @@ wasmtime_ssp_fd_sync(
 
 __wasi_errno_t
 wasmtime_ssp_fd_write(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, const __wasi_ciovec_t *iov, size_t iovcnt, size_t *nwritten)
 {
     struct fd_object *fo;
@@ -1384,9 +1342,7 @@ wasmtime_ssp_fd_write(
 
 __wasi_errno_t
 wasmtime_ssp_fd_advise(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_filesize_t offset, __wasi_filesize_t len,
     __wasi_advice_t advice)
 {
@@ -1453,9 +1409,7 @@ wasmtime_ssp_fd_advise(
 
 __wasi_errno_t
 wasmtime_ssp_fd_allocate(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_filesize_t offset, __wasi_filesize_t len)
 {
     struct fd_object *fo;
@@ -1794,9 +1748,7 @@ path_put(struct path_access *pa) UNLOCKS(pa->fd_object->refcount)
 
 __wasi_errno_t
 wasmtime_ssp_path_create_directory(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, const char *path, size_t pathlen)
 {
     struct path_access pa;
@@ -1842,9 +1794,7 @@ validate_path(const char *path, struct fd_prestats *pt)
 
 __wasi_errno_t
 wasmtime_ssp_path_link(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds, struct fd_prestats *prestats,
-#endif
     __wasi_fd_t old_fd, __wasi_lookupflags_t old_flags, const char *old_path,
     size_t old_path_len, __wasi_fd_t new_fd, const char *new_path,
     size_t new_path_len)
@@ -1901,9 +1851,7 @@ wasmtime_ssp_path_link(
 
 __wasi_errno_t
 wasmtime_ssp_path_open(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t dirfd, __wasi_lookupflags_t dirflags, const char *path,
     size_t pathlen, __wasi_oflags_t oflags, __wasi_rights_t fs_rights_base,
     __wasi_rights_t fs_rights_inheriting, __wasi_fdflags_t fs_flags,
@@ -2055,9 +2003,7 @@ fd_readdir_put(void *buf, size_t bufsize, size_t *bufused, const void *elem,
 
 __wasi_errno_t
 wasmtime_ssp_fd_readdir(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, void *buf, size_t nbyte, __wasi_dircookie_t cookie,
     size_t *bufused)
 {
@@ -2154,9 +2100,7 @@ wasmtime_ssp_fd_readdir(
 
 __wasi_errno_t
 wasmtime_ssp_path_readlink(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, const char *path, size_t pathlen, char *buf, size_t bufsize,
     size_t *bufused)
 {
@@ -2180,9 +2124,7 @@ wasmtime_ssp_path_readlink(
 
 __wasi_errno_t
 wasmtime_ssp_path_rename(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t old_fd, const char *old_path, size_t old_path_len,
     __wasi_fd_t new_fd, const char *new_path, size_t new_path_len)
 {
@@ -2227,9 +2169,7 @@ convert_stat(const struct stat *in, __wasi_filestat_t *out)
 
 __wasi_errno_t
 wasmtime_ssp_fd_filestat_get(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_filestat_t *buf)
 {
     struct fd_object *fo;
@@ -2300,9 +2240,7 @@ convert_utimens_arguments(__wasi_timestamp_t st_atim,
 
 __wasi_errno_t
 wasmtime_ssp_fd_filestat_set_size(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_filesize_t st_size)
 {
     struct fd_object *fo;
@@ -2320,9 +2258,7 @@ wasmtime_ssp_fd_filestat_set_size(
 
 __wasi_errno_t
 wasmtime_ssp_fd_filestat_set_times(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_timestamp_t st_atim, __wasi_timestamp_t st_mtim,
     __wasi_fstflags_t fstflags)
 {
@@ -2350,9 +2286,7 @@ wasmtime_ssp_fd_filestat_set_times(
 
 __wasi_errno_t
 wasmtime_ssp_path_filestat_get(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_lookupflags_t flags, const char *path,
     size_t pathlen, __wasi_filestat_t *buf)
 {
@@ -2390,9 +2324,7 @@ wasmtime_ssp_path_filestat_get(
 
 __wasi_errno_t
 wasmtime_ssp_path_filestat_set_times(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_lookupflags_t flags, const char *path,
     size_t pathlen, __wasi_timestamp_t st_atim, __wasi_timestamp_t st_mtim,
     __wasi_fstflags_t fstflags)
@@ -2429,9 +2361,7 @@ wasmtime_ssp_path_filestat_set_times(
 
 __wasi_errno_t
 wasmtime_ssp_path_symlink(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds, struct fd_prestats *prestats,
-#endif
     const char *old_path, size_t old_path_len, __wasi_fd_t fd,
     const char *new_path, size_t new_path_len)
 {
@@ -2466,9 +2396,7 @@ wasmtime_ssp_path_symlink(
 
 __wasi_errno_t
 wasmtime_ssp_path_unlink_file(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, const char *path, size_t pathlen)
 {
     struct path_access pa;
@@ -2503,9 +2431,7 @@ wasmtime_ssp_path_unlink_file(
 
 __wasi_errno_t
 wasmtime_ssp_path_remove_directory(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, const char *path, size_t pathlen)
 {
     struct path_access pa;
@@ -2532,9 +2458,7 @@ wasmtime_ssp_path_remove_directory(
 
 __wasi_errno_t
 wasmtime_ssp_poll_oneoff(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     const __wasi_subscription_t *in, __wasi_event_t *out, size_t nsubscriptions,
     size_t *nevents) NO_LOCK_ANALYSIS
 {
@@ -2796,9 +2720,7 @@ wasmtime_ssp_random_get(void *buf, size_t nbyte)
 
 __wasi_errno_t
 wasi_ssp_sock_accept(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_fdflags_t flags, __wasi_fd_t *fd_new)
 {
     __wasi_filetype_t wasi_type;
@@ -2844,9 +2766,7 @@ fail:
 
 __wasi_errno_t
 wasi_ssp_sock_addr_local(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_addr_t *addr)
 {
     struct fd_object *fo;
@@ -2871,9 +2791,7 @@ wasi_ssp_sock_addr_local(
 
 __wasi_errno_t
 wasi_ssp_sock_addr_remote(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_addr_t *addr)
 {
     struct fd_object *fo;
@@ -2927,9 +2845,7 @@ wasi_addr_to_string(const __wasi_addr_t *addr, char *buf, size_t buflen)
 
 __wasi_errno_t
 wasi_ssp_sock_bind(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds, struct addr_pool *addr_pool,
-#endif
     __wasi_fd_t fd, __wasi_addr_t *addr)
 {
     char buf[48] = { 0 };
@@ -2961,9 +2877,7 @@ wasi_ssp_sock_bind(
 
 __wasi_errno_t
 wasi_ssp_sock_addr_resolve(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds, char **ns_lookup_list,
-#endif
     const char *host, const char *service, __wasi_addr_info_hints_t *hints,
     __wasi_addr_info_t *addr_info, __wasi_size_t addr_info_size,
     __wasi_size_t *max_info_size)
@@ -3014,9 +2928,7 @@ wasi_ssp_sock_addr_resolve(
 
 __wasi_errno_t
 wasi_ssp_sock_connect(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds, struct addr_pool *addr_pool,
-#endif
     __wasi_fd_t fd, __wasi_addr_t *addr)
 {
     char buf[48] = { 0 };
@@ -3049,9 +2961,7 @@ wasi_ssp_sock_connect(
 
 __wasi_errno_t
 wasi_ssp_sock_get_recv_buf_size(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_size_t *size)
 {
     struct fd_object *fo;
@@ -3076,9 +2986,7 @@ wasi_ssp_sock_get_recv_buf_size(
 
 __wasi_errno_t
 wasi_ssp_sock_get_reuse_addr(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, uint8_t *reuse)
 {
 
@@ -3104,9 +3012,7 @@ wasi_ssp_sock_get_reuse_addr(
 
 __wasi_errno_t
 wasi_ssp_sock_get_reuse_port(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, uint8_t *reuse)
 {
     struct fd_object *fo;
@@ -3138,9 +3044,7 @@ wasi_ssp_sock_get_reuse_port(
 
 __wasi_errno_t
 wasi_ssp_sock_get_send_buf_size(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_size_t *size)
 {
     struct fd_object *fo;
@@ -3165,9 +3069,7 @@ wasi_ssp_sock_get_send_buf_size(
 
 __wasi_errno_t
 wasi_ssp_sock_listen(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_size_t backlog)
 {
     struct fd_object *fo;
@@ -3188,9 +3090,7 @@ wasi_ssp_sock_listen(
 
 __wasi_errno_t
 wasi_ssp_sock_open(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t poolfd, __wasi_address_family_t af, __wasi_sock_type_t socktype,
     __wasi_fd_t *sockfd)
 {
@@ -3235,9 +3135,7 @@ wasi_ssp_sock_open(
 
 __wasi_errno_t
 wasi_ssp_sock_set_recv_buf_size(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_size_t size)
 {
     struct fd_object *fo;
@@ -3260,9 +3158,7 @@ wasi_ssp_sock_set_recv_buf_size(
 
 __wasi_errno_t
 wasi_ssp_sock_set_reuse_addr(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, uint8_t reuse)
 {
     struct fd_object *fo;
@@ -3285,9 +3181,7 @@ wasi_ssp_sock_set_reuse_addr(
 
 __wasi_errno_t
 wasi_ssp_sock_set_reuse_port(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, uint8_t reuse)
 {
     struct fd_object *fo;
@@ -3316,9 +3210,7 @@ wasi_ssp_sock_set_reuse_port(
 
 __wasi_errno_t
 wasi_ssp_sock_set_send_buf_size(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t fd, __wasi_size_t size)
 {
     struct fd_object *fo;
@@ -3342,9 +3234,7 @@ wasi_ssp_sock_set_send_buf_size(
 
 __wasi_errno_t
 wasmtime_ssp_sock_recv(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock, void *buf, size_t buf_len, size_t *recv_len)
 {
     __wasi_addr_t src_addr;
@@ -3355,9 +3245,7 @@ wasmtime_ssp_sock_recv(
 
 __wasi_errno_t
 wasmtime_ssp_sock_recv_from(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock, void *buf, size_t buf_len, __wasi_riflags_t ri_flags,
     __wasi_addr_t *src_addr, size_t *recv_len)
 {
@@ -3385,9 +3273,7 @@ wasmtime_ssp_sock_recv_from(
 
 __wasi_errno_t
 wasmtime_ssp_sock_send(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock, const void *buf, size_t buf_len, size_t *sent_len)
 {
     struct fd_object *fo;
@@ -3411,9 +3297,7 @@ wasmtime_ssp_sock_send(
 
 __wasi_errno_t
 wasmtime_ssp_sock_send_to(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds, struct addr_pool *addr_pool,
-#endif
     __wasi_fd_t sock, const void *buf, size_t buf_len,
     __wasi_siflags_t si_flags, const __wasi_addr_t *dest_addr, size_t *sent_len)
 {
@@ -3450,9 +3334,7 @@ wasmtime_ssp_sock_send_to(
 
 __wasi_errno_t
 wasmtime_ssp_sock_shutdown(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock)
 {
     struct fd_object *fo;
@@ -3481,9 +3363,7 @@ wasmtime_ssp_sched_yield(void)
 
 __wasi_errno_t
 wasmtime_ssp_args_get(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct argv_environ_values *argv_environ,
-#endif
     char **argv, char *argv_buf)
 {
     for (size_t i = 0; i < argv_environ->argc; ++i) {
@@ -3498,9 +3378,7 @@ wasmtime_ssp_args_get(
 
 __wasi_errno_t
 wasmtime_ssp_args_sizes_get(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct argv_environ_values *argv_environ,
-#endif
     size_t *argc, size_t *argv_buf_size)
 {
     *argc = argv_environ->argc;
@@ -3510,9 +3388,7 @@ wasmtime_ssp_args_sizes_get(
 
 __wasi_errno_t
 wasmtime_ssp_environ_get(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct argv_environ_values *argv_environ,
-#endif
     char **environ, char *environ_buf)
 {
     for (size_t i = 0; i < argv_environ->environ_count; ++i) {
@@ -3529,9 +3405,7 @@ wasmtime_ssp_environ_get(
 
 __wasi_errno_t
 wasmtime_ssp_environ_sizes_get(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct argv_environ_values *argv_environ,
-#endif
     size_t *environ_count, size_t *environ_buf_size)
 {
     *environ_count = argv_environ->environ_count;
@@ -3757,11 +3631,7 @@ addr_pool_destroy(struct addr_pool *addr_pool)
     }
 }
 
-#ifndef WASMTIME_SSP_STATIC_CURFDS
 #define WASMTIME_SSP_PASSTHROUGH_FD_TABLE struct fd_table *curfds,
-#else
-#define WASMTIME_SSP_PASSTHROUGH_FD_TABLE
-#endif
 
 // Defines a function that passes through the socket option to the OS
 // implementation
@@ -3821,9 +3691,7 @@ WASMTIME_SSP_PASSTHROUGH_SOCKET_OPTION(get_ipv6_only, bool *)
 
 __wasi_errno_t
 wasmtime_ssp_sock_set_linger(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock, bool is_enabled, int linger_s)
 {
     struct fd_object *fo;
@@ -3842,9 +3710,7 @@ wasmtime_ssp_sock_set_linger(
 
 __wasi_errno_t
 wasmtime_ssp_sock_get_linger(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock, bool *is_enabled, int *linger_s)
 {
     struct fd_object *fo;
@@ -3864,9 +3730,7 @@ wasmtime_ssp_sock_get_linger(
 
 __wasi_errno_t
 wasmtime_ssp_sock_set_ip_add_membership(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock, __wasi_addr_ip_t *imr_multiaddr, uint32_t imr_interface)
 {
     struct fd_object *fo;
@@ -3890,9 +3754,7 @@ wasmtime_ssp_sock_set_ip_add_membership(
 
 __wasi_errno_t
 wasmtime_ssp_sock_set_ip_drop_membership(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock, __wasi_addr_ip_t *imr_multiaddr, uint32_t imr_interface)
 {
     struct fd_object *fo;
@@ -3916,9 +3778,7 @@ wasmtime_ssp_sock_set_ip_drop_membership(
 
 __wasi_errno_t
 wasmtime_ssp_sock_set_ip_multicast_loop(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock, bool ipv6, bool is_enabled)
 {
     struct fd_object *fo;
@@ -3937,9 +3797,7 @@ wasmtime_ssp_sock_set_ip_multicast_loop(
 
 __wasi_errno_t
 wasmtime_ssp_sock_get_ip_multicast_loop(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
-#endif
     __wasi_fd_t sock, bool ipv6, bool *is_enabled)
 {
     struct fd_object *fo;


### PR DESCRIPTION
as the upstream doesn't use this code anymore, there is little point
to keep this macro.
