### PR TITLE
Enable WASI tests on Windows CI

### DIFF
--- a/.github/workflows/compilation_on_windows.yml
+++ b/.github/workflows/compilation_on_windows.yml
@@ -44,6 +44,10 @@ env:
   DEFAULT_TEST_OPTIONS: "-s spec -b"
   MULTI_MODULES_TEST_OPTIONS: "-s spec -b -M"
   THREADS_TEST_OPTIONS: "-s spec -b -p"
+  WASI_TEST_OPTIONS: "-s wasi_certification -w"
+  WASI_TEST_FILTER: ${{ github.workspace }}/product-mini/platforms/windows/wasi_filtered_tests.json
+  # Used when building the WASI socket and thread tests
+  CC: ${{ github.workspace }}/wasi-sdk/bin/clang
 
 # Cancel any in-flight jobs for the same PR/branch so there's only one active
 # at a time
@@ -100,10 +104,30 @@ jobs:
             $DEFAULT_TEST_OPTIONS,
             $MULTI_MODULES_TEST_OPTIONS,
             $THREADS_TEST_OPTIONS,
+            $WASI_TEST_OPTIONS,
           ]
     steps:
       - name: checkout
         uses: actions/checkout@v3
+
+      - name: download and install wasi-sdk
+        if: matrix.test_option == '$WASI_TEST_OPTIONS'
+        run: |
+          curl "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk-20.0.m-mingw.tar.gz" -o wasi-sdk.tar.gz -L
+          mkdir wasi-sdk
+          tar -xzf wasi-sdk.tar.gz -C wasi-sdk --strip-components 1
+
+      - name: build socket api tests
+        shell: bash
+        if: matrix.test_option == '$WASI_TEST_OPTIONS'
+        run: ./build.sh
+        working-directory: ./core/iwasm/libraries/lib-socket/test/
+
+      - name: Build WASI thread tests
+        shell: bash
+        if: matrix.test_option == '$WASI_TEST_OPTIONS'
+        run: ./build.sh
+        working-directory: ./core/iwasm/libraries/lib-wasi-threads/test/
 
       - name: run tests
         shell: bash

--- a/core/iwasm/libraries/lib-socket/test/manifest.json
+++ b/core/iwasm/libraries/lib-socket/test/manifest.json
@@ -1,0 +1,3 @@
+{
+    "name": "WAMR lib-socket tests"
+}

--- a/core/shared/platform/windows/platform_internal.h
+++ b/core/shared/platform/windows/platform_internal.h
@@ -146,8 +146,19 @@ typedef enum windows_access_mode {
     windows_access_mode_write = 1 << 1
 } windows_access_mode;
 
