### PR TITLE
Fix memory size not updating

### DIFF
--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -2152,7 +2152,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 #if WASM_ENABLE_THREAD_MGR == 0
                     linear_mem_size = memory->memory_data_size;
 #else
-                    linear_mem_size = get_linear_mem_size();
+                    linear_mem_size = GET_LINEAR_MEMORY_SIZE(memory);
 #endif
 #endif
                 }

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -2149,7 +2149,11 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 #if !defined(OS_ENABLE_HW_BOUND_CHECK)              \
     || WASM_CPU_SUPPORTS_UNALIGNED_ADDR_ACCESS == 0 \
     || WASM_ENABLE_BULK_MEMORY != 0
+#if WASM_ENABLE_THREAD_MGR == 0
+                    linear_mem_size = memory->memory_data_size;
+#else
                     linear_mem_size = get_linear_mem_size();
+#endif
 #endif
                 }
 

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -1917,7 +1917,11 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 #if !defined(OS_ENABLE_HW_BOUND_CHECK)              \
     || WASM_CPU_SUPPORTS_UNALIGNED_ADDR_ACCESS == 0 \
     || WASM_ENABLE_BULK_MEMORY != 0
-                    linear_mem_size = get_linear_mem_size();
+#if WASM_ENABLE_THREAD_MGR == 0
+                    linear_mem_size = memory->memory_data_size;
+#else
+                    linear_mem_size = GET_LINEAR_MEMORY_SIZE(memory);
+#endif
 #endif
                 }
 


### PR DESCRIPTION
This commit fixes linear memory size not updating after growing.  This causes `memory.fill` to throw an exception after `memory.grow`.