### PR TITLE
Build samples in debug mode

### DIFF
--- a/.github/workflows/compilation_on_android_ubuntu.yml
+++ b/.github/workflows/compilation_on_android_ubuntu.yml
@@ -322,7 +322,7 @@ jobs:
         run: |
           VERBOSE=1
           cmake -S . -B build ${{ matrix.make_options }}
-          cmake --build build --config Release --parallel 4
+          cmake --build build --config Debug --parallel 4
           ctest --test-dir build --output-on-failure
         working-directory: samples/wasm-c-api
 
@@ -393,7 +393,7 @@ jobs:
           cd samples/file
           mkdir build && cd build
           cmake ..
-          cmake --build . --config Release --parallel 4
+          cmake --build . --config Debug --parallel 4
           ./src/iwasm -f wasm-app/file.wasm -d .
 
       - name: Build Sample [multi-thread]
@@ -401,7 +401,7 @@ jobs:
           cd samples/multi-thread
           mkdir build && cd build
           cmake ..
-          cmake --build . --config Release --parallel 4
+          cmake --build . --config Debug --parallel 4
           ./iwasm wasm-apps/test.wasm
 
       - name: Build Sample [multi-module]
@@ -409,7 +409,7 @@ jobs:
           cd samples/multi-module
           mkdir build && cd build
           cmake .. -DWAMR_BUILD_AOT=1
-          cmake --build . --config Release --parallel 4
+          cmake --build . --config Debug --parallel 4
           ./multi_module mC.wasm
           ./multi_module mC.aot
 
@@ -418,7 +418,7 @@ jobs:
           cd samples/spawn-thread
           mkdir build && cd build
           cmake ..
-          cmake --build . --config Release --parallel 4
+          cmake --build . --config Debug --parallel 4
           ./spawn_thread
 
       - name: Build Sample [ref-types]
@@ -426,7 +426,7 @@ jobs:
           cd samples/ref-types
           mkdir build && cd build
           cmake ..
-          cmake --build . --config Release --parallel 4
+          cmake --build . --config Debug --parallel 4
           ./hello
 
       - name: Build Sample [simple]
@@ -441,7 +441,7 @@ jobs:
           cd samples/wasi-threads
           mkdir build && cd build
           cmake ..
-          cmake --build . --config Release --parallel 4
+          cmake --build . --config Debug --parallel 4
           ./iwasm wasm-apps/no_pthread.wasm
 
       - name: Build Sample [shared-module]

--- a/.github/workflows/compilation_on_macos.yml
+++ b/.github/workflows/compilation_on_macos.yml
@@ -285,7 +285,7 @@ jobs:
           cd samples/file
           mkdir build && cd build
           cmake ..
-          cmake --build . --config Release --parallel 4
+          cmake --build . --config Debug --parallel 4
           ./src/iwasm -f wasm-app/file.wasm -d .
 
       - name: Build Sample [multi-thread]
@@ -293,7 +293,7 @@ jobs:
           cd samples/multi-thread
           mkdir build && cd build
           cmake ..
-          cmake --build . --config Release --parallel 4
+          cmake --build . --config Debug --parallel 4
           ./iwasm wasm-apps/test.wasm
 
       - name: Build Sample [multi-module]
@@ -301,7 +301,7 @@ jobs:
           cd samples/multi-module
           mkdir build && cd build
           cmake ..
-          cmake --build . --config Release --parallel 4
+          cmake --build . --config Debug --parallel 4
           ./multi_module mC.wasm
 
       - name: Build Sample [spawn-thread]
@@ -309,7 +309,7 @@ jobs:
           cd samples/spawn-thread
           mkdir build && cd build
           cmake ..
-          cmake --build . --config Release --parallel 4
+          cmake --build . --config Debug --parallel 4
           ./spawn_thread
 
       - name: Build Sample [ref-types]
@@ -317,7 +317,7 @@ jobs:
           cd samples/ref-types
           mkdir build && cd build
           cmake ..
-          cmake --build . --config Release --parallel 4
+          cmake --build . --config Debug --parallel 4
           ./hello
 
       - name: Build Sample [wasi-threads]
@@ -325,7 +325,7 @@ jobs:
           cd samples/wasi-threads
           mkdir build && cd build
           cmake ..
-          cmake --build . --config Release --parallel 4
+          cmake --build . --config Debug --parallel 4
           ./iwasm wasm-apps/no_pthread.wasm
 
       - name: Build Sample [shared-module]

--- a/.github/workflows/compilation_on_sgx.yml
+++ b/.github/workflows/compilation_on_sgx.yml
@@ -246,7 +246,7 @@ jobs:
           cd samples/file
           mkdir build && cd build
           cmake ..
-          cmake --build . --config Release --parallel 4
+          cmake --build . --config Debug --parallel 4
           cp wasm-app/file.wasm `pwd`/../../../product-mini/platforms/${{ matrix.platform }}/enclave-sample
 
       - name: Test Sample [file] in non-aot mode

--- a/samples/basic/build.sh
+++ b/samples/basic/build.sh
@@ -21,7 +21,7 @@ echo "#####################build basic project"
 cd ${CURR_DIR}
 mkdir -p cmake_build
 cd cmake_build
-cmake ..
+cmake .. -DCMAKE_BUILD_TYPE=Debug
 make -j ${nproc}
 if [ $? != 0 ];then
     echo "BUILD_FAIL basic exit as $?\n"

--- a/samples/shared-module/build.sh
+++ b/samples/shared-module/build.sh
@@ -21,7 +21,7 @@ echo "##################### build shared-module project"
 cd ${CURR_DIR}
 mkdir -p cmake_build
 cd cmake_build
-cmake ..
+cmake .. -DCMAKE_BUILD_TYPE=Debug
 make -j ${nproc}
 if [ $? != 0 ];then
     echo "BUILD_FAIL shared-module exit as $?\n"

--- a/samples/simple/build.sh
+++ b/samples/simple/build.sh
@@ -17,7 +17,7 @@ APP_LIB_SRC="${APP_FRAMEWORK_DIR}/base/app/*.c ${APP_FRAMEWORK_DIR}/sensor/app/*
              ${APP_FRAMEWORK_DIR}/connection/app/*.c ${NATIVE_LIBS}/*.c"
 WASM_APPS=${PWD}/wasm-apps
 CLEAN=
-CM_BUILD_TYPE="-DCMAKE_BUILD_TYPE=Release"
+CM_BUILD_TYPE="-DCMAKE_BUILD_TYPE=Debug"
 CM_TOOLCHAIN=""
 
 usage ()


### PR DESCRIPTION
Follow-up on #3008. Compiling samples in Debug mode allows us to take advantage of asserts and would have prevented the fix in #3008.