### PR TITLE
Fix switch-case fallthrough compilation warning

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -546,6 +546,7 @@ fd_object_release(wasm_exec_env_t env, struct fd_object *fo)
                     error = os_closedir(fo->directory.handle);
                     break;
                 }
+                // Fallthrough.
             default:
                 // The env == NULL case is for
                 // fd_table_destroy, path_get, path_put,


### PR DESCRIPTION
The commit fa5e9d72b039 ("Abstract POSIX filesystem functions") introduces the build warning:

./core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c: In function ‘fd_object_release’: ./core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c:545:20: warning: this statement may fall through [-Wimplicit-fallthrough=]
  545 |                 if (os_is_dir_stream_valid(&fo->directory.handle)) {
      |                    ^
./core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c:549:13: note: here
  549 |             default:
      |             ^~~~~~~

Refer to the commit fb4afc7ca43a ("Apply clang-format for core/iwasm compilation and libraries"), add one line "// Fallthrough." to make compiler happy.