### PR TITLE
freertos: to prevent deadlock, change to use os_recursive_mutex_init()

### DIFF
--- a/core/iwasm/common/wasm_exec_env.c
+++ b/core/iwasm/common/wasm_exec_env.c
@@ -44,7 +44,7 @@ wasm_exec_env_create_internal(struct WASMModuleInstanceCommon *module_inst,
 #endif
 
 #if WASM_ENABLE_THREAD_MGR != 0
-    if (os_mutex_init(&exec_env->wait_lock) != 0)
+    if (os_recursive_mutex_init(&exec_env->wait_lock) != 0)
         goto fail2;
 
     if (os_cond_init(&exec_env->wait_cond) != 0)

--- a/core/shared/platform/linux-sgx/sgx_thread.c
+++ b/core/shared/platform/linux-sgx/sgx_thread.c
@@ -82,6 +82,12 @@ os_mutex_init(korp_mutex *mutex)
 }
 
 int
+os_recursive_mutex_init(korp_mutex *mutex)
+{
+    return os_mutex_init(mutex);
+}
+
+int
 os_mutex_destroy(korp_mutex *mutex)
 {
 #ifndef SGX_DISABLE_PTHREAD


### PR DESCRIPTION
the case callstack:
pthread_create_wrapper
=>os_mutex_lock(&exec_env->wait_lock);
=>wasm_cluster_create_thread
====>wasm_exec_env_set_thread_info
=====>os_mutex_lock(&exec_env->wait_lock);    //deadlock here