### PR TITLE
Refactor clock functions to use WASI types

### DIFF
--- a/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
+++ b/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
@@ -193,7 +193,7 @@ wasi_clock_res_get(wasm_exec_env_t exec_env,
     if (!validate_native_addr(resolution, sizeof(wasi_timestamp_t)))
         return (wasi_errno_t)-1;
 
-    return wasmtime_ssp_clock_res_get(clock_id, resolution);
+    return os_clock_res_get(clock_id, resolution);
 }
 
 static wasi_errno_t
@@ -207,7 +207,7 @@ wasi_clock_time_get(wasm_exec_env_t exec_env,
     if (!validate_native_addr(time, sizeof(wasi_timestamp_t)))
         return (wasi_errno_t)-1;
 
-    return wasmtime_ssp_clock_time_get(clock_id, precision, time);
+    return os_clock_time_get(clock_id, precision, time);
 }
 
 static wasi_errno_t

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/include/wasmtime_ssp.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/include/wasmtime_ssp.h
@@ -42,17 +42,6 @@ wasmtime_ssp_args_sizes_get(struct argv_environ_values *arg_environ,
     WASMTIME_SSP_SYSCALL_NAME(args_sizes_get) WARN_UNUSED;
 
 __wasi_errno_t
-wasmtime_ssp_clock_res_get(__wasi_clockid_t clock_id,
-                           __wasi_timestamp_t *resolution)
-    WASMTIME_SSP_SYSCALL_NAME(clock_res_get) WARN_UNUSED;
-
-__wasi_errno_t
-wasmtime_ssp_clock_time_get(__wasi_clockid_t clock_id,
-                            __wasi_timestamp_t precision,
-                            __wasi_timestamp_t *time)
-    WASMTIME_SSP_SYSCALL_NAME(clock_time_get) WARN_UNUSED;
-
-__wasi_errno_t
 wasmtime_ssp_environ_get(struct argv_environ_values *arg_environ,
                          char **environs, char *environ_buf)
     WASMTIME_SSP_SYSCALL_NAME(environ_get) WARN_UNUSED;

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -94,7 +94,7 @@ ns_lookup_list_search(char **list, const char *host)
     return false;
 }
 
