### PR TITLE
Enable quick aot entry when hw bound check is disabled

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -1426,14 +1426,10 @@ invoke_native_with_hw_bound_check(WASMExecEnv *exec_env, void *func_ptr,
 #if WASM_ENABLE_QUICK_AOT_ENTRY != 0
         /* Quick call if the quick aot entry is registered */
         if (!signature && func_type->quick_aot_entry) {
-            void (*invoke_native)(
-                void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-                uint32 *argv_ret) = func_type->quick_aot_entry;
-            invoke_native(func_ptr,
-                          func_type->result_count > 0
-                              ? func_type->types[func_type->param_count]
-                              : VALUE_TYPE_VOID,
-                          exec_env, argv, argv_ret);
+            void (*invoke_native)(void *func_ptr, void *exec_env, uint32 *argv,
+                                  uint32 *argv_ret) =
+                func_type->quick_aot_entry;
+            invoke_native(func_ptr, exec_env, argv, argv_ret);
             ret = !aot_copy_exception(module_inst, NULL);
         }
         else
@@ -1472,7 +1468,26 @@ invoke_native_with_hw_bound_check(WASMExecEnv *exec_env, void *func_ptr,
 }
 #define invoke_native_internal invoke_native_with_hw_bound_check
 #else /* else of OS_ENABLE_HW_BOUND_CHECK */
-#define invoke_native_internal wasm_runtime_invoke_native
+static inline bool
+invoke_native_internal(WASMExecEnv *exec_env, void *func_ptr,
+                       const WASMFuncType *func_type, const char *signature,
+                       void *attachment, uint32 *argv, uint32 argc,
+                       uint32 *argv_ret)
+{
+#if WASM_ENABLE_QUICK_AOT_ENTRY != 0
+    /* Quick call if the quick aot entry is registered */
+    if (!signature && func_type->quick_aot_entry) {
+        AOTModuleInstance *module_inst =
+            (AOTModuleInstance *)exec_env->module_inst;
+        void (*invoke_native)(void *func_ptr, void *exec_env, uint32 *argv,
+                              uint32 *argv_ret) = func_type->quick_aot_entry;
+        invoke_native(func_ptr, exec_env, argv, argv_ret);
+        return !aot_copy_exception(module_inst, NULL);
+    }
+#endif
+    return wasm_runtime_invoke_native(exec_env, func_ptr, func_type, signature,
+                                      attachment, argv, argc, argv_ret);
+}
 #endif /* end of OS_ENABLE_HW_BOUND_CHECK */
 
 bool

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -1470,7 +1470,7 @@ invoke_native_with_hw_bound_check(WASMExecEnv *exec_env, void *func_ptr,
 #else /* else of OS_ENABLE_HW_BOUND_CHECK */
 static inline bool
 invoke_native_internal(WASMExecEnv *exec_env, void *func_ptr,
-                       const WASMFuncType *func_type, const char *signature,
+                       const WASMType *func_type, const char *signature,
                        void *attachment, uint32 *argv, uint32 argc,
                        uint32 *argv_ret)
 {

--- a/core/iwasm/common/wasm_native.c
+++ b/core/iwasm/common/wasm_native.c
@@ -618,819 +618,760 @@ wasm_native_destroy()
 
 #if WASM_ENABLE_QUICK_AOT_ENTRY != 0
 static void
-invoke_no_args_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-                 uint32 *argv_ret)
+invoke_no_args_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
+    void (*native_code)(WASMExecEnv *) = func_ptr;
     native_code(exec_env);
 }
 static void
-invoke_no_args_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-                 uint32 *argv_ret)
+invoke_no_args_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint32 (*native_code)() = func_ptr;
+    int32 (*native_code)(WASMExecEnv *) = func_ptr;
     argv_ret[0] = native_code(exec_env);
 }
 static void
-invoke_no_args_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-                 uint32 *argv_ret)
+invoke_no_args_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret = native_code(exec_env);
+    int64 (*native_code)(WASMExecEnv *) = func_ptr;
+    int64 ret = native_code(exec_env);
     PUT_I64_TO_ADDR(argv_ret, ret);
 }
 
 static void
-invoke_i_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-           uint32 *argv_ret)
+invoke_i_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
+    void (*native_code)(WASMExecEnv *, int32) = func_ptr;
     native_code(exec_env, argv[0]);
 }
 static void
-invoke_i_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-           uint32 *argv_ret)
+invoke_i_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint32 (*native_code)() = func_ptr;
+    int32 (*native_code)(WASMExecEnv *, int32) = func_ptr;
     argv_ret[0] = native_code(exec_env, argv[0]);
 }
 static void
-invoke_i_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-           uint32 *argv_ret)
+invoke_i_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret = native_code(exec_env, argv[0]);
+    int64 (*native_code)(WASMExecEnv *, int32) = func_ptr;
+    int64 ret = native_code(exec_env, argv[0]);
     PUT_I64_TO_ADDR(argv_ret, ret);
 }
 
 static void
-invoke_I_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-           uint32 *argv_ret)
+invoke_I_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, GET_I64_FROM_ADDR(argv));
+    void (*native_code)(WASMExecEnv *, int64) = func_ptr;
+    native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv));
 }
 static void
-invoke_I_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-           uint32 *argv_ret)
+invoke_I_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint32 (*native_code)() = func_ptr;
-    argv_ret[0] = native_code(exec_env, GET_I64_FROM_ADDR(argv));
+    int32 (*native_code)(WASMExecEnv *, int64) = func_ptr;
+    argv_ret[0] = native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv));
 }
 static void
-invoke_I_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-           uint32 *argv_ret)
+invoke_I_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret = native_code(exec_env, GET_I64_FROM_ADDR(argv));
+    int64 (*native_code)(WASMExecEnv *, int64) = func_ptr;
+    int64 ret = native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv));
     PUT_I64_TO_ADDR(argv_ret, ret);
 }
 
 static void
-invoke_ii_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-            uint32 *argv_ret)
+invoke_ii_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
+    void (*native_code)(WASMExecEnv *, int32, int32) = func_ptr;
     native_code(exec_env, argv[0], argv[1]);
 }
 static void
-invoke_ii_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-            uint32 *argv_ret)
+invoke_ii_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint32 (*native_code)() = func_ptr;
+    int32 (*native_code)(WASMExecEnv *, int32, int32) = func_ptr;
     argv_ret[0] = native_code(exec_env, argv[0], argv[1]);
 }
 static void
