### PR TITLE
Return uint32 from WASI functions

### DIFF
--- a/core/iwasm/libraries/libc-uvwasi/libc_uvwasi_wrapper.c
+++ b/core/iwasm/libraries/libc-uvwasi/libc_uvwasi_wrapper.c
@@ -30,7 +30,16 @@
     wasm_runtime_module_free(module_inst, offset)
 /* clang-format on */
 
-#define wasi_errno_t uvwasi_errno_t
+// uvwasi_errno_t is typedef'd to uint16 which is correct according to the ABI
+// specification. However, in WASM, the smallest integer type is int32. If we
+// return uint16, we would rely on language SDKs to implement the correct
+// behaviour of casting to uint16 before checking the value or using it any way.
+// Failure to do so can cause tricky bugs as the upper 16 bits of the error
+// result are not guaranteed to be zero'ed by us so the result essentially
+// contains garbage from the WASM app perspective. To prevent this, we return
+// uint32 directly instead so as not to be reliant on the correct behaviour of
+// any current/future SDK implementations.
+#define wasi_errno_t uint32_t
 #define wasi_fd_t uvwasi_fd_t
 #define wasi_clockid_t uvwasi_clockid_t
 #define wasi_timestamp_t uvwasi_timestamp_t

--- a/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.h
+++ b/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.h
@@ -18,7 +18,16 @@ typedef __wasi_advice_t wasi_advice_t;
 typedef __wasi_ciovec_t wasi_ciovec_t;
 typedef __wasi_clockid_t wasi_clockid_t;
 typedef __wasi_dircookie_t wasi_dircookie_t;
-typedef __wasi_errno_t wasi_errno_t;
+// __wasi_errno_t is typedef'd to uint16 which is correct according to the ABI
+// specification. However, in WASM, the smallest integer type is int32. If we
+// return uint16, we would rely on language SDKs to implement the correct
+// behaviour of casting to uint16 before checking the value or using it any way.
+// Failure to do so can cause tricky bugs as the upper 16 bits of the error
+// result are not guaranteed to be zero'ed by us so the result essentially
+// contains garbage from the WASM app perspective. To prevent this, we return
+// uint32 directly instead so as not to be reliant on the correct behaviour of
+// any current/future WASI SDK implemenations.
+typedef uint32_t wasi_errno_t;
 typedef __wasi_event_t wasi_event_t;
 typedef __wasi_exitcode_t wasi_exitcode_t;
 typedef __wasi_fdflags_t wasi_fdflags_t;


### PR DESCRIPTION
Returning uint16 from WASI functions is technically correct. However, the smallest integer type in WASM is int32 and since we don't guarantee that the upper 16 bits of the result are zero'ed, it can result in tricky bugs if the language SDK being used in the WASM app does not cast back immediately to uint16. To prevent this, we directly return uint32 instead, so that the result is well-defined as a 32-bit number.

I originally noticed this issue when building WAMR with clangcl on Windows and running a rust WASM app but there's no reason it wouldn't affect WAMR on other platforms built with different toolchains. I'll look to fix the rust SDK as well but this is still probably a good idea in case some other SDKs are not handling the error result correctly (i.e. casting to uint16).