-#ifndef BH_PLATFORM_WINDOWS
+#if !defined(BH_PLATFORM_WINDOWS) && CONFIG_HAS_CLOCK_NANOSLEEP
 static bool
 wasi_clockid_to_clockid(__wasi_clockid_t in, clockid_t *out)
 {
@@ -195,52 +195,6 @@ wasi_addr_ip_to_bh_ip_addr_buffer(__wasi_addr_ip_t *addr,
         out->ipv6[6] = htons(addr->addr.ip6.h2);
         out->ipv6[7] = htons(addr->addr.ip6.h3);
     }
-}
-
-static bool
-wasi_clockid_to_bh_clockid(__wasi_clockid_t in, bh_clock_id_t *out)
-{
-    switch (in) {
-        case __WASI_CLOCK_MONOTONIC:
-            *out = BH_CLOCK_ID_MONOTONIC;
-            return true;
-        case __WASI_CLOCK_PROCESS_CPUTIME_ID:
-            *out = BH_CLOCK_ID_PROCESS_CPUTIME_ID;
-            return true;
-        case __WASI_CLOCK_REALTIME:
-            *out = BH_CLOCK_ID_REALTIME;
-            return true;
-        case __WASI_CLOCK_THREAD_CPUTIME_ID:
-            *out = BH_CLOCK_ID_THREAD_CPUTIME_ID;
-            return true;
-        default:
-            return false;
-    }
-}
-
-__wasi_errno_t
-wasmtime_ssp_clock_res_get(__wasi_clockid_t clock_id,
-                           __wasi_timestamp_t *resolution)
-{
-    bh_clock_id_t bh_clockid;
-    if (!wasi_clockid_to_bh_clockid(clock_id, &bh_clockid))
-        return __WASI_EINVAL;
-    if (os_clock_res_get(clock_id, resolution) != BHT_OK)
-        return convert_errno(errno);
-    return __WASI_ESUCCESS;
-}
-
-__wasi_errno_t
-wasmtime_ssp_clock_time_get(__wasi_clockid_t clock_id,
-                            __wasi_timestamp_t precision,
-                            __wasi_timestamp_t *time)
-{
-    bh_clock_id_t bh_clockid;
-    if (!wasi_clockid_to_bh_clockid(clock_id, &bh_clockid))
-        return __WASI_EINVAL;
-    if (os_clock_time_get(clock_id, precision, time) != BHT_OK)
-        return convert_errno(errno);
-    return __WASI_ESUCCESS;
 }
 
 struct fd_prestat {

--- a/core/shared/platform/common/posix/platform_api_posix.cmake
+++ b/core/shared/platform/common/posix/platform_api_posix.cmake
@@ -6,7 +6,10 @@ set (PLATFORM_COMMON_POSIX_DIR ${CMAKE_CURRENT_LIST_DIR})
 file (GLOB_RECURSE source_all ${PLATFORM_COMMON_POSIX_DIR}/*.c)
 
 if (NOT WAMR_BUILD_LIBC_WASI EQUAL 1)
-    list(REMOVE_ITEM source_all ${PLATFORM_COMMON_POSIX_DIR}/posix_file.c)
+    list(REMOVE_ITEM source_all
+        ${PLATFORM_COMMON_POSIX_DIR}/posix_file.c
+        ${PLATFORM_COMMON_POSIX_DIR}/posix_clock.c
+    )
 else()
     include (${CMAKE_CURRENT_LIST_DIR}/../libc-util/platform_common_libc_util.cmake)
     set(source_all ${source_all} ${PLATFORM_COMMON_LIBC_UTIL_SOURCE})

--- a/core/shared/platform/common/posix/posix_clock.c
+++ b/core/shared/platform/common/posix/posix_clock.c
@@ -3,70 +3,84 @@
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
-#include "platform_api_vmcore.h"
+#include "libc_errno.h"
+#include "platform_api_extension.h"
 
 #define NANOSECONDS_PER_SECOND 1000000000ULL
 
-static bool
-bh_clockid_to_clockid(bh_clock_id_t in, clockid_t *out)
+static __wasi_errno_t
+wasi_clockid_to_clockid(__wasi_clockid_t in, clockid_t *out)
 {
     switch (in) {
-        case BH_CLOCK_ID_MONOTONIC:
+        case __WASI_CLOCK_MONOTONIC:
             *out = CLOCK_MONOTONIC;
-            return true;
-#if defined(CLOCK_PROCESS_CPUTIME_ID)
-        case BH_CLOCK_ID_PROCESS_CPUTIME_ID:
-            *out = CLOCK_PROCESS_CPUTIME_ID;
-            return true;
-#endif
-        case BH_CLOCK_ID_REALTIME:
+            return __WASI_ESUCCESS;
+        case __WASI_CLOCK_REALTIME:
             *out = CLOCK_REALTIME;
-            return true;
+            return __WASI_ESUCCESS;
+        case __WASI_CLOCK_PROCESS_CPUTIME_ID:
+#if defined(CLOCK_PROCESS_CPUTIME_ID)
+            *out = CLOCK_PROCESS_CPUTIME_ID;
+            return __WASI_ESUCCESS;
+#else
+            return __WASI_ENOTSUP;
+#endif
+        case __WASI_CLOCK_THREAD_CPUTIME_ID:
 #if defined(CLOCK_THREAD_CPUTIME_ID)
-        case BH_CLOCK_ID_THREAD_CPUTIME_ID:
             *out = CLOCK_THREAD_CPUTIME_ID;
-            return true;
+            return __WASI_ESUCCESS;
+#else
+            return __WASI_ENOTSUP;
 #endif
         default:
-            errno = EINVAL;
-            return false;
+            return __WASI_EINVAL;
     }
 }
 
-static uint64
+static __wasi_timestamp_t
 timespec_to_nanoseconds(const struct timespec *ts)
 {
     if (ts->tv_sec < 0)
         return 0;
-    if ((uint64)ts->tv_sec >= UINT64_MAX / NANOSECONDS_PER_SECOND)
+    if ((__wasi_timestamp_t)ts->tv_sec >= UINT64_MAX / NANOSECONDS_PER_SECOND)
         return UINT64_MAX;
-    return (uint64)ts->tv_sec * NANOSECONDS_PER_SECOND + (uint64)ts->tv_nsec;
+    return (__wasi_timestamp_t)ts->tv_sec * NANOSECONDS_PER_SECOND
+           + (__wasi_timestamp_t)ts->tv_nsec;
 }
 
-int
-os_clock_res_get(bh_clock_id_t clock_id, uint64 *resolution)
+__wasi_errno_t
+os_clock_res_get(__wasi_clockid_t clock_id, __wasi_timestamp_t *resolution)
 {
     clockid_t nclock_id;
-    if (!bh_clockid_to_clockid(clock_id, &nclock_id))
-        return BHT_ERROR;
+    __wasi_errno_t error = wasi_clockid_to_clockid(clock_id, &nclock_id);
+
+    if (error != __WASI_ESUCCESS)
+        return error;
+
     struct timespec ts;
     if (clock_getres(nclock_id, &ts) < 0)
-        return BHT_ERROR;
+        return convert_errno(errno);
+
     *resolution = timespec_to_nanoseconds(&ts);
 
-    return BHT_OK;
+    return error;
 }
 
-int
-os_clock_time_get(bh_clock_id_t clock_id, uint64 precision, uint64 *time)
+__wasi_errno_t
+os_clock_time_get(__wasi_clockid_t clock_id, __wasi_timestamp_t precision,
+                  __wasi_timestamp_t *time)
 {
     clockid_t nclock_id;
-    if (!bh_clockid_to_clockid(clock_id, &nclock_id))
-        return BHT_ERROR;
+    __wasi_errno_t error = wasi_clockid_to_clockid(clock_id, &nclock_id);
+
+    if (error != __WASI_ESUCCESS)
+        return error;
+
     struct timespec ts;
     if (clock_gettime(nclock_id, &ts) < 0)
-        return BHT_ERROR;
+        return convert_errno(errno);
+
     *time = timespec_to_nanoseconds(&ts);
 
-    return 0;
+    return error;
 }

--- a/core/shared/platform/include/platform_api_extension.h
+++ b/core/shared/platform/include/platform_api_extension.h
@@ -37,26 +37,6 @@ extern "C" {
  */
 
 /**
- * Get a resolution of the clock
- *
- * @param clock_id clock identifier
- * @param resolution output variable to store the clock resolution
- * @return BHT_OK if success; otherwise, BHT_ERROR
- */
-int
-os_clock_res_get(bh_clock_id_t clock_id, uint64 *resolution);
-
-/**
- * Get a current time of the clock
- *
- * @param clock_id clock identifier
- * @param time output variable to store the clock time
- * @return BHT_OK if success; otherwise, BHT_ERROR
- */
-int
-os_clock_time_get(bh_clock_id_t clock_id, uint64 precision, uint64 *time);
-
-/**
  * Creates a thread
  *
  * @param p_tid  [OUTPUT] the pointer of tid

--- a/core/shared/platform/include/platform_common.h
+++ b/core/shared/platform/include/platform_common.h
@@ -37,13 +37,6 @@ extern "C" {
 #define BH_TIME_T_MAX LONG_MAX
 #endif
 
-typedef enum {
-    BH_CLOCK_ID_REALTIME,
-    BH_CLOCK_ID_MONOTONIC,
-    BH_CLOCK_ID_PROCESS_CPUTIME_ID,
-    BH_CLOCK_ID_THREAD_CPUTIME_ID
-} bh_clock_id_t;
-
 #if defined(_MSC_BUILD)
 #if defined(COMPILING_WASM_RUNTIME_API)
 __declspec(dllexport) void *BH_MALLOC(unsigned int size);

--- a/core/shared/platform/include/platform_wasi.h
+++ b/core/shared/platform/include/platform_wasi.h
@@ -1093,6 +1093,33 @@ os_is_handle_valid(os_file_handle *handle);
 char *
 os_realpath(const char *path, char *resolved_path);
 
+/****************************************************
+ *                                                  *
+ *                Clock functions                   *
+ *                                                  *
+ ****************************************************/
+
+/**
+ * Get the resolution of the specified clock.
+ *
+ * @param clock_id clock identifier
+ * @param resolution output variable to store the clock resolution
+ */
+__wasi_errno_t
+os_clock_res_get(__wasi_clockid_t clock_id, __wasi_timestamp_t *resolution);
+
+/**
+ * Get the current time of the specified clock.
+ *
+ * @param clock_id clock identifier
+ * @param precision the maximum lag that the returned time value may have,
+ * compared to its actual value.
+ * @param time output variable to store the clock time
+ */
+__wasi_errno_t
+os_clock_time_get(__wasi_clockid_t clock_id, __wasi_timestamp_t precision,
+                  __wasi_timestamp_t *time);
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/shared/platform/linux-sgx/shared_platform.cmake
+++ b/core/shared/platform/linux-sgx/shared_platform.cmake
@@ -29,14 +29,15 @@ file (GLOB source_all ${PLATFORM_SHARED_DIR}/*.c)
 if (NOT WAMR_BUILD_LIBC_WASI EQUAL 1)
   add_definitions(-DSGX_DISABLE_WASI)
 else()
-  list(APPEND source_all ${PLATFORM_SHARED_DIR}/../common/posix/posix_file.c)
+  list(APPEND source_all
+      ${PLATFORM_SHARED_DIR}/../common/posix/posix_file.c
+      ${PLATFORM_SHARED_DIR}/../common/posix/posix_clock.c
+  )
   include (${CMAKE_CURRENT_LIST_DIR}/../common/libc-util/platform_common_libc_util.cmake)
   set(source_all ${source_all} ${PLATFORM_COMMON_LIBC_UTIL_SOURCE})
 endif()
 
 file (GLOB source_all_untrusted ${PLATFORM_SHARED_DIR}/untrusted/*.c)
-
-list(APPEND source_all ${PLATFORM_SHARED_DIR}/../common/posix/posix_clock.c)
 
 set (PLATFORM_SHARED_SOURCE ${source_all})
 

--- a/core/shared/platform/windows/win_file.c
+++ b/core/shared/platform/windows/win_file.c
@@ -86,46 +86,6 @@ convert_winsock_error_code(int error_code)
     }
 }
 
-// Convert a Windows error code to a WASI error code
-static __wasi_errno_t
-convert_windows_error_code(DWORD windows_error_code)
-{
-    switch (windows_error_code) {
-        case ERROR_INVALID_PARAMETER:
-        case ERROR_INVALID_HANDLE:
-        case ERROR_NEGATIVE_SEEK:
-            return __WASI_EINVAL;
-        case ERROR_SHARING_VIOLATION:
-        case ERROR_PIPE_BUSY:
-            return __WASI_EBUSY;
-        case ERROR_ACCESS_DENIED:
-            return __WASI_EACCES;
-        case ERROR_ALREADY_EXISTS:
-        case ERROR_FILE_EXISTS:
-            return __WASI_EEXIST;
-        case ERROR_NO_MORE_FILES:
-        case ERROR_FILE_NOT_FOUND:
-        case ERROR_INVALID_NAME:
-            return __WASI_ENOENT;
-        case ERROR_PRIVILEGE_NOT_HELD:
-            return __WASI_EPERM;
-        case ERROR_NOT_ENOUGH_MEMORY:
-            return __WASI_ENOMEM;
-        case ERROR_NOACCESS:
-            return __WASI_EFAULT;
-        case ERROR_DIR_NOT_EMPTY:
-            return __WASI_ENOTEMPTY;
-        case ERROR_DIRECTORY:
-            return __WASI_ENOTDIR;
-        case ERROR_IO_PENDING:
-        case ERROR_INSUFFICIENT_BUFFER:
-        case ERROR_INVALID_FLAGS:
-        case ERROR_NO_UNICODE_TRANSLATION:
-        default:
-            return __WASI_ENOSYS;
-    }
-}
-
 static __wasi_filetype_t
 get_disk_filetype(DWORD attribute)
 {

--- a/core/shared/platform/windows/win_util.c
+++ b/core/shared/platform/windows/win_util.c
@@ -19,3 +19,42 @@ convert_filetime_to_wasi_timestamp(LPFILETIME filetime)
     // represented in terms 100-nanosecond intervals.
     return (temp.QuadPart * 100ull) - NT_to_UNIX_epoch;
 }
+
+__wasi_errno_t
+convert_windows_error_code(DWORD windows_error_code)
+{
+    switch (windows_error_code) {
+        case ERROR_INVALID_PARAMETER:
+        case ERROR_INVALID_HANDLE:
+        case ERROR_NEGATIVE_SEEK:
+            return __WASI_EINVAL;
+        case ERROR_SHARING_VIOLATION:
+        case ERROR_PIPE_BUSY:
+            return __WASI_EBUSY;
+        case ERROR_ACCESS_DENIED:
+            return __WASI_EACCES;
+        case ERROR_ALREADY_EXISTS:
+        case ERROR_FILE_EXISTS:
+            return __WASI_EEXIST;
+        case ERROR_NO_MORE_FILES:
+        case ERROR_FILE_NOT_FOUND:
+        case ERROR_INVALID_NAME:
+            return __WASI_ENOENT;
+        case ERROR_PRIVILEGE_NOT_HELD:
+            return __WASI_EPERM;
+        case ERROR_NOT_ENOUGH_MEMORY:
+            return __WASI_ENOMEM;
+        case ERROR_NOACCESS:
+            return __WASI_EFAULT;
+        case ERROR_DIR_NOT_EMPTY:
+            return __WASI_ENOTEMPTY;
+        case ERROR_DIRECTORY:
+            return __WASI_ENOTDIR;
+        case ERROR_IO_PENDING:
+        case ERROR_INSUFFICIENT_BUFFER:
+        case ERROR_INVALID_FLAGS:
+        case ERROR_NO_UNICODE_TRANSLATION:
+        default:
+            return __WASI_EINVAL;
+    }
+}

--- a/core/shared/platform/windows/win_util.h
+++ b/core/shared/platform/windows/win_util.h
@@ -12,4 +12,8 @@
 __wasi_timestamp_t
 convert_filetime_to_wasi_timestamp(LPFILETIME filetime);
 
+// Convert a Windows error code to a WASI error code
+__wasi_errno_t
+convert_windows_error_code(DWORD windows_error_code);
+
 #endif /* end of _WIN_UTIL_H */

--- a/product-mini/platforms/nuttx/wamr.mk
+++ b/product-mini/platforms/nuttx/wamr.mk
@@ -250,6 +250,7 @@ CFLAGS += -I${SHARED_ROOT}/platform/common/libc-util
 CSRCS += blocking_op.c
 CSRCS += posix_socket.c
 CSRCS += posix_file.c
+CSRCS += posix_clock.c
 CSRCS += libc_errno.c
 CSRCS += libc_wasi_wrapper.c
 VPATH += $(IWASM_ROOT)/libraries/libc-wasi
@@ -364,7 +365,6 @@ CSRCS += nuttx_platform.c \
          posix_blocking_op.c \
          posix_thread.c \
          posix_time.c \
-         posix_clock.c \
          posix_sleep.c \
          mem_alloc.c \
          ems_kfc.c \


### PR DESCRIPTION
Refactoring the clock functions to use WASI types so we can simplify the code and remove some unnecessary boilerplate. See
https://github.com/bytecodealliance/wasm-micro-runtime/pull/2637#discussion_r1362202879 for details.