-invoke_ii_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-            uint32 *argv_ret)
+invoke_ii_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret = native_code(exec_env, argv[0], argv[1]);
+    int64 (*native_code)(WASMExecEnv *, int32, int32) = func_ptr;
+    int64 ret = native_code(exec_env, argv[0], argv[1]);
     PUT_I64_TO_ADDR(argv_ret, ret);
 }
 
 static void
-invoke_iI_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-            uint32 *argv_ret)
+invoke_iI_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, argv[0], GET_I64_FROM_ADDR(argv + 1));
+    void (*native_code)(WASMExecEnv *, int32, int64) = func_ptr;
+    native_code(exec_env, argv[0], GET_I64_FROM_ADDR((uint32 *)argv + 1));
 }
 static void
-invoke_iI_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-            uint32 *argv_ret)
+invoke_iI_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint32 (*native_code)() = func_ptr;
-    argv_ret[0] = native_code(exec_env, argv[0], GET_I64_FROM_ADDR(argv + 1));
+    int32 (*native_code)(WASMExecEnv *, int32, int64) = func_ptr;
+    argv_ret[0] =
+        native_code(exec_env, argv[0], GET_I64_FROM_ADDR((uint32 *)argv + 1));
 }
 static void
-invoke_iI_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-            uint32 *argv_ret)
+invoke_iI_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret = native_code(exec_env, argv[0], GET_I64_FROM_ADDR(argv + 1));
+    int64 (*native_code)(WASMExecEnv *, int32, int64) = func_ptr;
+    int64 ret =
+        native_code(exec_env, argv[0], GET_I64_FROM_ADDR((uint32 *)argv + 1));
     PUT_I64_TO_ADDR(argv_ret, ret);
 }
 
 static void
-invoke_Ii_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-            uint32 *argv_ret)
+invoke_Ii_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, GET_I64_FROM_ADDR(argv), argv[2]);
+    void (*native_code)(WASMExecEnv *, int64, int32) = func_ptr;
+    native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv), argv[2]);
 }
 static void
-invoke_Ii_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-            uint32 *argv_ret)
+invoke_Ii_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint32 (*native_code)() = func_ptr;
-    argv_ret[0] = native_code(exec_env, GET_I64_FROM_ADDR(argv), argv[2]);
+    int32 (*native_code)(WASMExecEnv *, int64, int32) = func_ptr;
+    argv_ret[0] =
+        native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv), argv[2]);
 }
 static void
-invoke_Ii_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-            uint32 *argv_ret)
+invoke_Ii_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret = native_code(exec_env, GET_I64_FROM_ADDR(argv), argv[2]);
+    int64 (*native_code)(WASMExecEnv *, int64, int32) = func_ptr;
+    int64 ret =
+        native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv), argv[2]);
     PUT_I64_TO_ADDR(argv_ret, ret);
 }
 
 static void
-invoke_II_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-            uint32 *argv_ret)
+invoke_II_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, GET_I64_FROM_ADDR(argv), GET_I64_FROM_ADDR(argv + 2));
+    void (*native_code)(WASMExecEnv *, int64, int64) = func_ptr;
+    native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                GET_I64_FROM_ADDR((uint32 *)argv + 2));
 }
 static void
-invoke_II_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-            uint32 *argv_ret)
+invoke_II_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint32 (*native_code)() = func_ptr;
-    argv_ret[0] = native_code(exec_env, GET_I64_FROM_ADDR(argv),
-                              GET_I64_FROM_ADDR(argv + 2));
+    int32 (*native_code)(WASMExecEnv *, int64, int64) = func_ptr;
+    argv_ret[0] = native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                              GET_I64_FROM_ADDR((uint32 *)argv + 2));
 }
 static void
-invoke_II_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-            uint32 *argv_ret)
+invoke_II_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret = native_code(exec_env, GET_I64_FROM_ADDR(argv),
-                             GET_I64_FROM_ADDR(argv + 2));
+    int64 (*native_code)(WASMExecEnv *, int64, int64) = func_ptr;
+    int64 ret = native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                            GET_I64_FROM_ADDR((uint32 *)argv + 2));
     PUT_I64_TO_ADDR(argv_ret, ret);
 }
 
 static void
-invoke_iii_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-             uint32 *argv_ret)
+invoke_iii_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
+    void (*native_code)(WASMExecEnv *, int32, int32, int32) = func_ptr;
     native_code(exec_env, argv[0], argv[1], argv[2]);
 }
 static void
-invoke_iii_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-             uint32 *argv_ret)
+invoke_iii_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint32 (*native_code)() = func_ptr;
+    int32 (*native_code)(WASMExecEnv *, int32, int32, int32) = func_ptr;
     argv_ret[0] = native_code(exec_env, argv[0], argv[1], argv[2]);
 }
 static void
-invoke_iii_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-             uint32 *argv_ret)
+invoke_iii_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret = native_code(exec_env, argv[0], argv[1], argv[2]);
+    int64 (*native_code)(WASMExecEnv *, int32, int32, int32) = func_ptr;
+    int64 ret = native_code(exec_env, argv[0], argv[1], argv[2]);
     PUT_I64_TO_ADDR(argv_ret, ret);
 }
 
 static void
-invoke_iiI_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-             uint32 *argv_ret)
+invoke_iiI_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, argv[0], argv[1], GET_I64_FROM_ADDR(argv + 2));
+    void (*native_code)(WASMExecEnv *, int32, int32, int64) = func_ptr;
+    native_code(exec_env, argv[0], argv[1],
+                GET_I64_FROM_ADDR((uint32 *)argv + 2));
 }
 static void
