### PR TITLE
aot compiler: Fix null abi issue

### DIFF
--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -2572,6 +2572,8 @@ aot_create_comp_context(const AOTCompData *comp_data, aot_comp_option_t option)
             }
             else if (is_baremetal_target(arch, cpu, abi)) {
                 vendor_sys = "-unknown-none-";
+                if (!abi)
+                    abi = "gnu";
             }
             else {
                 vendor_sys = "-pc-linux-";


### PR DESCRIPTION
Set `abi` to "gnu" for the bare-metal target when `abi` is NULL,
or the below `bh_assert` and `bh_memcpy` may deference a NULL
pointer. Error is reported when running wamrc compiled with
`cmake .. -DCMAKE_BUILD_TYPE=Debug`:
```
core/iwasm/compilation/aot_llvm.c:2584:13: runtime error:
  null pointer passed as argument 1, which is declared to never be null
```