### PR TITLE
aot debug: update DW_AT_producer

### DIFF
--- a/core/iwasm/compilation/debug/dwarf_extractor.cpp
+++ b/core/iwasm/compilation/debug/dwarf_extractor.cpp
@@ -152,7 +152,7 @@ dwarf_gen_mock_vm_info(AOTCompContext *comp_ctx)
 
     comp_unit = LLVMDIBuilderCreateCompileUnit(
       comp_ctx->debug_builder, LLVMDWARFSourceLanguageC, file_info,
-      "ant compiler", 12, 0, NULL, 0, 1, NULL, 0, LLVMDWARFEmissionFull, 0, 0,
+      "WAMR AoT compiler", 12, 0, NULL, 0, 1, NULL, 0, LLVMDWARFEmissionFull, 0, 0,
       0, "/", 1, "", 0);
 
     LLVMTypeRef ParamTys[] = {
@@ -208,8 +208,8 @@ dwarf_gen_comp_unit_info(const AOTCompContext *comp_ctx)
 
         comp_unit = LLVMDIBuilderCreateCompileUnit(
             comp_ctx->debug_builder, LLDB_TO_LLVM_LANG_TYPE(lang_type),
-            comp_ctx->debug_file, "ant compiler", 12, 0, NULL, 0, 1, NULL, 0,
-            LLVMDWARFEmissionFull, 0, 0, 0, "/", 1, "", 0);
+            comp_ctx->debug_file, "WAMR AoT compiler", 12, 0, NULL, 0, 1, NULL,
+            0, LLVMDWARFEmissionFull, 0, 0, 0, "/", 1, "", 0);
     }
     return comp_unit;
 }


### PR DESCRIPTION
currently we are using "ant compiler", which i guess a bit historical.

this commit changes it to use "WAMR AoT compiler" instead. hopefully the new value is less surprining for users.