### PR TITLE
Revert "Strip static and shared libraries of iwasm to reduce the bin..."

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,11 +107,6 @@ endif ()
 
 set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-# Set the strip command based on the system (GNU or Clang)
-if (CMAKE_STRIP)
-    set (CMAKE_STRIP_FLAGS "--strip-all")
-endif ()
-
 include (${WAMR_ROOT_DIR}/build-scripts/runtime_lib.cmake)
 
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security -Wshadow -Wno-unused-parameter")
@@ -146,15 +141,6 @@ endif ()
 
 install (TARGETS iwasm_static ARCHIVE DESTINATION lib)
 
-# If it's a Release build, strip the static library
-if (CMAKE_STRIP AND CMAKE_BUILD_TYPE STREQUAL "Release")
-  # Strip static library
-  message (STATUS "Stripping static library after build!")
-  add_custom_command (TARGET iwasm_static POST_BUILD
-      COMMAND ${CMAKE_STRIP} ${CMAKE_STRIP_FLAGS} $<TARGET_FILE:iwasm_static>
-  )
-endif ()
-
 # SHARED LIBRARY
 add_library (iwasm_shared SHARED ${WAMR_RUNTIME_LIB_SOURCE})
 set_target_properties (iwasm_shared PROPERTIES OUTPUT_NAME iwasm)
@@ -176,12 +162,3 @@ install (FILES
     ${WAMR_ROOT_DIR}/core/iwasm/include/wasm_export.h
     ${WAMR_ROOT_DIR}/core/iwasm/include/lib_export.h
     DESTINATION include)
-
-# If it's a Release build, strip the shared library
-if (CMAKE_STRIP AND CMAKE_BUILD_TYPE STREQUAL "Release")
-  # Strip shared library
-  message (STATUS "Stripping shared library after build!")
-  add_custom_command (TARGET iwasm_shared POST_BUILD
-      COMMAND ${CMAKE_STRIP} ${CMAKE_STRIP_FLAGS} $<TARGET_FILE:iwasm_shared>
-  )
-endif ()


### PR DESCRIPTION
This reverts commit 7e3a29d5e4564406c91ada436b1e33d53d1232cf.

* it doesn't work for macOS. ("unrecognized option: --strip-all")

* it doesn't work for ubuntu. https://github.com/bytecodealliance/wasm-micro-runtime/issues/2665