### PR TITLE
core/iwasm/aot: Default expected target to "arm64" on Mach

### DIFF
--- a/core/iwasm/aot/arch/aot_reloc_aarch64.c
+++ b/core/iwasm/aot/arch/aot_reloc_aarch64.c
@@ -53,7 +53,11 @@ get_target_symbol_map(uint32 *sym_num)
     return target_sym_map;
 }
 
+#if !__MACH__
 #define BUILD_TARGET_AARCH64_DEFAULT "aarch64v8"
+#else
+#define BUILD_TARGET_AARCH64_DEFAULT "arm64"
+#endif
 void
 get_current_target(char *target_buf, uint32 target_buf_size)
 {


### PR DESCRIPTION
This tricks the AOT loader logic into loading AOT-compiled ELF files on iOS when wamrc is configured to build 'arm64-pc-linux-gnu' targets, the default LLVM detects when wamrc is run directly on the device.