### PR TITLE
Enable AOT usage on M1 mac

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -3232,10 +3232,13 @@ aot_load_from_aot_file(const uint8 *buf, uint32 size, char *error_buf,
     if (!module)
         return NULL;
 
+    os_thread_jit_write_protect_np(false); /* Make memory writable */
     if (!load(buf, size, module, error_buf, error_buf_size)) {
         aot_unload(module);
         return NULL;
     }
+    os_thread_jit_write_protect_np(true); /* Make memory executable */
+    os_icache_flush(module->code, module->code_size);
 
     LOG_VERBOSE("Load module success.\n");
     return module;

--- a/core/iwasm/aot/arch/aot_reloc_aarch64.c
+++ b/core/iwasm/aot/arch/aot_reloc_aarch64.c
@@ -53,7 +53,12 @@ get_target_symbol_map(uint32 *sym_num)
     return target_sym_map;
 }
 
+#if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__)
+#define BUILD_TARGET_AARCH64_DEFAULT "arm64"
+#else
 #define BUILD_TARGET_AARCH64_DEFAULT "aarch64v8"
+#endif
+
 void
 get_current_target(char *target_buf, uint32 target_buf_size)
 {

--- a/core/shared/platform/alios/alios_platform.c
+++ b/core/shared/platform/alios/alios_platform.c
@@ -69,3 +69,7 @@ os_mprotect(void *addr, size_t size, int prot)
 void
 os_dcache_flush()
 {}
+
+void
+os_icache_flush(void *start, size_t len)
+{}

--- a/core/shared/platform/alios/alios_thread.c
+++ b/core/shared/platform/alios/alios_thread.c
@@ -359,3 +359,7 @@ os_thread_get_stack_boundary()
     /* TODO: get alios stack boundary */
     return NULL;
 }
+
+void
+os_thread_jit_write_protect_np(bool enabled)
+{}

--- a/core/shared/platform/common/posix/posix_memmap.c
+++ b/core/shared/platform/common/posix/posix_memmap.c
@@ -5,6 +5,10 @@
 
 #include "platform_api_vmcore.h"
 
+#if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__)
+#include <libkern/OSCacheControl.h>
+#endif
+
 #ifndef BH_ENABLE_TRACE_MMAP
 #define BH_ENABLE_TRACE_MMAP 0
 #endif
@@ -36,7 +40,11 @@ void *
 os_mmap(void *hint, size_t size, int prot, int flags)
 {
     int map_prot = PROT_NONE;
+#if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__)
+    int map_flags = MAP_ANONYMOUS | MAP_PRIVATE | MAP_JIT;
+#else
     int map_flags = MAP_ANONYMOUS | MAP_PRIVATE;
+#endif
     uint64 request_size, page_size;
     uint8 *addr = MAP_FAILED;
     uint32 i;
@@ -251,3 +259,11 @@ os_mprotect(void *addr, size_t size, int prot)
 void
 os_dcache_flush(void)
 {}
+
+void
+os_icache_flush(void *start, size_t len)
+{
+#if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__)
+    sys_icache_invalidate(start, len);
+#endif
+}

--- a/core/shared/platform/common/posix/posix_thread.c
+++ b/core/shared/platform/common/posix/posix_thread.c
@@ -418,6 +418,14 @@ os_thread_get_stack_boundary()
     return addr;
 }
 
+void
+os_thread_jit_write_protect_np(bool enabled)
+{
+#if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__)
+    pthread_jit_write_protect_np(enabled);
+#endif
+}
+
 #ifdef OS_ENABLE_HW_BOUND_CHECK
 
 #define SIG_ALT_STACK_SIZE (32 * 1024)

--- a/core/shared/platform/esp-idf/espidf_memmap.c
+++ b/core/shared/platform/esp-idf/espidf_memmap.c
@@ -100,6 +100,10 @@ void
 #endif
 }
 
+void
+os_icache_flush(void *start, size_t len)
+{}
+
 #if (WASM_MEM_DUAL_BUS_MIRROR != 0)
 void *
 os_get_dbus_mirror(void *ibus)

--- a/core/shared/platform/esp-idf/espidf_platform.c
+++ b/core/shared/platform/esp-idf/espidf_platform.c
@@ -53,6 +53,10 @@ os_thread_get_stack_boundary(void)
 #endif
 }
 
