### PR TITLE
Fix bug in memory.init and memory.grow opcodes for fast-jit when multithreading is enabled

### DIFF
--- a/core/iwasm/fast-jit/jit_frontend.c
+++ b/core/iwasm/fast-jit/jit_frontend.c
@@ -218,43 +218,152 @@ get_aux_stack_bottom_reg(JitFrame *frame)
     return frame->aux_stack_bottom_reg;
 }
 
+#if WASM_ENABLE_SHARED_MEMORY != 0
+static bool
+is_shared_memory(WASMModule *module, uint32 mem_idx)
+{
+    WASMMemory *memory;
+    WASMMemoryImport *memory_import;
+    bool is_shared;
+
+    /* TODO: for now, only one memory in total is allowed, in the future should
+     * change this logic to support multiple memories */
+    if (module->memory_count != 0) {
+        memory = &module->memories[mem_idx];
+        is_shared = memory->flags & 0x02 ? true : false;
+    }
+    else if (module->import_memory_count != 0) {
+        memory_import = &(module->import_memories[mem_idx].u.memory);
+        is_shared = memory_import->flags & 0x02 ? true : false;
+    }
+
+    return is_shared;
+}
+#endif
+
 JitReg
-get_memory_data_reg(JitFrame *frame, uint32 mem_idx)
+get_memory_inst_reg(JitFrame *frame, uint32 mem_idx)
 {
     JitCompContext *cc = frame->cc;
     JitReg module_inst_reg = get_module_inst_reg(frame);
-    uint32 memory_data_offset;
+    uint32 memory_inst_offset;
+#if WASM_ENABLE_SHARED_MEMORY != 0
+    JitReg memories_addr;
+    uint32 memories_offset;
+    bool is_shared;
+#endif
+
+    if (frame->memory_regs[mem_idx].memory_inst)
+        return frame->memory_regs[mem_idx].memory_inst;
+
+    frame->memory_regs[mem_idx].memory_inst =
+        cc->memory_regs[mem_idx].memory_inst;
 
     bh_assert(mem_idx == 0);
 #if WASM_ENABLE_SHARED_MEMORY != 0
-    uint32 memories_offset = (uint32)offsetof(WASMModuleInstance, memories);
-    JitReg memories_addr = jit_cc_new_reg_ptr(cc);
-    JitReg memories_mem_idx_addr = jit_cc_new_reg_ptr(cc);
-    memory_data_offset = (uint32)offsetof(WASMMemoryInstance, memory_data);
-    if (!frame->memory_regs[mem_idx].memory_data) {
-        frame->memory_regs[mem_idx].memory_data =
-            cc->memory_regs[mem_idx].memory_data;
+    is_shared = is_shared_memory(cc->cur_wasm_module, mem_idx);
+    if (is_shared) {
+        memories_addr = jit_cc_new_reg_ptr(cc);
+        memories_offset = (uint32)offsetof(WASMModuleInstance, memories);
         /* module_inst->memories */
         GEN_INSN(LDPTR, memories_addr, module_inst_reg,
                  NEW_CONST(I32, memories_offset));
         /* module_inst->memories[mem_idx], mem_idx can only be 0 now */
-        GEN_INSN(LDPTR, memories_mem_idx_addr, memories_addr,
+        GEN_INSN(LDPTR, frame->memory_regs[mem_idx].memory_inst, memories_addr,
                  NEW_CONST(I32, mem_idx));
+    }
+    else
+#endif
+    {
+        memory_inst_offset =
+            (uint32)offsetof(WASMModuleInstance, global_table_data.bytes);
+        GEN_INSN(LDPTR, frame->memory_regs[mem_idx].memory_inst,
+                 module_inst_reg, NEW_CONST(I32, memory_inst_offset));
+    }
+
+    return frame->memory_regs[mem_idx].memory_inst;
+}
+
+JitReg
+get_cur_page_count_reg(JitFrame *frame, uint32 mem_idx)
+{
+    JitCompContext *cc = frame->cc;
+    JitReg module_inst_reg;
+    uint32 cur_page_count_offset;
+#if WASM_ENABLE_SHARED_MEMORY != 0
+    JitReg memory_inst_reg;
+    bool is_shared;
+#endif
+
+    if (frame->memory_regs[mem_idx].cur_page_count)
+        return frame->memory_regs[mem_idx].cur_page_count;
+
+    frame->memory_regs[mem_idx].cur_page_count =
+        cc->memory_regs[mem_idx].cur_page_count;
+
+    /* Get current page count */
+    bh_assert(mem_idx == 0);
+#if WASM_ENABLE_SHARED_MEMORY != 0
+    is_shared = is_shared_memory(cc->cur_wasm_module, mem_idx);
+    if (is_shared) {
+        memory_inst_reg = get_memory_inst_reg(frame, mem_idx);
+        cur_page_count_offset =
+            (uint32)offsetof(WASMMemoryInstance, cur_page_count);
+        /* memories[mem_idx]->cur_page_count_offset */
+        GEN_INSN(LDI32, frame->memory_regs[mem_idx].cur_page_count,
+                 memory_inst_reg, NEW_CONST(I32, cur_page_count_offset));
+    }
+    else
+#endif
+    {
+        module_inst_reg = get_module_inst_reg(frame);
+        cur_page_count_offset =
+            (uint32)offsetof(WASMModuleInstance, global_table_data.bytes)
+            + (uint32)offsetof(WASMMemoryInstance, cur_page_count);
+        GEN_INSN(LDI32, frame->memory_regs[mem_idx].cur_page_count,
+                 module_inst_reg, NEW_CONST(I32, cur_page_count_offset));
+    }
+
+    return frame->memory_regs[mem_idx].cur_page_count;
+}
+
+JitReg
+get_memory_data_reg(JitFrame *frame, uint32 mem_idx)
+{
+    JitCompContext *cc = frame->cc;
+    JitReg module_inst_reg;
+    uint32 memory_data_offset;
+#if WASM_ENABLE_SHARED_MEMORY != 0
+    JitReg memory_inst_reg;
+    bool is_shared;
+#endif
+
+    if (frame->memory_regs[mem_idx].memory_data)
+        return frame->memory_regs[mem_idx].memory_data;
+
+    frame->memory_regs[mem_idx].memory_data =
+        cc->memory_regs[mem_idx].memory_data;
+
+    bh_assert(mem_idx == 0);
+#if WASM_ENABLE_SHARED_MEMORY != 0
+    is_shared = is_shared_memory(cc->cur_wasm_module, mem_idx);
+    if (is_shared) {
+        memory_inst_reg = get_memory_inst_reg(frame, mem_idx);
+        memory_data_offset = (uint32)offsetof(WASMMemoryInstance, memory_data);
         /* memories[mem_idx]->memory_data */
         GEN_INSN(LDPTR, frame->memory_regs[mem_idx].memory_data,
-                 memories_mem_idx_addr, NEW_CONST(I32, memory_data_offset));
+                 memory_inst_reg, NEW_CONST(I32, memory_data_offset));
     }
-#else
-    memory_data_offset =
-        (uint32)offsetof(WASMModuleInstance, global_table_data.bytes)
-        + (uint32)offsetof(WASMMemoryInstance, memory_data);
-    if (!frame->memory_regs[mem_idx].memory_data) {
-        frame->memory_regs[mem_idx].memory_data =
-            cc->memory_regs[mem_idx].memory_data;
+    else
+#endif
+    {
+        module_inst_reg = get_module_inst_reg(frame);
+        memory_data_offset =
+            (uint32)offsetof(WASMModuleInstance, global_table_data.bytes)
+            + (uint32)offsetof(WASMMemoryInstance, memory_data);
         GEN_INSN(LDPTR, frame->memory_regs[mem_idx].memory_data,
                  module_inst_reg, NEW_CONST(I32, memory_data_offset));
     }
-#endif
     return frame->memory_regs[mem_idx].memory_data;
 }
 
@@ -262,40 +371,40 @@ JitReg
 get_memory_data_end_reg(JitFrame *frame, uint32 mem_idx)
 {
     JitCompContext *cc = frame->cc;
-    JitReg module_inst_reg = get_module_inst_reg(frame);
+    JitReg module_inst_reg;
     uint32 memory_data_end_offset;
+#if WASM_ENABLE_SHARED_MEMORY != 0
+    JitReg memory_inst_reg;
+    bool is_shared;
+#endif
+
+    if (frame->memory_regs[mem_idx].memory_data_end)
+        return frame->memory_regs[mem_idx].memory_data_end;
+
+    frame->memory_regs[mem_idx].memory_data_end =
+        cc->memory_regs[mem_idx].memory_data_end;
 
     bh_assert(mem_idx == 0);
 #if WASM_ENABLE_SHARED_MEMORY != 0
-    uint32 memories_offset = (uint32)offsetof(WASMModuleInstance, memories);
-    JitReg memories_addr = jit_cc_new_reg_ptr(cc);
-    JitReg memories_mem_idx_addr = jit_cc_new_reg_ptr(cc);
-    memory_data_end_offset =
-        (uint32)offsetof(WASMMemoryInstance, memory_data_end);
-    if (!frame->memory_regs[mem_idx].memory_data_end) {
-        frame->memory_regs[mem_idx].memory_data_end =
-            cc->memory_regs[mem_idx].memory_data_end;
-        /* module_inst->memories */
-        GEN_INSN(LDPTR, memories_addr, module_inst_reg,
-                 NEW_CONST(I32, memories_offset));
-        /* module_inst->memories[mem_idx] */
-        GEN_INSN(LDPTR, memories_mem_idx_addr, memories_addr,
-                 NEW_CONST(I32, mem_idx));
+    is_shared = is_shared_memory(cc->cur_wasm_module, mem_idx);
+    if (is_shared) {
+        memory_inst_reg = get_memory_inst_reg(frame, mem_idx);
+        memory_data_end_offset =
+            (uint32)offsetof(WASMMemoryInstance, memory_data_end);
         /* memories[mem_idx]->memory_data_end */
         GEN_INSN(LDPTR, frame->memory_regs[mem_idx].memory_data_end,
-                 memories_mem_idx_addr, NEW_CONST(I32, memory_data_end_offset));
+                 memory_inst_reg, NEW_CONST(I32, memory_data_end_offset));
     }
-#else
-    memory_data_end_offset =
-        (uint32)offsetof(WASMModuleInstance, global_table_data.bytes)
-        + (uint32)offsetof(WASMMemoryInstance, memory_data_end);
-    if (!frame->memory_regs[mem_idx].memory_data_end) {
-        frame->memory_regs[mem_idx].memory_data_end =
-            cc->memory_regs[mem_idx].memory_data_end;
+    else
+#endif
+    {
+        module_inst_reg = get_module_inst_reg(frame);
+        memory_data_end_offset =
+            (uint32)offsetof(WASMModuleInstance, global_table_data.bytes)
+            + (uint32)offsetof(WASMMemoryInstance, memory_data_end);
         GEN_INSN(LDPTR, frame->memory_regs[mem_idx].memory_data_end,
                  module_inst_reg, NEW_CONST(I32, memory_data_end_offset));
     }
-#endif
     return frame->memory_regs[mem_idx].memory_data_end;
 }
 
@@ -303,44 +412,43 @@ JitReg
 get_mem_bound_check_1byte_reg(JitFrame *frame, uint32 mem_idx)
 {
     JitCompContext *cc = frame->cc;
-    JitReg module_inst_reg = get_module_inst_reg(frame);
+    JitReg module_inst_reg;
     uint32 mem_bound_check_1byte_offset;
+#if WASM_ENABLE_SHARED_MEMORY != 0
+    JitReg memory_inst_reg;
+    bool is_shared;
+#endif
+
+    if (frame->memory_regs[mem_idx].mem_bound_check_1byte)
+        return frame->memory_regs[mem_idx].mem_bound_check_1byte;
+
+    frame->memory_regs[mem_idx].mem_bound_check_1byte =
+        cc->memory_regs[mem_idx].mem_bound_check_1byte;
 
     bh_assert(mem_idx == 0);
+
 #if WASM_ENABLE_SHARED_MEMORY != 0
-    uint32 memories_offset = (uint32)offsetof(WASMModuleInstance, memories);
-    JitReg memories_addr = jit_cc_new_reg_ptr(cc);
-    JitReg memories_mem_idx_addr = jit_cc_new_reg_ptr(cc);
-    mem_bound_check_1byte_offset =
-        (uint32)offsetof(WASMMemoryInstance, mem_bound_check_1byte);
-    if (!frame->memory_regs[mem_idx].mem_bound_check_1byte) {
-        frame->memory_regs[mem_idx].mem_bound_check_1byte =
-            cc->memory_regs[mem_idx].mem_bound_check_1byte;
-        /* module_inst->memories */
-        GEN_INSN(LDPTR, memories_addr, module_inst_reg,
-                 NEW_CONST(I32, memories_offset));
-        /* module_inst->memories[mem_idx] */
-        GEN_INSN(LDPTR, memories_mem_idx_addr, memories_addr,
-                 NEW_CONST(I32, mem_idx));
+    is_shared = is_shared_memory(cc->cur_wasm_module, mem_idx);
+    if (is_shared) {
+        memory_inst_reg = get_memory_inst_reg(frame, mem_idx);
+        mem_bound_check_1byte_offset =
+            (uint32)offsetof(WASMMemoryInstance, mem_bound_check_1byte);
         /* memories[mem_idx]->mem_bound_check_1byte */
 #if UINTPTR_MAX == UINT64_MAX
         GEN_INSN(LDI64, frame->memory_regs[mem_idx].mem_bound_check_1byte,
-                 memories_mem_idx_addr,
-                 NEW_CONST(I32, mem_bound_check_1byte_offset));
+                 memory_inst_reg, NEW_CONST(I32, mem_bound_check_1byte_offset));
 #else
         GEN_INSN(LDI32, frame->memory_regs[mem_idx].mem_bound_check_1byte,
-                 memories_mem_idx_addr,
-                 NEW_CONST(I32, mem_bound_check_1byte_offset));
+                 memory_inst_reg, NEW_CONST(I32, mem_bound_check_1byte_offset));
 #endif
     }
-#else /* else of WASM_ENABLE_SHARED_MEMORY != 0 */
-    mem_bound_check_1byte_offset =
-        (uint32)offsetof(WASMModuleInstance, global_table_data.bytes)
-        + (uint32)offsetof(WASMMemoryInstance, mem_bound_check_1byte);
-
-    if (!frame->memory_regs[mem_idx].mem_bound_check_1byte) {
-        frame->memory_regs[mem_idx].mem_bound_check_1byte =
-            cc->memory_regs[mem_idx].mem_bound_check_1byte;
+    else
+#endif
+    {
+        module_inst_reg = get_module_inst_reg(frame);
+        mem_bound_check_1byte_offset =
+            (uint32)offsetof(WASMModuleInstance, global_table_data.bytes)
+            + (uint32)offsetof(WASMMemoryInstance, mem_bound_check_1byte);
 #if UINTPTR_MAX == UINT64_MAX
         GEN_INSN(LDI64, frame->memory_regs[mem_idx].mem_bound_check_1byte,
                  module_inst_reg, NEW_CONST(I32, mem_bound_check_1byte_offset));
@@ -349,7 +457,6 @@ get_mem_bound_check_1byte_reg(JitFrame *frame, uint32 mem_idx)
                  module_inst_reg, NEW_CONST(I32, mem_bound_check_1byte_offset));
 #endif
     }
-#endif /* end of WASM_ENABLE_SHARED_MEMORY != 0 */
     return frame->memory_regs[mem_idx].mem_bound_check_1byte;
 }
 
@@ -357,44 +464,45 @@ JitReg
 get_mem_bound_check_2bytes_reg(JitFrame *frame, uint32 mem_idx)
 {
     JitCompContext *cc = frame->cc;
-    JitReg module_inst_reg = get_module_inst_reg(frame);
+    JitReg module_inst_reg;
     uint32 mem_bound_check_2bytes_offset;
+#if WASM_ENABLE_SHARED_MEMORY != 0
+    JitReg memory_inst_reg;
+    bool is_shared;
+#endif
+
+    if (frame->memory_regs[mem_idx].mem_bound_check_2bytes)
+        return frame->memory_regs[mem_idx].mem_bound_check_2bytes;
+
+    frame->memory_regs[mem_idx].mem_bound_check_2bytes =
+        cc->memory_regs[mem_idx].mem_bound_check_2bytes;
 
     bh_assert(mem_idx == 0);
+
 #if WASM_ENABLE_SHARED_MEMORY != 0
-    uint32 memories_offset = (uint32)offsetof(WASMModuleInstance, memories);
-    JitReg memories_addr = jit_cc_new_reg_ptr(cc);
-    JitReg memories_mem_idx_addr = jit_cc_new_reg_ptr(cc);
-    mem_bound_check_2bytes_offset =
-        (uint32)offsetof(WASMMemoryInstance, mem_bound_check_2bytes);
-    if (!frame->memory_regs[mem_idx].mem_bound_check_2bytes) {
-        frame->memory_regs[mem_idx].mem_bound_check_2bytes =
-            cc->memory_regs[mem_idx].mem_bound_check_2bytes;
-        /* module_inst->memories */
-        GEN_INSN(LDPTR, memories_addr, module_inst_reg,
-                 NEW_CONST(I32, memories_offset));
-        /* module_inst->memories[mem_idx] */
-        GEN_INSN(LDPTR, memories_mem_idx_addr, memories_addr,
-                 NEW_CONST(I32, mem_idx));
+    is_shared = is_shared_memory(cc->cur_wasm_module, mem_idx);
+    if (is_shared) {
+        memory_inst_reg = get_memory_inst_reg(frame, mem_idx);
+        mem_bound_check_2bytes_offset =
+            (uint32)offsetof(WASMMemoryInstance, mem_bound_check_2bytes);
         /* memories[mem_idx]->mem_bound_check_2bytes */
 #if UINTPTR_MAX == UINT64_MAX
         GEN_INSN(LDI64, frame->memory_regs[mem_idx].mem_bound_check_2bytes,
-                 memories_mem_idx_addr,
+                 memory_inst_reg,
                  NEW_CONST(I32, mem_bound_check_2bytes_offset));
 #else
         GEN_INSN(LDI32, frame->memory_regs[mem_idx].mem_bound_check_2bytes,
-                 memories_mem_idx_addr,
+                 memory_inst_reg,
                  NEW_CONST(I32, mem_bound_check_2bytes_offset));
 #endif
     }
-#else /* else of WASM_ENABLE_SHARED_MEMORY != 0 */
-    mem_bound_check_2bytes_offset =
-        (uint32)offsetof(WASMModuleInstance, global_table_data.bytes)
-        + (uint32)offsetof(WASMMemoryInstance, mem_bound_check_2bytes);
-
-    if (!frame->memory_regs[mem_idx].mem_bound_check_2bytes) {
-        frame->memory_regs[mem_idx].mem_bound_check_2bytes =
-            cc->memory_regs[mem_idx].mem_bound_check_2bytes;
+    else
+#endif
+    {
+        module_inst_reg = get_module_inst_reg(frame);
+        mem_bound_check_2bytes_offset =
+            (uint32)offsetof(WASMModuleInstance, global_table_data.bytes)
+            + (uint32)offsetof(WASMMemoryInstance, mem_bound_check_2bytes);
 #if UINTPTR_MAX == UINT64_MAX
         GEN_INSN(LDI64, frame->memory_regs[mem_idx].mem_bound_check_2bytes,
                  module_inst_reg,
@@ -405,7 +513,6 @@ get_mem_bound_check_2bytes_reg(JitFrame *frame, uint32 mem_idx)
                  NEW_CONST(I32, mem_bound_check_2bytes_offset));
 #endif
     }
-#endif /* end of WASM_ENABLE_SHARED_MEMORY != 0 */
     return frame->memory_regs[mem_idx].mem_bound_check_2bytes;
 }
 
@@ -413,44 +520,45 @@ JitReg
 get_mem_bound_check_4bytes_reg(JitFrame *frame, uint32 mem_idx)
 {
     JitCompContext *cc = frame->cc;
-    JitReg module_inst_reg = get_module_inst_reg(frame);
+    JitReg module_inst_reg;
     uint32 mem_bound_check_4bytes_offset;
+#if WASM_ENABLE_SHARED_MEMORY != 0
+    JitReg memory_inst_reg;
+    bool is_shared;
+#endif
+
+    if (frame->memory_regs[mem_idx].mem_bound_check_4bytes)
+        return frame->memory_regs[mem_idx].mem_bound_check_4bytes;
+
+    frame->memory_regs[mem_idx].mem_bound_check_4bytes =
+        cc->memory_regs[mem_idx].mem_bound_check_4bytes;
 
     bh_assert(mem_idx == 0);
+
 #if WASM_ENABLE_SHARED_MEMORY != 0
-    uint32 memories_offset = (uint32)offsetof(WASMModuleInstance, memories);
-    JitReg memories_addr = jit_cc_new_reg_ptr(cc);
-    JitReg memories_mem_idx_addr = jit_cc_new_reg_ptr(cc);
-    mem_bound_check_4bytes_offset =
-        (uint32)offsetof(WASMMemoryInstance, mem_bound_check_4bytes);
-    if (!frame->memory_regs[mem_idx].mem_bound_check_4bytes) {
-        frame->memory_regs[mem_idx].mem_bound_check_4bytes =
-            cc->memory_regs[mem_idx].mem_bound_check_4bytes;
-        /* module_inst->memories */
-        GEN_INSN(LDPTR, memories_addr, module_inst_reg,
-                 NEW_CONST(I32, memories_offset));
-        /* module_inst->memories[mem_idx] */
-        GEN_INSN(LDPTR, memories_mem_idx_addr, memories_addr,
-                 NEW_CONST(I32, mem_idx));
+    is_shared = is_shared_memory(cc->cur_wasm_module, mem_idx);
+    if (is_shared) {
+        memory_inst_reg = get_memory_inst_reg(frame, mem_idx);
+        mem_bound_check_4bytes_offset =
+            (uint32)offsetof(WASMMemoryInstance, mem_bound_check_4bytes);
         /* memories[mem_idx]->mem_bound_check_4bytes */
 #if UINTPTR_MAX == UINT64_MAX
         GEN_INSN(LDI64, frame->memory_regs[mem_idx].mem_bound_check_4bytes,
-                 memories_mem_idx_addr,
+                 memory_inst_reg,
                  NEW_CONST(I32, mem_bound_check_4bytes_offset));
 #else
         GEN_INSN(LDI32, frame->memory_regs[mem_idx].mem_bound_check_4bytes,
-                 memories_mem_idx_addr,
+                 memory_inst_reg,
                  NEW_CONST(I32, mem_bound_check_4bytes_offset));
 #endif
     }
-#else /* else of WASM_ENABLE_SHARED_MEMORY != 0 */
-    mem_bound_check_4bytes_offset =
-        (uint32)offsetof(WASMModuleInstance, global_table_data.bytes)
-        + (uint32)offsetof(WASMMemoryInstance, mem_bound_check_4bytes);
-
-    if (!frame->memory_regs[mem_idx].mem_bound_check_4bytes) {
-        frame->memory_regs[mem_idx].mem_bound_check_4bytes =
-            cc->memory_regs[mem_idx].mem_bound_check_4bytes;
+    else
+#endif
+    {
+        module_inst_reg = get_module_inst_reg(frame);
+        mem_bound_check_4bytes_offset =
+            (uint32)offsetof(WASMModuleInstance, global_table_data.bytes)
+            + (uint32)offsetof(WASMMemoryInstance, mem_bound_check_4bytes);
 #if UINTPTR_MAX == UINT64_MAX
         GEN_INSN(LDI64, frame->memory_regs[mem_idx].mem_bound_check_4bytes,
                  module_inst_reg,
@@ -461,7 +569,6 @@ get_mem_bound_check_4bytes_reg(JitFrame *frame, uint32 mem_idx)
                  NEW_CONST(I32, mem_bound_check_4bytes_offset));
 #endif
     }
-#endif /* end of WASM_ENABLE_SHARED_MEMORY != 0 */
     return frame->memory_regs[mem_idx].mem_bound_check_4bytes;
 }
 
@@ -469,44 +576,45 @@ JitReg
 get_mem_bound_check_8bytes_reg(JitFrame *frame, uint32 mem_idx)
 {
     JitCompContext *cc = frame->cc;
-    JitReg module_inst_reg = get_module_inst_reg(frame);
+    JitReg module_inst_reg;
     uint32 mem_bound_check_8bytes_offset;
+#if WASM_ENABLE_SHARED_MEMORY != 0
+    JitReg memory_inst_reg;
+    bool is_shared;
+#endif
+
+    if (frame->memory_regs[mem_idx].mem_bound_check_8bytes)
+        return frame->memory_regs[mem_idx].mem_bound_check_8bytes;
+
+    frame->memory_regs[mem_idx].mem_bound_check_8bytes =
+        cc->memory_regs[mem_idx].mem_bound_check_8bytes;
 
     bh_assert(mem_idx == 0);
+
 #if WASM_ENABLE_SHARED_MEMORY != 0
-    uint32 memories_offset = (uint32)offsetof(WASMModuleInstance, memories);
-    JitReg memories_addr = jit_cc_new_reg_ptr(cc);
-    JitReg memories_mem_idx_addr = jit_cc_new_reg_ptr(cc);
-    mem_bound_check_8bytes_offset =
-        (uint32)offsetof(WASMMemoryInstance, mem_bound_check_8bytes);
-    if (!frame->memory_regs[mem_idx].mem_bound_check_8bytes) {
-        frame->memory_regs[mem_idx].mem_bound_check_8bytes =
-            cc->memory_regs[mem_idx].mem_bound_check_8bytes;
-        /* module_inst->memories */
-        GEN_INSN(LDPTR, memories_addr, module_inst_reg,
-                 NEW_CONST(I32, memories_offset));
-        /* module_inst->memories[mem_idx] */
-        GEN_INSN(LDPTR, memories_mem_idx_addr, memories_addr,
-                 NEW_CONST(I32, mem_idx));
+    is_shared = is_shared_memory(cc->cur_wasm_module, mem_idx);
+    if (is_shared) {
+        memory_inst_reg = get_memory_inst_reg(frame, mem_idx);
+        mem_bound_check_8bytes_offset =
+            (uint32)offsetof(WASMMemoryInstance, mem_bound_check_8bytes);
         /* memories[mem_idx]->mem_bound_check_8bytes */
 #if UINTPTR_MAX == UINT64_MAX
         GEN_INSN(LDI64, frame->memory_regs[mem_idx].mem_bound_check_8bytes,
-                 memories_mem_idx_addr,
+                 memory_inst_reg,
                  NEW_CONST(I32, mem_bound_check_8bytes_offset));
 #else
         GEN_INSN(LDI32, frame->memory_regs[mem_idx].mem_bound_check_8bytes,
-                 memories_mem_idx_addr,
+                 memory_inst_reg,
                  NEW_CONST(I32, mem_bound_check_8bytes_offset));
 #endif
     }
-#else /* else of WASM_ENABLE_SHARED_MEMORY != 0 */
-    mem_bound_check_8bytes_offset =
-        (uint32)offsetof(WASMModuleInstance, global_table_data.bytes)
-        + (uint32)offsetof(WASMMemoryInstance, mem_bound_check_8bytes);
-
-    if (!frame->memory_regs[mem_idx].mem_bound_check_8bytes) {
-        frame->memory_regs[mem_idx].mem_bound_check_8bytes =
-            cc->memory_regs[mem_idx].mem_bound_check_8bytes;
+    else
+#endif
+    {
+        module_inst_reg = get_module_inst_reg(frame);
+        mem_bound_check_8bytes_offset =
+            (uint32)offsetof(WASMModuleInstance, global_table_data.bytes)
+            + (uint32)offsetof(WASMMemoryInstance, mem_bound_check_8bytes);
 #if UINTPTR_MAX == UINT64_MAX
         GEN_INSN(LDI64, frame->memory_regs[mem_idx].mem_bound_check_8bytes,
                  module_inst_reg,
@@ -517,7 +625,6 @@ get_mem_bound_check_8bytes_reg(JitFrame *frame, uint32 mem_idx)
                  NEW_CONST(I32, mem_bound_check_8bytes_offset));
 #endif
     }
-#endif /* end of WASM_ENABLE_SHARED_MEMORY != 0 */
     return frame->memory_regs[mem_idx].mem_bound_check_8bytes;
 }
 
@@ -525,44 +632,45 @@ JitReg
 get_mem_bound_check_16bytes_reg(JitFrame *frame, uint32 mem_idx)
 {
     JitCompContext *cc = frame->cc;
-    JitReg module_inst_reg = get_module_inst_reg(frame);
+    JitReg module_inst_reg;
     uint32 mem_bound_check_16bytes_offset;
+#if WASM_ENABLE_SHARED_MEMORY != 0
+    JitReg memory_inst_reg;
+    bool is_shared;
+#endif
+
+    if (frame->memory_regs[mem_idx].mem_bound_check_16bytes)
+        return frame->memory_regs[mem_idx].mem_bound_check_16bytes;
+
+    frame->memory_regs[mem_idx].mem_bound_check_16bytes =
+        cc->memory_regs[mem_idx].mem_bound_check_16bytes;
 
     bh_assert(mem_idx == 0);
+
 #if WASM_ENABLE_SHARED_MEMORY != 0
-    uint32 memories_offset = (uint32)offsetof(WASMModuleInstance, memories);
-    JitReg memories_addr = jit_cc_new_reg_ptr(cc);
-    JitReg memories_mem_idx_addr = jit_cc_new_reg_ptr(cc);
-    mem_bound_check_16bytes_offset =
-        (uint32)offsetof(WASMMemoryInstance, mem_bound_check_16bytes);
-    if (!frame->memory_regs[mem_idx].mem_bound_check_16bytes) {
-        frame->memory_regs[mem_idx].mem_bound_check_16bytes =
-            cc->memory_regs[mem_idx].mem_bound_check_16bytes;
-        /* module_inst->memories */
-        GEN_INSN(LDPTR, memories_addr, module_inst_reg,
-                 NEW_CONST(I32, memories_offset));
-        /* module_inst->memories[mem_idx] */
-        GEN_INSN(LDPTR, memories_mem_idx_addr, memories_addr,
-                 NEW_CONST(I32, mem_idx));
+    is_shared = is_shared_memory(cc->cur_wasm_module, mem_idx);
+    if (is_shared) {
+        memory_inst_reg = get_memory_inst_reg(frame, mem_idx);
+        mem_bound_check_16bytes_offset =
+            (uint32)offsetof(WASMMemoryInstance, mem_bound_check_16bytes);
         /* memories[mem_idx]->mem_bound_check_16bytes */
 #if UINTPTR_MAX == UINT64_MAX
         GEN_INSN(LDI64, frame->memory_regs[mem_idx].mem_bound_check_16bytes,
-                 memories_mem_idx_addr,
+                 memory_inst_reg,
                  NEW_CONST(I32, mem_bound_check_16bytes_offset));
 #else
         GEN_INSN(LDI32, frame->memory_regs[mem_idx].mem_bound_check_16bytes,
-                 memories_mem_idx_addr,
+                 memory_inst_reg,
                  NEW_CONST(I32, mem_bound_check_16bytes_offset));
 #endif
     }
-#else /* else of WASM_ENABLE_SHARED_MEMORY != 0 */
-    mem_bound_check_16bytes_offset =
-        (uint32)offsetof(WASMModuleInstance, global_table_data.bytes)
-        + (uint32)offsetof(WASMMemoryInstance, mem_bound_check_16bytes);
-
-    if (!frame->memory_regs[mem_idx].mem_bound_check_16bytes) {
-        frame->memory_regs[mem_idx].mem_bound_check_16bytes =
-            cc->memory_regs[mem_idx].mem_bound_check_16bytes;
+    else
+#endif
+    {
+        module_inst_reg = get_module_inst_reg(frame);
+        mem_bound_check_16bytes_offset =
+            (uint32)offsetof(WASMModuleInstance, global_table_data.bytes)
+            + (uint32)offsetof(WASMMemoryInstance, mem_bound_check_16bytes);
 #if UINTPTR_MAX == UINT64_MAX
         GEN_INSN(LDI64, frame->memory_regs[mem_idx].mem_bound_check_16bytes,
                  module_inst_reg,
@@ -573,7 +681,6 @@ get_mem_bound_check_16bytes_reg(JitFrame *frame, uint32 mem_idx)
                  NEW_CONST(I32, mem_bound_check_16bytes_offset));
 #endif
     }
-#endif /* end of WASM_ENABLE_SHARED_MEMORY != 0 */
     return frame->memory_regs[mem_idx].mem_bound_check_16bytes;
 }
 
@@ -629,6 +736,8 @@ clear_fixed_virtual_regs(JitFrame *frame)
 
     count = module->import_memory_count + module->memory_count;
     for (i = 0; i < count; i++) {
+        frame->memory_regs[i].memory_inst = 0;
+        frame->memory_regs[i].cur_page_count = 0;
         frame->memory_regs[i].memory_data = 0;
         frame->memory_regs[i].memory_data_end = 0;
         frame->memory_regs[i].mem_bound_check_1byte = 0;
@@ -653,6 +762,7 @@ clear_memory_regs(JitFrame *frame)
 
     count = module->import_memory_count + module->memory_count;
     for (i = 0; i < count; i++) {
+        frame->memory_regs[i].cur_page_count = 0;
         frame->memory_regs[i].memory_data = 0;
         frame->memory_regs[i].memory_data_end = 0;
         frame->memory_regs[i].mem_bound_check_1byte = 0;
@@ -821,6 +931,8 @@ create_fixed_virtual_regs(JitCompContext *cc)
         }
 
         for (i = 0; i < count; i++) {
+            cc->memory_regs[i].memory_inst = jit_cc_new_reg_ptr(cc);
+            cc->memory_regs[i].cur_page_count = jit_cc_new_reg_I32(cc);
             cc->memory_regs[i].memory_data = jit_cc_new_reg_ptr(cc);
             cc->memory_regs[i].memory_data_end = jit_cc_new_reg_ptr(cc);
             cc->memory_regs[i].mem_bound_check_1byte = jit_cc_new_reg_ptr(cc);

--- a/core/iwasm/fast-jit/jit_frontend.c
+++ b/core/iwasm/fast-jit/jit_frontend.c
@@ -226,17 +226,14 @@ is_shared_memory(WASMModule *module, uint32 mem_idx)
     WASMMemoryImport *memory_import;
     bool is_shared;
 
-    /* TODO: for now, only one memory in total is allowed, in the future should
-     * change this logic to support multiple memories */
-    if (module->memory_count != 0) {
-        memory = &module->memories[mem_idx];
-        is_shared = memory->flags & 0x02 ? true : false;
-    }
-    else if (module->import_memory_count != 0) {
+    if (mem_idx < module->import_memory_count) {
         memory_import = &(module->import_memories[mem_idx].u.memory);
         is_shared = memory_import->flags & 0x02 ? true : false;
     }
-
+    else {
+        memory = &module->memories[mem_idx - module->import_memory_count];
+        is_shared = memory->flags & 0x02 ? true : false;
+    }
     return is_shared;
 }
 #endif

--- a/core/iwasm/fast-jit/jit_frontend.h
+++ b/core/iwasm/fast-jit/jit_frontend.h
@@ -193,6 +193,12 @@ JitReg
 get_aux_stack_bottom_reg(JitFrame *frame);
 
 JitReg
+get_memory_inst_reg(JitFrame *frame, uint32 mem_idx);
+
+JitReg
+get_cur_page_count_reg(JitFrame *frame, uint32 mem_idx);
+
+JitReg
 get_memory_data_reg(JitFrame *frame, uint32 mem_idx);
 
 JitReg

--- a/core/iwasm/fast-jit/jit_ir.h
+++ b/core/iwasm/fast-jit/jit_ir.h
@@ -866,6 +866,8 @@ typedef struct JitValueSlot {
 typedef struct JitMemRegs {
     /* The following registers should be re-loaded after
        memory.grow, callbc and callnative */
+    JitReg memory_inst;
+    JitReg cur_page_count;
     JitReg memory_data;
     JitReg memory_data_end;
     JitReg mem_bound_check_1byte;


### PR DESCRIPTION
Modify the approach to calculate the offset and access the data members in `WASMMemoryInstance` when shared memory(multithreading) is enabled. Instead of calculating it from the module instance base address, now use `module_inst -> memories[0]` as the base address for memory.init, memory.grow, and certain boundary check related APIs.