### PR TITLE
Enable wasm_runtime_terminate for single-threading

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -2548,7 +2548,6 @@ wasm_runtime_clear_exception(WASMModuleInstanceCommon *module_inst_comm)
     wasm_runtime_set_exception(module_inst_comm, NULL);
 }
 
-#if WASM_ENABLE_THREAD_MGR != 0
 void
 wasm_runtime_terminate(WASMModuleInstanceCommon *module_inst_comm)
 {
@@ -2558,7 +2557,6 @@ wasm_runtime_terminate(WASMModuleInstanceCommon *module_inst_comm)
               || module_inst_comm->module_type == Wasm_Module_AoT);
     wasm_set_exception(module_inst, "terminated by user");
 }
-#endif
 
 void
 wasm_runtime_set_custom_data_internal(

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -940,9 +940,6 @@ wasm_runtime_clear_exception(wasm_module_inst_t module_inst);
  *  - Another thread has a copy of `wasm_module_inst_t` of
  *    the module instance and wants to terminate it asynchronously.
  *
- * This function is provided only when WAMR is built with threading enabled.
- * (`WASM_ENABLE_THREAD_MGR=1`)
- *
  * @param module_inst the WASM module instance
  */
 WASM_RUNTIME_API_EXTERN void


### PR DESCRIPTION
The host embedder may also want to terminate the wasm instance
for single-threading mode, and it should work by setting exception
to the wasm instance.