+void
+os_thread_jit_write_protect_np(bool enabled)
+{}
+
 int
 os_usleep(uint32 usec)
 {

--- a/core/shared/platform/include/platform_api_vmcore.h
+++ b/core/shared/platform/include/platform_api_vmcore.h
@@ -82,6 +82,13 @@ uint8 *
 os_thread_get_stack_boundary(void);
 
 /**
+ * Set whether the MAP_JIT region write protection is enabled for this thread.
+ * Pass true to make the region executable, false to make it writable.
+ */
+void
+os_thread_jit_write_protect_np(bool enabled);
+
+/**
  ************** mutext APIs ***********
  *  vmcore:  Not required until pthread is supported by runtime
  *  app-mgr: Must be implemented
@@ -142,6 +149,12 @@ os_get_dbus_mirror(void *ibus);
  */
 void
 os_dcache_flush(void);
+
+/**
+ * Flush instruction cache.
+ */
+void
+os_icache_flush(void *start, size_t len);
 
 #ifdef __cplusplus
 }

--- a/core/shared/platform/linux-sgx/sgx_platform.c
+++ b/core/shared/platform/linux-sgx/sgx_platform.c
@@ -195,3 +195,7 @@ os_mprotect(void *addr, size_t size, int prot)
 void
 os_dcache_flush(void)
 {}
+
+void
+os_icache_flush(void *start, size_t len)
+{}

--- a/core/shared/platform/linux-sgx/sgx_thread.c
+++ b/core/shared/platform/linux-sgx/sgx_thread.c
@@ -210,3 +210,7 @@ os_thread_get_stack_boundary()
     /* TODO: get sgx stack boundary */
     return NULL;
 }
+
+void
+os_thread_jit_write_protect_np(bool enabled)
+{}

--- a/core/shared/platform/nuttx/nuttx_platform.c
+++ b/core/shared/platform/nuttx/nuttx_platform.c
@@ -144,6 +144,10 @@ os_dcache_flush()
     bus_sync();
 }
 
+void
+os_icache_flush(void *start, size_t len)
+{}
+
 #if (WASM_MEM_DUAL_BUS_MIRROR != 0)
 void *
 os_get_dbus_mirror(void *ibus)

--- a/core/shared/platform/riot/riot_platform.c
+++ b/core/shared/platform/riot/riot_platform.c
@@ -79,3 +79,7 @@ os_dcache_flush(void)
     irq_unlock(key);
 #endif
 }
+
+void
+os_icache_flush(void *start, size_t len)
+{}

--- a/core/shared/platform/riot/riot_thread.c
+++ b/core/shared/platform/riot/riot_thread.c
@@ -430,3 +430,7 @@ os_thread_get_stack_boundary()
     return NULL;
 #endif
 }
+
+void
+os_thread_jit_write_protect_np(bool enabled)
+{}

--- a/core/shared/platform/rt-thread/rtt_platform.c
+++ b/core/shared/platform/rt-thread/rtt_platform.c
@@ -140,6 +140,10 @@ os_thread_get_stack_boundary(void)
     return tid->stack_addr;
 }
 
+void
+os_thread_jit_write_protect_np(bool enabled)
+{}
+
 int
 os_mutex_init(korp_mutex *mutex)
 {
@@ -206,4 +210,8 @@ os_mprotect(void *addr, size_t size, int prot)
 
 void
 os_dcache_flush(void)
+{}
+
+void
+os_icache_flush(void *start, size_t len)
 {}

--- a/core/shared/platform/windows/platform_init.c
+++ b/core/shared/platform/windows/platform_init.c
@@ -73,3 +73,7 @@ os_getpagesize()
 void
 os_dcache_flush(void)
 {}
+
+void
+os_icache_flush(void *start, size_t len)
+{}

--- a/core/shared/platform/windows/win_thread.c
+++ b/core/shared/platform/windows/win_thread.c
@@ -712,6 +712,10 @@ os_thread_get_stack_boundary()
     return thread_stack_boundary;
 }
 
+void
+os_thread_jit_write_protect_np(bool enabled)
+{}
+
 #ifdef OS_ENABLE_HW_BOUND_CHECK
 static os_thread_local_attribute bool thread_signal_inited = false;
 

--- a/core/shared/platform/zephyr/zephyr_platform.c
+++ b/core/shared/platform/zephyr/zephyr_platform.c
@@ -215,6 +215,10 @@ os_dcache_flush()
 }
 
 void
+os_icache_flush(void *start, size_t len)
+{}
+
+void
 set_exec_mem_alloc_func(exec_mem_alloc_func_t alloc_func,
                         exec_mem_free_func_t free_func)
 {

--- a/core/shared/platform/zephyr/zephyr_thread.c
+++ b/core/shared/platform/zephyr/zephyr_thread.c
@@ -574,3 +574,7 @@ os_thread_get_stack_boundary()
     return NULL;
 #endif
 }
+
+void
+os_thread_jit_write_protect_np(bool enabled)
+{}


### PR DESCRIPTION
After reading the [docs](https://developer.apple.com/documentation/apple-silicon/porting-just-in-time-compilers-to-apple-silicon), I managed to use AOT on my M1 mac.

Issue: https://github.com/bytecodealliance/wasm-micro-runtime/issues/1365