### PR TITLE
Get rid of compilation warnings and minor doc fix

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -5873,7 +5873,7 @@ wasm_runtime_register_sub_module(const WASMModuleCommon *parent_module,
 {
     /* register sub_module into its parent sub module list */
     WASMRegisteredModule *node = NULL;
-    bh_list_status ret;
+    bh_list_status ret = BH_LIST_ERROR;
 
     if (wasm_runtime_search_sub_module(parent_module, sub_module_name)) {
         LOG_DEBUG("%s has been registered in its parent", sub_module_name);

--- a/core/shared/platform/common/posix/posix_file.c
+++ b/core/shared/platform/common/posix/posix_file.c
@@ -479,7 +479,7 @@ os_preadv(os_file_handle handle, const struct __wasi_iovec_t *iov, int iovcnt,
 
     // Allocate a single buffer to fit all data.
     size_t totalsize = 0;
-    for (size_t i = 0; i < iovcnt; ++i)
+    for (int i = 0; i < iovcnt; ++i)
         totalsize += iov[i].buf_len;
 
     char *buf = BH_MALLOC(totalsize);
@@ -498,7 +498,7 @@ os_preadv(os_file_handle handle, const struct __wasi_iovec_t *iov, int iovcnt,
 
     // Copy data back to vectors.
     size_t bufoff = 0;
-    for (size_t i = 0; i < iovcnt; ++i) {
+    for (int i = 0; i < iovcnt; ++i) {
         if (bufoff + iov[i].buf_len < (size_t)len) {
             memcpy(iov[i].buf, buf + bufoff, iov[i].buf_len);
             bufoff += iov[i].buf_len;
@@ -533,14 +533,14 @@ os_pwritev(os_file_handle handle, const struct __wasi_ciovec_t *iov, int iovcnt,
     else {
         // Allocate a single buffer to fit all data.
         size_t totalsize = 0;
-        for (size_t i = 0; i < iovcnt; ++i)
+        for (int i = 0; i < iovcnt; ++i)
             totalsize += iov[i].buf_len;
         char *buf = BH_MALLOC(totalsize);
         if (buf == NULL) {
             return __WASI_ENOMEM;
         }
         size_t bufoff = 0;
-        for (size_t i = 0; i < iovcnt; ++i) {
+        for (int i = 0; i < iovcnt; ++i) {
             memcpy(buf + bufoff, iov[i].buf, iov[i].buf_len);
             bufoff += iov[i].buf_len;
         }

--- a/samples/multi-module/README.md
+++ b/samples/multi-module/README.md
@@ -9,12 +9,12 @@ $ mkdir build
 $ cd build
 $ cmake ..
 $ make
-$ # It will build multi-module runtime and 
+$ # It will build multi_module runtime and 
 $ # wasm file under the ./build .
 $ # If you have built wamrc,
 $ # aot file will also genrate.
-$ ./multi-module mC.wasm
+$ ./multi_module mC.wasm
 $ ...
-$ ./multi-module mC.aot
+$ ./multi_module mC.aot
 $ ...
 


### PR DESCRIPTION
Warnings:
```bash
wasm-micro-runtime/core/iwasm/common/wasm_runtime_common.c:5902:34: note: uninitialized use occurs here
    bh_assert(BH_LIST_SUCCESS == ret);
wasm-micro-runtime/core/iwasm/common/wasm_runtime_common.c:5876:5: note: variable 'ret' is declared here
    bh_list_status ret;
    ^
```

```bash
wasm-micro-runtime/core/shared/platform/common/posix/posix_file.c:482:26: warning: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'int' [-Wsign-compare]
    for (size_t i = 0; i < iovcnt; ++i)
                       ~ ^ ~~~~~~
```