### PR TITLE
Fix windows compilation on C++20

### DIFF
--- a/core/shared/platform/windows/win_atomic.cpp
+++ b/core/shared/platform/windows/win_atomic.cpp
@@ -14,8 +14,8 @@ void
 bh_atomic_thread_fence(int mem_order)
 {
     std::memory_order order =
-        (std::memory_order)(std::memory_order::memory_order_relaxed + mem_order
-                            - os_memory_order_relaxed);
+        (std::memory_order)((int)std::memory_order::memory_order_relaxed
+                            + mem_order - os_memory_order_relaxed);
     std::atomic_thread_fence(order);
 }
 


### PR DESCRIPTION
Since C++20, std::memory_order is defined as an enum class so requires explicit casting to an int when adding enum values. See https://en.cppreference.com/w/cpp/atomic/memory_order.