### PR TITLE
Fix repeatedly initialize shared memory data and protect the memory's fields

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -558,9 +558,6 @@ memory_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
      * again here */
 #endif /* end of OS_ENABLE_HW_BOUND_CHECK */
 
-    if (memory_data_size > UINT32_MAX)
-        memory_data_size = UINT32_MAX;
-
     memory_inst->module_type = Wasm_Module_AoT;
     memory_inst->num_bytes_per_page = num_bytes_per_page;
     memory_inst->cur_page_count = init_page_count;

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -640,6 +640,9 @@ memories_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
     AOTMemoryInstance *memories, *memory_inst;
     AOTMemInitData *data_seg;
     uint64 total_size;
+#if WASM_ENABLE_SHARED_MEMORY != 0
+    bool is_shared_memory;
+#endif
 
     module_inst->memory_count = memory_count;
     total_size = sizeof(AOTMemoryInstance *) * (uint64)memory_count;
@@ -666,6 +669,15 @@ memories_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
         /* Ignore setting memory init data if no memory inst is created */
         return true;
     }
+
+#if WASM_ENABLE_SHARED_MEMORY != 0
+    /* Currently we have only one memory instance */
+    is_shared_memory = module->memories[0].memory_flags & 0x02 ? true : false;
+    if (is_shared_memory && parent != NULL) {
+        /* Ignore setting memory init data if the memory has been initialized */
+        return true;
+    }
+#endif
 
     for (i = 0; i < module->mem_init_data_count; i++) {
         data_seg = module->mem_init_data_list[i];

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -499,24 +499,29 @@ memory_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
     memory_data_size = (uint64)num_bytes_per_page * init_page_count;
     max_memory_data_size = (uint64)num_bytes_per_page * max_page_count;
     bh_assert(memory_data_size <= UINT32_MAX);
-    bh_assert(max_memory_data_size <= UINT32_MAX);
+    bh_assert(max_memory_data_size <= 4 * (uint64)BH_GB);
     (void)max_memory_data_size;
 
 #ifndef OS_ENABLE_HW_BOUND_CHECK
-#if WASM_ENABLE_SHARED_MEMORY == 0
-    /* Allocate initial memory size when memory is non-shared */
-    if (memory_data_size > 0
-        && !(p = runtime_malloc(memory_data_size, error_buf, error_buf_size))) {
-        return NULL;
+#if WASM_ENABLE_SHARED_MEMORY != 0
+    if (is_shared_memory) {
+        /* Allocate maximum memory size when memory is shared */
+        if (max_memory_data_size > 0
+            && !(p = runtime_malloc(max_memory_data_size, error_buf,
+                                    error_buf_size))) {
+            return NULL;
+        }
     }
-#else
-    /* Allocate maximum memory size when memory is shared */
-    if (max_memory_data_size > 0
-        && !(p = runtime_malloc(max_memory_data_size, error_buf,
-                                error_buf_size))) {
-        return NULL;
-    }
+    else
 #endif
+    {
+        /* Allocate initial memory size when memory is not shared */
+        if (memory_data_size > 0
+            && !(p = runtime_malloc(memory_data_size, error_buf,
+                                    error_buf_size))) {
+            return NULL;
+        }
+    }
 #else /* else of OS_ENABLE_HW_BOUND_CHECK */
     memory_data_size = (memory_data_size + page_size - 1) & ~(page_size - 1);
 

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -382,7 +382,7 @@ memory_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
     uint32 inc_page_count, aux_heap_base, global_idx;
     uint32 bytes_of_last_page, bytes_to_page_end;
     uint32 heap_offset = num_bytes_per_page * init_page_count;
-    uint64 total_size;
+    uint64 memory_data_size, max_memory_data_size;
     uint8 *p = NULL, *global_addr;
 #ifdef OS_ENABLE_HW_BOUND_CHECK
     uint8 *mapped_mem;
@@ -496,23 +496,29 @@ memory_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
                 module->aux_stack_size);
     LOG_VERBOSE("  heap offset: %u, heap size: %d\n", heap_offset, heap_size);
 
-    total_size = (uint64)num_bytes_per_page * init_page_count;
-#if WASM_ENABLE_SHARED_MEMORY != 0
-    if (is_shared_memory) {
-        /* Allocate max page for shared memory */
-        total_size = (uint64)num_bytes_per_page * max_page_count;
-    }
-#endif
-    bh_assert(total_size <= UINT32_MAX);
+    memory_data_size = (uint64)num_bytes_per_page * init_page_count;
+    max_memory_data_size = (uint64)num_bytes_per_page * max_page_count;
+    bh_assert(memory_data_size <= UINT32_MAX);
+    bh_assert(max_memory_data_size <= UINT32_MAX);
+    (void)max_memory_data_size;
 
 #ifndef OS_ENABLE_HW_BOUND_CHECK
-    /* Allocate memory */
-    if (total_size > 0
-        && !(p = runtime_malloc(total_size, error_buf, error_buf_size))) {
+#if WASM_ENABLE_SHARED_MEMORY == 0
+    /* Allocate initial memory size when memory is non-shared */
+    if (memory_data_size > 0
+        && !(p = runtime_malloc(memory_data_size, error_buf, error_buf_size))) {
         return NULL;
     }
 #else
-    total_size = (total_size + page_size - 1) & ~(page_size - 1);
+    /* Allocate maximum memory size when memory is shared */
+    if (max_memory_data_size > 0
+        && !(p = runtime_malloc(max_memory_data_size, error_buf,
+                                error_buf_size))) {
+        return NULL;
+    }
+#endif
+#else /* else of OS_ENABLE_HW_BOUND_CHECK */
+    memory_data_size = (memory_data_size + page_size - 1) & ~(page_size - 1);
 
     /* Totally 8G is mapped, the opcode load/store address range is 0 to 8G:
      *   ea = i + memarg.offset
@@ -526,17 +532,18 @@ memory_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
     }
 
 #ifdef BH_PLATFORM_WINDOWS
-    if (!os_mem_commit(p, total_size, MMAP_PROT_READ | MMAP_PROT_WRITE)) {
+    if (!os_mem_commit(p, memory_data_size, MMAP_PROT_READ | MMAP_PROT_WRITE)) {
         set_error_buf(error_buf, error_buf_size, "commit memory failed");
         os_munmap(mapped_mem, map_size);
         return NULL;
     }
 #endif
 
-    if (os_mprotect(p, total_size, MMAP_PROT_READ | MMAP_PROT_WRITE) != 0) {
+    if (os_mprotect(p, memory_data_size, MMAP_PROT_READ | MMAP_PROT_WRITE)
+        != 0) {
         set_error_buf(error_buf, error_buf_size, "mprotect memory failed");
 #ifdef BH_PLATFORM_WINDOWS
-        os_mem_decommit(p, total_size);
+        os_mem_decommit(p, memory_data_size);
 #endif
         os_munmap(mapped_mem, map_size);
         return NULL;
@@ -545,18 +552,18 @@ memory_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
      * again here */
 #endif /* end of OS_ENABLE_HW_BOUND_CHECK */
 
-    if (total_size > UINT32_MAX)
-        total_size = UINT32_MAX;
+    if (memory_data_size > UINT32_MAX)
+        memory_data_size = UINT32_MAX;
 
     memory_inst->module_type = Wasm_Module_AoT;
     memory_inst->num_bytes_per_page = num_bytes_per_page;
     memory_inst->cur_page_count = init_page_count;
     memory_inst->max_page_count = max_page_count;
-    memory_inst->memory_data_size = (uint32)total_size;
+    memory_inst->memory_data_size = (uint32)memory_data_size;
 
     /* Init memory info */
     memory_inst->memory_data = p;
-    memory_inst->memory_data_end = p + (uint32)total_size;
+    memory_inst->memory_data_end = p + (uint32)memory_data_size;
 
     /* Initialize heap info */
     memory_inst->heap_data = p + heap_offset;
@@ -579,19 +586,24 @@ memory_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
         }
     }
 
