### PR TITLE
fix(sgx-ra): fix building when enclave is built without librats ahead.

### DIFF
--- a/samples/sgx-ra/CMakeLists.txt
+++ b/samples/sgx-ra/CMakeLists.txt
@@ -69,6 +69,7 @@ execute_process (
 add_custom_target (
               iwasm ALL
               DEPENDS vmlib_untrusted vmlib_untrusted vmlib
+              COMMAND make -C ${SGX_PLATFORM_DIR}/enclave-sample clean
               COMMAND make -C  ${SGX_PLATFORM_DIR}/enclave-sample SGX_MODE=HW SGX_DEBUG=1 VMLIB_BUILD_DIR=${CMAKE_BINARY_DIR}
               COMMAND ${CMAKE_COMMAND} -E copy ${SGX_PLATFORM_DIR}/enclave-sample/enclave.signed.so ${CMAKE_BINARY_DIR}
               COMMAND ${CMAKE_COMMAND} -E copy ${SGX_PLATFORM_DIR}/enclave-sample/iwasm ${CMAKE_BINARY_DIR}


### PR DESCRIPTION
This PR introduces minor changes to address the issue with building the sgx-ra sample when the enclave under the path product-mini/platforms/linux-sgx/enclave-sample is built beforehand.

When the enclave is built without librats beforehead, an error occurs as the following without the changes:
```bash
...
GEN  =>  App/Enclave_u.c
CC   <=  App/Enclave_u.c
CP libvmlib_untrusted.a  <=  /home/haoxuan/wasm-micro-runtime/samples/sgx-ra/build/libvmlib_untrusted.a
LINK =>  iwasm
GEN  =>  Enclave/Enclave_t.c
CC   <=  Enclave/Enclave_t.c
CP libvmlib.a  <=  /home/haoxuan/wasm-micro-runtime/samples/sgx-ra/build/libvmlib.a
/usr/local/bin/ld: libvmlib.a(lib_rats_wrapper.c.o): in function `librats_collect_wrapper':
lib_rats_wrapper.c:(.text.librats_collect_wrapper+0x4a): undefined reference to `wasm_runtime_get_module_hash'
collect2: error: ld returned 1 exit status
make[3]: *** [Makefile:250: enclave.so] Error 1
make[2]: *** [CMakeFiles/iwasm.dir/build.make:57: CMakeFiles/iwasm] Error 2
make[1]: *** [CMakeFiles/Makefile2:448: CMakeFiles/iwasm.dir/all] Error 2
make: *** [Makefile:130: all] Error 2
```

The CMakeLists in sgx-ra uses the `sed` command to modify the WAMR_BUILD_LIB_RATS flag in the Makefile, which is included in the Enclave_C_Flags. This should have enabled compilation with wasm_runtime_get_module_hash defined. The reason for this error is unclear and may require further investigation. I simply fix it by incorporating the make clean command before executing the make command for the enclave.