### PR TITLE
Return stack frames of crashed thread when using wasm-c-api

### DIFF
--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -1981,8 +1981,13 @@ wasm_trap_new_internal(wasm_store_t *store,
         }
 
         for (i = 0; i < trap->frames->num_elems; i++) {
+#if WASM_ENABLE_THREAD_MGR != 0
             ((wasm_frame_vec_t *)trap->frames)->data[i]->instance =
                 frame_instance;
+#else
+            (((wasm_frame_t *)trap->frames->data) + i)->instance =
+                frame_instance;
+#endif
         }
     }
 #else
@@ -2077,7 +2082,11 @@ wasm_trap_trace(const wasm_trap_t *trap, own wasm_frame_vec_t *out)
     }
 
     for (i = 0; i < trap->frames->num_elems; i++) {
+#if WASM_ENABLE_THREAD_MGR != 0
         wasm_frame_t *frame = ((wasm_frame_vec_t *)trap->frames)->data[i];
+#else
+        wasm_frame_t *frame = ((wasm_frame_t *)trap->frames->data) + i;
+#endif
         if (!(out->data[i] =
                   wasm_frame_new(frame->instance, frame->module_offset,
                                  frame->func_index, frame->func_offset))) {

--- a/core/iwasm/common/wasm_c_api_internal.h
+++ b/core/iwasm/common/wasm_c_api_internal.h
@@ -238,4 +238,7 @@ wasm_memory_new_internal(wasm_store_t *store, uint16 memory_idx_rt,
 wasm_table_t *
 wasm_table_new_internal(wasm_store_t *store, uint16 table_idx_rt,
                         WASMModuleInstanceCommon *inst_comm_rt);
+
+void
+wasm_frame_vec_clone_internal(wasm_frame_vec_t *src, wasm_frame_vec_t *out);
 #endif /* _WASM_C_API_INTERNAL_H */

--- a/core/iwasm/common/wasm_c_api_internal.h
+++ b/core/iwasm/common/wasm_c_api_internal.h
@@ -240,5 +240,5 @@ wasm_table_new_internal(wasm_store_t *store, uint16 table_idx_rt,
                         WASMModuleInstanceCommon *inst_comm_rt);
 
 void
-wasm_frame_vec_clone_internal(wasm_frame_vec_t *src, wasm_frame_vec_t *out);
+wasm_frame_vec_clone_internal(Vector *src, Vector *out);
 #endif /* _WASM_C_API_INTERNAL_H */

--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -1307,9 +1307,10 @@ wasm_cluster_set_exception(WASMExecEnv *exec_env, const char *exception)
     data.skip = NULL;
     data.exception = exception;
 
+    os_mutex_lock(&cluster->lock);
 #if WASM_ENABLE_DUMP_CALL_STACK != 0
     if (has_exception) {
-        /* Save the stack trace of the crashed thread into the cluster */
+        /* Save the stack frames of the crashed thread into the cluster */
         WASMModuleInstance *module_inst =
             (WASMModuleInstance *)get_module_inst(exec_env);
 
@@ -1329,9 +1330,7 @@ wasm_cluster_set_exception(WASMExecEnv *exec_env, const char *exception)
         }
 #endif
     }
-#endif
-
-    os_mutex_lock(&cluster->lock);
+#endif /* WASM_ENABLE_DUMP_CALL_STACK != 0 */
     cluster->has_exception = has_exception;
     traverse_list(&cluster->exec_env_list, set_exception_visitor, &data);
     os_mutex_unlock(&cluster->lock);

--- a/core/iwasm/libraries/thread-mgr/thread_manager.h
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.h
@@ -54,9 +54,9 @@ struct WASMCluster {
 
 #if WASM_ENABLE_DUMP_CALL_STACK != 0
     /* When an exception occurs in a thread, the stack frames of that thread are
-     * saved into the claster
+     * saved into the cluster
      */
-    Vector *exception_frames;
+    Vector exception_frames;
 #endif
 };
 

--- a/core/iwasm/libraries/thread-mgr/thread_manager.h
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.h
@@ -51,6 +51,13 @@ struct WASMCluster {
 #if WASM_ENABLE_DEBUG_INTERP != 0
     WASMDebugInstance *debug_inst;
 #endif
+
+#if WASM_ENABLE_DUMP_CALL_STACK != 0
+    /* When an exception occurs in a thread, the stack frames of that thread are
+     * saved into the claster
+     */
+    Vector *exception_frames;
+#endif
 };
 
 void


### PR DESCRIPTION
When using the wasm-c-api and there's a trap, `wasm_func_call()` returns a `wasm_trap_t *` object.
No matter which thread crashes, the trap contains the stack frames of the main thread.

With this PR, when there's an exception, the stack frames of the thread where the exception occurs are stored into the thread cluster. `wasm_func_call()` can then return those stack frames.