### PR TITLE
Fix some typo and unify the AOT file format for init data

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -1057,8 +1057,7 @@ load_mem_init_data_list(const uint8 **p_buf, const uint8 *buf_end,
         data_list[i]->memory_index = memory_index;
 #endif
         data_list[i]->offset.init_expr_type = init_value.init_expr_type;
-        /* can only be i32 or get_global for now */
-        data_list[i]->offset.u.i32 = init_value.u.i32;
+        data_list[i]->offset.u = init_value.u;
         data_list[i]->byte_count = byte_count;
         read_byte_array(buf, buf_end, data_list[i]->bytes,
                         data_list[i]->byte_count);
@@ -1956,17 +1955,22 @@ load_types(const uint8 **p_buf, const uint8 *buf_end, AOTModule *module,
     /* Create each function type */
     for (i = 0; i < module->type_count; i++) {
         uint32 type_flag;
-        uint32 param_count, result_count;
+        uint32 dummy, param_count, result_count;
         uint32 param_cell_num, ret_cell_num;
         uint64 size1;
 
         buf = align_ptr(buf, 4);
         read_uint16(buf, buf_end, type_flag);
-        /* Dummy read to ignore the is_sub_final and parent_type_idx */
-        read_uint16(buf, buf_end, param_count);
-        read_uint32(buf, buf_end, param_count);
+        /* Dummy read to ignore the is_sub_final, parent_type_idx,
+         * rec_count, rec_idx */
+        read_uint16(buf, buf_end, dummy);
+        read_uint32(buf, buf_end, dummy);
+        read_uint16(buf, buf_end, dummy);
+        read_uint16(buf, buf_end, dummy);
         read_uint16(buf, buf_end, param_count);
         read_uint16(buf, buf_end, result_count);
+        /* Dummy read to ignore the ref_type_map_count */
+        read_uint16(buf, buf_end, dummy);
 
         size1 = (uint64)param_count + (uint64)result_count;
         size = offsetof(AOTFuncType, types) + size1;

--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -1184,22 +1184,13 @@ load_init_expr(const uint8 **p_buf, const uint8 *buf_end, AOTModule *module,
         case INIT_EXPR_TYPE_GET_GLOBAL:
             read_uint32(buf, buf_end, expr->u.global_index);
             break;
-#if WASM_ENABLE_GC == 0 && WASM_ENABLE_REF_TYPES != 0
+#if WASM_ENABLE_GC != 0 || WASM_ENABLE_REF_TYPES != 0
         case INIT_EXPR_TYPE_FUNCREF_CONST:
         case INIT_EXPR_TYPE_REFNULL_CONST:
-#if UINTPTR_MAX == UINT64_MAX
-            read_uint64(buf, buf_end, expr->u.ref_index);
-#else
-            read_uint32(buf, buf_end, expr->u.ref_index);
-#endif
-            break;
-#elif WASM_ENABLE_GC != 0
-        case INIT_EXPR_TYPE_FUNCREF_CONST:
             read_uint32(buf, buf_end, expr->u.ref_index);
             break;
-        case INIT_EXPR_TYPE_REFNULL_CONST:
-            read_uint32(buf, buf_end, expr->u.type_index);
-            break;
+#endif /* end of WASM_ENABLE_GC != 0 || WASM_ENABLE_REF_TYPES != 0 */
+#if WASM_ENABLE_GC != 0
         case INIT_EXPR_TYPE_I31_NEW:
             read_uint32(buf, buf_end, expr->u.i32);
             break;
@@ -1321,7 +1312,7 @@ load_init_expr(const uint8 **p_buf, const uint8 *buf_end, AOTModule *module,
             }
             break;
         }
-#endif /* end of WASM_ENABLE_GC == 0 && WASM_ENABLE_REF_TYPES != 0 */
+#endif /* end of WASM_ENABLE_GC != 0 */
         default:
             set_error_buf(error_buf, error_buf_size, "invalid init expr type.");
             return false;

--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -1955,22 +1955,14 @@ load_types(const uint8 **p_buf, const uint8 *buf_end, AOTModule *module,
     /* Create each function type */
     for (i = 0; i < module->type_count; i++) {
         uint32 type_flag;
-        uint32 dummy, param_count, result_count;
+        uint32 param_count, result_count;
         uint32 param_cell_num, ret_cell_num;
         uint64 size1;
 
         buf = align_ptr(buf, 4);
         read_uint16(buf, buf_end, type_flag);
-        /* Dummy read to ignore the is_sub_final, parent_type_idx,
-         * rec_count, rec_idx */
-        read_uint16(buf, buf_end, dummy);
-        read_uint32(buf, buf_end, dummy);
-        read_uint16(buf, buf_end, dummy);
-        read_uint16(buf, buf_end, dummy);
         read_uint16(buf, buf_end, param_count);
         read_uint16(buf, buf_end, result_count);
-        /* Dummy read to ignore the ref_type_map_count */
-        read_uint16(buf, buf_end, dummy);
 
         size1 = (uint64)param_count + (uint64)result_count;
         size = offsetof(AOTFuncType, types) + size1;

--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -1041,8 +1041,8 @@ load_mem_init_data_list(const uint8 **p_buf, const uint8 *buf_end,
 
         read_uint32(buf, buf_end, is_passive);
         read_uint32(buf, buf_end, memory_index);
-        if (!load_init_expr(&buf, buf_end, module, &init_value,
-                            error_buf, error_buf_size)) {
+        if (!load_init_expr(&buf, buf_end, module, &init_value, error_buf,
+                            error_buf_size)) {
             return false;
         }
         read_uint32(buf, buf_end, byte_count);
@@ -1194,7 +1194,7 @@ load_init_expr(const uint8 **p_buf, const uint8 *buf_end, AOTModule *module,
             read_uint32(buf, buf_end, expr->u.ref_index);
 #endif
             break;
-#else /* else of WASM_ENABLE_GC == 0 */
+#else  /* else of WASM_ENABLE_GC == 0 */
         case INIT_EXPR_TYPE_FUNCREF_CONST:
             read_uint32(buf, buf_end, expr->u.ref_index);
             break;

--- a/core/iwasm/compilation/aot_emit_aot_file.c
+++ b/core/iwasm/compilation/aot_emit_aot_file.c
@@ -570,11 +570,8 @@ get_func_type_size(AOTCompContext *comp_ctx, AOTFuncType *func_type)
     else
 #endif
     {
-        /* type flag(2 bytes) + is_sub_final(2 bytes) + parent_type_idx(4 bytes)
-         * + rec_count(2 bytes) + rec_idx(2 bytes)
-         * + param count + result count + types
-         * + ref_type_map_count(2 bytes) */
-        return (uint32)sizeof(uint16) * 9 + func_type->param_count
+        /* type flag + param count + result count + types */
+        return (uint32)sizeof(uint16) * 3 + func_type->param_count
                + func_type->result_count;
     }
 }
@@ -2159,18 +2156,12 @@ aot_emit_type_info(uint8 *buf, uint8 *buf_end, uint32 *p_offset,
             offset = align_uint(offset, 4);
             /* If GC is disabled, only emit function type info */
             EMIT_U16(WASM_TYPE_FUNC);
-            /* Emit dummy is_sub_final */
-            EMIT_U16(0);
-            /* Emit parent_type_index */
-            EMIT_U32(0);
-            /* Emit dummy rec_count*/
-            EMIT_U16(0);
-            /* Emit dummy rec_idx */
-            EMIT_U16(0);
+            /* Omit to emit dummy padding for is_sub_final,
+             * parent_type_index, rec_count, rec_idx, 10 bytes in total */
             EMIT_U16(func_types[i]->param_count);
             EMIT_U16(func_types[i]->result_count);
-            /* Emit dummy ref_type_map_count */
-            EMIT_U16(0);
+            /* Omit to emit dummy padding for ref_type_map_count, 2 bytes in
+             * total */
             EMIT_BUF(func_types[i]->types,
                      func_types[i]->param_count + func_types[i]->result_count);
         }

--- a/core/iwasm/compilation/aot_emit_aot_file.c
+++ b/core/iwasm/compilation/aot_emit_aot_file.c
@@ -299,16 +299,9 @@ get_init_expr_size(const AOTCompContext *comp_ctx, const AOTCompData *comp_data,
             break;
         case INIT_EXPR_TYPE_FUNCREF_CONST:
         case INIT_EXPR_TYPE_REFNULL_CONST:
-            if (!comp_ctx->enable_gc) {
-                /* ref_index */
-                size += comp_ctx->pointer_size;
-                break;
-            }
-            else {
-                /* type_index */
-                size += sizeof(uint32);
-                break;
-            }
+            /* ref_index */
+            size += sizeof(uint32);
+            break;
 #if WASM_ENABLE_GC != 0
         case INIT_EXPR_TYPE_I31_NEW:
             /* i32 */
@@ -1821,19 +1814,8 @@ aot_emit_init_expr(uint8 *buf, uint8 *buf_end, uint32 *p_offset,
             break;
         case INIT_EXPR_TYPE_FUNCREF_CONST:
         case INIT_EXPR_TYPE_REFNULL_CONST:
-            if (!comp_ctx->enable_gc) {
-                if (comp_ctx->pointer_size == 4) {
-                    EMIT_U32(expr->u.ref_index);
-                }
-                else {
-                    EMIT_U64(expr->u.ref_index);
-                }
-                break;
-            }
-            else {
-                EMIT_U32(expr->u.ref_index);
-                break;
-            }
+            EMIT_U32(expr->u.ref_index);
+            break;
 #if WASM_ENABLE_GC != 0
         case INIT_EXPR_TYPE_I31_NEW:
             EMIT_U32(expr->u.i32);

--- a/core/iwasm/compilation/aot_emit_aot_file.c
+++ b/core/iwasm/compilation/aot_emit_aot_file.c
@@ -304,12 +304,12 @@ get_init_expr_size(const AOTCompContext *comp_ctx, const AOTCompData *comp_data,
                 size += comp_ctx->pointer_size;
                 break;
             }
-#if WASM_ENABLE_GC != 0
             else {
                 /* type_index */
                 size += sizeof(uint32);
                 break;
             }
+#if WASM_ENABLE_GC != 0
         case INIT_EXPR_TYPE_I31_NEW:
             /* i32 */
             size += sizeof(uint32);
@@ -1830,11 +1830,11 @@ aot_emit_init_expr(uint8 *buf, uint8 *buf_end, uint32 *p_offset,
                 }
                 break;
             }
-#if WASM_ENABLE_GC != 0
             else {
                 EMIT_U32(expr->u.ref_index);
                 break;
             }
+#if WASM_ENABLE_GC != 0
         case INIT_EXPR_TYPE_I31_NEW:
             EMIT_U32(expr->u.i32);
             break;
@@ -2225,8 +2225,8 @@ aot_emit_global_info(uint8 *buf, uint8 *buf_end, uint32 *p_offset,
         offset = align_uint(offset, 4);
         EMIT_U8(global->type);
         EMIT_U8(global->is_mutable);
-        /* padding */
-        EMIT_U16(0);
+
+        offset = align_uint(offset, 4);
         if (!aot_emit_init_expr(buf, buf_end, &offset, comp_ctx,
                                 &global->init_expr))
             return false;

--- a/core/iwasm/interpreter/wasm.h
+++ b/core/iwasm/interpreter/wasm.h
@@ -208,6 +208,11 @@ typedef union WASMValue {
         uint32 type_index;
         uint32 N;
     } array_new_default;
+    /* pointer to a memory space holding more data, current usage:
+     *  struct.new init value: WASMStructNewInitValues *
+     *  array.new init value: WASMArrayNewInitValues *
+     */
+    void *data;
 #endif
 } WASMValue;
 #endif /* end of WASM_VALUE_DEFINED */

--- a/tests/wamr-test-suites/spec-test-script/thread_proposal_ignore_cases.patch
+++ b/tests/wamr-test-suites/spec-test-script/thread_proposal_ignore_cases.patch
@@ -211,6 +211,21 @@ index 1ea2b06..8eded37 100644
  (assert_return (invoke $module1 "call-8") (i32.const 69))
  (assert_return (invoke $module1 "call-9") (i32.const 70))
 +;)
+diff --git a/test/core/table.wast b/test/core/table.wast
+index 0bc43ca6..ee5209ec 100644
+--- a/test/core/table.wast
++++ b/test/core/table.wast
+@@ -8,8 +8,8 @@
+ (module (table 0 65536 funcref))
+ (module (table 0 0xffff_ffff funcref))
+ 
+-(assert_invalid (module (table 0 funcref) (table 0 funcref)) "multiple tables")
+-(assert_invalid (module (table (import "spectest" "table") 0 funcref) (table 0 funcref)) "multiple tables")
++(module (table 0 funcref) (table 0 funcref))
++(module (table (import "spectest" "table") 0 funcref) (table 0 funcref))
+ 
+ (assert_invalid (module (elem (i32.const 0))) "unknown table")
+ (assert_invalid (module (elem (i32.const 0) $f) (func $f)) "unknown table")
 diff --git a/test/core/thread.wast b/test/core/thread.wast
 index c3456a6..83fc281 100644
 --- a/test/core/thread.wast

--- a/tests/wamr-test-suites/test_wamr.sh
+++ b/tests/wamr-test-suites/test_wamr.sh
@@ -789,6 +789,7 @@ function trigger()
     local EXTRA_COMPILE_FLAGS=""
     # default enabled features
     EXTRA_COMPILE_FLAGS+=" -DWAMR_BUILD_BULK_MEMORY=1"
+    EXTRA_COMPILE_FLAGS+=" -DWAMR_BUILD_REF_TYPES=1"
 
     if [[ ${ENABLE_MULTI_MODULE} == 1 ]];then
         EXTRA_COMPILE_FLAGS+=" -DWAMR_BUILD_MULTI_MODULE=1"
@@ -798,9 +799,6 @@ function trigger()
 
     if [[ ${ENABLE_MULTI_THREAD} == 1 ]];then
         EXTRA_COMPILE_FLAGS+=" -DWAMR_BUILD_LIB_PTHREAD=1"
-        EXTRA_COMPILE_FLAGS+=" -DWAMR_BUILD_REF_TYPES=0"
-    else
-        EXTRA_COMPILE_FLAGS+=" -DWAMR_BUILD_REF_TYPES=1"
     fi
 
     if [[ ${ENABLE_SIMD} == 1 ]]; then
@@ -811,7 +809,6 @@ function trigger()
 
     if [[ ${ENABLE_GC} == 1 ]]; then
         EXTRA_COMPILE_FLAGS+=" -DWAMR_BUILD_GC=1"
-        EXTRA_COMPILE_FLAGS+=" -DWAMR_BUILD_REF_TYPES=1"
         EXTRA_COMPILE_FLAGS+=" -DWAMR_BUILD_BULK_MEMORY=1"
         EXTRA_COMPILE_FLAGS+=" -DWAMR_BUILD_TAIL_CALL=1"
     fi


### PR DESCRIPTION
Unify the emitting and loading logic for table/memory/global init data