### PR TITLE
Fix default vprintf on UWP

### DIFF
--- a/core/shared/platform/windows/platform_internal.h
+++ b/core/shared/platform/windows/platform_internal.h
@@ -183,9 +183,6 @@ typedef uint32_t os_raw_file_handle;
 // implementation of vprintf on debug builds so output from WASI libc is sent to
 // the debugger and not lost completely.
 #if !defined(BH_VPRINTF) && !defined(NDEBUG) && WINAPI_PARTITION_DESKTOP == 0
-int
-uwp_print_to_debugger(const char *format, va_list ap);
-
 #define BH_VPRINTF uwp_print_to_debugger
 #define UWP_DEFAULT_VPRINTF
 #endif


### PR DESCRIPTION
`platform_common.h` already has a declaration for BH_VPRINTF so we can get rid of the one in `platform_internal.h`. Also add some explicit casts to avoid MSVC compiler warnings.