### PR TITLE
Fix typos of CIDR in docs and help text

### DIFF
--- a/doc/socket_api.md
+++ b/doc/socket_api.md
@@ -58,7 +58,7 @@ enabled.
 
 _iwasm_ accepts address ranges via an option, `--addr-pool`, to implement
 the capability control. All IP address the WebAssembly application may need to `bind()` or `connect()`
-should be announced first. Every IP address should be in CIRD notation.
+should be announced first. Every IP address should be in CIDR notation.
 
 ```bash
 $ iwasm --addr-pool=1.2.3.4/15,2.3.4.6/16 socket_example.wasm

--- a/product-mini/platforms/common/libc_wasi.c
+++ b/product-mini/platforms/common/libc_wasi.c
@@ -47,7 +47,7 @@ libc_wasi_print_help()
            "--map-dir=<guest-path2::host-path2>\n");
     printf("  --addr-pool=<addrs>      Grant wasi access to the given network "
            "addresses in\n");
-    printf("                           CIRD notation to the program, seperated "
+    printf("                           CIDR notation to the program, seperated "
            "with ',',\n");
     printf("                           for example:\n");
     printf("                             --addr-pool=1.2.3.4/15,2.3.4.5/16\n");

--- a/product-mini/platforms/linux-sgx/enclave-sample/App/App.cpp
+++ b/product-mini/platforms/linux-sgx/enclave-sample/App/App.cpp
@@ -228,7 +228,7 @@ print_help()
     printf("                         to the program, for example:\n");
     printf("                           --dir=<dir1> --dir=<dir2>\n");
     printf("  --addr-pool=           Grant wasi access to the given network addresses in\n");
-    printf("                         CIRD notation to the program, seperated with ',',\n");
+    printf("                         CIDR notation to the program, seperated with ',',\n");
     printf("                         for example:\n");
     printf("                           --addr-pool=1.2.3.4/15,2.3.4.5/16\n");
     printf("  --max-threads=n        Set maximum thread number per cluster, default is 4\n");


### PR DESCRIPTION
Fixes typos of CIDR in socket documentation and libc WASI help text.