-invoke_iiI_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-             uint32 *argv_ret)
+invoke_iiI_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint32 (*native_code)() = func_ptr;
+    int32 (*native_code)(WASMExecEnv *, int32, int32, int64) = func_ptr;
+    argv_ret[0] = native_code(exec_env, argv[0], argv[1],
+                              GET_I64_FROM_ADDR((uint32 *)argv + 2));
+}
+static void
+invoke_iiI_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
+{
+    int64 (*native_code)(WASMExecEnv *, int32, int32, int64) = func_ptr;
+    int64 ret = native_code(exec_env, argv[0], argv[1],
+                            GET_I64_FROM_ADDR((uint32 *)argv + 2));
+    PUT_I64_TO_ADDR(argv_ret, ret);
+}
+
+static void
+invoke_iIi_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
+{
+    void (*native_code)(WASMExecEnv *, int32, int64, int32) = func_ptr;
+    native_code(exec_env, argv[0], GET_I64_FROM_ADDR((uint32 *)argv + 1),
+                argv[3]);
+}
+static void
+invoke_iIi_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
+{
+    int32 (*native_code)(WASMExecEnv *, int32, int64, int32) = func_ptr;
+    argv_ret[0] = native_code(exec_env, argv[0],
+                              GET_I64_FROM_ADDR((uint32 *)argv + 1), argv[3]);
+}
+static void
+invoke_iIi_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
+{
+    int64 (*native_code)(WASMExecEnv *, int32, int64, int32) = func_ptr;
+    int64 ret = native_code(exec_env, argv[0],
+                            GET_I64_FROM_ADDR((uint32 *)argv + 1), argv[3]);
+    PUT_I64_TO_ADDR(argv_ret, ret);
+}
+
+static void
+invoke_iII_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
+{
+    void (*native_code)(WASMExecEnv *, int32, int64, int64) = func_ptr;
+    native_code(exec_env, argv[0], GET_I64_FROM_ADDR((uint32 *)argv + 1),
+                GET_I64_FROM_ADDR((uint32 *)argv + 3));
+}
+static void
+invoke_iII_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
+{
+    int32 (*native_code)(WASMExecEnv *, int32, int64, int64) = func_ptr;
     argv_ret[0] =
-        native_code(exec_env, argv[0], argv[1], GET_I64_FROM_ADDR(argv + 2));
+        native_code(exec_env, argv[0], GET_I64_FROM_ADDR((uint32 *)argv + 1),
+                    GET_I64_FROM_ADDR((uint32 *)argv + 3));
 }
 static void
-invoke_iiI_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-             uint32 *argv_ret)
+invoke_iII_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret =
-        native_code(exec_env, argv[0], argv[1], GET_I64_FROM_ADDR(argv + 2));
+    int64 (*native_code)(WASMExecEnv *, int32, int64, int64) = func_ptr;
+    int64 ret =
+        native_code(exec_env, argv[0], GET_I64_FROM_ADDR((uint32 *)argv + 1),
+                    GET_I64_FROM_ADDR((uint32 *)argv + 3));
     PUT_I64_TO_ADDR(argv_ret, ret);
 }
 
 static void
-invoke_iIi_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-             uint32 *argv_ret)
+invoke_Iii_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, argv[0], GET_I64_FROM_ADDR(argv + 1), argv[3]);
+    void (*native_code)(WASMExecEnv *, int64, int32, int32) = func_ptr;
+    native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv), argv[2], argv[3]);
 }
 static void
-invoke_iIi_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-             uint32 *argv_ret)
+invoke_Iii_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint32 (*native_code)() = func_ptr;
-    argv_ret[0] =
-        native_code(exec_env, argv[0], GET_I64_FROM_ADDR(argv + 1), argv[3]);
+    int32 (*native_code)(WASMExecEnv *, int64, int32, int32) = func_ptr;
+    argv_ret[0] = native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                              argv[2], argv[3]);
 }
 static void
-invoke_iIi_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-             uint32 *argv_ret)
+invoke_Iii_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret =
-        native_code(exec_env, argv[0], GET_I64_FROM_ADDR(argv + 1), argv[3]);
+    int64 (*native_code)(WASMExecEnv *, int64, int32, int32) = func_ptr;
+    int64 ret = native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                            argv[2], argv[3]);
     PUT_I64_TO_ADDR(argv_ret, ret);
 }
 
 static void
-invoke_iII_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-             uint32 *argv_ret)
+invoke_IiI_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, argv[0], GET_I64_FROM_ADDR(argv + 1),
-                GET_I64_FROM_ADDR(argv + 3));
+    void (*native_code)(WASMExecEnv *, int64, int32, int64) = func_ptr;
+    native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv), argv[2],
+                GET_I64_FROM_ADDR((uint32 *)argv + 3));
 }
 static void
-invoke_iII_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-             uint32 *argv_ret)
+invoke_IiI_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint32 (*native_code)() = func_ptr;
-    argv_ret[0] = native_code(exec_env, argv[0], GET_I64_FROM_ADDR(argv + 1),
-                              GET_I64_FROM_ADDR(argv + 3));
+    int32 (*native_code)(WASMExecEnv *, int64, int32, int64) = func_ptr;
+    argv_ret[0] = native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                              argv[2], GET_I64_FROM_ADDR((uint32 *)argv + 3));
 }
 static void
-invoke_iII_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-             uint32 *argv_ret)
+invoke_IiI_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret = native_code(exec_env, argv[0], GET_I64_FROM_ADDR(argv + 1),
-                             GET_I64_FROM_ADDR(argv + 3));
+    int64 (*native_code)(WASMExecEnv *, int64, int32, int64) = func_ptr;
+    int64 ret = native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                            argv[2], GET_I64_FROM_ADDR((uint32 *)argv + 3));
     PUT_I64_TO_ADDR(argv_ret, ret);
 }
 
 static void
-invoke_Iii_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-             uint32 *argv_ret)
+invoke_IIi_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, GET_I64_FROM_ADDR(argv), argv[2], argv[3]);
+    void (*native_code)(WASMExecEnv *, int64, int64, int32) = func_ptr;
+    native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                GET_I64_FROM_ADDR((uint32 *)argv + 2), argv[4]);
 }
 static void
-invoke_Iii_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-             uint32 *argv_ret)
+invoke_IIi_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint32 (*native_code)() = func_ptr;
-    argv_ret[0] =
-        native_code(exec_env, GET_I64_FROM_ADDR(argv), argv[2], argv[3]);
+    int32 (*native_code)(WASMExecEnv *, int64, int64, int32) = func_ptr;
+    argv_ret[0] = native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                              GET_I64_FROM_ADDR((uint32 *)argv + 2), argv[4]);
 }
 static void
-invoke_Iii_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-             uint32 *argv_ret)
+invoke_IIi_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret =
-        native_code(exec_env, GET_I64_FROM_ADDR(argv), argv[2], argv[3]);
+    int64 (*native_code)(WASMExecEnv *, int64, int64, int32) = func_ptr;
+    int64 ret = native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                            GET_I64_FROM_ADDR((uint32 *)argv + 2), argv[4]);
     PUT_I64_TO_ADDR(argv_ret, ret);
 }
 
 static void
-invoke_IiI_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-             uint32 *argv_ret)
+invoke_III_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, GET_I64_FROM_ADDR(argv), argv[2],
-                GET_I64_FROM_ADDR(argv + 3));
+    void (*native_code)(WASMExecEnv *, int64, int64, int64) = func_ptr;
+    native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                GET_I64_FROM_ADDR((uint32 *)argv + 2),
+                GET_I64_FROM_ADDR((uint32 *)argv + 4));
 }
 static void
