### PR TITLE
Change is_shared_memory type from bool to uint8

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -605,7 +605,7 @@ memory_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
 
 #if WASM_ENABLE_SHARED_MEMORY != 0
     if (is_shared_memory) {
-        memory_inst->is_shared_memory = true;
+        memory_inst->is_shared_memory = 1;
         memory_inst->ref_count = 1;
     }
 #endif

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -386,7 +386,7 @@ memory_instantiate(WASMModuleInstance *module_inst, WASMModuleInstance *parent,
 
 #if WASM_ENABLE_SHARED_MEMORY != 0
     if (is_shared_memory) {
-        memory->is_shared_memory = true;
+        memory->is_shared_memory = 1;
         memory->ref_count = 1;
     }
 #endif

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -81,10 +81,15 @@ struct WASMMemoryInstance {
     /* Module type */
     uint32 module_type;
 
-    bool is_shared_memory;
+    /* Whether the memory is shared */
+    uint8 is_shared_memory;
 
-    /* Shared memory flag */
-    bh_atomic_16_t ref_count; /* 0: non-shared, > 0: reference count */
+    /* One byte padding */
+    uint8 __padding__;
+
+    /* Reference count of the memory instance:
+         0: non-shared memory, > 0: shared memory */
+    bh_atomic_16_t ref_count;
 
     /* Number bytes per page */
     uint32 num_bytes_per_page;


### PR DESCRIPTION
Change WASMMemoryInstance's field is_shared_memory's type from bool
to uint8 whose size is fixed, so as to make WASMMemoryInstance's size
and layout fixed and not break AOT ABI.

See discussion in https://github.com/bytecodealliance/wasm-micro-runtime/pull/2682.