### PR TITLE
refactor stress tests to make them runnable in reactor mode

### DIFF
--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -8,9 +8,11 @@ on:
     types:
       - opened
       - synchronize
-    #running nightly pipeline if you're changing it 
+    # running nightly pipeline if you're changing it 
+    # stress tests are run only in nightly at the moment, so running them in they are changed
     paths:
       - ".github/workflows/nightly_run.yml"
+      - "core/iwasm/libraries/lib-wasi-threads/stress-test/**"
       
   # midnight UTC
   schedule:

--- a/core/iwasm/libraries/lib-wasi-threads/stress-test/build.sh
+++ b/core/iwasm/libraries/lib-wasi-threads/stress-test/build.sh
@@ -60,6 +60,7 @@ for test_c in *.c; do
         -Wl,--export=wasi_thread_start \
         -Wl,--export=malloc \
         -Wl,--export=free \
+        -Wl,--export=test \
         $sysroot_command \
         $test_c -o $test_wasm
 done

--- a/core/iwasm/libraries/lib-wasi-threads/stress-test/errorcheck_mutex_stress_test.c
+++ b/core/iwasm/libraries/lib-wasi-threads/stress-test/errorcheck_mutex_stress_test.c
@@ -7,8 +7,8 @@
 #include <errno.h>
 #include "mutex_common.h"
 
-int
-main()
+void
+test()
 {
     pthread_mutex_t mutex;
 
@@ -24,4 +24,11 @@ main()
     run_common_tests(&mutex);
     fprintf(stderr, "Errorcheck mutex test is completed\n");
     pthread_mutex_destroy(&mutex);
+}
+
+int
+main()
+{
+    test();
+    return 0;
 }

--- a/core/iwasm/libraries/lib-wasi-threads/stress-test/normal_mutex_stress_test.c
+++ b/core/iwasm/libraries/lib-wasi-threads/stress-test/normal_mutex_stress_test.c
@@ -7,8 +7,8 @@
 #include <errno.h>
 #include "mutex_common.h"
 
-int
-main()
+void
+test()
 {
     pthread_mutex_t mutex;
     pthread_mutex_init(&mutex, NULL);
@@ -17,4 +17,11 @@ main()
 
     fprintf(stderr, "Normal mutex test is completed\n");
     pthread_mutex_destroy(&mutex);
+}
+
+int
+main()
+{
+    test();
+    return 0;
 }

--- a/core/iwasm/libraries/lib-wasi-threads/stress-test/recursive_mutex_stress_test.c
+++ b/core/iwasm/libraries/lib-wasi-threads/stress-test/recursive_mutex_stress_test.c
@@ -31,8 +31,8 @@ same_thread_multiple_rec_mutex_lock(void *mutex)
     return NULL;
 }
 
-int
-main()
+void
+test()
 {
     pthread_mutex_t mutex;
 
@@ -62,4 +62,11 @@ main()
 
     fprintf(stderr, "Recursive mutex test is completed\n");
     pthread_mutex_destroy(&mutex);
+}
+
+int
+main()
+{
+    test();
+    return 0;
 }

--- a/core/iwasm/libraries/lib-wasi-threads/stress-test/spawn_stress_test.c
+++ b/core/iwasm/libraries/lib-wasi-threads/stress-test/spawn_stress_test.c
@@ -16,13 +16,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-enum CONSTANTS {
-    NUM_ITER = 100000,
-    NUM_RETRY = 8,
-    MAX_NUM_THREADS = 12,
-    RETRY_SLEEP_TIME_US = 2000,
-};
-
 unsigned prime_numbers_count = 0;
 
 bool
@@ -49,10 +42,10 @@ check_if_prime(void *value)
 }
 
 unsigned int
-validate()
+validate(int iter_num)
 {
     unsigned int counter = 0;
-    for (unsigned int i = 2; i <= NUM_ITER; ++i) {
+    for (unsigned int i = 2; i <= iter_num; ++i) {
         counter += is_prime(i);
     }
 
@@ -60,11 +53,12 @@ validate()
 }
 
 void
-spawn_thread(pthread_t *thread, unsigned int *arg)
+spawn_thread(pthread_t *thread, int retry_time_us, int retry_num,
+             unsigned int *arg)
 {
     int status_code = -1;
-    int timeout_us = RETRY_SLEEP_TIME_US;
-    for (int tries = 0; status_code != 0 && tries < NUM_RETRY; ++tries) {
+    int timeout_us = retry_time_us;
+    for (int tries = 0; status_code != 0 && tries < retry_num; ++tries) {
         status_code = pthread_create(thread, NULL, &check_if_prime, arg);
         assert(status_code == 0 || status_code == EAGAIN);
         if (status_code == EAGAIN) {
@@ -76,42 +70,56 @@ spawn_thread(pthread_t *thread, unsigned int *arg)
     assert(status_code == 0 && "Thread creation should succeed");
 }
 
-int
-main(int argc, char **argv)
+void
+test(int iter_num, int retry_num, int max_threads_num, int retry_time_us)
 {
-    pthread_t threads[MAX_NUM_THREADS];
-    unsigned int args[MAX_NUM_THREADS];
+    pthread_t threads[max_threads_num];
+    unsigned int args[max_threads_num];
     double percentage = 0.1;
 
-    for (unsigned int factorised_number = 2; factorised_number < NUM_ITER;
+    for (unsigned int factorised_number = 2; factorised_number < iter_num;
          ++factorised_number) {
-        if (factorised_number > NUM_ITER * percentage) {
+        if (factorised_number > iter_num * percentage) {
             fprintf(stderr, "Stress test is %d%% finished\n",
                     (unsigned int)(percentage * 100));
             percentage += 0.1;
         }
 
-        unsigned int thread_num = factorised_number % MAX_NUM_THREADS;
+        unsigned int thread_num = factorised_number % max_threads_num;
         if (threads[thread_num] != 0) {
             assert(pthread_join(threads[thread_num], NULL) == 0);
         }
 
         args[thread_num] = factorised_number;
 
-        usleep(RETRY_SLEEP_TIME_US);
-        spawn_thread(&threads[thread_num], &args[thread_num]);
+        usleep(retry_time_us);
+        spawn_thread(&threads[thread_num], retry_time_us, retry_num,
+                     &args[thread_num]);
         assert(threads[thread_num] != 0);
     }
 
-    for (int i = 0; i < MAX_NUM_THREADS; ++i) {
+    for (int i = 0; i < max_threads_num; ++i) {
         assert(threads[i] == 0 || pthread_join(threads[i], NULL) == 0);
     }
 
     // Check the test results
     assert(
-        prime_numbers_count == validate()
+        prime_numbers_count == validate(iter_num)
         && "Answer mismatch between tested code and reference implementation");
 
     fprintf(stderr, "Stress test finished successfully\n");
+}
+
+enum DEFAULT_PARAMETERS {
+    ITER_NUM = 20000,
+    RETRY_NUM = 8,
+    MAX_THREADS_NUM = 12,
+    RETRY_SLEEP_TIME_US = 2000,
+};
+
+int
+main(int argc, char **argv)
+{
+    test(ITER_NUM, RETRY_NUM, MAX_THREADS_NUM, RETRY_SLEEP_TIME_US);
     return 0;
 }


### PR DESCRIPTION
to run a function in reactor mode with parameters, we want to call an arbitary function which name is exported instead of calling _start as passing params to _start  does not pass them to main. it might be benefitical for some usecases with multimodule apps  and/or other cases that primarily use reactor mode 