### PR TITLE
Fix comment in WAMR_MEM_DUAL_BUS_MIRROR

### DIFF
--- a/core/config.h
+++ b/core/config.h
@@ -477,7 +477,7 @@
 /* Some chip cannot support external ram with rwx attr at the same time,
    it has to map it into 2 spaces of idbus and dbus, code in dbus can be
    read/written and read/executed in ibus. so there are 2 steps to execute
-   the code, first, copy&do relocaiton in dbus space, and second execute
+   the code, first, copy & do relocation in dbus space, and second execute
    it in ibus space, since in the 2 spaces the contents are the same,
    so we call it bus mirror.
  */


### PR DESCRIPTION
Fixes a small typo in the WAMR_MEM_DUAL_BUS_MIRROR description.