### PR TITLE
Handle ambiguous fstflags on fd_filestat_set_times

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -1891,7 +1891,13 @@ wasmtime_ssp_fd_filestat_set_times(wasm_exec_env_t exec_env,
     if ((fstflags
          & ~(__WASI_FILESTAT_SET_ATIM | __WASI_FILESTAT_SET_ATIM_NOW
              | __WASI_FILESTAT_SET_MTIM | __WASI_FILESTAT_SET_MTIM_NOW))
-        != 0)
+            != 0
+        || (fstflags
+            & (__WASI_FILESTAT_SET_ATIM | __WASI_FILESTAT_SET_ATIM_NOW))
+               == (__WASI_FILESTAT_SET_ATIM | __WASI_FILESTAT_SET_ATIM_NOW)
+        || (fstflags
+            & (__WASI_FILESTAT_SET_MTIM | __WASI_FILESTAT_SET_MTIM_NOW))
+               == (__WASI_FILESTAT_SET_MTIM | __WASI_FILESTAT_SET_MTIM_NOW))
         return __WASI_EINVAL;
 
     struct fd_object *fo;


### PR DESCRIPTION
It's possible to set both `atim` and `atim_now` in the [`fstflags`](https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md#-fstflags-record) parameter.  Same goes for `mtin` and `mtim_now`.  However, it's ambiguous which time should be set in these two cases.  This commit checks this and returns `inval`.  This behavior is consistent across Wasmtime and WasmEdge.