### PR TITLE
Fix typo in Zephyr simple example

### DIFF
--- a/product-mini/platforms/zephyr/simple/src/main.c
+++ b/product-mini/platforms/zephyr/simple/src/main.c
@@ -248,7 +248,7 @@ fail1:
 
     end = k_uptime_get_32();
 
-    printf("elpase: %d\n", (end - start));
+    printf("elapsed: %d\n", (end - start));
 }
 
 #define MAIN_THREAD_STACK_SIZE (CONFIG_MAIN_THREAD_STACK_SIZE)


### PR DESCRIPTION
Fixes small typo of elapsed in Zephyr simple example.