### PR TITLE
core/iwasm: Support mapped file system access on non-libuv WASI

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -3046,7 +3046,7 @@ wasm_runtime_init_wasi(WASMModuleInstanceCommon *module_inst,
         if (mapping_copy != mapping_copy_buf)
             wasm_runtime_free(mapping_copy);
 
-        if (!map_mapped && !map_host) {
+        if (!map_mapped || !map_host) {
             if (error_buf)
                 snprintf(error_buf, error_buf_size,
                          "error while pre-opening mapped directory %s: "

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -3029,7 +3029,7 @@ wasm_runtime_init_wasi(WASMModuleInstanceCommon *module_inst,
         char *map_mapped = NULL, *map_host = NULL;
         const unsigned long max_len = strlen(map_dir_list[i]) * 2 + 3;
 
-        // Allocation limit for runtime environments with reduced stack size
+        /* Allocation limit for runtime environments with reduced stack size */
         if (max_len > 256) {
             if (!(mapping_copy = wasm_runtime_malloc(max_len))) {
                 snprintf(error_buf, error_buf_size,
@@ -3038,12 +3038,9 @@ wasm_runtime_init_wasi(WASMModuleInstanceCommon *module_inst,
             }
         }
 
-        strncpy(mapping_copy, map_dir_list[i], strlen(map_dir_list[i]));
+        strncpy(mapping_copy, map_dir_list[i], strlen(map_dir_list[i]) + 1);
         map_mapped = strtok(mapping_copy, "::");
         map_host = strtok(NULL, "::");
-
-        if (mapping_copy != mapping_copy_buf)
-            wasm_runtime_free(mapping_copy);
 
         if (!map_mapped || !map_host) {
             if (error_buf)
@@ -3059,6 +3056,8 @@ wasm_runtime_init_wasi(WASMModuleInstanceCommon *module_inst,
                 snprintf(error_buf, error_buf_size,
                          "error while pre-opening mapped directory %s: %d\n",
                          map_host, errno);
+            if (mapping_copy != mapping_copy_buf)
+                wasm_runtime_free(mapping_copy);
             goto fail;
         }
 
@@ -3068,6 +3067,8 @@ wasm_runtime_init_wasi(WASMModuleInstanceCommon *module_inst,
                 snprintf(error_buf, error_buf_size,
                          "error while pre-opening mapped directory %s: %d\n",
                          map_host, errno);
+            if (mapping_copy != mapping_copy_buf)
+                wasm_runtime_free(mapping_copy);
             goto fail;
         }
 
@@ -3078,8 +3079,13 @@ wasm_runtime_init_wasi(WASMModuleInstanceCommon *module_inst,
                          "error while pre-opening mapped directory %s: "
                          "insertion failed\n",
                          dir_list[i]);
+            if (mapping_copy != mapping_copy_buf)
+                wasm_runtime_free(mapping_copy);
             goto fail;
         }
+
+        if (mapping_copy != mapping_copy_buf)
+            wasm_runtime_free(mapping_copy);
     }
 
     /* addr_pool(textual) -> apool */

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -3047,7 +3047,12 @@ wasm_runtime_init_wasi(WASMModuleInstanceCommon *module_inst,
             wasm_runtime_free(mapping_copy);
 
         if (!map_mapped && !map_host) {
-            continue;
+            if (error_buf)
+                snprintf(error_buf, error_buf_size,
+                         "error while pre-opening mapped directory %s: "
+                         "invalid map\n",
+                         map_host);
+            goto fail;
         }
 
         path = realpath(map_host, resolved_path);

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -3047,6 +3047,8 @@ wasm_runtime_init_wasi(WASMModuleInstanceCommon *module_inst,
                 snprintf(error_buf, error_buf_size,
                          "error while pre-opening mapped directory: "
                          "invalid map\n");
+            if (mapping_copy != mapping_copy_buf)
+                wasm_runtime_free(mapping_copy);
             goto fail;
         }
 

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -3026,7 +3026,7 @@ wasm_runtime_init_wasi(WASMModuleInstanceCommon *module_inst,
     for (i = 0; i < map_dir_count; i++, wasm_fd++) {
         char mapping_copy_buf[256];
         char *mapping_copy = mapping_copy_buf;
-        const char *map_mapped, *map_host;
+        char *map_mapped = NULL, *map_host = NULL;
         const unsigned long max_len = strlen(map_dir_list[i]) * 2 + 3;
 
         // Allocation limit for runtime environments with reduced stack size

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -3033,8 +3033,7 @@ wasm_runtime_init_wasi(WASMModuleInstanceCommon *module_inst,
         if (max_len > 256) {
             if (!(mapping_copy = wasm_runtime_malloc(max_len))) {
                 snprintf(error_buf, error_buf_size,
-                         "error while pre-opening mapped directory %s: %d\n",
-                         map_host, errno);
+                         "error while allocating for directory mapping\n");
                 goto fail;
             }
         }
@@ -3049,9 +3048,8 @@ wasm_runtime_init_wasi(WASMModuleInstanceCommon *module_inst,
         if (!map_mapped || !map_host) {
             if (error_buf)
                 snprintf(error_buf, error_buf_size,
-                         "error while pre-opening mapped directory %s: "
-                         "invalid map\n",
-                         map_host);
+                         "error while pre-opening mapped directory: "
+                         "invalid map\n");
             goto fail;
         }
 

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -423,6 +423,7 @@ wasm_runtime_get_module_hash(wasm_module_t module);
  * @param dir_list      The list of directories to preopen. (real path)
  * @param dir_count     The number of elements in dir_list.
  * @param map_dir_list  The list of directories to preopen. (mapped path)
+ *                      Format for each map entry: <guest-path>::<host-path>
  * @param map_dir_count The number of elements in map_dir_list.
  *                      If map_dir_count is smaller than dir_count,
  *                      mapped path is assumed to be same as the

--- a/product-mini/platforms/posix/main.c
+++ b/product-mini/platforms/posix/main.c
@@ -75,7 +75,7 @@ print_help()
     printf("  --dir=<dir>              Grant wasi access to the given host directories\n");
     printf("                           to the program, for example:\n");
     printf("                             --dir=<dir1> --dir=<dir2>\n");
-    printf("  --map-dir=<dir>          Grant wasi access to the given host directories\n");
+    printf("  --map-dir=<guest::host>  Grant wasi access to the given host directories\n");
     printf("                           to the program at a specific guest path, for example:\n");
     printf("                             --map-dir=<guest-path1::host-path1> --map-dir=<guest-path2::host-path2>\n");
     printf("  --addr-pool=<addrs>      Grant wasi access to the given network addresses in\n");

--- a/product-mini/platforms/posix/main.c
+++ b/product-mini/platforms/posix/main.c
@@ -75,6 +75,9 @@ print_help()
     printf("  --dir=<dir>              Grant wasi access to the given host directories\n");
     printf("                           to the program, for example:\n");
     printf("                             --dir=<dir1> --dir=<dir2>\n");
+    printf("  --map-dir=<dir>          Grant wasi access to the given host directories\n");
+    printf("                           to the program at a specific guest path, for example:\n");
+    printf("                             --map-dir=<guest-path1::host-path1> --map-dir=<guest-path2::host-path2>\n");
     printf("  --addr-pool=<addrs>      Grant wasi access to the given network addresses in\n");
     printf("                           CIRD notation to the program, seperated with ',',\n");
     printf("                           for example:\n");
@@ -573,6 +576,8 @@ main(int argc, char *argv[])
 #if WASM_ENABLE_LIBC_WASI != 0
     const char *dir_list[8] = { NULL };
     uint32 dir_list_size = 0;
+    const char *map_dir_list[8] = { NULL };
+    uint32 map_dir_list_size = 0;
     const char *env_list[8] = { NULL };
     uint32 env_list_size = 0;
     const char *addr_pool[8] = { NULL };
@@ -710,6 +715,16 @@ main(int argc, char *argv[])
                 return 1;
             }
             dir_list[dir_list_size++] = argv[0] + 6;
+        }
+        else if (!strncmp(argv[0], "--map-dir=", 10)) {
+            if (argv[0][10] == '\0')
+                return print_help();
+            if (map_dir_list_size >= sizeof(map_dir_list) / sizeof(char *)) {
+                printf("Only allow max map dir number %d\n",
+                       (int)(sizeof(map_dir_list) / sizeof(char *)));
+                return 1;
+            }
+            map_dir_list[map_dir_list_size++] = argv[0] + 10;
         }
         else if (!strncmp(argv[0], "--env=", 6)) {
             char *tmp_env;
@@ -920,7 +935,8 @@ main(int argc, char *argv[])
     }
 
 #if WASM_ENABLE_LIBC_WASI != 0
-    wasm_runtime_set_wasi_args(wasm_module, dir_list, dir_list_size, NULL, 0,
+    wasm_runtime_set_wasi_args(wasm_module, dir_list, dir_list_size,
+                               map_dir_list, map_dir_list_size,
                                env_list, env_list_size, argv, argc);
 
     wasm_runtime_set_wasi_addr_pool(wasm_module, addr_pool, addr_pool_size);

--- a/product-mini/platforms/posix/main.c
+++ b/product-mini/platforms/posix/main.c
@@ -936,8 +936,8 @@ main(int argc, char *argv[])
 
 #if WASM_ENABLE_LIBC_WASI != 0
     wasm_runtime_set_wasi_args(wasm_module, dir_list, dir_list_size,
-                               map_dir_list, map_dir_list_size,
-                               env_list, env_list_size, argv, argc);
+                               map_dir_list, map_dir_list_size, env_list,
+                               env_list_size, argv, argc);
 
     wasm_runtime_set_wasi_addr_pool(wasm_module, addr_pool, addr_pool_size);
     wasm_runtime_set_wasi_ns_lookup_pool(wasm_module, ns_lookup_pool,


### PR DESCRIPTION
Similar to the for-loop above it, this patch just adds another one iterating through map_dir with the ability to set the guest path to a different target. It follows the format "guest-path::host-path".