### PR TITLE
fd_object_release: Preserve errno

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -642,6 +642,7 @@ static void
 fd_object_release(struct fd_object *fo) UNLOCKS(fo->refcount)
 {
     if (refcount_release(&fo->refcount)) {
+        int saved_errno = errno;
         switch (fo->type) {
             case __WASI_FILETYPE_DIRECTORY:
                 // For directories we may keep track of a DIR object. Calling
@@ -659,6 +660,7 @@ fd_object_release(struct fd_object *fo) UNLOCKS(fo->refcount)
                 break;
         }
         wasm_runtime_free(fo);
+        errno = saved_errno;
     }
 }
 


### PR DESCRIPTION
Preserve errno because this function is often used like the following. The caller wants to report the error from the main operation (`lseek` in this example), not from fd_object_release.

```
    off_t ret = lseek(fd_number(fo), offset, nwhence);
    fd_object_release(fo);
    if (ret < 0)
        return convert_errno(errno);
```