### PR TITLE
Fix typo in CI config and suppress STORE_U8 in TSAN

### DIFF
--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -666,7 +666,7 @@ jobs:
 
       - name: run tests
         timeout-minutes: 40
-        run: ./test_wamr.sh ${{ matrix.test_option }} -t ${{ matrix.running_mode }} -T %{{matrix.sanitizer}}
+        run: ./test_wamr.sh ${{ matrix.test_option }} -t ${{ matrix.running_mode }} -T "${{ matrix.sanitizer }}"
         working-directory: ./tests/wamr-test-suites
 
       #only install x32 support libraries when to run x86_32 cases

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -54,6 +54,12 @@ STORE_U16(void *addr, uint16_t value)
 {
     *(uint16_t *)(addr) = (uint16_t)(value);
 }
+static inline void
+STORE_U8(void *addr, uint8_t value)
+{
+    *(uint8 *)addr = value;
+}
+
 /* For LOAD opcodes */
 #define LOAD_I64(addr) (*(int64 *)(addr))
 #define LOAD_F64(addr) (*(float64 *)(addr))
@@ -173,6 +179,13 @@ STORE_U32(void *addr, uint32_t value)
         }
     }
 }
+
+static inline void
+STORE_U8(void *addr, uint8_t value)
+{
+    *(uint8 *)addr = value;
+}
+
 static inline void
 STORE_U16(void *addr, uint16_t value)
 {

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -1692,7 +1692,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 frame_ip += 2;
                 addr_ret = GET_OFFSET();
                 CHECK_MEMORY_OVERFLOW(1);
-                frame_lp[addr_ret] = (uint32)(*(uint8 *)maddr);
+                frame_lp[addr_ret] = (uint32)(*(uint8 *)(maddr));
                 HANDLE_OP_END();
             }
 
@@ -1817,7 +1817,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 addr = GET_OPERAND(uint32, I32, 2);
                 frame_ip += 4;
                 CHECK_MEMORY_OVERFLOW(1);
-                *(uint8 *)maddr = (uint8)sval;
+                STORE_U8(maddr, (uint8_t)sval);
                 HANDLE_OP_END();
             }
 

--- a/tests/wamr-test-suites/tsan_suppressions.txt
+++ b/tests/wamr-test-suites/tsan_suppressions.txt
@@ -1,6 +1,7 @@
 # Proposing to accept this risk for now. It might be wasi-libc related.
 # https://github.com/bytecodealliance/wasm-micro-runtime/pull/1963#issuecomment-1455342931
 race:STORE_U32
+race:STORE_U8
 
 # Suppressing signal-unsafe inside of a signal for AOT mode 
 # see https://github.com/bytecodealliance/wasm-micro-runtime/issues/2248#issuecomment-1630189656


### PR DESCRIPTION
This typo prevented sanitizers to work in the CI. 

Because corresponding issues were found locally, we didn't miss anything initially