### PR TITLE
Upgrade clang-format version from 12 to 14

### DIFF
--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   compliance_job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/ci/coding_guidelines_check.py
+++ b/ci/coding_guidelines_check.py
@@ -13,8 +13,8 @@ import subprocess
 import sys
 import unittest
 
-CLANG_FORMAT_CMD = "clang-format-12"
-GIT_CLANG_FORMAT_CMD = "git-clang-format-12"
+CLANG_FORMAT_CMD = "clang-format-14"
+GIT_CLANG_FORMAT_CMD = "git-clang-format-14"
 
 # glob style patterns
 EXCLUDE_PATHS = [
@@ -96,20 +96,20 @@ def run_clang_format(file_path: pathlib, root: pathlib) -> bool:
 
 def run_clang_format_diff(root: pathlib, commits: str) -> bool:
     """
-    Use `clang-format-12` or `git-clang-format-12` to check code format of
+    Use `clang-format-14` or `git-clang-format-14` to check code format of
     the PR, with a commit range specified. It is required to format the
     code before committing the PR, or it might fail to pass the CI check:
 
-    1. Install clang-format-12.0.0
-    Normally we can install it by `sudo apt-get install clang-format-12`,
-    or download the `clang+llvm-12.0.0-xxx-tar.xz` package from
-      https://github.com/llvm/llvm-project/releases/tag/llvmorg-12.0.0
+    1. Install clang-format-14.0.0
+    Normally we can install it by `sudo apt-get install clang-format-14`,
+    or download the `clang+llvm-14.0.0-xxx-tar.xz` package from
+      https://github.com/llvm/llvm-project/releases/tag/llvmorg-14.0.0
     and install it
 
     2. Format the C/C++ source file
     ``` shell
     cd path/to/wamr/root
-    clang-format-12 --style file -i path/to/file
+    clang-format-14 --style file -i path/to/file
     ```
 
     The code wrapped by `/* clang-format off */` and `/* clang-format on */`


### PR DESCRIPTION
`clang-12` has been removed from Ubuntu `22.04`: https://github.com/actions/runner-images/blob/ubuntu22/20230924.1/images/linux/Ubuntu2204-Readme.md and the coding guidelines job started to fail.

[Last job](https://github.com/bytecodealliance/wasm-micro-runtime/actions/runs/6324887158/job/17175263160) using 22.04.3 version `20230917.1.0` was still fine, but the [latest](https://github.com/bytecodealliance/wasm-micro-runtime/actions/runs/6338189476/job/17214782992?pr=2599) with `20230924.1.0` fails.
Unfortunately, there's no way to pin the version: https://github.com/actions/runner-images/issues/2894.

As an alternative, we could downgrade to use Ubuntu 20.04 and keep `clang-12`.