### PR TITLE
Fix Android compile error

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/blocking_op.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/blocking_op.c
@@ -35,9 +35,6 @@ blocking_op_readv(wasm_exec_env_t exec_env, int fd, const struct iovec *iov,
 
 #if CONFIG_HAS_PREADV
 ssize_t
-preadv(int fd, const struct iovec *iov, int iovcnt, off_t offset);
-
-ssize_t
 blocking_op_preadv(wasm_exec_env_t exec_env, int fd, const struct iovec *iov,
                    int iovcnt, off_t offset)
 {
@@ -78,9 +75,6 @@ blocking_op_writev(wasm_exec_env_t exec_env, int fd, const struct iovec *iov,
 }
 
 #if CONFIG_HAS_PWRITEV
-ssize_t
-pwritev(int fd, const struct iovec *iov, int iovcnt, off_t offset);
-
 ssize_t
 blocking_op_pwritev(wasm_exec_env_t exec_env, int fd, const struct iovec *iov,
                     int iovcnt, off_t offset)

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/blocking_op.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/blocking_op.c
@@ -35,6 +35,9 @@ blocking_op_readv(wasm_exec_env_t exec_env, int fd, const struct iovec *iov,
 
 #if CONFIG_HAS_PREADV
 ssize_t
+preadv(int fd, const struct iovec *iov, int iovcnt, off_t offset);
+
+ssize_t
 blocking_op_preadv(wasm_exec_env_t exec_env, int fd, const struct iovec *iov,
                    int iovcnt, off_t offset)
 {
@@ -75,6 +78,9 @@ blocking_op_writev(wasm_exec_env_t exec_env, int fd, const struct iovec *iov,
 }
 
 #if CONFIG_HAS_PWRITEV
+ssize_t
+pwritev(int fd, const struct iovec *iov, int iovcnt, off_t offset);
+
 ssize_t
 blocking_op_pwritev(wasm_exec_env_t exec_env, int fd, const struct iovec *iov,
                     int iovcnt, off_t offset)

--- a/core/shared/platform/android/platform_internal.h
+++ b/core/shared/platform/android/platform_internal.h
@@ -139,15 +139,11 @@ seekdir(DIR *__dir, long __location);
 
 #endif
 
-#if __ANDROID_API__ < 24
-
 ssize_t
 preadv(int __fd, const struct iovec *__iov, int __count, off_t __offset);
 
 ssize_t
 pwritev(int __fd, const struct iovec *__iov, int __count, off_t __offset);
-
-#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Seems the CI uses clang-17.0.2 to build iwasm for Android platform, and
reported compile error:
https://github.com/bytecodealliance/wasm-micro-runtime/actions/runs/6308980430/job/17128073777
```bash
/home/runner/work/wasm-micro-runtime/wasm-micro-runtime/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/blocking_op.c:45:19: error: call to undeclared function 'preadv'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    ssize_t ret = preadv(fd, iov, iovcnt, offset);
                  ^
/home/runner/work/wasm-micro-runtime/wasm-micro-runtime/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/blocking_op.c:86:19: error: call to undeclared function 'pwritev'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    ssize_t ret = pwritev(fd, iov, iovcnt, offset);
                  ^
2 errors generated.
```