-invoke_IiI_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-             uint32 *argv_ret)
+invoke_III_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint32 (*native_code)() = func_ptr;
-    argv_ret[0] = native_code(exec_env, GET_I64_FROM_ADDR(argv), argv[2],
-                              GET_I64_FROM_ADDR(argv + 3));
+    int32 (*native_code)(WASMExecEnv *, int64, int64, int64) = func_ptr;
+    argv_ret[0] = native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                              GET_I64_FROM_ADDR((uint32 *)argv + 2),
+                              GET_I64_FROM_ADDR((uint32 *)argv + 4));
 }
 static void
-invoke_IiI_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-             uint32 *argv_ret)
+invoke_III_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret = native_code(exec_env, GET_I64_FROM_ADDR(argv), argv[2],
-                             GET_I64_FROM_ADDR(argv + 3));
+    int64 (*native_code)(WASMExecEnv *, int64, int64, int64) = func_ptr;
+    int64 ret = native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                            GET_I64_FROM_ADDR((uint32 *)argv + 2),
+                            GET_I64_FROM_ADDR((uint32 *)argv + 4));
     PUT_I64_TO_ADDR(argv_ret, ret);
 }
 
 static void
-invoke_IIi_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-             uint32 *argv_ret)
+invoke_iiii_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, GET_I64_FROM_ADDR(argv), GET_I64_FROM_ADDR(argv + 2),
-                argv[4]);
-}
-static void
-invoke_IIi_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-             uint32 *argv_ret)
-{
-    uint32 (*native_code)() = func_ptr;
-    argv_ret[0] = native_code(exec_env, GET_I64_FROM_ADDR(argv),
-                              GET_I64_FROM_ADDR(argv + 2), argv[4]);
-}
-static void
-invoke_IIi_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-             uint32 *argv_ret)
-{
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret = native_code(exec_env, GET_I64_FROM_ADDR(argv),
-                             GET_I64_FROM_ADDR(argv + 2), argv[4]);
-    PUT_I64_TO_ADDR(argv_ret, ret);
-}
-
-static void
-invoke_III_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-             uint32 *argv_ret)
-{
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, GET_I64_FROM_ADDR(argv), GET_I64_FROM_ADDR(argv + 2),
-                GET_I64_FROM_ADDR(argv + 4));
-}
-static void
-invoke_III_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-             uint32 *argv_ret)
-{
-    uint32 (*native_code)() = func_ptr;
-    argv_ret[0] =
-        native_code(exec_env, GET_I64_FROM_ADDR(argv),
-                    GET_I64_FROM_ADDR(argv + 2), GET_I64_FROM_ADDR(argv + 4));
-}
-static void
-invoke_III_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-             uint32 *argv_ret)
-{
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret =
-        native_code(exec_env, GET_I64_FROM_ADDR(argv),
-                    GET_I64_FROM_ADDR(argv + 2), GET_I64_FROM_ADDR(argv + 4));
-    PUT_I64_TO_ADDR(argv_ret, ret);
-}
-
-static void
-invoke_iiii_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
-{
-    void (*native_code)() = func_ptr;
+    void (*native_code)(WASMExecEnv *, int32, int32, int32, int32) = func_ptr;
     native_code(exec_env, argv[0], argv[1], argv[2], argv[3]);
 }
 static void
-invoke_iiii_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_iiii_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint32 (*native_code)() = func_ptr;
+    int32 (*native_code)(WASMExecEnv *, int32, int32, int32, int32) = func_ptr;
     argv_ret[0] = native_code(exec_env, argv[0], argv[1], argv[2], argv[3]);
 }
 static void
-invoke_iiii_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_iiii_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret = native_code(exec_env, argv[0], argv[1], argv[2], argv[3]);
+    int64 (*native_code)(WASMExecEnv *, int32, int32, int32, int32) = func_ptr;
+    int64 ret = native_code(exec_env, argv[0], argv[1], argv[2], argv[3]);
     PUT_I64_TO_ADDR(argv_ret, ret);
 }
 
 static void
-invoke_iiiI_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_iiiI_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
+    void (*native_code)(WASMExecEnv *, int32, int32, int32, int64) = func_ptr;
     native_code(exec_env, argv[0], argv[1], argv[2],
-                GET_I64_FROM_ADDR(argv + 3));
+                GET_I64_FROM_ADDR((uint32 *)argv + 3));
 }
 static void
-invoke_iiiI_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_iiiI_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint32 (*native_code)() = func_ptr;
+    int32 (*native_code)(WASMExecEnv *, int32, int32, int32, int64) = func_ptr;
     argv_ret[0] = native_code(exec_env, argv[0], argv[1], argv[2],
-                              GET_I64_FROM_ADDR(argv + 3));
+                              GET_I64_FROM_ADDR((uint32 *)argv + 3));
 }
 static void
-invoke_iiiI_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_iiiI_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret = native_code(exec_env, argv[0], argv[1], argv[2],
-                             GET_I64_FROM_ADDR(argv + 3));
+    int64 (*native_code)(WASMExecEnv *, int32, int32, int32, int64) = func_ptr;
+    int64 ret = native_code(exec_env, argv[0], argv[1], argv[2],
+                            GET_I64_FROM_ADDR((uint32 *)argv + 3));
     PUT_I64_TO_ADDR(argv_ret, ret);
 }
 
 static void
-invoke_iiIi_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_iiIi_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, argv[0], argv[1], GET_I64_FROM_ADDR(argv + 2),
-                argv[4]);
+    void (*native_code)(WASMExecEnv *, int32, int32, int64, int32) = func_ptr;
+    native_code(exec_env, argv[0], argv[1],
+                GET_I64_FROM_ADDR((uint32 *)argv + 2), argv[4]);
 }
 static void
-invoke_iiIi_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_iiIi_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint32 (*native_code)() = func_ptr;
+    int32 (*native_code)(WASMExecEnv *, int32, int32, int64, int32) = func_ptr;
     argv_ret[0] = native_code(exec_env, argv[0], argv[1],
-                              GET_I64_FROM_ADDR(argv + 2), argv[4]);
+                              GET_I64_FROM_ADDR((uint32 *)argv + 2), argv[4]);
 }
 static void
