### PR TITLE
Fix invalid use of jit_reg_is_const_val in fast-jit

### DIFF
--- a/core/iwasm/fast-jit/fe/jit_emit_compare.c
+++ b/core/iwasm/fast-jit/fe/jit_emit_compare.c
@@ -227,7 +227,7 @@ jit_compile_op_f32_compare(JitCompContext *cc, FloatCond cond)
     POP_F32(rhs);
     POP_F32(lhs);
 
-    if (jit_reg_is_const_val(lhs) && jit_reg_is_const_val(rhs)) {
+    if (jit_reg_is_const(lhs) && jit_reg_is_const(rhs)) {
         float32 lvalue = jit_cc_get_const_F32(cc, lhs);
         float32 rvalue = jit_cc_get_const_F32(cc, rhs);
 
@@ -290,7 +290,7 @@ jit_compile_op_f64_compare(JitCompContext *cc, FloatCond cond)
     POP_F64(rhs);
     POP_F64(lhs);
 
-    if (jit_reg_is_const_val(lhs) && jit_reg_is_const_val(rhs)) {
+    if (jit_reg_is_const(lhs) && jit_reg_is_const(rhs)) {
         float64 lvalue = jit_cc_get_const_F64(cc, lhs);
         float64 rvalue = jit_cc_get_const_F64(cc, rhs);
 

--- a/core/iwasm/fast-jit/fe/jit_emit_control.c
+++ b/core/iwasm/fast-jit/fe/jit_emit_control.c
@@ -808,7 +808,7 @@ jit_compile_op_block(JitCompContext *cc, uint8 **p_frame_ip,
     else if (label_type == LABEL_TYPE_IF) {
         POP_I32(value);
 
-        if (!jit_reg_is_const_val(value)) {
+        if (!jit_reg_is_const(value)) {
             /* Compare value is not constant, create condition br IR */
 
             /* Create entry block */


### PR DESCRIPTION
`jit_reg_is_const_val` only checks whether the register is a const register and
the const value is stored in the register.
Should use `jit_reg_is_const` instead in the front end.

Reported in #2710.