### PR TITLE
Avoid unused thread_id warning and recompile multi-module sample

### DIFF
--- a/samples/multi-module/CMakeLists.txt
+++ b/samples/multi-module/CMakeLists.txt
@@ -132,6 +132,7 @@ endif()
 # .c -> .wasm
 ExternalProject_Add(WASM_MODULE
   SOURCE_DIR         ${CMAKE_CURRENT_SOURCE_DIR}/wasm-apps
+  BUILD_ALWAYS TRUE
   UPDATE_COMMAND     ""
   PATCH_COMMAND      ""
   CONFIGURE_COMMAND  ${CMAKE_COMMAND}

--- a/samples/wasi-threads/wasm-apps/wasi_thread_start.h
+++ b/samples/wasi-threads/wasm-apps/wasi_thread_start.h
@@ -9,6 +9,7 @@
 
 /* See https://github.com/WebAssembly/wasi-threads#design-choice-thread-ids */
 #define ASSERT_VALID_TID(TID) \
+    (void)TID;                \
     assert(TID >= 1 && TID <= 0x1FFFFFFF && "Invalid thread ID")
 
 typedef struct {


### PR DESCRIPTION
- Unused var warning (when building in release mode):
```bash
wasm-micro-runtime/samples/wasi-threads/wasm-apps/no_pthread.c:44:9: warning: variable 'thread_id' set but not used [-Wunused-but-set-variable]
    int thread_id;
        ^
1 warning generated.
```

- When using the multi-module example and changing the files in `wasm-apps`, they don't get recompiled when the sample is rebuilt. Adding `BUILD_ALWAYS` as it's done in other samples.