### PR TITLE
to support posix file api for freertos

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
@@ -34,7 +34,7 @@
 #define CONFIG_HAS_GETRANDOM 0
 #endif
 
-#if defined(__CloudABI__)
+#if defined(__CloudABI__) || defined(BH_PLATFORM_FREERTOS)
 #define CONFIG_HAS_CAP_ENTER 1
 #else
 #define CONFIG_HAS_CAP_ENTER 0


### PR DESCRIPTION
due to freertos like embedded system, no so rich api like linux, so make it easier configurations. currently test file api in wasm app pass.