-invoke_iiIi_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_iiIi_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret = native_code(exec_env, argv[0], argv[1],
-                             GET_I64_FROM_ADDR(argv + 2), argv[4]);
+    int64 (*native_code)(WASMExecEnv *, int32, int32, int64, int32) = func_ptr;
+    int64 ret = native_code(exec_env, argv[0], argv[1],
+                            GET_I64_FROM_ADDR((uint32 *)argv + 2), argv[4]);
     PUT_I64_TO_ADDR(argv_ret, ret);
 }
 
 static void
-invoke_iiII_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_iiII_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, argv[0], argv[1], GET_I64_FROM_ADDR(argv + 2),
-                GET_I64_FROM_ADDR(argv + 4));
+    void (*native_code)(WASMExecEnv *, int32, int32, int64, int64) = func_ptr;
+    native_code(exec_env, argv[0], argv[1],
+                GET_I64_FROM_ADDR((uint32 *)argv + 2),
+                GET_I64_FROM_ADDR((uint32 *)argv + 4));
 }
 static void
-invoke_iiII_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_iiII_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint32 (*native_code)() = func_ptr;
+    int32 (*native_code)(WASMExecEnv *, int32, int32, int64, int64) = func_ptr;
+    argv_ret[0] = native_code(exec_env, argv[0], argv[1],
+                              GET_I64_FROM_ADDR((uint32 *)argv + 2),
+                              GET_I64_FROM_ADDR((uint32 *)argv + 4));
+}
+static void
+invoke_iiII_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
+{
+    int64 (*native_code)(WASMExecEnv *, int32, int32, int64, int64) = func_ptr;
+    int64 ret = native_code(exec_env, argv[0], argv[1],
+                            GET_I64_FROM_ADDR((uint32 *)argv + 2),
+                            GET_I64_FROM_ADDR((uint32 *)argv + 4));
+    PUT_I64_TO_ADDR(argv_ret, ret);
+}
+
+static void
+invoke_iIii_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
+{
+    void (*native_code)(WASMExecEnv *, int32, int64, int32, int32) = func_ptr;
+    native_code(exec_env, argv[0], GET_I64_FROM_ADDR((uint32 *)argv + 1),
+                argv[3], argv[4]);
+}
+static void
+invoke_iIii_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
+{
+    int32 (*native_code)(WASMExecEnv *, int32, int64, int32, int32) = func_ptr;
     argv_ret[0] =
-        native_code(exec_env, argv[0], argv[1], GET_I64_FROM_ADDR(argv + 2),
-                    GET_I64_FROM_ADDR(argv + 4));
+        native_code(exec_env, argv[0], GET_I64_FROM_ADDR((uint32 *)argv + 1),
+                    argv[3], argv[4]);
 }
 static void
-invoke_iiII_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_iIii_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret =
-        native_code(exec_env, argv[0], argv[1], GET_I64_FROM_ADDR(argv + 2),
-                    GET_I64_FROM_ADDR(argv + 4));
+    int64 (*native_code)(WASMExecEnv *, int32, int64, int32, int32) = func_ptr;
+    int64 ret =
+        native_code(exec_env, argv[0], GET_I64_FROM_ADDR((uint32 *)argv + 1),
+                    argv[3], argv[4]);
     PUT_I64_TO_ADDR(argv_ret, ret);
 }
 
 static void
-invoke_iIii_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_iIiI_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, argv[0], GET_I64_FROM_ADDR(argv + 1), argv[3],
+    void (*native_code)(WASMExecEnv *, int32, int64, int32, int64) = func_ptr;
+    native_code(exec_env, argv[0], GET_I64_FROM_ADDR((uint32 *)argv + 1),
+                argv[3], GET_I64_FROM_ADDR((uint32 *)argv + 4));
+}
+static void
+invoke_iIiI_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
+{
+    int32 (*native_code)(WASMExecEnv *, int32, int64, int32, int64) = func_ptr;
+    argv_ret[0] =
+        native_code(exec_env, argv[0], GET_I64_FROM_ADDR((uint32 *)argv + 1),
+                    argv[3], GET_I64_FROM_ADDR((uint32 *)argv + 4));
+}
+static void
+invoke_iIiI_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
+{
+    int64 (*native_code)(WASMExecEnv *, int32, int64, int32, int64) = func_ptr;
+    int64 ret =
+        native_code(exec_env, argv[0], GET_I64_FROM_ADDR((uint32 *)argv + 1),
+                    argv[3], GET_I64_FROM_ADDR((uint32 *)argv + 4));
+    PUT_I64_TO_ADDR(argv_ret, ret);
+}
+
+static void
+invoke_iIIi_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
+{
+    void (*native_code)(WASMExecEnv *, int32, int64, int64, int32) = func_ptr;
+    native_code(exec_env, argv[0], GET_I64_FROM_ADDR((uint32 *)argv + 1),
+                GET_I64_FROM_ADDR((uint32 *)argv + 3), argv[5]);
+}
+static void
+invoke_iIIi_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
+{
+    int32 (*native_code)(WASMExecEnv *, int32, int64, int64, int32) = func_ptr;
+    argv_ret[0] =
+        native_code(exec_env, argv[0], GET_I64_FROM_ADDR((uint32 *)argv + 1),
+                    GET_I64_FROM_ADDR((uint32 *)argv + 3), argv[5]);
+}
+static void
+invoke_iIIi_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
+{
+    int64 (*native_code)(WASMExecEnv *, int32, int64, int64, int32) = func_ptr;
+    int64 ret =
+        native_code(exec_env, argv[0], GET_I64_FROM_ADDR((uint32 *)argv + 1),
+                    GET_I64_FROM_ADDR((uint32 *)argv + 3), argv[5]);
+    PUT_I64_TO_ADDR(argv_ret, ret);
+}
+
+static void
+invoke_iIII_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
+{
+    void (*native_code)(WASMExecEnv *, int32, int64, int64, int64) = func_ptr;
+    native_code(exec_env, argv[0], GET_I64_FROM_ADDR((uint32 *)argv + 1),
+                GET_I64_FROM_ADDR((uint32 *)argv + 3),
+                GET_I64_FROM_ADDR((uint32 *)argv + 5));
+}
+static void
+invoke_iIII_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
+{
+    int32 (*native_code)(WASMExecEnv *, int32, int64, int64, int64) = func_ptr;
+    argv_ret[0] =
+        native_code(exec_env, argv[0], GET_I64_FROM_ADDR((uint32 *)argv + 1),
+                    GET_I64_FROM_ADDR((uint32 *)argv + 3),
+                    GET_I64_FROM_ADDR((uint32 *)argv + 5));
+}
+static void
+invoke_iIII_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
+{
+    int64 (*native_code)(WASMExecEnv *, int32, int64, int64, int64) = func_ptr;
+    int64 ret =
+        native_code(exec_env, argv[0], GET_I64_FROM_ADDR((uint32 *)argv + 1),
+                    GET_I64_FROM_ADDR((uint32 *)argv + 3),
+                    GET_I64_FROM_ADDR((uint32 *)argv + 5));
+    PUT_I64_TO_ADDR(argv_ret, ret);
+}
+
+static void
+invoke_Iiii_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
+{
+    void (*native_code)(WASMExecEnv *, int64, int32, int32, int32) = func_ptr;
+    native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv), argv[2], argv[3],
                 argv[4]);
 }
 static void