-    if (total_size > 0) {
+    if (memory_data_size > 0) {
 #if UINTPTR_MAX == UINT64_MAX
-        memory_inst->mem_bound_check_1byte.u64 = total_size - 1;
-        memory_inst->mem_bound_check_2bytes.u64 = total_size - 2;
-        memory_inst->mem_bound_check_4bytes.u64 = total_size - 4;
-        memory_inst->mem_bound_check_8bytes.u64 = total_size - 8;
-        memory_inst->mem_bound_check_16bytes.u64 = total_size - 16;
+        memory_inst->mem_bound_check_1byte.u64 = memory_data_size - 1;
+        memory_inst->mem_bound_check_2bytes.u64 = memory_data_size - 2;
+        memory_inst->mem_bound_check_4bytes.u64 = memory_data_size - 4;
+        memory_inst->mem_bound_check_8bytes.u64 = memory_data_size - 8;
+        memory_inst->mem_bound_check_16bytes.u64 = memory_data_size - 16;
 #else
-        memory_inst->mem_bound_check_1byte.u32[0] = (uint32)total_size - 1;
-        memory_inst->mem_bound_check_2bytes.u32[0] = (uint32)total_size - 2;
-        memory_inst->mem_bound_check_4bytes.u32[0] = (uint32)total_size - 4;
-        memory_inst->mem_bound_check_8bytes.u32[0] = (uint32)total_size - 8;
-        memory_inst->mem_bound_check_16bytes.u32[0] = (uint32)total_size - 16;
+        memory_inst->mem_bound_check_1byte.u32[0] =
+            (uint32)memory_data_size - 1;
+        memory_inst->mem_bound_check_2bytes.u32[0] =
+            (uint32)memory_data_size - 2;
+        memory_inst->mem_bound_check_4bytes.u32[0] =
+            (uint32)memory_data_size - 4;
+        memory_inst->mem_bound_check_8bytes.u32[0] =
+            (uint32)memory_data_size - 8;
+        memory_inst->mem_bound_check_16bytes.u32[0] =
+            (uint32)memory_data_size - 16;
 #endif
     }
 
@@ -613,7 +625,7 @@ fail1:
 #else
 #ifdef BH_PLATFORM_WINDOWS
     if (memory_inst->memory_data)
-        os_mem_decommit(p, total_size);
+        os_mem_decommit(p, memory_data_size);
 #endif
     os_munmap(mapped_mem, map_size);
 #endif
@@ -2310,7 +2322,9 @@ aot_memory_init(AOTModuleInstance *module_inst, uint32 seg_index, uint32 offset,
     maddr = wasm_runtime_addr_app_to_native(
         (WASMModuleInstanceCommon *)module_inst, dst);
 
+    SHARED_MEMORY_LOCK(memory_inst);
     bh_memcpy_s(maddr, memory_inst->memory_data_size - dst, data + offset, len);
+    SHARED_MEMORY_UNLOCK(memory_inst);
     return true;
 }
 

--- a/core/iwasm/common/wasm_memory.c
+++ b/core/iwasm/common/wasm_memory.c
@@ -608,22 +608,23 @@ wasm_get_default_memory(WASMModuleInstance *module_inst)
         return NULL;
 }
 
