### PR TITLE
Fix wamr-test-suites script issue for macos

### DIFF
--- a/tests/wamr-test-suites/test_wamr.sh
+++ b/tests/wamr-test-suites/test_wamr.sh
@@ -329,12 +329,12 @@ function setup_wabt()
         if [ ! -f ${WAT2WASM} ]; then
             case ${PLATFORM} in
                 cosmopolitan)
-                    ;&
+                    ;;
                 linux)
                     WABT_PLATFORM=ubuntu
                     ;;
                 darwin)
-                    WABT_PLATFORM=macos
+                    WABT_PLATFORM=macos-12
                     ;;
                 windows)
                     WABT_PLATFORM=windows


### PR DESCRIPTION
Update the wabt release binary name for macos and fix a syntax error:

```bash
./test_wamr.sh: line 356: syntax error near unexpected token `;'
./test_wamr.sh: line 356: `                    ;&'
```