### PR TITLE
bugfix: three unsigned narrow op should be interpreted as signed as the simd proposal

### DIFF
--- a/core/iwasm/compilation/simd/simd_conversions.c
+++ b/core/iwasm/compilation/simd/simd_conversions.c
@@ -158,7 +158,11 @@ simd_integer_narrow_common(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         return false;
     }
 
-    /* sat */
+    /* Refer to:
+     * https://github.com/WebAssembly/spec/blob/main/proposals/simd/SIMD.md#integer-to-integer-narrowing
+     * Regardless of the whether the operation is signed or unsigned, the input
+     * lanes are interpreted as signed integers.
+     */
     if (!(vec1 = simd_saturate(comp_ctx, func_ctx, e_sat_i16x8, vec1, min, max,
                                true))
         || !(vec2 = simd_saturate(comp_ctx, func_ctx, e_sat_i16x8, vec2, min,

--- a/core/iwasm/compilation/simd/simd_conversions.c
+++ b/core/iwasm/compilation/simd/simd_conversions.c
@@ -160,9 +160,9 @@ simd_integer_narrow_common(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
     /* sat */
     if (!(vec1 = simd_saturate(comp_ctx, func_ctx, e_sat_i16x8, vec1, min, max,
-                               is_signed))
+                               true))
         || !(vec2 = simd_saturate(comp_ctx, func_ctx, e_sat_i16x8, vec2, min,
-                                  max, is_signed))) {
+                                  max, true))) {
         return false;
     }
 


### PR DESCRIPTION
![image](https://github.com/bytecodealliance/wasm-micro-runtime/assets/10509166/17025121-29b3-46a5-a484-779503ee095c)
