### PR TITLE
Attestation: free JSON from the Wasm module heap

### DIFF
--- a/core/iwasm/libraries/lib-rats/lib_rats_wrapper.c
+++ b/core/iwasm/libraries/lib-rats/lib_rats_wrapper.c
@@ -17,7 +17,7 @@
 #include "lib_rats_common.h"
 
 static int
-librats_collect_wrapper(wasm_exec_env_t exec_env, char **evidence_json,
+librats_collect_wrapper(wasm_exec_env_t exec_env, uint32_t *evidence_json,
                         const char *buffer, uint32_t buffer_size)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
@@ -47,7 +47,7 @@ librats_collect_wrapper(wasm_exec_env_t exec_env, char **evidence_json,
         return (int)RATS_ATTESTER_ERR_NO_MEM;
     }
     bh_memcpy_s(str_ret, json_size, json, json_size);
-    *((int *)evidence_json) = str_ret_offset;
+    *evidence_json = str_ret_offset;
     free(json);
 
     return 0;
@@ -98,11 +98,11 @@ librats_parse_evidence_wrapper(wasm_exec_env_t exec_env,
 
 static void
 librats_dispose_evidence_json_wrapper(wasm_exec_env_t exec_env,
-                                      char *evidence_json)
+                                      uint32_t evidence_json)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
 
-    module_free((uintptr_t)evidence_json);
+    module_free(evidence_json);
 }
 
 /* clang-format off */
@@ -114,7 +114,7 @@ static NativeSymbol native_symbols_lib_rats[] = {
     REG_NATIVE_FUNC(librats_collect, "(**~)i"),
     REG_NATIVE_FUNC(librats_verify, "(*~*~)i"),
     REG_NATIVE_FUNC(librats_parse_evidence, "(*~*~)i"),
-    REG_NATIVE_FUNC(librats_dispose_evidence_json, "(*)")
+    REG_NATIVE_FUNC(librats_dispose_evidence_json, "(i)")
 };
 
 uint32_t

--- a/core/iwasm/libraries/lib-rats/lib_rats_wrapper.c
+++ b/core/iwasm/libraries/lib-rats/lib_rats_wrapper.c
@@ -96,6 +96,15 @@ librats_parse_evidence_wrapper(wasm_exec_env_t exec_env,
     return 0;
 }
 
+static void
+librats_dispose_evidence_json_wrapper(wasm_exec_env_t exec_env,
+                                      char *evidence_json)
+{
+    wasm_module_inst_t module_inst = get_module_inst(exec_env);
+
+    module_free((uintptr_t)evidence_json);
+}
+
 /* clang-format off */
 #define REG_NATIVE_FUNC(func_name, signature) \
     { #func_name, func_name##_wrapper, signature, NULL }
@@ -104,7 +113,8 @@ librats_parse_evidence_wrapper(wasm_exec_env_t exec_env,
 static NativeSymbol native_symbols_lib_rats[] = {
     REG_NATIVE_FUNC(librats_collect, "(**~)i"),
     REG_NATIVE_FUNC(librats_verify, "(*~*~)i"),
-    REG_NATIVE_FUNC(librats_parse_evidence, "(*~*~)i")
+    REG_NATIVE_FUNC(librats_parse_evidence, "(*~*~)i"),
+    REG_NATIVE_FUNC(librats_dispose_evidence_json, "(*)")
 };
 
 uint32_t

--- a/core/iwasm/libraries/lib-rats/lib_rats_wrapper.h
+++ b/core/iwasm/libraries/lib-rats/lib_rats_wrapper.h
@@ -41,6 +41,9 @@ librats_parse_evidence(const char *evidence_json, uint32_t json_size,
                            evidence_json ? strlen(evidence_json) + 1 : 0, \
                            evidence, sizeof(rats_sgx_evidence_t))
 
+void
+librats_dispose_evidence_json(char *evidence_json);
+
 #ifdef __cplusplus
 }
 #endif

--- a/samples/sgx-ra/wasm-app/main.c
+++ b/samples/sgx-ra/wasm-app/main.c
@@ -106,7 +106,7 @@ main(int argc, char **argv)
 
 err:
     if (evidence_json) {
-        free(evidence_json);
+        librats_dispose_evidence_json(evidence_json);
     }
 
     if (evidence) {


### PR DESCRIPTION
Dear developers,

The JSON evidence is allocated on the module instance heap, but no API was given to dispose of this memory buffer.
The sample mentions using the function `free`, which (I think) behaves differently depending on the execution context.
Typically, using the attestation API in a loop in a complex program (AOT) leads to a sudden stop of the program (without error output).

After investigation, I discovered that calling `free` in the Wasm app to dispose of the JSON evidence was the issue.
While the logic of memory allocation is quite complex to understand and have a full picture of it, my understanding is that calling `free` from the Wasm app may be different than calling the `module_free` macro in the runtime.
Since the JSON evidence is allocated using `module_malloc`, the corresponding free logic must be called accordingly.

This fix provides a new function called `librats_dispose_evidence_json`, enabling to free the JSON evidence directly from the Wasm app.