### PR TITLE
Enable MASM automatically in runtime_lib.cmake

### DIFF
--- a/build-scripts/runtime_lib.cmake
+++ b/build-scripts/runtime_lib.cmake
@@ -165,7 +165,11 @@ file (GLOB header
 )
 LIST (APPEND RUNTIME_LIB_HEADER_LIST ${header})
 
-enable_language (ASM)
+if (WAMR_BUILD_PLATFORM STREQUAL "windows")
+    enable_language (ASM_MASM)
+else()
+    enable_language (ASM)
+endif()
 
 include (${SHARED_PLATFORM_CONFIG})
 include (${SHARED_DIR}/mem-alloc/mem_alloc.cmake)

--- a/product-mini/platforms/windows/CMakeLists.txt
+++ b/product-mini/platforms/windows/CMakeLists.txt
@@ -4,7 +4,6 @@
 cmake_minimum_required (VERSION 2.9)
 
 project (iwasm C ASM CXX)
-enable_language(ASM_MASM)
 # set (CMAKE_VERBOSE_MAKEFILE 1)
 
 set (WAMR_BUILD_PLATFORM "windows")

--- a/samples/basic/CMakeLists.txt
+++ b/samples/basic/CMakeLists.txt
@@ -9,7 +9,6 @@ if (NOT WAMR_BUILD_PLATFORM STREQUAL "windows")
   project (basic)
 else()
   project (basic C ASM)
-  enable_language (ASM_MASM)
 endif()
 
 ################  runtime settings  ################

--- a/samples/file/src/CMakeLists.txt
+++ b/samples/file/src/CMakeLists.txt
@@ -9,7 +9,6 @@ if (NOT WAMR_BUILD_PLATFORM STREQUAL "windows")
   project (iwasm)
 else()
   project (iwasm C ASM)
-  enable_language (ASM_MASM)
 endif()
 
 ################  runtime settings  ################

--- a/samples/inst-context-threads/CMakeLists.txt
+++ b/samples/inst-context-threads/CMakeLists.txt
@@ -9,7 +9,6 @@ if (NOT WAMR_BUILD_PLATFORM STREQUAL "windows")
   project (inst-context)
 else()
   project (inst-context C ASM)
-  enable_language (ASM_MASM)
 endif()
 
 ################  runtime settings  ################

--- a/samples/inst-context/CMakeLists.txt
+++ b/samples/inst-context/CMakeLists.txt
@@ -9,7 +9,6 @@ if (NOT WAMR_BUILD_PLATFORM STREQUAL "windows")
   project (inst-context)
 else()
   project (inst-context C ASM)
-  enable_language (ASM_MASM)
 endif()
 
 ################  runtime settings  ################

--- a/samples/ref-types/CMakeLists.txt
+++ b/samples/ref-types/CMakeLists.txt
@@ -9,7 +9,6 @@ if (NOT WAMR_BUILD_PLATFORM STREQUAL "windows")
   project(ref-types)
 else()
   project (ref-types C ASM)
-  enable_language (ASM_MASM)
 endif()
 
 ################  runtime settings  ################

--- a/samples/wasm-c-api/CMakeLists.txt
+++ b/samples/wasm-c-api/CMakeLists.txt
@@ -9,7 +9,6 @@ if (NOT WAMR_BUILD_PLATFORM STREQUAL "windows")
   project(c-api)
 else()
   project (c-api C ASM)
-  enable_language (ASM_MASM)
 endif()
 
 if(NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
MASM (Microsoft Macro Assembler) needs to be enabled to successfully compile .asm files on Windows. Without enabling this language automatically in runtime_lib.cmake, Windows cmake projects using WAMR get hard-to-diagnose linker errors about missing symbols as the assembly file is not compiled at all.