+// These enum values are defined to be the same as the corresponding WASI
+// fdflags so they can be used interchangeably.
+typedef enum windows_fdflags {
+    windows_fdflags_append = 1 << 0,
+    windows_fdflags_dsync = 1 << 1,
+    windows_fdflags_nonblock = 1 << 2,
+    windows_fdflags_rsync = 1 << 3,
+    windows_fdflags_sync = 1 << 4
+} windows_fdflags;
+
 typedef struct windows_handle {
     windows_handle_type type;
+    windows_fdflags fdflags;
     windows_access_mode access_mode;
     union {
         HANDLE handle;

--- a/core/shared/platform/windows/win_socket.c
+++ b/core/shared/platform/windows/win_socket.c
@@ -70,6 +70,7 @@ os_socket_create(bh_socket_t *sock, bool is_ipv4, bool is_tcp)
 
     (*sock)->type = windows_handle_type_socket;
     (*sock)->access_mode = windows_access_mode_read | windows_access_mode_write;
+    (*sock)->fdflags = 0;
 
     if (is_ipv4) {
         af = AF_INET;
@@ -174,6 +175,7 @@ os_socket_accept(bh_socket_t server_sock, bh_socket_t *sock, void *addr,
 
     (*sock)->type = windows_handle_type_socket;
     (*sock)->access_mode = windows_access_mode_read | windows_access_mode_write;
+    (*sock)->fdflags = 0;
     (*sock)->raw.socket =
         accept(server_sock->raw.socket, (struct sockaddr *)&addr_tmp, &len);
 

--- a/product-mini/platforms/windows/wasi_filtered_tests.json
+++ b/product-mini/platforms/windows/wasi_filtered_tests.json
@@ -1,0 +1,51 @@
+{
+    "WASI C tests": {
+        "fdopendir-with-access": "Not implemented",
+        "lseek": "Not implemented"
+    },
+    "WASI Rust tests": {
+        "dangling_symlink": "Not implemented",
+        "directory_seek": "Not implemented",
+        "dir_fd_op_failures": "Not implemented",
+        "fd_advise": "Not implemented",
+        "fd_fdstat_set_rights": "Not implemented",
+        "fd_filestat_set": "Not implemented",
+        "fd_flags_set": "Not implemented",
+        "fd_readdir": "Not implemented",
+        "file_allocate": "Not implemented",
+        "file_seek_tell": "Not implemented",
+        "file_truncation": "Not implemented",
+        "nofollow_errors": "Not implemented",
+        "path_exists": "Not implemented",
+        "path_filestat": "Not implemented",
+        "path_link": "Not implemented",
+        "path_open_preopen": "Not implemented",
+        "path_rename": "Not implemented",
+        "path_rename_dir_trailing_slashes": "Not implemented",
+        "path_symlink_trailing_slashes": "Not implemented",
+        "poll_oneoff_stdio": "Not implemented",
+        "readlink": "Not implemented (path_symlink)",
+        "symlink_create": "Not implemented",
+        "symlink_filestat": "Not implemented",
+        "symlink_loop": "Not implemented",
+        "truncation_rights": "Not implemented"
+    },
+    "WASI threads proposal": {
+        "wasi_threads_exit_main_wasi_read": "Blocking ops not implemented",
+        "wasi_threads_exit_nonmain_wasi_read": "Blocking ops not implemented",
+        "wasi_threads_return_main_wasi_read": "Blocking ops not implemented",
+        "wasi_threads_return_main_wasi": "Blocking ops not implemented",
+        "wasi_threads_exit_nonmain_wasi": "Blocking ops not implemented",
+        "wasi_threads_exit_main_wasi": "Blocking ops not implemented"
+    },
+    "WAMR lib-socket tests": {
+        "nslookup": "Not implemented",
+        "tcp_udp": "Not implemented"
+    },
+    "lib-wasi-threads tests": {
+        "nonmain_proc_exit_sleep": "poll_oneoff not implemented",
+        "main_proc_exit_sleep": "poll_oneoff not implemented",
+        "main_trap_sleep": "poll_oneoff not implemented",
+        "nonmain_trap_sleep": "poll_oneoff not implemented"
+    }
+}

--- a/tests/wamr-test-suites/test_wamr.sh
+++ b/tests/wamr-test-suites/test_wamr.sh
@@ -566,7 +566,7 @@ function wasi_certification_test()
     cd wasi-testsuite
     git reset --hard ${WASI_TESTSUITE_COMMIT}
 
-    bash ../../wasi-test-script/run_wasi_tests.sh $1 $TARGET \
+    bash ../../wasi-test-script/run_wasi_tests.sh $1 $TARGET $WASI_TEST_FILTER \
         | tee -a ${REPORT_DIR}/wasi_test_report.txt
     ret=${PIPESTATUS[0]}
 
@@ -834,6 +834,17 @@ function trigger()
     if [[ "$WAMR_BUILD_SANITIZER" == "tsan" ]]; then
         echo "Setting run with tsan"
         EXTRA_COMPILE_FLAGS+=" -DWAMR_BUILD_SANITIZER=tsan"
+    fi
+
+    # Make sure we're using the builtin WASI libc implementation
+    # if we're running the wasi certification tests.
+    if [[ $TEST_CASE_ARR ]]; then
+        for test in "${TEST_CASE_ARR[@]}"; do
+            if [[ "$test" == "wasi_certification" ]]; then
+                EXTRA_COMPILE_FLAGS+=" -DWAMR_BUILD_LIBC_UVWASI=0 -DWAMR_BUILD_LIBC_WASI=1"
+                break
+            fi
+        done
     fi
 
     for t in "${TYPE[@]}"; do


### PR DESCRIPTION
I've split this up change into two commits to make it (hopefully!) easier to review.
-  the first commit adds the ability to filter tests in the WASI test runner. 
- the second commit actually enables the WASI tests in CI and implements some additional WASI functions on Windows. Without implementing these additional APIs, it's not possible to run any of the tests since most of them need to at least create/delete a file/directory.