### PR TITLE
Enhance setting write gs base with cmake variable

### DIFF
--- a/build-scripts/config_common.cmake
+++ b/build-scripts/config_common.cmake
@@ -421,32 +421,42 @@ if (WAMR_BUILD_STATIC_PGO EQUAL 1)
   add_definitions (-DWASM_ENABLE_STATIC_PGO=1)
   message ("     AOT static PGO enabled")
 endif ()
-if (WAMR_DISABLE_WRITE_GS_BASE EQUAL 1)
-  add_definitions (-DWASM_DISABLE_WRITE_GS_BASE=1)
-  message ("     Write linear memory base addr to x86 GS register disabled")
-elseif (WAMR_BUILD_TARGET STREQUAL "X86_64"
-        AND WAMR_BUILD_PLATFORM STREQUAL "linux")
-  set (TEST_WRGSBASE_SOURCE "${CMAKE_BINARY_DIR}/test_wrgsbase.c")
-  file (WRITE "${TEST_WRGSBASE_SOURCE}" "
-  #include <stdio.h>
-  #include <stdint.h>
-  int main() {
-      uint64_t value;
-      asm volatile (\"wrgsbase %0\" : : \"r\"(value));
-      printf(\"WRGSBASE instruction is available.\\n\");
-      return 0;
-  }")
-  # Try to compile and run the test program
-  try_run (TEST_WRGSBASE_RESULT
-    TEST_WRGSBASE_COMPILED
-    ${CMAKE_BINARY_DIR}/test_wrgsbase
-    SOURCES ${TEST_WRGSBASE_SOURCE}
-    CMAKE_FLAGS -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-  )
-  #message("${TEST_WRGSBASE_COMPILED}, ${TEST_WRGSBASE_RESULT}")
-  if (NOT TEST_WRGSBASE_RESULT EQUAL 0)
+if (WAMR_BUILD_TARGET STREQUAL "X86_64"
+    AND WAMR_BUILD_PLATFORM STREQUAL "linux")
+  # disabled by user or in cross compilation environment
+  if (WAMR_DISABLE_WRITE_GS_BASE EQUAL 1 OR CMAKE_CROSSCOMPILING)
     add_definitions (-DWASM_DISABLE_WRITE_GS_BASE=1)
     message ("     Write linear memory base addr to x86 GS register disabled")
+  # enabled by user
+  elseif (WAMR_DISABLE_WRITE_GS_BASE EQUAL 0)
+    add_definitions (-DWASM_DISABLE_WRITE_GS_BASE=0)
+    message ("     Write linear memory base addr to x86 GS register enabled")
+  # auto-detected by the compiler
+  else ()
+    set (TEST_WRGSBASE_SOURCE "${CMAKE_BINARY_DIR}/test_wrgsbase.c")
+    file (WRITE "${TEST_WRGSBASE_SOURCE}" "
+    #include <stdio.h>
+    #include <stdint.h>
+    int main() {
+        uint64_t value;
+        asm volatile (\"wrgsbase %0\" : : \"r\"(value));
+        printf(\"WRGSBASE instruction is available.\\n\");
+        return 0;
+    }")
+    # Try to compile and run the test program
+    try_run (TEST_WRGSBASE_RESULT
+      TEST_WRGSBASE_COMPILED
+      ${CMAKE_BINARY_DIR}/test_wrgsbase
+      SOURCES ${TEST_WRGSBASE_SOURCE}
+      CMAKE_FLAGS -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+    )
+    #message("${TEST_WRGSBASE_COMPILED}, ${TEST_WRGSBASE_RESULT}")
+    if (TEST_WRGSBASE_RESULT EQUAL 0)
+      message ("     Write linear memory base addr to x86 GS register enabled")
+    else ()
+      add_definitions (-DWASM_DISABLE_WRITE_GS_BASE=1)
+      message ("     Write linear memory base addr to x86 GS register disabled")
+    endif ()
   endif ()
 endif ()
 if (WAMR_CONFIGUABLE_BOUNDS_CHECKS EQUAL 1)


### PR DESCRIPTION
In linux x86-64, developer can use cmake variable to configure whether
to enable writing linear memory base address to x86 GS register or not:
- `cmake -DWAMR_DISABLE_WRITE_GS_BASE=1`: disabled it
- `cmake -DWAMR_DISABLE_WRITE_GS_BASE=0`: enabled it
- `cmake` without `-DWAMR_DISABLE_WRITE_GS_BASE=1/0`:
        auto-detected by the compiler
