### PR TITLE
Revert "Grab `cluster->lock` when modifying `exec_env->module_inst` (…

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -982,8 +982,7 @@ execute_post_instantiate_functions(AOTModuleInstance *module_inst,
            wasm functions, and ensure that the exec_env's module inst
            is the correct one. */
         module_inst_main = exec_env_main->module_inst;
-        wasm_exec_env_set_module_inst(exec_env,
-                                      (WASMModuleInstanceCommon *)module_inst);
+        exec_env->module_inst = (WASMModuleInstanceCommon *)module_inst;
     }
     else {
         /* Try using the existing exec_env */
@@ -1008,8 +1007,7 @@ execute_post_instantiate_functions(AOTModuleInstance *module_inst,
                module inst to ensure that the exec_env's module inst
                is the correct one. */
             module_inst_main = exec_env->module_inst;
-            wasm_exec_env_set_module_inst(
-                exec_env, (WASMModuleInstanceCommon *)module_inst);
+            exec_env->module_inst = (WASMModuleInstanceCommon *)module_inst;
         }
     }
 
@@ -1059,12 +1057,12 @@ execute_post_instantiate_functions(AOTModuleInstance *module_inst,
 fail:
     if (is_sub_inst) {
         /* Restore the parent exec_env's module inst */
-        wasm_exec_env_restore_module_inst(exec_env_main, module_inst_main);
+        exec_env_main->module_inst = module_inst_main;
     }
     else {
         if (module_inst_main)
             /* Restore the existing exec_env's module inst */
-            wasm_exec_env_restore_module_inst(exec_env, module_inst_main);
+            exec_env->module_inst = module_inst_main;
         if (exec_env_created)
             wasm_exec_env_destroy(exec_env_created);
     }
@@ -1753,8 +1751,7 @@ execute_malloc_function(AOTModuleInstance *module_inst, WASMExecEnv *exec_env,
                module inst to ensure that the exec_env's module inst
                is the correct one. */
             module_inst_old = exec_env->module_inst;
-            wasm_exec_env_set_module_inst(
-                exec_env, (WASMModuleInstanceCommon *)module_inst);
+            exec_env->module_inst = (WASMModuleInstanceCommon *)module_inst;
         }
     }
 
@@ -1765,7 +1762,7 @@ execute_malloc_function(AOTModuleInstance *module_inst, WASMExecEnv *exec_env,
 
     if (module_inst_old)
         /* Restore the existing exec_env's module inst */
-        wasm_exec_env_restore_module_inst(exec_env, module_inst_old);
+        exec_env->module_inst = module_inst_old;
 
     if (exec_env_created)
         wasm_exec_env_destroy(exec_env_created);
@@ -1821,8 +1818,7 @@ execute_free_function(AOTModuleInstance *module_inst, WASMExecEnv *exec_env,
                module inst to ensure that the exec_env's module inst
                is the correct one. */
             module_inst_old = exec_env->module_inst;
-            wasm_exec_env_set_module_inst(
-                exec_env, (WASMModuleInstanceCommon *)module_inst);
+            exec_env->module_inst = (WASMModuleInstanceCommon *)module_inst;
         }
     }
 
