### PR TITLE
Enable spectest for riscv32 ilp32d on NuttX

### DIFF
--- a/.github/workflows/spec_test_on_nuttx.yml
+++ b/.github/workflows/spec_test_on_nuttx.yml
@@ -58,11 +58,11 @@ jobs:
             target: "riscv32",
             fpu_type: "none"
           },
-          # {
-          #   config: "boards/risc-v/qemu-rv/rv-virt/configs/nsh",
-          #   target: "riscv32_ilp32d",
-          #   fpu_type: "dp"
-          # },
+          {
+            config: "boards/risc-v/qemu-rv/rv-virt/configs/nsh",
+            target: "riscv32_ilp32d",
+            fpu_type: "dp"
+          },
           {
             config: "boards/risc-v/qemu-rv/rv-virt/configs/nsh64",
             target: "riscv64",
@@ -92,6 +92,8 @@ jobs:
         exclude:
           # XIP is not fully supported yet on RISCV64, some relocations can not be resolved
           - target_config: { config: "boards/risc-v/qemu-rv/rv-virt/configs/nsh64" }
+            wamr_test_option: { mode: "-t aot -X" }
+          - target_config: { config: "boards/risc-v/qemu-rv/rv-virt/configs/nsh", target: "riscv32_ilp32d" }
             wamr_test_option: { mode: "-t aot -X" }
 
     steps:


### PR DESCRIPTION
Depends on #2894 