### PR TITLE
test_wamr.sh: bump wasi-testsuite version

### DIFF
--- a/tests/wamr-test-suites/test_wamr.sh
+++ b/tests/wamr-test-suites/test_wamr.sh
@@ -55,7 +55,8 @@ PLATFORM=$(uname -s | tr A-Z a-z)
 PARALLELISM=0
 ENABLE_QEMU=0
 QEMU_FIRMWARE=""
-WASI_TESTSUITE_COMMIT="aca78d919355ae00af141e6741a439039615b257"
+# prod/testsuite-all branch
+WASI_TESTSUITE_COMMIT="cf64229727f71043d5849e73934e249e12cb9e06"
 
 while getopts ":s:cabgvt:m:MCpSXxwPGQF:" opt
 do


### PR DESCRIPTION
On posix-like platforms, the rest of wasi-threads tests should pass after the recent changes including the following PRs:

https://github.com/bytecodealliance/wasm-micro-runtime/pull/2516 https://github.com/bytecodealliance/wasm-micro-runtime/pull/2524 https://github.com/bytecodealliance/wasm-micro-runtime/pull/2529