### PR TITLE
core/iwasm/compilation: Support AOT with LLVM 17

### DIFF
--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -526,12 +526,18 @@ aot_add_precheck_function(AOTCompContext *comp_ctx, LLVMModuleRef module,
     }
     wasm_runtime_free(params);
     params = NULL;
+
+#if LLVM_VERSION_MAJOR < 17
     if (aot_target_precheck_can_use_musttail(comp_ctx)) {
         LLVMSetTailCallKind(retval, LLVMTailCallKindMustTail);
     }
     else {
         LLVMSetTailCallKind(retval, LLVMTailCallKindTail);
     }
+#else
+    LLVMSetTailCall(retval, true);
+#endif
+
     if (ret_type == VOID_TYPE) {
         if (!LLVMBuildRetVoid(b)) {
             goto fail;
@@ -2172,8 +2178,10 @@ bool
 aot_compiler_init(void)
 {
     /* Initialize LLVM environment */
-
+#if LLVM_VERSION_MAJOR < 17
     LLVMInitializeCore(LLVMGetGlobalPassRegistry());
+#endif
+
 #if WASM_ENABLE_WAMR_COMPILER != 0
     /* Init environment of all targets for AOT compiler */
     LLVMInitializeAllTargetInfos();

--- a/core/iwasm/compilation/aot_llvm.h
+++ b/core/iwasm/compilation/aot_llvm.h
@@ -15,15 +15,18 @@
 #include "llvm-c/ExecutionEngine.h"
 #include "llvm-c/Analysis.h"
 #include "llvm-c/BitWriter.h"
+#if LLVM_VERSION_MAJOR < 17
 #include "llvm-c/Transforms/Utils.h"
 #include "llvm-c/Transforms/Scalar.h"
 #include "llvm-c/Transforms/Vectorize.h"
 #include "llvm-c/Transforms/PassManagerBuilder.h"
+#include "llvm-c/Initialization.h"
+#endif
 
 #include "llvm-c/Orc.h"
 #include "llvm-c/Error.h"
 #include "llvm-c/Support.h"
-#include "llvm-c/Initialization.h"
+
 #include "llvm-c/TargetMachine.h"
 #include "llvm-c/LLJIT.h"
 #if WASM_ENABLE_DEBUG_AOT != 0

--- a/core/iwasm/compilation/aot_llvm_extra.cpp
+++ b/core/iwasm/compilation/aot_llvm_extra.cpp
@@ -5,11 +5,13 @@
 
 #include <llvm/Passes/StandardInstrumentations.h>
 #include <llvm/Support/Error.h>
+#if LLVM_VERSION_MAJOR < 17
 #include <llvm/ADT/None.h>
 #include <llvm/ADT/Optional.h>
+#include <llvm/ADT/Triple.h>
+#endif
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/Twine.h>
-#include <llvm/ADT/Triple.h>
 #include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/CodeGen/TargetPassConfig.h>
 #include <llvm/ExecutionEngine/ExecutionEngine.h>
@@ -18,7 +20,9 @@
 #include <llvm/Target/TargetMachine.h>
 #include <llvm-c/Core.h>
 #include <llvm-c/ExecutionEngine.h>
+#if LLVM_VERSION_MAJOR < 17
 #include <llvm-c/Initialization.h>
+#endif
 #include <llvm/ExecutionEngine/GenericValue.h>
 #include <llvm/ExecutionEngine/JITEventListener.h>
 #include <llvm/ExecutionEngine/RTDyldMemoryManager.h>
@@ -30,6 +34,9 @@
 #include <llvm/IR/PassManager.h>
 #include <llvm/Support/CommandLine.h>
 #include <llvm/Support/ErrorHandling.h>
+#if LLVM_VERSION_MAJOR >= 17
+#include <llvm/Support/PGOOptions.h>
+#endif
 #include <llvm/Target/CodeGenCWrappers.h>
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Target/TargetOptions.h>
@@ -54,6 +61,13 @@
 
 using namespace llvm;
 using namespace llvm::orc;
+
+#if LLVM_VERSION_MAJOR >= 17
+namespace llvm {
+template<typename T>
+using Optional = std::optional<T>;
+}
+#endif
 
 LLVM_C_EXTERN_C_BEGIN
 
@@ -110,7 +124,14 @@ ExpandMemoryOpPass::run(Function &F, FunctionAnalysisManager &AM)
             Memcpy->eraseFromParent();
         }
         else if (MemMoveInst *Memmove = dyn_cast<MemMoveInst>(MemCall)) {
+#if LLVM_VERSION_MAJOR >= 17
+            Function *ParentFunc = Memcpy->getParent()->getParent();
+            const TargetTransformInfo &TTI =
+                AM.getResult<TargetIRAnalysis>(*ParentFunc);
+            expandMemMoveAsLoop(Memmove, TTI);
+#else
             expandMemMoveAsLoop(Memmove);
+#endif
             Memmove->eraseFromParent();
         }
         else if (MemSetInst *Memset = dyn_cast<MemSetInst>(MemCall)) {
@@ -181,6 +202,9 @@ aot_apply_llvm_new_pass_manager(AOTCompContext *comp_ctx, LLVMModuleRef module)
 #else
     Optional<PGOOptions> PGO = llvm::None;
 #endif
+
+// TODO
+#if LLVM_VERSION_MAJOR < 17
     if (comp_ctx->enable_llvm_pgo) {
         /* Disable static counter allocation for value profiler,
            it will be allocated by runtime */
@@ -191,6 +215,7 @@ aot_apply_llvm_new_pass_manager(AOTCompContext *comp_ctx, LLVMModuleRef module)
     else if (comp_ctx->use_prof_file) {
         PGO = PGOOptions(comp_ctx->use_prof_file, "", "", PGOOptions::IRUse);
     }
+#endif
 
 #ifdef DEBUG_PASS
     PassInstrumentationCallbacks PIC;

--- a/core/iwasm/compilation/aot_llvm_extra.cpp
+++ b/core/iwasm/compilation/aot_llvm_extra.cpp
@@ -125,7 +125,7 @@ ExpandMemoryOpPass::run(Function &F, FunctionAnalysisManager &AM)
         }
         else if (MemMoveInst *Memmove = dyn_cast<MemMoveInst>(MemCall)) {
 #if LLVM_VERSION_MAJOR >= 17
-            Function *ParentFunc = Memcpy->getParent()->getParent();
+            Function *ParentFunc = Memmove->getParent()->getParent();
             const TargetTransformInfo &TTI =
                 AM.getResult<TargetIRAnalysis>(*ParentFunc);
             expandMemMoveAsLoop(Memmove, TTI);

--- a/core/iwasm/compilation/aot_llvm_extra2.cpp
+++ b/core/iwasm/compilation/aot_llvm_extra2.cpp
@@ -4,8 +4,10 @@
  */
 
 #include <llvm-c/TargetMachine.h>
+#if LLVM_VERSION_MAJOR < 17
 #include <llvm/ADT/None.h>
 #include <llvm/ADT/Optional.h>
+#endif
 #include <llvm/IR/Instructions.h>
 #if LLVM_VERSION_MAJOR >= 14
 #include <llvm/MC/TargetRegistry.h>
@@ -17,6 +19,13 @@
 #include "bh_assert.h"
 
 #include "aot_llvm_extra2.h"
+
+#if LLVM_VERSION_MAJOR >= 17
+namespace llvm {
+template<typename T>
+using Optional = std::optional<T>;
+}
+#endif
 
 static llvm::Optional<llvm::Reloc::Model>
 convert(LLVMRelocMode reloc_mode)

--- a/core/iwasm/compilation/aot_orc_extra.cpp
+++ b/core/iwasm/compilation/aot_orc_extra.cpp
@@ -8,8 +8,10 @@
 #include "llvm-c/OrcEE.h"
 #include "llvm-c/TargetMachine.h"
 
+#if LLVM_VERSION_MAJOR < 17
 #include "llvm/ADT/None.h"
 #include "llvm/ADT/Optional.h"
+#endif
 #include "llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h"
 #include "llvm/ExecutionEngine/Orc/LLJIT.h"
 #include "llvm/ExecutionEngine/Orc/ObjectTransformLayer.h"
@@ -20,6 +22,13 @@
 
 #include "aot_orc_extra.h"
 #include "aot.h"
+
+#if LLVM_VERSION_MAJOR >= 17
+namespace llvm {
+template<typename T>
+using Optional = std::optional<T>;
+}
+#endif
 
 using namespace llvm;
 using namespace llvm::orc;


### PR DESCRIPTION
Adapt API usage to new interfaces where applicable, including LLVM function usage, obsoleted llvm::Optional type & removal of unavailable headers.