### PR TITLE
Check arguments before calling bh_hash_map_find

### DIFF
--- a/core/iwasm/common/wasm_shared_memory.c
+++ b/core/iwasm/common/wasm_shared_memory.c
@@ -176,7 +176,7 @@ acquire_wait_info(void *address, AtomicWaitNode *wait_node)
     AtomicWaitInfo *wait_info = NULL;
     bh_list_status ret;
 
-    if (address)
+    if (wait_map && address) /* avoid passing NULL to bh_hash_map_find */
         wait_info = (AtomicWaitInfo *)bh_hash_map_find(wait_map, address);
 
     if (!wait_node) {

--- a/core/iwasm/common/wasm_shared_memory.c
+++ b/core/iwasm/common/wasm_shared_memory.c
@@ -176,8 +176,9 @@ acquire_wait_info(void *address, AtomicWaitNode *wait_node)
     AtomicWaitInfo *wait_info = NULL;
     bh_list_status ret;
 
-    if (wait_map && address) /* avoid passing NULL to bh_hash_map_find */
-        wait_info = (AtomicWaitInfo *)bh_hash_map_find(wait_map, address);
+    bh_assert(address != NULL);
+
+    wait_info = (AtomicWaitInfo *)bh_hash_map_find(wait_map, address);
 
     if (!wait_node) {
         return wait_info;

--- a/core/iwasm/libraries/lib-pthread/lib_pthread_wrapper.c
+++ b/core/iwasm/libraries/lib-pthread/lib_pthread_wrapper.c
@@ -468,7 +468,7 @@ get_thread_info(wasm_exec_env_t exec_env, uint32 handle)
     WASMCluster *cluster = wasm_exec_env_get_cluster(exec_env);
     ClusterInfoNode *info = get_cluster_info(cluster);
 
-    if (!info) {
+    if (!info || !handle) {
         return NULL;
     }
 
@@ -1144,6 +1144,10 @@ sem_open_wrapper(wasm_exec_env_t exec_env, const char *name, int32 oflags,
      * For Unix like system, it's dedicated for multiple processes.
      */
 
+    if (!name) { /* avoid passing NULL to bh_hash_map_find and os_sem_open */
+        return -1;
+    }
+
     if ((info_node = bh_hash_map_find(sem_info_map, (void *)name))) {
         return info_node->handle;
     }
@@ -1276,7 +1280,13 @@ sem_unlink_wrapper(wasm_exec_env_t exec_env, const char *name)
     (void)exec_env;
     int32 ret_val;
 
-    ThreadInfoNode *info_node = bh_hash_map_find(sem_info_map, (void *)name);
+    ThreadInfoNode *info_node;
+
+    if (!name) { /* avoid passing NULL to bh_hash_map_find */
+        return -1;
+    }
+
+    info_node = bh_hash_map_find(sem_info_map, (void *)name);
     if (!info_node || info_node->type != T_SEM)
         return -1;
 


### PR DESCRIPTION
Check whether the arguments are NULL before calling bh_hash_map_find,
or lots of "HashMap find elem failed: map or key is NULL" warnings may
be dumped. Reported in #3053.