### PR TITLE
Return __WASI_EINVAL from fd_prestat_dir_name

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -819,12 +819,14 @@ wasmtime_ssp_fd_prestat_dir_name(struct fd_prestats *prestats, __wasi_fd_t fd,
         rwlock_unlock(&prestats->lock);
         return error;
     }
-    if (path_len != strlen(prestat->dir)) {
+
+    const size_t prestat_dir_len = strlen(prestat->dir);
+    if (path_len < prestat_dir_len) {
         rwlock_unlock(&prestats->lock);
-        return EINVAL;
+        return __WASI_EINVAL;
     }
 
-    bh_memcpy_s(path, (uint32)path_len, prestat->dir, (uint32)path_len);
+    bh_memcpy_s(path, (uint32)path_len, prestat->dir, (uint32)prestat_dir_len);
 
     rwlock_unlock(&prestats->lock);
 


### PR DESCRIPTION
Return a WASI error code (rather than a host POSIX one). In addition,
there is no need to return an error in the case that the provided buffer
is too large.