-invoke_iIii_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_Iiii_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint32 (*native_code)() = func_ptr;
-    argv_ret[0] = native_code(exec_env, argv[0], GET_I64_FROM_ADDR(argv + 1),
-                              argv[3], argv[4]);
+    int32 (*native_code)(WASMExecEnv *, int64, int32, int32, int32) = func_ptr;
+    argv_ret[0] = native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                              argv[2], argv[3], argv[4]);
 }
 static void
-invoke_iIii_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_Iiii_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret = native_code(exec_env, argv[0], GET_I64_FROM_ADDR(argv + 1),
-                             argv[3], argv[4]);
+    int64 (*native_code)(WASMExecEnv *, int64, int32, int32, int32) = func_ptr;
+    int64 ret = native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                            argv[2], argv[3], argv[4]);
     PUT_I64_TO_ADDR(argv_ret, ret);
 }
 
 static void
-invoke_iIiI_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_IiiI_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, argv[0], GET_I64_FROM_ADDR(argv + 1), argv[3],
-                GET_I64_FROM_ADDR(argv + 4));
-}
-static void
-invoke_iIiI_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
-{
-    uint32 (*native_code)() = func_ptr;
-    argv_ret[0] = native_code(exec_env, argv[0], GET_I64_FROM_ADDR(argv + 1),
-                              argv[3], GET_I64_FROM_ADDR(argv + 4));
-}
-static void
-invoke_iIiI_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
-{
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret = native_code(exec_env, argv[0], GET_I64_FROM_ADDR(argv + 1),
-                             argv[3], GET_I64_FROM_ADDR(argv + 4));
-    PUT_I64_TO_ADDR(argv_ret, ret);
+    void (*native_code)(WASMExecEnv *, int64, int32, int32, int64) = func_ptr;
+    native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv), argv[2], argv[3],
+                GET_I64_FROM_ADDR((uint32 *)argv + 4));
 }
 
 static void
-invoke_iIIi_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_IiiI_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, argv[0], GET_I64_FROM_ADDR(argv + 1),
-                GET_I64_FROM_ADDR(argv + 3), argv[5]);
-}
-static void
-invoke_iIIi_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
-{
-    uint32 (*native_code)() = func_ptr;
-    argv_ret[0] = native_code(exec_env, argv[0], GET_I64_FROM_ADDR(argv + 1),
-                              GET_I64_FROM_ADDR(argv + 3), argv[5]);
-}
-static void
-invoke_iIIi_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
-{
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret = native_code(exec_env, argv[0], GET_I64_FROM_ADDR(argv + 1),
-                             GET_I64_FROM_ADDR(argv + 3), argv[5]);
-    PUT_I64_TO_ADDR(argv_ret, ret);
-}
-
-static void
-invoke_iIII_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
-{
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, argv[0], GET_I64_FROM_ADDR(argv + 1),
-                GET_I64_FROM_ADDR(argv + 3), GET_I64_FROM_ADDR(argv + 5));
-}
-static void
-invoke_iIII_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
-{
-    uint32 (*native_code)() = func_ptr;
+    int32 (*native_code)(WASMExecEnv *, int64, int32, int32, int64) = func_ptr;
     argv_ret[0] =
-        native_code(exec_env, argv[0], GET_I64_FROM_ADDR(argv + 1),
-                    GET_I64_FROM_ADDR(argv + 3), GET_I64_FROM_ADDR(argv + 5));
+        native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv), argv[2],
+                    argv[3], GET_I64_FROM_ADDR((uint32 *)argv + 4));
 }
+
 static void
-invoke_iIII_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_IiiI_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret =
-        native_code(exec_env, argv[0], GET_I64_FROM_ADDR(argv + 1),
-                    GET_I64_FROM_ADDR(argv + 3), GET_I64_FROM_ADDR(argv + 5));
+    int64 (*native_code)(WASMExecEnv *, int64, int32, int32, int64) = func_ptr;
+    int64 ret =
+        native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv), argv[2],
+                    argv[3], GET_I64_FROM_ADDR((uint32 *)argv + 4));
     PUT_I64_TO_ADDR(argv_ret, ret);
 }
 
 static void
-invoke_Iiii_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_IiIi_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, GET_I64_FROM_ADDR(argv), argv[2], argv[3], argv[4]);
+    void (*native_code)(WASMExecEnv *, int64, int32, int64, int32) = func_ptr;
+    native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv), argv[2],
+                GET_I64_FROM_ADDR((uint32 *)argv + 3), argv[5]);
 }
 static void
