### PR TITLE
Do not clone stack frames if there's no trap

### DIFF
--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -1924,11 +1924,13 @@ wasm_frame_func_offset(const wasm_frame_t *frame)
 void
 wasm_frame_vec_clone_internal(Vector *src, Vector *out)
 {
-    bh_assert(src->num_elems != 0 && src->data);
-
-    bh_vector_destroy(out);
-    if (!bh_vector_init(out, src->num_elems, sizeof(WASMCApiFrame), false)) {
+    if (src->num_elems == 0) {
         bh_vector_destroy(out);
+        return;
+    }
+
+    if (!bh_vector_destroy(out)
+        || !bh_vector_init(out, src->num_elems, sizeof(WASMCApiFrame), false)) {
         return;
     }
 


### PR DESCRIPTION
When running the [no_pthread sample](https://github.com/bytecodealliance/wasm-micro-runtime/blob/main/samples/wasi-threads/wasm-apps/no_pthread.c), the assert was failing on `src->num_elems != 0`.
That's because, if the exception is `proc_exit`, there's no trap (the execution didn't fail, no stack frames). 

The problem was not detected in CI because there we build in release mode: https://github.com/bytecodealliance/wasm-micro-runtime/blob/08442458b12244f2cacb2f49573bb84e9433071f/.github/workflows/compilation_on_macos.yml#L328 

Should we use debug instead so that we can take advantage of asserts?