-static void
-update_mem_bound_check_bytes(WASMMemoryInstance *memory, uint64 total_size_new)
+void
+wasm_runtime_set_mem_bound_check_bytes(WASMMemoryInstance *memory,
+                                       uint64 memory_data_size)
 {
 #if WASM_ENABLE_FAST_JIT != 0 || WASM_ENABLE_JIT != 0 || WASM_ENABLE_AOT != 0
 #if UINTPTR_MAX == UINT64_MAX
-    memory->mem_bound_check_1byte.u64 = total_size_new - 1;
-    memory->mem_bound_check_2bytes.u64 = total_size_new - 2;
-    memory->mem_bound_check_4bytes.u64 = total_size_new - 4;
-    memory->mem_bound_check_8bytes.u64 = total_size_new - 8;
-    memory->mem_bound_check_16bytes.u64 = total_size_new - 16;
+    memory->mem_bound_check_1byte.u64 = memory_data_size - 1;
+    memory->mem_bound_check_2bytes.u64 = memory_data_size - 2;
+    memory->mem_bound_check_4bytes.u64 = memory_data_size - 4;
+    memory->mem_bound_check_8bytes.u64 = memory_data_size - 8;
+    memory->mem_bound_check_16bytes.u64 = memory_data_size - 16;
 #else
-    memory->mem_bound_check_1byte.u32[0] = (uint32)total_size_new - 1;
-    memory->mem_bound_check_2bytes.u32[0] = (uint32)total_size_new - 2;
-    memory->mem_bound_check_4bytes.u32[0] = (uint32)total_size_new - 4;
-    memory->mem_bound_check_8bytes.u32[0] = (uint32)total_size_new - 8;
-    memory->mem_bound_check_16bytes.u32[0] = (uint32)total_size_new - 16;
+    memory->mem_bound_check_1byte.u32[0] = (uint32)memory_data_size - 1;
+    memory->mem_bound_check_2bytes.u32[0] = (uint32)memory_data_size - 2;
+    memory->mem_bound_check_4bytes.u32[0] = (uint32)memory_data_size - 4;
+    memory->mem_bound_check_8bytes.u32[0] = (uint32)memory_data_size - 8;
+    memory->mem_bound_check_16bytes.u32[0] = (uint32)memory_data_size - 16;
 #endif
 #endif
 }
