### PR TITLE
tests/wamr-test-suites/test_wamr.sh: don't bother to build shared library

### DIFF
--- a/tests/wamr-test-suites/test_wamr.sh
+++ b/tests/wamr-test-suites/test_wamr.sh
@@ -697,7 +697,7 @@ function build_iwasm_with_cfg()
         && if [ -d build ]; then rm -rf build/*; else mkdir build; fi \
         && cd build \
         && cmake $* .. \
-        && make -j 4
+        && make -j 4 iwasm
         cd ${WAMR_DIR}/product-mini/platforms/linux-sgx/enclave-sample \
         && make clean \
         && make SPEC_TEST=1
@@ -706,7 +706,7 @@ function build_iwasm_with_cfg()
         && if [ -d build ]; then rm -rf build/*; else mkdir build; fi \
         && cd build \
         && cmake $* .. \
-        && cmake --build . -j 4 --config RelWithDebInfo
+        && cmake --build . -j 4 --config RelWithDebInfo --target iwasm
     fi
 
     if [ "$?" != 0 ];then


### PR DESCRIPTION
This script only uses the iwasm command.