### PR TITLE
(freertos): minor changes for freertos libc_wasi build adaption

### DIFF
--- a/core/iwasm/aot/debug/jit_debug.c
+++ b/core/iwasm/aot/debug/jit_debug.c
@@ -23,7 +23,6 @@
 
 #include <stdio.h>
 #include <assert.h>
-#include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>

--- a/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
+++ b/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
@@ -1047,7 +1047,7 @@ execute_interruptible_poll_oneoff(
 
         if (wasm_cluster_is_thread_terminated(exec_env)) {
             wasm_runtime_free(in_copy);
-            return EINTR;
+            return __WASI_EINTR;
         }
         else if (*nevents > 0) {
             all_outs_are_type_clock = true;

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
@@ -54,7 +54,7 @@
 #endif
 
 #if !defined(__APPLE__) && !defined(BH_PLATFORM_LINUX_SGX) && !defined(_WIN32) \
-    && !defined(__COSMOPOLITAN__)
+    && !defined(__COSMOPOLITAN__) && !defined(BH_PLATFORM_FREERTOS)
 #define CONFIG_HAS_PTHREAD_CONDATTR_SETCLOCK 1
 #else
 #define CONFIG_HAS_PTHREAD_CONDATTR_SETCLOCK 0


### PR DESCRIPTION
background:
when I try to enable WAMR_BUILD_LIBC_WASI, got a lots of errors, outside of wasm repo I will try to implement some missing API,  but inside wasm repo need some minor changes.