### PR TITLE
Bugfix:  Issue #2880 -  Corrects Zephyr include files for current versions of Zephyr

### DIFF
--- a/core/app-mgr/app-manager/platform/zephyr/app_mgr_zephyr.c
+++ b/core/app-mgr/app-manager/platform/zephyr/app_mgr_zephyr.c
@@ -10,11 +10,11 @@
 #if KERNEL_VERSION_NUMBER < 0x030200 /* version 3.2.0 */
 #include <zephyr.h>
 #include <kernel.h>
-#else 
+#else
 #include <zephyr/kernel.h>
-#endif 
+#endif
 
-#if 0   
+#if 0
 #include <sigverify.h>
 #endif
 typedef struct k_timer_watchdog {

--- a/core/app-mgr/app-manager/platform/zephyr/app_mgr_zephyr.c
+++ b/core/app-mgr/app-manager/platform/zephyr/app_mgr_zephyr.c
@@ -6,9 +6,15 @@
 #include "app_manager.h"
 #include "bh_platform.h"
 #include <autoconf.h>
+
+#if KERNEL_VERSION_NUMBER < 0x030200 /* version 3.2.0 */
 #include <zephyr.h>
 #include <kernel.h>
-#if 0
+#else 
+#include <zephyr/kernel.h>
+#endif 
+
+#if 0   
 #include <sigverify.h>
 #endif
 typedef struct k_timer_watchdog {

--- a/samples/gui/wasm-runtime-wgl/src/platform/zephyr/XPT2046.c
+++ b/samples/gui/wasm-runtime-wgl/src/platform/zephyr/XPT2046.c
@@ -13,9 +13,9 @@
 #if KERNEL_VERSION_NUMBER < 0x030200 /* version 3.2.0 */
 #include <zephyr.h>
 #include <kernel.h>
-#else 
+#else
 #include <zephyr/kernel.h>
-#endif 
+#endif
 
 #if USE_XPT2046
 

--- a/samples/gui/wasm-runtime-wgl/src/platform/zephyr/XPT2046.c
+++ b/samples/gui/wasm-runtime-wgl/src/platform/zephyr/XPT2046.c
@@ -10,8 +10,12 @@
 #include <string.h>
 #include "drivers/spi.h"
 
-#include "zephyr.h"
-#include "kernel.h"
+#if KERNEL_VERSION_NUMBER < 0x030200 /* version 3.2.0 */
+#include <zephyr.h>
+#include <kernel.h>
+#else 
+#include <zephyr/kernel.h>
+#endif 
 
 #if USE_XPT2046
 

--- a/samples/gui/wasm-runtime-wgl/src/platform/zephyr/display_ili9340.h
+++ b/samples/gui/wasm-runtime-wgl/src/platform/zephyr/display_ili9340.h
@@ -7,7 +7,12 @@
 #define ZEPHYR_DRIVERS_DISPLAY_DISPLAY_ILI9340_H_
 #include "board_config.h"
 #include <autoconf.h>
+
+#if KERNEL_VERSION_NUMBER < 0x030200 /* version 3.2.0 */
 #include <zephyr.h>
+#else 
+#include <zephyr/kernel.h>
+#endif 
 
 #define ILI9340_CMD_ENTER_SLEEP 0x10
 #define ILI9340_CMD_EXIT_SLEEP 0x11

--- a/samples/gui/wasm-runtime-wgl/src/platform/zephyr/display_ili9340.h
+++ b/samples/gui/wasm-runtime-wgl/src/platform/zephyr/display_ili9340.h
@@ -10,9 +10,9 @@
 
 #if KERNEL_VERSION_NUMBER < 0x030200 /* version 3.2.0 */
 #include <zephyr.h>
-#else 
+#else
 #include <zephyr/kernel.h>
-#endif 
+#endif
 
 #define ILI9340_CMD_ENTER_SLEEP 0x10
 #define ILI9340_CMD_EXIT_SLEEP 0x11

--- a/samples/gui/wasm-runtime-wgl/src/platform/zephyr/iwasm_main.c
+++ b/samples/gui/wasm-runtime-wgl/src/platform/zephyr/iwasm_main.c
@@ -33,7 +33,7 @@ wgl_init();
 
 #if KERNEL_VERSION_NUMBER < 0x030200 /* version 3.2.0 */
 #include <zephyr.h>
-#else 
+#else
 #include <zephyr/kernel.h>
 #endif
 
@@ -82,7 +82,8 @@ host_send(void *ctx, const char *buf, int size)
 
 void
 host_destroy()
-{}
+{
+}
 
 /* clang-format off */
 host_interface interface = {

--- a/samples/gui/wasm-runtime-wgl/src/platform/zephyr/iwasm_main.c
+++ b/samples/gui/wasm-runtime-wgl/src/platform/zephyr/iwasm_main.c
@@ -82,8 +82,7 @@ host_send(void *ctx, const char *buf, int size)
 
 void
 host_destroy()
-{
-}
+{}
 
 /* clang-format off */
 host_interface interface = {

--- a/samples/gui/wasm-runtime-wgl/src/platform/zephyr/iwasm_main.c
+++ b/samples/gui/wasm-runtime-wgl/src/platform/zephyr/iwasm_main.c
@@ -31,7 +31,12 @@ xpt2046_init(void);
 extern void
 wgl_init();
 
+#if KERNEL_VERSION_NUMBER < 0x030200 /* version 3.2.0 */
 #include <zephyr.h>
+#else 
+#include <zephyr/kernel.h>
+#endif
+
 #include <drivers/uart.h>
 #include <device.h>
 

--- a/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/XPT2046.c
+++ b/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/XPT2046.c
@@ -13,9 +13,9 @@
 #if KERNEL_VERSION_NUMBER < 0x030200 /* version 3.2.0 */
 #include <zephyr.h>
 #include <kernel.h>
-#else 
+#else
 #include <zephyr/kernel.h>
-#endif 
+#endif
 
 #if USE_XPT2046
 

--- a/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/XPT2046.c
+++ b/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/XPT2046.c
@@ -10,8 +10,12 @@
 #include <string.h>
 #include "drivers/spi.h"
 
-#include "zephyr.h"
-#include "kernel.h"
+#if KERNEL_VERSION_NUMBER < 0x030200 /* version 3.2.0 */
+#include <zephyr.h>
+#include <kernel.h>
+#else 
+#include <zephyr/kernel.h>
+#endif 
 
 #if USE_XPT2046
 

--- a/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/display_ili9340.h
+++ b/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/display_ili9340.h
@@ -10,7 +10,7 @@
 
 #if KERNEL_VERSION_NUMBER < 0x030200 /* version 3.2.0 */
 #include <zephyr.h>
-#else 
+#else
 #include <zephyr/kernel.h>
 #endif
 

--- a/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/display_ili9340.h
+++ b/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/display_ili9340.h
@@ -7,7 +7,12 @@
 #define ZEPHYR_DRIVERS_DISPLAY_DISPLAY_ILI9340_H_
 #include "board_config.h"
 #include <autoconf.h>
+
+#if KERNEL_VERSION_NUMBER < 0x030200 /* version 3.2.0 */
 #include <zephyr.h>
+#else 
+#include <zephyr/kernel.h>
+#endif
 
 #define ILI9340_CMD_ENTER_SLEEP 0x10
 #define ILI9340_CMD_EXIT_SLEEP 0x11

--- a/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/iwasm_main.c
+++ b/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/iwasm_main.c
@@ -75,8 +75,7 @@ host_send(void *ctx, const char *buf, int size)
 
 void
 host_destroy()
-{
-}
+{}
 
 /* clang-format off */
 host_interface interface = {

--- a/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/iwasm_main.c
+++ b/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/iwasm_main.c
@@ -18,9 +18,9 @@
 
 #if KERNEL_VERSION_NUMBER < 0x030200 /* version 3.2.0 */
 #include <zephyr.h>
-#else 
+#else
 #include <zephyr/kernel.h>
-#endif 
+#endif
 
 #include <drivers/uart.h>
 #include <device.h>
@@ -75,7 +75,8 @@ host_send(void *ctx, const char *buf, int size)
 
 void
 host_destroy()
-{}
+{
+}
 
 /* clang-format off */
 host_interface interface = {

--- a/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/iwasm_main.c
+++ b/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/iwasm_main.c
@@ -16,7 +16,12 @@
 #include "connection_native_api.h"
 #include "display_indev.h"
 
+#if KERNEL_VERSION_NUMBER < 0x030200 /* version 3.2.0 */
 #include <zephyr.h>
+#else 
+#include <zephyr/kernel.h>
+#endif 
+
 #include <drivers/uart.h>
 #include <device.h>
 


### PR DESCRIPTION
This fixes bug #2880.  Zephyr 3.2 made changes to how headers are reference (see [release notes](https://docs.zephyrproject.org/latest/releases/release-notes-3.2.html)).  Work item [49578](https://github.com/zephyrproject-rtos/zephyr/issues/49578) deprecated the old headers names.  The current WAMR codebase references these old headers, thus causing compile errors with current versions of Zephyr.

This update adds #ifdefs around the header names.  With this change, compiling with Zephyr 3.2.0 and above will use the new header files.  Prior versions will use the existing code.

I have tested this with Zephyr 3.2.0, 3.30, and the latest Zephyr release.  I have not verified this with the current LTS version (2.7.0).