### PR TITLE
Update binary size info in README.md

### DIFF
--- a/.github/workflows/compilation_on_nuttx.yml
+++ b/.github/workflows/compilation_on_nuttx.yml
@@ -61,8 +61,6 @@ jobs:
           "boards/arm/rp2040/raspberrypi-pico/configs/nsh",
           # cortex-m7
           "boards/arm/stm32h7/nucleo-h743zi/configs/nsh",
-          # riscv32imc
-          "boards/risc-v/espressif/esp32c3-generic/configs/nsh",
           # riscv32gc
           "boards/risc-v/qemu-rv/rv-virt/configs/nsh",
           # riscv64gc
@@ -114,3 +112,26 @@ jobs:
           cd nuttx
           tools/configure.sh ${{ matrix.nuttx_board_config }}
           make -j$(nproc) EXTRAFLAGS=-Werror
+
+      - name: Checkout Bloaty
+        uses: actions/checkout@v3
+        with:
+          repository: google/bloaty
+          submodules: recursive
+          path: bloaty
+
+      - name: Build Bloaty
+        run: |
+          cmake -Bbuild -GNinja bloaty
+          cmake --build build
+
+      - name: Size Report
+        run: |
+          echo "Build target: ${{ matrix.nuttx_board_config }}"
+          echo "WAMR build config: ${{ matrix.wamr_config_option }}"
+          echo "WAMR size:"
+          build/bloaty -d compileunits --source-filter wamr nuttx/nuttx
+          echo "libc-builtin size (if enabled):"
+          build/bloaty -d compileunits --source-filter libc-builtin nuttx/nuttx
+          echo "libc-wasi size (if enabled):"
+          build/bloaty -d compileunits --source-filter libc-wasi nuttx/nuttx

--- a/README.md
+++ b/README.md
@@ -21,7 +21,12 @@ WebAssembly Micro Runtime (WAMR) is a lightweight standalone WebAssembly (Wasm) 
 
 ### Key features
 - Full compliant to the W3C Wasm MVP
-- Small runtime binary size (~85K for interpreter and ~50K for AOT) and low memory usage
+- Small runtime binary size (core vmlib on cortex-m4f with tail-call/bulk memroy/shared memroy support, text size from bloaty)
+  * ~58.9K for fast interpreter
+  * ~56.3K for classic interpreter
+  * ~29.4K for aot runtime
+  * ~21.4K for libc-wasi library
+  * ~3.7K for libc-builtin library
 - Near to native speed by AOT and JIT
 - Self-implemented AOT module loader to enable AOT working on Linux, Windows, MacOS, Android, SGX and MCU systems
 - Choices of Wasm application libc support: the built-in libc subset for the embedded environment or [WASI](https://github.com/WebAssembly/WASI) for the standard libc


### PR DESCRIPTION
The size info is from bloaty, which is a tool to measure binary size. With WAMR intergrated to NuttX with essential features.

Example usage and output (WAMR stuff only):
```
➜  sim bloaty -s file nuttx/nuttx -d compileunits --source-filter wamr
    FILE SIZE        VM SIZE
 --------------  --------------
  13.1%   108Ki  19.4%  14.6Ki    wamr/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
  12.2%   100Ki   0.1%      50    wamr/core/iwasm/common/wasm_c_api.c
  10.6%  87.1Ki   8.7%  6.54Ki    wamr/core/iwasm/common/wasm_runtime_common.c
   9.2%  76.1Ki  12.6%  9.45Ki    wamr/core/iwasm/aot/aot_loader.c
   8.9%  73.6Ki  12.5%  9.38Ki    wamr/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
   7.1%  58.7Ki   9.0%  6.79Ki    wamr/core/iwasm/aot/aot_runtime.c
   3.6%  29.3Ki   5.6%  4.21Ki    wamr/core/iwasm/libraries/libc-builtin/libc_builtin_wrapper.c
   3.2%  26.2Ki   3.6%  2.73Ki    wamr/core/shared/platform/common/posix/posix_socket.c
   2.9%  24.0Ki   2.7%  2.01Ki    wamr/core/iwasm/common/wasm_memory.c
   2.8%  23.2Ki   2.3%  1.74Ki    wamr/core/iwasm/common/wasm_application.c
   2.6%  21.5Ki   3.3%  2.46Ki    wamr/core/shared/platform/common/posix/posix_file.c
   2.5%  20.4Ki   1.9%  1.45Ki    wamr/core/iwasm/common/wasm_native.c
   2.4%  20.0Ki   2.0%  1.51Ki    wamr/core/iwasm/aot/arch/aot_reloc_riscv.c
   2.1%  17.3Ki   1.6%  1.20Ki    wamr/core/iwasm/common/wasm_shared_memory.c
   2.0%  16.4Ki   2.4%  1.81Ki    wamr/core/shared/mem-alloc/ems/ems_alloc.c
   1.9%  15.9Ki   2.4%  1.81Ki    wamr/product-mini/platforms/nuttx/main.c
   1.7%  13.8Ki   1.4%  1.05Ki    wamr/core/iwasm/aot/aot_intrinsic.c
   1.5%  12.2Ki   0.4%     312    wamr/core/iwasm/common/wasm_exec_env.c
   1.4%  11.8Ki   0.8%     618    wamr/core/shared/platform/common/posix/posix_thread.c
   1.0%  8.20Ki   1.2%     952    wamr/core/shared/utils/bh_hashmap.c
   0.9%  7.52Ki   0.8%     636    wamr/core/shared/utils/bh_vector.c
   0.9%  7.46Ki   0.8%     618    wamr/core/shared/mem-alloc/ems/ems_kfc.c
   0.8%  6.89Ki   1.0%     744    wamr/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/blocking_op.c
   0.8%  6.65Ki   0.5%     356    wamr/core/shared/platform/nuttx/nuttx_platform.c
   0.5%  4.25Ki   0.4%     316    wamr/core/shared/utils/bh_common.c
   0.4%  3.70Ki   0.3%     248    wamr/core/shared/utils/bh_log.c
   0.4%  3.52Ki   0.4%     330    wamr/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/random.c
   0.4%  3.07Ki   0.1%      40    wamr/core/shared/mem-alloc/mem_alloc.c
   0.3%  2.52Ki   0.3%     196    wamr/core/shared/utils/uncommon/bh_read_file.c
   0.3%  2.36Ki   0.3%     216    wamr/core/shared/platform/common/posix/posix_clock.c
   0.3%  2.27Ki   0.1%     106    wamr/core/shared/utils/bh_list.c
   0.2%  1.91Ki   0.6%     430    wamr/core/shared/platform/common/libc-util/libc_errno.c
   0.2%  1.78Ki   0.1%      94    wamr/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/str.c
   0.2%  1.73Ki   0.0%       6    wamr/core/iwasm/common/wasm_blocking_op.c
   0.2%  1.42Ki   0.1%      74    wamr/core/shared/utils/bh_bitmap.c
   0.1%  1.02Ki   0.1%      82    wamr/core/shared/platform/common/posix/posix_time.c
   0.1%     751   0.2%     138    wamr/core/iwasm/common/arch/invokeNative_riscv.S
 100.0%   823Ki 100.0%  75.1Ki    TOTAL
```