### PR TITLE
Look for "_initialize" only if "_start" not found

### DIFF
--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -3988,19 +3988,23 @@ check_wasi_abi_compatibility(const WASMModule *module,
             return false;
         }
     }
-
-    /* (func (export "_initialize") (...) */
-    initialize = wasm_loader_find_export(
-        module, "", "_initialize", EXPORT_KIND_FUNC, error_buf, error_buf_size);
-    if (initialize) {
-        WASMType *func_type =
-            module->functions[initialize->index - module->import_function_count]
-                ->func_type;
-        if (func_type->param_count || func_type->result_count) {
-            set_error_buf(
-                error_buf, error_buf_size,
-                "the signature of builtin _initialize function is wrong");
-            return false;
+    else {
+        /* (func (export "_initialize") (...) */
+        initialize =
+            wasm_loader_find_export(module, "", "_initialize", EXPORT_KIND_FUNC,
+                                    error_buf, error_buf_size);
+        if (initialize) {
+            WASMType *func_type =
+                module
+                    ->functions[initialize->index
+                                - module->import_function_count]
+                    ->func_type;
+            if (func_type->param_count || func_type->result_count) {
+                set_error_buf(
+                    error_buf, error_buf_size,
+                    "the signature of builtin _initialize function is wrong");
+                return false;
+            }
         }
     }
 


### PR DESCRIPTION
A wasm module can be either a command or a reactor, so it can export either `_start` or `_initialize`.
Currently, if a command module is run, `iwasm` still looks for `_initialize`, resulting in the warning `can not find an export 0 named _initialize in the module`:

```bash
[08:15:00:315 - 1DC30DB40]: Load type section success.

[08:15:00:332 - 1DC30DB40]: Load import section success.

[08:15:00:335 - 1DC30DB40]: Load function section success.

[08:15:00:337 - 1DC30DB40]: Load export section success.

[08:15:00:339 - 1DC30DB40]: Load code segment section success.

[08:15:00:384 - 1DC30DB40]: /Users/eloparco/dev/forks/wasm-micro-runtime/core/iwasm/common/wasm_runtime_common.c, line 5838, can not find an export 0 named _initialize in the module 
[08:15:00:387 - 1DC30DB40]: Load module success.

[08:15:00:401 - 1DC30DB40]: Memory instantiate:
[08:15:00:402 - 1DC30DB40]:   page bytes: 65536, init pages: 1, max pages: 1
[08:15:00:404 - 1DC30DB40]:   heap offset: 65536, heap size: 0

[08:15:00:409 - 1DC30DB40]: Memory instantiate success.
```