### PR TITLE
fix potential wamrc bug when translating block opcode

### DIFF
--- a/core/iwasm/compilation/aot_emit_control.c
+++ b/core/iwasm/compilation/aot_emit_control.c
@@ -335,6 +335,7 @@ push_aot_block_to_stack_and_pass_params(AOTCompContext *comp_ctx,
          * after branch instruction, should position the builder before the last
          * branch instruction */
         br_inst = LLVMGetLastInstruction(block_curr);
+        bh_assert(LLVMGetInstructionOpcode(br_inst) == LLVMBr);
         LLVMPositionBuilderBefore(comp_ctx->builder, br_inst);
 
         /* Pop param values from current block's

--- a/core/iwasm/compilation/aot_emit_control.c
+++ b/core/iwasm/compilation/aot_emit_control.c
@@ -281,7 +281,7 @@ push_aot_block_to_stack_and_pass_params(AOTCompContext *comp_ctx,
                                         AOTBlock *block)
 {
     uint32 i, param_index;
-    LLVMValueRef value;
+    LLVMValueRef value, br_inst;
     uint64 size;
     char name[32];
     LLVMBasicBlockRef block_curr = CURR_BLOCK();
@@ -329,7 +329,13 @@ push_aot_block_to_stack_and_pass_params(AOTCompContext *comp_ctx,
                 }
             }
         }
-        SET_BUILDER_POS(block_curr);
+
+        /* At this point, already built the branch instruction to jump to the
+         * new BB, to avoid generating zext instruction from POP that would come
+         * after branch instruction, should position the builder before the last
+         * branch instruction */
+        br_inst = LLVMGetLastInstruction(block_curr);
+        LLVMPositionBuilderBefore(comp_ctx->builder, br_inst);
 
         /* Pop param values from current block's
          * value stack and add to param phis.

--- a/core/iwasm/compilation/aot_emit_control.c
+++ b/core/iwasm/compilation/aot_emit_control.c
@@ -330,10 +330,10 @@ push_aot_block_to_stack_and_pass_params(AOTCompContext *comp_ctx,
             }
         }
 
-        /* At this point, already built the branch instruction to jump to the
-         * new BB, to avoid generating zext instruction from POP that would come
-         * after branch instruction, should position the builder before the last
-         * branch instruction */
+        /* At this point, the branch instruction was already built to jump to
+         * the new BB, to avoid generating zext instruction from the popped
+         * operand that would come after branch instruction, we should position
+         * the builder before the last branch instruction */
         br_inst = LLVMGetLastInstruction(block_curr);
         bh_assert(LLVMGetInstructionOpcode(br_inst) == LLVMBr);
         LLVMPositionBuilderBefore(comp_ctx->builder, br_inst);


### PR DESCRIPTION
Fix a wamrc bug mentioned in https://github.com/bytecodealliance/wasm-micro-runtime/issues/2620 (the sign extension instruction is inserted after the terminator when compare instruction precedes a block)