@@ -1830,7 +1826,7 @@ execute_free_function(AOTModuleInstance *module_inst, WASMExecEnv *exec_env,
 
     if (module_inst_old)
         /* Restore the existing exec_env's module inst */
-        wasm_exec_env_restore_module_inst(exec_env, module_inst_old);
+        exec_env->module_inst = module_inst_old;
 
     if (exec_env_created)
         wasm_exec_env_destroy(exec_env_created);

--- a/core/iwasm/common/wasm_exec_env.c
+++ b/core/iwasm/common/wasm_exec_env.c
@@ -202,52 +202,7 @@ void
 wasm_exec_env_set_module_inst(WASMExecEnv *exec_env,
                               WASMModuleInstanceCommon *const module_inst)
 {
-#if WASM_ENABLE_THREAD_MGR != 0
-    wasm_cluster_traverse_lock(exec_env);
-#endif
     exec_env->module_inst = module_inst;
-#if WASM_ENABLE_THREAD_MGR != 0
-    wasm_cluster_traverse_unlock(exec_env);
-#endif
-}
-
-void
-wasm_exec_env_restore_module_inst(
-    WASMExecEnv *exec_env, WASMModuleInstanceCommon *const module_inst_common)
-{
-    WASMModuleInstanceCommon *old_module_inst_common = exec_env->module_inst;
-    WASMModuleInstance *old_module_inst =
-        (WASMModuleInstance *)old_module_inst_common;
-    WASMModuleInstance *module_inst = (WASMModuleInstance *)module_inst_common;
-    char cur_exception[EXCEPTION_BUF_LEN];
-
-#if WASM_ENABLE_THREAD_MGR != 0
-    wasm_cluster_traverse_lock(exec_env);
-#endif
-    exec_env->module_inst = module_inst_common;
-    /*
-     * propagate an exception if any.
-     */
-    exception_lock(old_module_inst);
-    if (old_module_inst->cur_exception[0] != '\0') {
-        bh_memcpy_s(cur_exception, sizeof(cur_exception),
-                    old_module_inst->cur_exception,
-                    sizeof(old_module_inst->cur_exception));
-    }
-    else {
-        cur_exception[0] = '\0';
-    }
-    exception_unlock(old_module_inst);
-#if WASM_ENABLE_THREAD_MGR != 0
-    wasm_cluster_traverse_unlock(exec_env);
-#endif
-    if (cur_exception[0] != '\0') {
-        exception_lock(module_inst);
-        bh_memcpy_s(module_inst->cur_exception,
-                    sizeof(module_inst->cur_exception), cur_exception,
-                    sizeof(cur_exception));
-        exception_unlock(module_inst);
-    }
 }
 
 void

--- a/core/iwasm/common/wasm_exec_env.h
+++ b/core/iwasm/common/wasm_exec_env.h
@@ -292,10 +292,6 @@ wasm_exec_env_set_module_inst(
     WASMExecEnv *exec_env, struct WASMModuleInstanceCommon *const module_inst);
 
 void
-wasm_exec_env_restore_module_inst(
-    WASMExecEnv *exec_env, struct WASMModuleInstanceCommon *const module_inst);
-
-void
 wasm_exec_env_set_thread_info(WASMExecEnv *exec_env);
 
 #if WASM_ENABLE_THREAD_MGR != 0

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -1013,8 +1013,7 @@ wasm_interp_call_func_import(WASMModuleInstance *module_inst,
     }
 
     /* - module_inst */
-    wasm_exec_env_set_module_inst(exec_env,
-                                  (WASMModuleInstanceCommon *)sub_module_inst);
+    exec_env->module_inst = (WASMModuleInstanceCommon *)sub_module_inst;
     /* - aux_stack_boundary */
     aux_stack_origin_boundary = exec_env->aux_stack_boundary.boundary;
     exec_env->aux_stack_boundary.boundary =
@@ -1036,8 +1035,15 @@ wasm_interp_call_func_import(WASMModuleInstance *module_inst,
     prev_frame->ip = ip;
     exec_env->aux_stack_boundary.boundary = aux_stack_origin_boundary;
     exec_env->aux_stack_bottom.bottom = aux_stack_origin_bottom;
-    wasm_exec_env_restore_module_inst(exec_env,
-                                      (WASMModuleInstanceCommon *)module_inst);
+    exec_env->module_inst = (WASMModuleInstanceCommon *)module_inst;
+
+    /* transfer exception if it is thrown */
+    if (wasm_copy_exception(sub_module_inst, NULL)) {
+        bh_memcpy_s(module_inst->cur_exception,
+                    sizeof(module_inst->cur_exception),
+                    sub_module_inst->cur_exception,
+                    sizeof(sub_module_inst->cur_exception));
+    }
 }
 #endif
 

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -1031,8 +1031,7 @@ wasm_interp_call_func_import(WASMModuleInstance *module_inst,
     }
 
     /* - module_inst */
-    wasm_exec_env_set_module_inst(exec_env,
-                                  (WASMModuleInstanceCommon *)sub_module_inst);
+    exec_env->module_inst = (WASMModuleInstanceCommon *)sub_module_inst;
     /* - aux_stack_boundary */
     aux_stack_origin_boundary = exec_env->aux_stack_boundary.boundary;
     exec_env->aux_stack_boundary.boundary =
@@ -1054,8 +1053,15 @@ wasm_interp_call_func_import(WASMModuleInstance *module_inst,
     prev_frame->ip = ip;
     exec_env->aux_stack_boundary.boundary = aux_stack_origin_boundary;
     exec_env->aux_stack_bottom.bottom = aux_stack_origin_bottom;
-    wasm_exec_env_restore_module_inst(exec_env,
-                                      (WASMModuleInstanceCommon *)module_inst);
+    exec_env->module_inst = (WASMModuleInstanceCommon *)module_inst;
+
+    /* transfer exception if it is thrown */
+    if (wasm_copy_exception(sub_module_inst, NULL)) {
+        bh_memcpy_s(module_inst->cur_exception,
+                    sizeof(module_inst->cur_exception),
+                    sub_module_inst->cur_exception,
+                    sizeof(sub_module_inst->cur_exception));
+    }
 }
 #endif
 

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1062,8 +1062,7 @@ execute_post_instantiate_functions(WASMModuleInstance *module_inst,
            wasm functions, and ensure that the exec_env's module inst
            is the correct one. */
         module_inst_main = exec_env_main->module_inst;
-        wasm_exec_env_set_module_inst(exec_env,
-                                      (WASMModuleInstanceCommon *)module_inst);
+        exec_env->module_inst = (WASMModuleInstanceCommon *)module_inst;
     }
     else {
         /* Try using the existing exec_env */
@@ -1088,8 +1087,7 @@ execute_post_instantiate_functions(WASMModuleInstance *module_inst,
                module inst to ensure that the exec_env's module inst
                is the correct one. */
             module_inst_main = exec_env->module_inst;
-            wasm_exec_env_set_module_inst(
-                exec_env, (WASMModuleInstanceCommon *)module_inst);
+            exec_env->module_inst = (WASMModuleInstanceCommon *)module_inst;
         }
     }
 
@@ -1122,12 +1120,12 @@ execute_post_instantiate_functions(WASMModuleInstance *module_inst,
 fail:
     if (is_sub_inst) {
         /* Restore the parent exec_env's module inst */
-        wasm_exec_env_restore_module_inst(exec_env_main, module_inst_main);
+        exec_env_main->module_inst = module_inst_main;
     }
     else {
         if (module_inst_main)
             /* Restore the existing exec_env's module inst */
-            wasm_exec_env_restore_module_inst(exec_env, module_inst_main);
+            exec_env->module_inst = module_inst_main;
         if (exec_env_created)
             wasm_exec_env_destroy(exec_env_created);
     }
@@ -1196,8 +1194,7 @@ execute_malloc_function(WASMModuleInstance *module_inst, WASMExecEnv *exec_env,
                module inst to ensure that the exec_env's module inst
                is the correct one. */
             module_inst_old = exec_env->module_inst;
-            wasm_exec_env_set_module_inst(
-                exec_env, (WASMModuleInstanceCommon *)module_inst);
+            exec_env->module_inst = (WASMModuleInstanceCommon *)module_inst;
         }
     }
 
@@ -1208,7 +1205,7 @@ execute_malloc_function(WASMModuleInstance *module_inst, WASMExecEnv *exec_env,
 
     if (module_inst_old)
         /* Restore the existing exec_env's module inst */
-        wasm_exec_env_restore_module_inst(exec_env, module_inst_old);
+        exec_env->module_inst = module_inst_old;
 
     if (exec_env_created)
         wasm_exec_env_destroy(exec_env_created);
@@ -1264,8 +1261,7 @@ execute_free_function(WASMModuleInstance *module_inst, WASMExecEnv *exec_env,
                module inst to ensure that the exec_env's module inst
                is the correct one. */
             module_inst_old = exec_env->module_inst;
-            wasm_exec_env_set_module_inst(
-                exec_env, (WASMModuleInstanceCommon *)module_inst);
+            exec_env->module_inst = (WASMModuleInstanceCommon *)module_inst;
         }
     }
 
@@ -1273,7 +1269,7 @@ execute_free_function(WASMModuleInstance *module_inst, WASMExecEnv *exec_env,
 
     if (module_inst_old)
         /* Restore the existing exec_env's module inst */
-        wasm_exec_env_restore_module_inst(exec_env, module_inst_old);
+        exec_env->module_inst = module_inst_old;
 
     if (exec_env_created)
         wasm_exec_env_destroy(exec_env_created);

--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -1406,19 +1406,3 @@ exception_unlock(WASMModuleInstance *module_inst)
 {
     os_mutex_unlock(&_exception_lock);
 }
-
-void
-wasm_cluster_traverse_lock(WASMExecEnv *exec_env)
-{
-    WASMCluster *cluster = wasm_exec_env_get_cluster(exec_env);
-    bh_assert(cluster);
-    os_mutex_lock(&cluster->lock);
-}
-
-void
-wasm_cluster_traverse_unlock(WASMExecEnv *exec_env)
-{
-    WASMCluster *cluster = wasm_exec_env_get_cluster(exec_env);
-    bh_assert(cluster);
-    os_mutex_unlock(&cluster->lock);
-}

--- a/core/iwasm/libraries/thread-mgr/thread_manager.h
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.h
@@ -215,12 +215,6 @@ wasm_cluster_set_debug_inst(WASMCluster *cluster, WASMDebugInstance *inst);
 
 #endif /* end of WASM_ENABLE_DEBUG_INTERP != 0 */
 
-void
-wasm_cluster_traverse_lock(WASMExecEnv *exec_env);
-
-void
-wasm_cluster_traverse_unlock(WASMExecEnv *exec_env);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
…#2685)"

This reverts commit 24c4d256b32465e2979d7d7fee358d1db6d90c90.

It has a deadlock issue like:
    wasm_runtime_spawn_exec_env
    wasm_cluster_spawn_exec_env (hold the lock)
    wasm_runtime_instantiate_internal
    wasm_instantiate
    execute_post_instantiate_functions
    wasm_exec_env_set_module_inst (grab the lock again)