### PR TITLE
Enable more LLVM backend for release wamrc

### DIFF
--- a/.github/workflows/release_process.yml
+++ b/.github/workflows/release_process.yml
@@ -56,21 +56,21 @@ jobs:
     uses: ./.github/workflows/build_llvm_libraries.yml
     with:
       os: "ubuntu-20.04"
-      arch: "X86"
+      arch: "AArch64 ARM Mips RISCV X86"
 
   build_llvm_libraries_on_ubuntu_2204:
     needs: [create_tag, create_release]
     uses: ./.github/workflows/build_llvm_libraries.yml
     with:
       os: "ubuntu-22.04"
-      arch: "X86"
+      arch: "AArch64 ARM Mips RISCV X86"
 
   build_llvm_libraries_on_macos:
     needs: [create_tag, create_release]
     uses: ./.github/workflows/build_llvm_libraries.yml
     with:
       os: "macos-latest"
-      arch: "X86"
+      arch: "AArch64 ARM Mips RISCV X86"
 
   #
   # WAMRC


### PR DESCRIPTION
As mentioned in https://github.com/bytecodealliance/wasm-micro-runtime/issues/2504, originally the release `wamrc` only has X86 target enabled. This PR enables more targets for release `wamrc`, including AArch64, ARM, Mips, RISCV