### PR TITLE
classic-interp: Handle SIMD opcode when JIT is enabled

### DIFF
--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -3844,6 +3844,12 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
         HANDLE_OP(WASM_OP_REF_IS_NULL)
         HANDLE_OP(WASM_OP_REF_FUNC)
 #endif
+#if WASM_ENABLE_JIT != 0 && WASM_ENABLE_SIMD != 0
+        /* SIMD isn't supported by interpreter, but when JIT is
+           enabled, `iwasm --interp <wasm_file>` may be run to
+           trigger the SIMD opcode in interpreter */
+        HANDLE_OP(WASM_OP_SIMD_PREFIX)
+#endif
         HANDLE_OP(WASM_OP_UNUSED_0x14)
         HANDLE_OP(WASM_OP_UNUSED_0x15)
         HANDLE_OP(WASM_OP_UNUSED_0x16)

--- a/core/iwasm/interpreter/wasm_opcode.h
+++ b/core/iwasm/interpreter/wasm_opcode.h
@@ -684,9 +684,10 @@ typedef enum WASMAtomicEXTOpcode {
 #define SET_GOTO_TABLE_ELEM(opcode) [opcode] = HANDLE_OPCODE(opcode)
 
 #if WASM_ENABLE_JIT != 0 && WASM_ENABLE_SIMD != 0
-#define SET_GOTO_TABLE_SIMD_PREFIX_ELEM SET_GOTO_TABLE_ELEM(WASM_OP_SIMD_PREFIX),
+#define SET_GOTO_TABLE_SIMD_PREFIX_ELEM() \
+    SET_GOTO_TABLE_ELEM(WASM_OP_SIMD_PREFIX),
 #else
-#define SET_GOTO_TABLE_SIMD_PREFIX_ELEM
+#define SET_GOTO_TABLE_SIMD_PREFIX_ELEM()
 #endif
 
 /*
@@ -912,7 +913,7 @@ typedef enum WASMAtomicEXTOpcode {
         HANDLE_OPCODE(EXT_OP_IF),                    /* 0xd5 */ \
         HANDLE_OPCODE(EXT_OP_BR_TABLE_CACHE),        /* 0xd6 */ \
         SET_GOTO_TABLE_ELEM(WASM_OP_MISC_PREFIX),    /* 0xfc */ \
-        SET_GOTO_TABLE_SIMD_PREFIX_ELEM              /* 0xfd */ \
+        SET_GOTO_TABLE_SIMD_PREFIX_ELEM()            /* 0xfd */ \
         SET_GOTO_TABLE_ELEM(WASM_OP_ATOMIC_PREFIX),  /* 0xfe */ \
         DEF_DEBUG_BREAK_HANDLE()                                \
     };

--- a/core/iwasm/interpreter/wasm_opcode.h
+++ b/core/iwasm/interpreter/wasm_opcode.h
@@ -683,6 +683,12 @@ typedef enum WASMAtomicEXTOpcode {
 
 #define SET_GOTO_TABLE_ELEM(opcode) [opcode] = HANDLE_OPCODE(opcode)
 
+#if WASM_ENABLE_JIT != 0 && WASM_ENABLE_SIMD != 0
+#define SET_GOTO_TABLE_SIMD_PREFIX_ELEM SET_GOTO_TABLE_ELEM(WASM_OP_SIMD_PREFIX),
+#else
+#define SET_GOTO_TABLE_SIMD_PREFIX_ELEM
+#endif
+
 /*
  * Macro used to generate computed goto tables for the C interpreter.
  */
@@ -906,6 +912,7 @@ typedef enum WASMAtomicEXTOpcode {
         HANDLE_OPCODE(EXT_OP_IF),                    /* 0xd5 */ \
         HANDLE_OPCODE(EXT_OP_BR_TABLE_CACHE),        /* 0xd6 */ \
         SET_GOTO_TABLE_ELEM(WASM_OP_MISC_PREFIX),    /* 0xfc */ \
+        SET_GOTO_TABLE_SIMD_PREFIX_ELEM              /* 0xfd */ \
         SET_GOTO_TABLE_ELEM(WASM_OP_ATOMIC_PREFIX),  /* 0xfe */ \
         DEF_DEBUG_BREAK_HANDLE()                                \
     };


### PR DESCRIPTION
Though SIMD isn't supported by interpreter, when JIT is enabled,
developer may run `iwasm --interp <wasm_file>` to trigger the SIMD
opcode in interpreter, which isn't handled before this PR.