### PR TITLE
Fix boundary check typo in AOT compiler context

### DIFF
--- a/core/iwasm/compilation/aot_llvm.h
+++ b/core/iwasm/compilation/aot_llvm.h
@@ -321,10 +321,10 @@ typedef struct AOTCompContext {
     /* Bulk memory feature */
     bool enable_bulk_memory;
 
-    /* Bounday Check */
+    /* Boundary Check */
     bool enable_bound_check;
 
-    /* Native stack bounday Check */
+    /* Native stack boundary Check */
     bool enable_stack_bound_check;
 
     /* Native stack usage estimation */


### PR DESCRIPTION
Fixes typo in docstrings for boundary check in the AOT compiler context.