### PR TITLE
remove module instance from hashmap in wasi_nn_destroy

### DIFF
--- a/core/iwasm/libraries/wasi-nn/src/wasi_nn.c
+++ b/core/iwasm/libraries/wasi-nn/src/wasi_nn.c
@@ -163,6 +163,7 @@ void
 wasi_nn_destroy(wasm_module_inst_t instance)
 {
     WASINNContext *wasi_nn_ctx = wasm_runtime_get_wasi_nn_ctx(instance);
+    bh_hash_map_remove(hashmap, (void *)instance, NULL, NULL);
     wasi_nn_ctx_destroy(wasi_nn_ctx);
 }
 


### PR DESCRIPTION
When destroying wasi-nn context, module instance should be also removed from hashmap to avoid memory leak.

issue: https://github.com/bytecodealliance/wasm-micro-runtime/issues/2612