### PR TITLE
Enforce compilation errors

### DIFF
--- a/build-scripts/runtime_lib.cmake
+++ b/build-scripts/runtime_lib.cmake
@@ -197,3 +197,6 @@ set (source_all
 )
 
 set (WAMR_RUNTIME_LIB_SOURCE ${source_all})
+
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-parameter -Werror")
+message ("-- CMAKE_C_FLAGS: ${CMAKE_C_FLAGS}")

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -5778,7 +5778,7 @@ wasm_runtime_register_sub_module(const WASMModuleCommon *parent_module,
 {
     /* register sub_module into its parent sub module list */
     WASMRegisteredModule *node = NULL;
-    bh_list_status ret;
+    bh_list_status ret = BH_LIST_ERROR;
 
     if (wasm_runtime_search_sub_module(parent_module, sub_module_name)) {
         LOG_DEBUG("%s has been registered in its parent", sub_module_name);

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -2922,8 +2922,11 @@ load(const uint8 *buf, uint32 size, WASMModule *module, char *error_buf,
 }
 
 WASMModule *
-wasm_loader_load(uint8 *buf, uint32 size, char *error_buf,
-                 uint32 error_buf_size)
+wasm_loader_load(uint8 *buf, uint32 size,
+#if WASM_ENABLE_MULTI_MODULE != 0
+                 bool main_module,
+#endif
+                 char *error_buf, uint32 error_buf_size)
 {
     WASMModule *module = create_module(error_buf, error_buf_size);
     if (!module) {

--- a/core/shared/platform/common/posix/posix_socket.c
+++ b/core/shared/platform/common/posix/posix_socket.c
@@ -219,7 +219,7 @@ int
 os_socket_accept(bh_socket_t server_sock, bh_socket_t *sock, void *addr,
                  unsigned int *addrlen)
 {
-    *sock = accept(server_sock, addr, addrlen);
+    *sock = accept(server_sock, addr, (socklen_t *)addrlen);
 
     if (*sock < 0) {
         return BHT_ERROR;

--- a/core/shared/utils/bh_assert.h
+++ b/core/shared/utils/bh_assert.h
@@ -19,7 +19,7 @@ bh_assert_internal(int64 v, const char *file_name, int line_number,
 #define bh_assert(expr) \
     bh_assert_internal((int64)(uintptr_t)(expr), __FILE__, __LINE__, #expr)
 #else
-#define bh_assert(expr) (void)0
+#define bh_assert(expr) ((void)(expr))
 #endif /* end of BH_DEBUG */
 
 #if !defined(__has_extension)

--- a/wamr-compiler/CMakeLists.txt
+++ b/wamr-compiler/CMakeLists.txt
@@ -256,6 +256,7 @@ if (WIN32)
   add_definitions(-D_WINSOCK_DEPRECATED_NO_WARNINGS)
 endif()
 
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
 # message ("-- CMAKE_C_FLAGS: ${CMAKE_C_FLAGS}")
 
 add_library (vmlib


### PR DESCRIPTION
Fail compilation of `iwasm` and `wamrc` if warnings.
One of the use cases is to forget removing unused variables, e.g. #1913.