### PR TITLE
Fix CMSIS import with Zephyr 3.4+

### DIFF
--- a/core/shared/platform/zephyr/platform_internal.h
+++ b/core/shared/platform/zephyr/platform_internal.h
@@ -42,21 +42,23 @@
 #include <net/net_ip.h>
 #include <net/net_core.h>
 #include <net/net_context.h>
-
-#ifdef CONFIG_ARM_MPU
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
-#endif
 #else /* else of KERNEL_VERSION_NUMBER < 0x030200 */
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_context.h>
+#endif /* end of KERNEL_VERSION_NUMBER < 0x030200 */
 
 #ifdef CONFIG_ARM_MPU
+#if KERNEL_VERSION_NUMBER < 0x030200 /* version 3.2.0 */
+#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#elif KERNEL_VERSION_NUMBER < 0x030400 /* version 3.4.0 */
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#else /* > 3.4.0 */
+#include <cmsis_core.h>
 #endif
-#endif /* end of KERNEL_VERSION_NUMBER < 0x030200 */
+#endif
 
 #ifndef BH_PLATFORM_ZEPHYR
 #define BH_PLATFORM_ZEPHYR


### PR DESCRIPTION
Fixes the import path for CMSIS in Zephyr versions > 3.4.

See https://github.com/zephyrproject-rtos/zephyr/pull/59855 for more information.