### PR TITLE
aot compiler: Fix handle next reachable if block

### DIFF
--- a/core/iwasm/compilation/aot_emit_control.c
+++ b/core/iwasm/compilation/aot_emit_control.c
@@ -221,6 +221,16 @@ handle_next_reachable_block(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         return true;
     }
 
+    if (block->label_type == LABEL_TYPE_IF && block->llvm_else_block
+        && !block->skip_wasm_code_else
+        && *p_frame_ip <= block->wasm_code_else) {
+        /* Clear value stack and start to translate else branch */
+        aot_value_stack_destroy(&block->value_stack);
+        SET_BUILDER_POS(block->llvm_else_block);
+        *p_frame_ip = block->wasm_code_else + 1;
+        return true;
+    }
+
     *p_frame_ip = block->wasm_code_end + 1;
     SET_BUILDER_POS(block->llvm_end_block);
 

--- a/core/iwasm/compilation/aot_emit_control.c
+++ b/core/iwasm/compilation/aot_emit_control.c
@@ -202,6 +202,9 @@ handle_next_reachable_block(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                 *p_frame_ip = block->wasm_code_else + 1;
                 /* Push back the block */
                 aot_block_stack_push(&func_ctx->block_stack, block);
+                /* Recover parameters of else branch */
+                for (i = 0; i < block->param_count; i++)
+                    PUSH(block->else_param_phis[i], block->param_types[i]);
                 return true;
             }
             else if (block->llvm_end_block) {
@@ -226,6 +229,9 @@ handle_next_reachable_block(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         && *p_frame_ip <= block->wasm_code_else) {
         /* Clear value stack and start to translate else branch */
         aot_value_stack_destroy(&block->value_stack);
+        /* Recover parameters of else branch */
+        for (i = 0; i < block->param_count; i++)
+            PUSH(block->else_param_phis[i], block->param_types[i]);
         SET_BUILDER_POS(block->llvm_else_block);
         *p_frame_ip = block->wasm_code_else + 1;
         return true;

--- a/core/iwasm/compilation/aot_emit_function.c
+++ b/core/iwasm/compilation/aot_emit_function.c
@@ -22,11 +22,14 @@ static bool
 is_win_platform(AOTCompContext *comp_ctx)
 {
     char *triple = LLVMGetTargetMachineTriple(comp_ctx->target_machine);
+    bool ret;
 
     bh_assert(triple);
-    if (strstr(triple, "win32") || strstr(triple, "win"))
-        return true;
-    return false;
+    ret = (strstr(triple, "win32") || strstr(triple, "win")) ? true : false;
+
+    LLVMDisposeMessage(triple);
+
+    return ret;
 }
 
 static bool


### PR DESCRIPTION
The popped reachable block may be if block whose else branch hasn't been
translated, and should push the params for the else block if there are.

And use LLVMDisposeMessage to free memory allocated in is_win_platform.