### PR TITLE
Add flag to control Winsocket initialization

### DIFF
--- a/core/config.h
+++ b/core/config.h
@@ -231,6 +231,17 @@
 #define WASM_ENABLE_LOG 1
 #endif
 
+/* When this flag is set, WAMR will not automatically
+ * initialize sockets on Windows platforms. The host
+ * application is responsible for calling WSAStartup()
+ * before executing WAMR code that uses sockets, and
+ * calling WSACleanup() after.
+ * This flag passes control of socket initialization from
+ * WAMR to the host application. */
+#ifndef WASM_ENABLE_HOST_SOCKET_INIT
+#define WASM_ENABLE_HOST_SOCKET_INIT 0
+#endif
+
 #ifndef WASM_CPU_SUPPORTS_UNALIGNED_ADDR_ACCESS
 #if defined(BUILD_TARGET_X86_32) || defined(BUILD_TARGET_X86_64) \
     || defined(BUILD_TARGET_AARCH64)

--- a/core/shared/platform/windows/win_socket.c
+++ b/core/shared/platform/windows/win_socket.c
@@ -32,6 +32,7 @@ static bool is_winsock_inited = false;
 int
 init_winsock()
 {
+#if WASM_ENABLE_HOST_SOCKET_INIT == 0
     WSADATA wsaData;
 
     if (!is_winsock_inited) {
@@ -42,6 +43,7 @@ init_winsock()
 
         is_winsock_inited = true;
     }
+#endif
 
     return BHT_OK;
 }
@@ -49,9 +51,11 @@ init_winsock()
 void
 deinit_winsock()
 {
+#if WASM_ENABLE_HOST_SOCKET_INIT == 0
     if (is_winsock_inited) {
         WSACleanup();
     }
+#endif
 }
 
 int


### PR DESCRIPTION
When WAMR is embedded to other application, the lifecycle of the socket might conflict with other usecases. E.g. if WAMR is deinitialized before any other use of sockets, the application goes into the invalid state. The new flag allows host application to take control over the socket initialization.