@@ -688,7 +689,7 @@ wasm_enlarge_memory_internal(WASMModuleInstance *module, uint32 inc_page_count)
         memory->memory_data_size = (uint32)total_size_new;
         memory->memory_data_end = memory->memory_data + (uint32)total_size_new;
 
-        update_mem_bound_check_bytes(memory, total_size_new);
+        wasm_runtime_set_mem_bound_check_bytes(memory, total_size_new);
         return true;
     }
 #endif
@@ -740,7 +741,7 @@ wasm_enlarge_memory_internal(WASMModuleInstance *module, uint32 inc_page_count)
     memory->memory_data = memory_data_new;
     memory->memory_data_end = memory_data_new + (uint32)total_size_new;
 
-    update_mem_bound_check_bytes(memory, total_size_new);
+    wasm_runtime_set_mem_bound_check_bytes(memory, total_size_new);
 
 #if defined(os_writegsbase)
     /* write base addr of linear memory to GS segment register */
@@ -846,7 +847,7 @@ wasm_enlarge_memory_internal(WASMModuleInstance *module, uint32 inc_page_count)
     memory->memory_data_size = (uint32)total_size_new;
     memory->memory_data_end = memory->memory_data + (uint32)total_size_new;
 
-    update_mem_bound_check_bytes(memory, total_size_new);
+    wasm_runtime_set_mem_bound_check_bytes(memory, total_size_new);
 
 return_func:
     if (!ret && enlarge_memory_error_cb) {

--- a/core/iwasm/common/wasm_memory.c
+++ b/core/iwasm/common/wasm_memory.c
@@ -274,14 +274,6 @@ wasm_runtime_get_mem_alloc_info(mem_alloc_info_t *mem_alloc_info)
     return false;
 }
 
-#if WASM_ENABLE_SHARED_MEMORY != 0
-#define SHARED_MEMORY_LOCK(memory) shared_memory_lock(memory)
-#define SHARED_MEMORY_UNLOCK(memory) shared_memory_unlock(memory)
-#else
-#define SHARED_MEMORY_LOCK(memory) (void)0
-#define SHARED_MEMORY_UNLOCK(memory) (void)0
-#endif
-
 bool
 wasm_runtime_validate_app_addr(WASMModuleInstanceCommon *module_inst_comm,
                                uint32 app_offset, uint32 size)
@@ -673,9 +665,8 @@ wasm_enlarge_memory_internal(WASMModuleInstance *module, uint32 inc_page_count)
         memory->num_bytes_per_page = num_bytes_per_page;
         memory->cur_page_count = total_page_count;
         memory->max_page_count = max_page_count;
-        /* No need to update memory->memory_data_size as it is
-           initialized with the maximum memory data size for
-           shared memory */
+        memory->memory_data_size = (uint32)total_size_new;
+        memory->memory_data_end = memory->memory_data + (uint32)total_size_new;
         return true;
     }
 #endif

--- a/core/iwasm/common/wasm_memory.h
+++ b/core/iwasm/common/wasm_memory.h
@@ -25,6 +25,10 @@ unsigned
 wasm_runtime_memory_pool_size();
 
 void
