### PR TITLE
samples/spawn-thread: tweak to expose a bug

### DIFF
--- a/samples/spawn-thread/wasm-apps/CMakeLists.txt
+++ b/samples/spawn-thread/wasm-apps/CMakeLists.txt
@@ -29,6 +29,7 @@ set (DEFINED_SYMBOLS
 set (CMAKE_EXE_LINKER_FLAGS
     "-Wl,--shared-memory,--max-memory=131072,       \
     -Wl,--no-entry,--strip-all,--export=sum,        \
+    -Wl,--export=return_bss,        \
     -Wl,--export=__heap_base,--export=__data_end    \
     -Wl,--export=__wasm_call_ctors  \
     -Wl,--allow-undefined-file=${DEFINED_SYMBOLS}"

--- a/samples/spawn-thread/wasm-apps/sum.c
+++ b/samples/spawn-thread/wasm-apps/sum.c
@@ -3,6 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
+/*
+ * have something in bss so that llvm synthesizes
+ * wasm start function for this module.
+ */
+char *
+return_bss()
+{
+    static char bss[4096];
+    return bss;
+}
+
 int
 sum(int start, int length)
 {


### PR DESCRIPTION
this would expose the deadlock bug, which has been fixed by https://github.com/bytecodealliance/wasm-micro-runtime/pull/2882