### PR TITLE
Fix compilation error on iOS due to macOS-specific APIs

### DIFF
--- a/core/shared/platform/common/posix/posix_memmap.c
+++ b/core/shared/platform/common/posix/posix_memmap.c
@@ -6,7 +6,7 @@
 #include "platform_api_vmcore.h"
 
 #if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__) \
-    && TARGET_OS_OSX
+    && defined(TARGET_OS_OSX) && TARGET_OS_OSX != 0
 #include <libkern/OSCacheControl.h>
 #endif
 
@@ -42,7 +42,7 @@ os_mmap(void *hint, size_t size, int prot, int flags, os_file_handle file)
 {
     int map_prot = PROT_NONE;
 #if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__) \
-    && TARGET_OS_OSX
+    && defined(TARGET_OS_OSX) && TARGET_OS_OSX != 0
     int map_flags = MAP_ANONYMOUS | MAP_PRIVATE | MAP_JIT;
 #else
     int map_flags = MAP_ANONYMOUS | MAP_PRIVATE;
@@ -266,7 +266,7 @@ void
 os_icache_flush(void *start, size_t len)
 {
 #if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__) \
-    && TARGET_OS_OSX
+    && defined(TARGET_OS_OSX) && TARGET_OS_OSX != 0
     sys_icache_invalidate(start, len);
 #endif
 }

--- a/core/shared/platform/common/posix/posix_memmap.c
+++ b/core/shared/platform/common/posix/posix_memmap.c
@@ -5,7 +5,8 @@
 
 #include "platform_api_vmcore.h"
 
-#if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__) && TARGET_OS_OSX
+#if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__) \
+    && TARGET_OS_OSX
 #include <libkern/OSCacheControl.h>
 #endif
 
@@ -40,7 +41,8 @@ void *
 os_mmap(void *hint, size_t size, int prot, int flags, os_file_handle file)
 {
     int map_prot = PROT_NONE;
-#if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__) && TARGET_OS_OSX
+#if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__) \
+    && TARGET_OS_OSX
     int map_flags = MAP_ANONYMOUS | MAP_PRIVATE | MAP_JIT;
 #else
     int map_flags = MAP_ANONYMOUS | MAP_PRIVATE;
@@ -263,7 +265,8 @@ os_dcache_flush(void)
 void
 os_icache_flush(void *start, size_t len)
 {
-#if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__) && TARGET_OS_OSX
+#if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__) \
+    && TARGET_OS_OSX
     sys_icache_invalidate(start, len);
 #endif
 }

--- a/core/shared/platform/common/posix/posix_memmap.c
+++ b/core/shared/platform/common/posix/posix_memmap.c
@@ -5,7 +5,7 @@
 
 #include "platform_api_vmcore.h"
 
-#if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__)
+#if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__) && TARGET_OS_OSX
 #include <libkern/OSCacheControl.h>
 #endif
 
@@ -40,7 +40,7 @@ void *
 os_mmap(void *hint, size_t size, int prot, int flags, os_file_handle file)
 {
     int map_prot = PROT_NONE;
-#if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__)
+#if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__) && TARGET_OS_OSX
     int map_flags = MAP_ANONYMOUS | MAP_PRIVATE | MAP_JIT;
 #else
     int map_flags = MAP_ANONYMOUS | MAP_PRIVATE;
@@ -263,7 +263,7 @@ os_dcache_flush(void)
 void
 os_icache_flush(void *start, size_t len)
 {
-#if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__)
+#if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__) && TARGET_OS_OSX
     sys_icache_invalidate(start, len);
 #endif
 }

--- a/core/shared/platform/common/posix/posix_memmap.c
+++ b/core/shared/platform/common/posix/posix_memmap.c
@@ -5,8 +5,7 @@
 
 #include "platform_api_vmcore.h"
 
-#if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__) \
-    && defined(TARGET_OS_OSX) && TARGET_OS_OSX != 0
+#if defined(__APPLE__) || defined(__MACH__)
 #include <libkern/OSCacheControl.h>
 #endif
 
@@ -265,8 +264,7 @@ os_dcache_flush(void)
 void
 os_icache_flush(void *start, size_t len)
 {
-#if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__) \
-    && defined(TARGET_OS_OSX) && TARGET_OS_OSX != 0
+#if defined(__APPLE__) || defined(__MACH__)
     sys_icache_invalidate(start, len);
 #endif
 }

--- a/core/shared/platform/common/posix/posix_thread.c
+++ b/core/shared/platform/common/posix/posix_thread.c
@@ -476,7 +476,7 @@ os_thread_get_stack_boundary()
 void
 os_thread_jit_write_protect_np(bool enabled)
 {
-#if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__)
+#if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__) && TARGET_OS_OSX
     pthread_jit_write_protect_np(enabled);
 #endif
 }

--- a/core/shared/platform/common/posix/posix_thread.c
+++ b/core/shared/platform/common/posix/posix_thread.c
@@ -477,7 +477,7 @@ void
 os_thread_jit_write_protect_np(bool enabled)
 {
 #if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__) \
-    && TARGET_OS_OSX
+    && defined(TARGET_OS_OSX) && TARGET_OS_OSX != 0
     pthread_jit_write_protect_np(enabled);
 #endif
 }

--- a/core/shared/platform/common/posix/posix_thread.c
+++ b/core/shared/platform/common/posix/posix_thread.c
@@ -476,7 +476,8 @@ os_thread_get_stack_boundary()
 void
 os_thread_jit_write_protect_np(bool enabled)
 {
-#if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__) && TARGET_OS_OSX
+#if (defined(__APPLE__) || defined(__MACH__)) && defined(__arm64__) \
+    && TARGET_OS_OSX
     pthread_jit_write_protect_np(enabled);
 #endif
 }


### PR DESCRIPTION
This commit addresses a compilation issue on the iOS platform within the wasm-micro-runtime project-mini. The problem was caused by the usage of certain APIs that are exclusive to macOS. The code has been updated to include platform-specific preprocessor directives, ensuring that these macOS-specific APIs are only called when compiling for macOS. This change preserves the functionality on macOS while allowing successful compilation on iOS.
<img width="567" alt="截屏2024-01-10 15 47 54" src="https://github.com/bytecodealliance/wasm-micro-runtime/assets/53246970/8fc43ff7-7cb1-49ed-814e-20a9039afa28">
