### PR TITLE
run_wasi_tests.sh: provide stdin by ourselves

### DIFF
--- a/tests/wamr-test-suites/wasi-test-script/pipe.py
+++ b/tests/wamr-test-suites/wasi-test-script/pipe.py
@@ -1,0 +1,19 @@
+#! /usr/bin/env python3
+
+# Copyright (C) 2023 YAMAMOTO Takashi
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This is a copy of https://github.com/yamt/toywasm/blob/master/test/pipe.py
+
+# keep stdout open until the peer closes it
+
+import sys
+import select
+
+p = select.poll()
+p.register(sys.stdout, select.POLLHUP)
+# http://gnats.netbsd.org/cgi-bin/query-pr-single.pl?number=57369
+while True:
+    l = p.poll(1)
+    if l:
+        break

--- a/tests/wamr-test-suites/wasi-test-script/run_wasi_tests.sh
+++ b/tests/wamr-test-suites/wasi-test-script/run_wasi_tests.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
+THIS_DIR=$(cd $(dirname $0) && pwd -P)
+
 readonly MODE=$1
 readonly TARGET=$2
 
@@ -63,7 +65,8 @@ if [[ $MODE != "aot" ]];then
     python3 -m venv wasi-env && source wasi-env/bin/activate
     python3 -m pip install -r test-runner/requirements.txt
 
-    TEST_RUNTIME_EXE="${IWASM_CMD}" python3 test-runner/wasi_test_runner.py \
+    export TEST_RUNTIME_EXE="${IWASM_CMD}"
+    python3 ${THIS_DIR}/pipe.py | python3 test-runner/wasi_test_runner.py \
             -r adapters/wasm-micro-runtime.py \
             -t \
                 ${C_TESTS} \


### PR DESCRIPTION
This improves test consistency between typical local environments and github runners.

This is necessary for some of latest wasi-threads tests.

Also, IIRC, wasmtime test runner does something similar and some of their WASI tests rely on it.

cf. https://github.com/yamt/toywasm/commit/570e6706312cbdccb9d5268347186b441a24444b