### PR TITLE
Avoid memory import failure when WASI threads enabled

### DIFF
--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -1163,23 +1163,31 @@ load_memory_import(const uint8 **p_buf, const uint8 *buf_end,
             (WASMModuleCommon *)parent_module, sub_module_name, error_buf,
             error_buf_size);
         if (!sub_module) {
+#if WASM_ENABLE_LIB_WASI_THREADS != 0
+            /* Avoid memory import failure when wasi-threads is enabled
+               and the memory is shared */
+            if (!(declare_max_page_count_flag & 2))
+                return false;
+#else
             return false;
+#endif /* WASM_ENABLE_LIB_WASI_THREADS */
         }
+        else {
+            linked_memory = wasm_loader_resolve_memory(
+                sub_module_name, memory_name, declare_init_page_count,
+                declare_max_page_count, error_buf, error_buf_size);
+            if (!linked_memory) {
+                return false;
+            }
 
-        linked_memory = wasm_loader_resolve_memory(
-            sub_module_name, memory_name, declare_init_page_count,
-            declare_max_page_count, error_buf, error_buf_size);
-        if (!linked_memory) {
-            return false;
+            /**
+             * reset with linked memory limit
+             */
+            memory->import_module = sub_module;
+            memory->import_memory_linked = linked_memory;
+            declare_init_page_count = linked_memory->init_page_count;
+            declare_max_page_count = linked_memory->max_page_count;
         }
-
-        /**
-         * reset with linked memory limit
-         */
-        memory->import_module = sub_module;
-        memory->import_memory_linked = linked_memory;
-        declare_init_page_count = linked_memory->init_page_count;
-        declare_max_page_count = linked_memory->max_page_count;
     }
 #endif
 


### PR DESCRIPTION
According to the specification:
```
When instantiating a module which is expected to run
with `wasi-threads`, the WASI host must first allocate shared memories to
satisfy the module's imports.
```
[source](https://github.com/WebAssembly/wasi-threads/blob/main/README.md?plain=1#L133-L135)

Currently, if a test from the spec is executed while having the `multi-module` feature enabled, WAMR fails with `WASM module load failed: unknown import`.
That happens because spec tests use memory like this: `(memory (export "memory") (import "foo" "bar") 1 1 shared)` [source](https://github.com/WebAssembly/wasi-threads/blob/main/test/testsuite/wasi_threads_exit_main_block.wat#L8) and WAMR tries to find a registered module named `foo`.

At the moment, there is no specific module name that can be used to identify that the memory is imported because using WASI threads: https://github.com/WebAssembly/wasi-threads/issues/33, so this PR only avoids treating the submodule dependency not being found as a failure.