+wasm_runtime_set_mem_bound_check_bytes(WASMMemoryInstance *memory,
+                                       uint64 memory_data_size);
+
+void
 wasm_runtime_set_enlarge_mem_error_callback(
     const enlarge_memory_error_callback_t callback, void *user_data);
 

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -3038,7 +3038,8 @@ wasm_runtime_init_wasi(WASMModuleInstanceCommon *module_inst,
             }
         }
 
-        strncpy(mapping_copy, map_dir_list[i], strlen(map_dir_list[i]) + 1);
+        bh_memcpy_s(mapping_copy, max_len, map_dir_list[i],
+                    (uint32)(strlen(map_dir_list[i]) + 1));
         map_mapped = strtok(mapping_copy, "::");
         map_host = strtok(NULL, "::");
 

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -298,6 +298,14 @@ LOAD_I16(void *addr)
 
 #endif /* WASM_CPU_SUPPORTS_UNALIGNED_ADDR_ACCESS != 0 */
 
+#if WASM_ENABLE_SHARED_MEMORY != 0
+#define SHARED_MEMORY_LOCK(memory) shared_memory_lock(memory)
+#define SHARED_MEMORY_UNLOCK(memory) shared_memory_unlock(memory)
+#else
+#define SHARED_MEMORY_LOCK(memory) (void)0
+#define SHARED_MEMORY_UNLOCK(memory) (void)0
+#endif
+
 typedef struct WASMModuleCommon {
     /* Module type, for module loaded from WASM bytecode binary,
        this field is Wasm_Module_Bytecode, and this structure should

--- a/core/iwasm/common/wasm_shared_memory.c
+++ b/core/iwasm/common/wasm_shared_memory.c
@@ -313,7 +313,7 @@ wasm_runtime_atomic_wait(WASMModuleInstanceCommon *module, void *address,
     if ((uint8 *)address < module_inst->memories[0]->memory_data
         || (uint8 *)address + (wait64 ? 8 : 4)
                > module_inst->memories[0]->memory_data_end) {
-        SHARED_MEMORY_LOCK(module_inst->memories[0]);
+        SHARED_MEMORY_UNLOCK(module_inst->memories[0]);
         wasm_runtime_set_exception(module, "out of bounds memory access");
         return -1;
     }

--- a/core/iwasm/common/wasm_shared_memory.c
+++ b/core/iwasm/common/wasm_shared_memory.c
@@ -146,14 +146,6 @@ shared_memory_unlock(WASMMemoryInstance *memory)
     os_mutex_unlock(&_shared_memory_lock);
 }
 
-#if WASM_ENABLE_SHARED_MEMORY != 0
-#define SHARED_MEMORY_LOCK(memory) shared_memory_lock(memory)
-#define SHARED_MEMORY_UNLOCK(memory) shared_memory_unlock(memory)
-#else
-#define SHARED_MEMORY_LOCK(memory) (void)0
-#define SHARED_MEMORY_UNLOCK(memory) (void)0
-#endif
-
 /* Atomics wait && notify APIs */
 static uint32
 wait_address_hash(const void *address)
@@ -309,15 +301,15 @@ wasm_runtime_atomic_wait(WASMModuleInstanceCommon *module, void *address,
         return -1;
     }
 
-    SHARED_MEMORY_LOCK(module_inst->memories[0]);
+    shared_memory_lock(module_inst->memories[0]);
     if ((uint8 *)address < module_inst->memories[0]->memory_data
         || (uint8 *)address + (wait64 ? 8 : 4)
                > module_inst->memories[0]->memory_data_end) {
-        SHARED_MEMORY_UNLOCK(module_inst->memories[0]);
+        shared_memory_unlock(module_inst->memories[0]);
         wasm_runtime_set_exception(module, "out of bounds memory access");
         return -1;
     }
-    SHARED_MEMORY_UNLOCK(module_inst->memories[0]);
+    shared_memory_unlock(module_inst->memories[0]);
 
 #if WASM_ENABLE_THREAD_MGR != 0
     exec_env =
@@ -434,11 +426,11 @@ wasm_runtime_atomic_notify(WASMModuleInstanceCommon *module, void *address,
     bh_assert(module->module_type == Wasm_Module_Bytecode
               || module->module_type == Wasm_Module_AoT);
 
-    SHARED_MEMORY_LOCK(module_inst->memories[0]);
+    shared_memory_lock(module_inst->memories[0]);
     out_of_bounds =
         ((uint8 *)address < module_inst->memories[0]->memory_data
          || (uint8 *)address + 4 > module_inst->memories[0]->memory_data_end);
-    SHARED_MEMORY_UNLOCK(module_inst->memories[0]);
+    shared_memory_unlock(module_inst->memories[0]);
 
     if (out_of_bounds) {
         wasm_runtime_set_exception(module, "out of bounds memory access");

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -1375,7 +1375,15 @@ load_memory(const uint8 **p_buf, const uint8 *buf_end, WASMMemory *memory,
         return false;
     }
     if (memory->flags > 1) {
-        set_error_buf(error_buf, error_buf_size, "integer too large");
+        if (memory->flags & 2) {
+            set_error_buf(error_buf, error_buf_size,
+                          "shared memory flag was found, "
+                          "please enable shared memory, lib-pthread "
+                          "or lib-wasi-threads");
+        }
+        else {
+            set_error_buf(error_buf, error_buf_size, "invalid memory flags");
+        }
         return false;
     }
 #else

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1774,10 +1774,23 @@ wasm_instantiate(WASMModule *module, WASMModuleInstance *parent,
         uint8 *memory_data = NULL;
         uint64 memory_size = 0;
         WASMDataSeg *data_seg = module->data_segments[i];
+#if WASM_ENABLE_SHARED_MEMORY != 0
+        bool is_shared_memory;
+#endif
 
 #if WASM_ENABLE_BULK_MEMORY != 0
         if (data_seg->is_passive)
             continue;
+#endif
+
+#if WASM_ENABLE_SHARED_MEMORY != 0
+        /* Currently we have only one memory instance */
+        is_shared_memory = module->memories[0].flags & 0x02 ? true : false;
+        if (is_shared_memory && parent != NULL) {
+            /* Ignore setting memory init data if the memory has been
+             * initialized */
+            continue;
+        }
 #endif
 
         /* has check it in loader */

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1785,7 +1785,13 @@ wasm_instantiate(WASMModule *module, WASMModuleInstance *parent,
 
 #if WASM_ENABLE_SHARED_MEMORY != 0
         /* Currently we have only one memory instance */
-        is_shared_memory = module->memories[0].flags & 0x02 ? true : false;
+        if (module->import_memory_count > 0) {
+            is_shared_memory =
+                module->import_memories[0].u.memory.flags ? true : false;
+        }
+        else {
+            is_shared_memory = module->memories[0].flags & 0x2 ? true : false;
+        }
         if (is_shared_memory && parent != NULL) {
             /* Ignore setting memory init data if the memory has been
              * initialized */

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1786,11 +1786,12 @@ wasm_instantiate(WASMModule *module, WASMModuleInstance *parent,
 #if WASM_ENABLE_SHARED_MEMORY != 0
         /* Currently we have only one memory instance */
         if (module->import_memory_count > 0) {
-            is_shared_memory =
-                module->import_memories[0].u.memory.flags ? true : false;
+            is_shared_memory = (module->import_memories[0].u.memory.flags & 0x2)
+                                   ? true
+                                   : false;
         }
         else {
-            is_shared_memory = module->memories[0].flags & 0x2 ? true : false;
+            is_shared_memory = (module->memories[0].flags & 0x2) ? true : false;
         }
         if (is_shared_memory && parent != NULL) {
             /* Ignore setting memory init data if the memory has been

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -342,9 +342,6 @@ memory_instantiate(WASMModuleInstance *module_inst, WASMModuleInstance *parent,
      * again here */
 #endif /* end of OS_ENABLE_HW_BOUND_CHECK */
 
-    if (memory_data_size > UINT32_MAX)
-        memory_data_size = (uint32)memory_data_size;
-
     memory->module_type = Wasm_Module_Bytecode;
     memory->num_bytes_per_page = num_bytes_per_page;
     memory->cur_page_count = init_page_count;


### PR DESCRIPTION
Add shared memory lock when accessing some fields of the memory instance
when the memory instance is shared.
And avoid repeatedly initializing the shared memory data when creating the
child thread in lib-pthread or lib-wasi-threads.