### PR TITLE
Avoid reporting timestamp if custom logger is used

### DIFF
--- a/core/shared/utils/bh_log.c
+++ b/core/shared/utils/bh_log.c
@@ -43,7 +43,9 @@ bh_log(LogLevel log_level, const char *file, int line, const char *fmt, ...)
              "%02" PRIu32 ":%02" PRIu32 ":%02" PRIu32 ":%03" PRIu32, h, m, s,
              mills);
 
+#ifndef BH_VPRINTF
     os_printf("[%s - %" PRIXPTR "]: ", buf, (uintptr_t)self);
+#endif
 
     if (file)
         os_printf("%s, line %d, ", file, line);


### PR DESCRIPTION
Loggers (e.g. glog) usually come with instrumentation to add timestamp and other information when reporting.
That results in the timestamp being reported twice, making the output confusing.