### PR TITLE
Add context to enlarge memory error callback

### DIFF
--- a/core/iwasm/common/wasm_memory.c
+++ b/core/iwasm/common/wasm_memory.c
@@ -26,6 +26,7 @@ static Memory_Mode memory_mode = MEMORY_MODE_UNKNOWN;
 static mem_allocator_t pool_allocator = NULL;
 
 static enlarge_memory_error_callback_t enlarge_memory_error_cb;
+static void *enlarge_memory_error_user_data;
 
 #if WASM_MEM_ALLOC_WITH_USER_DATA != 0
 static void *allocator_user_data = NULL;
@@ -716,7 +717,8 @@ return_func:
 
         enlarge_memory_error_cb(inc_page_count, total_size_old, 0,
                                 failure_reason,
-                                (WASMModuleInstanceCommon *)module, exec_env);
+                                (WASMModuleInstanceCommon *)module, exec_env,
+                                enlarge_memory_error_user_data);
     }
 
     return ret;
@@ -822,7 +824,8 @@ return_func:
 
         enlarge_memory_error_cb(inc_page_count, total_size_old, 0,
                                 failure_reason,
-                                (WASMModuleInstanceCommon *)module, exec_env);
+                                (WASMModuleInstanceCommon *)module, exec_env,
+                                enlarge_memory_error_user_data);
     }
 
     return ret;
@@ -831,9 +834,10 @@ return_func:
 
 void
 wasm_runtime_set_enlarge_mem_error_callback(
-    const enlarge_memory_error_callback_t callback)
+    const enlarge_memory_error_callback_t callback, void *user_data)
 {
     enlarge_memory_error_cb = callback;
+    enlarge_memory_error_user_data = user_data;
 }
 
 bool

--- a/core/iwasm/common/wasm_memory.h
+++ b/core/iwasm/common/wasm_memory.h
@@ -26,7 +26,7 @@ wasm_runtime_memory_pool_size();
 
 void
 wasm_runtime_set_enlarge_mem_error_callback(
-    const enlarge_memory_error_callback_t callback);
+    const enlarge_memory_error_callback_t callback, void *user_data);
 
 #ifdef __cplusplus
 }

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -1447,14 +1447,15 @@ typedef enum {
 typedef void (*enlarge_memory_error_callback_t)(
     uint32_t inc_page_count, uint64_t current_memory_size,
     uint32_t memory_index, enlarge_memory_error_reason_t failure_reason,
-    wasm_module_inst_t instance, wasm_exec_env_t exec_env);
+    wasm_module_inst_t instance, wasm_exec_env_t exec_env,
+    void* user_data);
 
 /**
  * Setup callback invoked when memory.grow fails
  */
 WASM_RUNTIME_API_EXTERN void
 wasm_runtime_set_enlarge_mem_error_callback(
-    const enlarge_memory_error_callback_t callback);
+    const enlarge_memory_error_callback_t callback, void *user_data);
 
 /*
  * module instance context APIs


### PR DESCRIPTION
Follow-up on https://github.com/bytecodealliance/wasm-micro-runtime/pull/2522.
When trying to use the callback in practice (from an embedder), I realized that not being able to pass some context (i.e. data passed from the embedder that can be used in the callback) is quite limiting.