### PR TITLE
Do not inherit WASM_SUSPEND_FLAG_BLOCKING from the parent thread

### DIFF
--- a/core/iwasm/common/wasm_suspend_flags.h
+++ b/core/iwasm/common/wasm_suspend_flags.h
@@ -35,6 +35,8 @@ typedef union WASMSuspendFlags {
 #define WASM_SUSPEND_FLAGS_FETCH_AND(s_flags, val) \
     BH_ATOMIC_32_FETCH_AND(s_flags.flags, val)
 
+#define WASM_SUSPEND_FLAG_INHERIT_MASK (~WASM_SUSPEND_FLAG_BLOCKING)
+
 #if WASM_SUSPEND_FLAGS_IS_ATOMIC != 0
 #define WASM_SUSPEND_FLAGS_LOCK(lock) (void)0
 #define WASM_SUSPEND_FLAGS_UNLOCK(lock) (void)0

--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -574,7 +574,8 @@ wasm_cluster_spawn_exec_env(WASMExecEnv *exec_env)
     }
 
     /* Inherit suspend_flags of parent thread */
-    new_exec_env->suspend_flags.flags = exec_env->suspend_flags.flags;
+    new_exec_env->suspend_flags.flags =
+        (exec_env->suspend_flags.flags & WASM_SUSPEND_FLAG_INHERIT_MASK);
 
     if (!wasm_cluster_add_exec_env(cluster, new_exec_env)) {
         goto fail4;
@@ -729,7 +730,8 @@ wasm_cluster_create_thread(WASMExecEnv *exec_env,
     }
 
     /* Inherit suspend_flags of parent thread */
-    new_exec_env->suspend_flags.flags = exec_env->suspend_flags.flags;
+    new_exec_env->suspend_flags.flags =
+        (exec_env->suspend_flags.flags & WASM_SUSPEND_FLAG_INHERIT_MASK);
 
     if (!wasm_cluster_add_exec_env(cluster, new_exec_env))
         goto fail2;


### PR DESCRIPTION
It seems that some users want to wrap rather large chunk of code with wasm_runtime_begin_blocking_op/wasm_runtime_end_blocking_op.

If the wrapped code happens to have a call to
eg. wasm_runtime_spawn_exec_env, WASM_SUSPEND_FLAG_BLOCKING is inherited to the child exec_env and it causes unexpected behaviors.