### PR TITLE
Fix nightly-run CI failure

### DIFF
--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -383,7 +383,9 @@ jobs:
       - name: Build Sample [wasm-c-api]
         run: |
           VERBOSE=1
-          cmake -S . -B build ${{ matrix.make_options }} -D WAMR_BUILD_SANITIZER="${{matrix.sanitizer}}"
+          cmake -S . -B build ${{ matrix.make_options }} \
+                -D WAMR_BUILD_SANITIZER="${{matrix.sanitizer}}" \
+                -D WAMR_BUILD_QUICK_AOT_ENTRY=0
           cmake --build build --config Release --parallel 4
           ctest --test-dir build --output-on-failure
         working-directory: samples/wasm-c-api


### PR DESCRIPTION
Not know how to make `__attribute__((no_sanitize_address))` take effect
on gcc in Ubuntu-20.04, just disable quick AOT entry for wasm-c-api
sample in nightly-run CI.