-invoke_Iiii_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_IiIi_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint32 (*native_code)() = func_ptr;
-    argv_ret[0] = native_code(exec_env, GET_I64_FROM_ADDR(argv), argv[2],
-                              argv[3], argv[4]);
-}
-static void
-invoke_Iiii_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
-{
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret = native_code(exec_env, GET_I64_FROM_ADDR(argv), argv[2],
-                             argv[3], argv[4]);
-    PUT_I64_TO_ADDR(argv_ret, ret);
-}
-
-static void
-invoke_IiiI_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
-{
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, GET_I64_FROM_ADDR(argv), argv[2], argv[3],
-                GET_I64_FROM_ADDR(argv + 4));
-}
-
-static void
-invoke_IiiI_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
-{
-    uint32 (*native_code)() = func_ptr;
-    argv_ret[0] = native_code(exec_env, GET_I64_FROM_ADDR(argv), argv[2],
-                              argv[3], GET_I64_FROM_ADDR(argv + 4));
-}
-
-static void
-invoke_IiiI_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
-{
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret = native_code(exec_env, GET_I64_FROM_ADDR(argv), argv[2],
-                             argv[3], GET_I64_FROM_ADDR(argv + 4));
-    PUT_I64_TO_ADDR(argv_ret, ret);
-}
-
-static void
-invoke_IiIi_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
-{
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, GET_I64_FROM_ADDR(argv), argv[2],
-                GET_I64_FROM_ADDR(argv + 3), argv[5]);
-}
-static void
-invoke_IiIi_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
-{
-    uint32 (*native_code)() = func_ptr;
-    argv_ret[0] = native_code(exec_env, GET_I64_FROM_ADDR(argv), argv[2],
-                              GET_I64_FROM_ADDR(argv + 3), argv[5]);
-}
-static void
-invoke_IiIi_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
-{
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret = native_code(exec_env, GET_I64_FROM_ADDR(argv), argv[2],
-                             GET_I64_FROM_ADDR(argv + 3), argv[5]);
-    PUT_I64_TO_ADDR(argv_ret, ret);
-}
-
-static void
-invoke_IiII_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
-{
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, GET_I64_FROM_ADDR(argv), argv[2],
-                GET_I64_FROM_ADDR(argv + 3), GET_I64_FROM_ADDR(argv + 5));
-}
-static void
-invoke_IiII_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
-{
-    uint32 (*native_code)() = func_ptr;
+    int32 (*native_code)(WASMExecEnv *, int64, int32, int64, int32) = func_ptr;
     argv_ret[0] =
-        native_code(exec_env, GET_I64_FROM_ADDR(argv), argv[2],
-                    GET_I64_FROM_ADDR(argv + 3), GET_I64_FROM_ADDR(argv + 5));
+        native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv), argv[2],
+                    GET_I64_FROM_ADDR((uint32 *)argv + 3), argv[5]);
 }
 static void
-invoke_IiII_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_IiIi_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret =
-        native_code(exec_env, GET_I64_FROM_ADDR(argv), argv[2],
-                    GET_I64_FROM_ADDR(argv + 3), GET_I64_FROM_ADDR(argv + 5));
+    int64 (*native_code)(WASMExecEnv *, int64, int32, int64, int32) = func_ptr;
+    int64 ret =
+        native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv), argv[2],
+                    GET_I64_FROM_ADDR((uint32 *)argv + 3), argv[5]);
     PUT_I64_TO_ADDR(argv_ret, ret);
 }
 
 static void
-invoke_IIii_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_IiII_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, GET_I64_FROM_ADDR(argv), GET_I64_FROM_ADDR(argv + 2),
-                argv[4], argv[5]);
+    void (*native_code)(WASMExecEnv *, int64, int32, int64, int64) = func_ptr;
+    native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv), argv[2],
+                GET_I64_FROM_ADDR((uint32 *)argv + 3),
+                GET_I64_FROM_ADDR((uint32 *)argv + 5));
 }
 static void
-invoke_IIii_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_IiII_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint32 (*native_code)() = func_ptr;
-    argv_ret[0] = native_code(exec_env, GET_I64_FROM_ADDR(argv),
-                              GET_I64_FROM_ADDR(argv + 2), argv[4], argv[5]);
+    int32 (*native_code)(WASMExecEnv *, int64, int32, int64, int64) = func_ptr;
+    argv_ret[0] = native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                              argv[2], GET_I64_FROM_ADDR((uint32 *)argv + 3),
+                              GET_I64_FROM_ADDR((uint32 *)argv + 5));
 }
 static void
-invoke_IIii_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_IiII_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret = native_code(exec_env, GET_I64_FROM_ADDR(argv),
-                             GET_I64_FROM_ADDR(argv + 2), argv[4], argv[5]);
+    int64 (*native_code)(WASMExecEnv *, int64, int32, int64, int64) = func_ptr;
+    int64 ret = native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                            argv[2], GET_I64_FROM_ADDR((uint32 *)argv + 3),
+                            GET_I64_FROM_ADDR((uint32 *)argv + 5));
     PUT_I64_TO_ADDR(argv_ret, ret);
 }
 
 static void
-invoke_IIiI_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_IIii_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, GET_I64_FROM_ADDR(argv), GET_I64_FROM_ADDR(argv + 2),
-                argv[4], GET_I64_FROM_ADDR(argv + 5));
+    void (*native_code)(WASMExecEnv *, int64, int64, int32, int32) = func_ptr;
+    native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                GET_I64_FROM_ADDR((uint32 *)argv + 2), argv[4], argv[5]);
 }
 static void
-invoke_IIiI_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_IIii_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint32 (*native_code)() = func_ptr;
-    argv_ret[0] = native_code(exec_env, GET_I64_FROM_ADDR(argv),
-                              GET_I64_FROM_ADDR(argv + 2), argv[4],
-                              GET_I64_FROM_ADDR(argv + 5));
+    int32 (*native_code)(WASMExecEnv *, int64, int64, int32, int32) = func_ptr;
+    argv_ret[0] =
+        native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                    GET_I64_FROM_ADDR((uint32 *)argv + 2), argv[4], argv[5]);
 }
 static void
-invoke_IIiI_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_IIii_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret = native_code(exec_env, GET_I64_FROM_ADDR(argv),
-                             GET_I64_FROM_ADDR(argv + 2), argv[4],
-                             GET_I64_FROM_ADDR(argv + 5));
+    int64 (*native_code)(WASMExecEnv *, int64, int64, int32, int32) = func_ptr;
+    int64 ret =
+        native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                    GET_I64_FROM_ADDR((uint32 *)argv + 2), argv[4], argv[5]);
     PUT_I64_TO_ADDR(argv_ret, ret);
 }
 
 static void
-invoke_IIIi_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_IIiI_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, GET_I64_FROM_ADDR(argv), GET_I64_FROM_ADDR(argv + 2),
-                GET_I64_FROM_ADDR(argv + 4), argv[6]);
+    void (*native_code)(WASMExecEnv *, int64, int64, int32, int64) = func_ptr;
+    native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                GET_I64_FROM_ADDR((uint32 *)argv + 2), argv[4],
+                GET_I64_FROM_ADDR((uint32 *)argv + 5));
 }
 static void
-invoke_IIIi_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_IIiI_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint32 (*native_code)() = func_ptr;
-    argv_ret[0] = native_code(exec_env, GET_I64_FROM_ADDR(argv),
-                              GET_I64_FROM_ADDR(argv + 2),
-                              GET_I64_FROM_ADDR(argv + 4), argv[6]);
+    int32 (*native_code)(WASMExecEnv *, int64, int64, int32, int64) = func_ptr;
+    argv_ret[0] = native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                              GET_I64_FROM_ADDR((uint32 *)argv + 2), argv[4],
+                              GET_I64_FROM_ADDR((uint32 *)argv + 5));
 }
 static void
-invoke_IIIi_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_IIiI_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret = native_code(exec_env, GET_I64_FROM_ADDR(argv),
-                             GET_I64_FROM_ADDR(argv + 2),
-                             GET_I64_FROM_ADDR(argv + 4), argv[6]);
+    int64 (*native_code)(WASMExecEnv *, int64, int64, int32, int64) = func_ptr;
+    int64 ret = native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                            GET_I64_FROM_ADDR((uint32 *)argv + 2), argv[4],
+                            GET_I64_FROM_ADDR((uint32 *)argv + 5));
     PUT_I64_TO_ADDR(argv_ret, ret);
 }
 
 static void
-invoke_IIII_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_IIIi_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
-    native_code(exec_env, GET_I64_FROM_ADDR(argv), GET_I64_FROM_ADDR(argv + 2),
-                GET_I64_FROM_ADDR(argv + 4), GET_I64_FROM_ADDR(argv + 6));
+    void (*native_code)(WASMExecEnv *, int64, int64, int64, int32) = func_ptr;
+    native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                GET_I64_FROM_ADDR((uint32 *)argv + 2),
+                GET_I64_FROM_ADDR((uint32 *)argv + 4), argv[6]);
 }
 static void
-invoke_IIII_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_IIIi_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint32 (*native_code)() = func_ptr;
-    argv_ret[0] = native_code(
-        exec_env, GET_I64_FROM_ADDR(argv), GET_I64_FROM_ADDR(argv + 2),
-        GET_I64_FROM_ADDR(argv + 4), GET_I64_FROM_ADDR(argv + 6));
+    int32 (*native_code)(WASMExecEnv *, int64, int64, int64, int32) = func_ptr;
+    argv_ret[0] = native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                              GET_I64_FROM_ADDR((uint32 *)argv + 2),
+                              GET_I64_FROM_ADDR((uint32 *)argv + 4), argv[6]);
 }
 static void
-invoke_IIII_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-              uint32 *argv_ret)
+invoke_IIIi_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret = native_code(
-        exec_env, GET_I64_FROM_ADDR(argv), GET_I64_FROM_ADDR(argv + 2),
-        GET_I64_FROM_ADDR(argv + 4), GET_I64_FROM_ADDR(argv + 6));
+    int64 (*native_code)(WASMExecEnv *, int64, int64, int64, int32) = func_ptr;
+    int64 ret = native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                            GET_I64_FROM_ADDR((uint32 *)argv + 2),
+                            GET_I64_FROM_ADDR((uint32 *)argv + 4), argv[6]);
     PUT_I64_TO_ADDR(argv_ret, ret);
 }
 
 static void
-invoke_iiiii_v(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-               uint32 *argv_ret)
+invoke_IIII_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    void (*native_code)() = func_ptr;
+    void (*native_code)(WASMExecEnv *, int64, int64, int64, int64) = func_ptr;
+    native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                GET_I64_FROM_ADDR((uint32 *)argv + 2),
+                GET_I64_FROM_ADDR((uint32 *)argv + 4),
+                GET_I64_FROM_ADDR((uint32 *)argv + 6));
+}
+static void
+invoke_IIII_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
+{
+    int32 (*native_code)(WASMExecEnv *, int64, int64, int64, int64) = func_ptr;
+    argv_ret[0] = native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                              GET_I64_FROM_ADDR((uint32 *)argv + 2),
+                              GET_I64_FROM_ADDR((uint32 *)argv + 4),
+                              GET_I64_FROM_ADDR((uint32 *)argv + 6));
+}
+static void
+invoke_IIII_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
+{
+    int64 (*native_code)(WASMExecEnv *, int64, int64, int64, int64) = func_ptr;
+    int64 ret = native_code(exec_env, GET_I64_FROM_ADDR((uint32 *)argv),
+                            GET_I64_FROM_ADDR((uint32 *)argv + 2),
+                            GET_I64_FROM_ADDR((uint32 *)argv + 4),
+                            GET_I64_FROM_ADDR((uint32 *)argv + 6));
+    PUT_I64_TO_ADDR(argv_ret, ret);
+}
+
+static void
+invoke_iiiii_v(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
+{
+    void (*native_code)(WASMExecEnv *, int32, int32, int32, int32, int32) =
+        func_ptr;
     native_code(exec_env, argv[0], argv[1], argv[2], argv[3], argv[4]);
 }
 static void
-invoke_iiiii_i(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-               uint32 *argv_ret)
+invoke_iiiii_i(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint32 (*native_code)() = func_ptr;
+    int32 (*native_code)(WASMExecEnv *, int32, int32, int32, int32, int32) =
+        func_ptr;
     argv_ret[0] =
         native_code(exec_env, argv[0], argv[1], argv[2], argv[3], argv[4]);
 }
 static void
-invoke_iiiii_I(void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-               uint32 *argv_ret)
+invoke_iiiii_I(void *func_ptr, void *exec_env, int32 *argv, int32 *argv_ret)
 {
-    uint64 (*native_code)() = func_ptr;
-    uint64 ret =
+    int64 (*native_code)(WASMExecEnv *, int32, int32, int32, int32, int32) =
+        func_ptr;
+    int64 ret =
         native_code(exec_env, argv[0], argv[1], argv[2], argv[3], argv[4]);
     PUT_I64_TO_ADDR(argv_ret, ret);
 }

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -4207,14 +4207,11 @@ llvm_jit_call_func_bytecode(WASMModuleInstance *module_inst,
 #if WASM_ENABLE_QUICK_AOT_ENTRY != 0
         /* Quick call if the quick jit entry is registered */
         if (func_type->quick_aot_entry) {
-            void (*invoke_native)(
-                void *func_ptr, uint8 ret_type, void *exec_env, uint32 *argv,
-                uint32 *argv_ret) = func_type->quick_aot_entry;
-            invoke_native(module_inst->func_ptrs[func_idx],
-                          func_type->result_count > 0
-                              ? func_type->types[func_type->param_count]
-                              : VALUE_TYPE_VOID,
-                          exec_env, argv, argv);
+            void (*invoke_native)(void *func_ptr, void *exec_env, uint32 *argv,
+                                  uint32 *argv_ret) =
+                func_type->quick_aot_entry;
+            invoke_native(module_inst->func_ptrs[func_idx], exec_env, argv,
+                          argv);
             ret = !wasm_copy_exception(module_inst, NULL);
         }
         else


### PR DESCRIPTION
And remove unnecessary ret_type for the quick aot entries.
And declare detailed prototype of aot function to call in each quick aot entry
to make it clearer.