### PR TITLE
Fix download link for wasi-sdk.

### DIFF
--- a/doc/build_wasm_app.md
+++ b/doc/build_wasm_app.md
@@ -5,7 +5,7 @@ Prepare WASM building environments
 
 For C and C++, WASI-SDK version 19.0+ is the major tool supported by WAMR to build WASM applications. Also, we can use [Emscripten SDK (EMSDK)](https://github.com/emscripten-core/emsdk), but it is not recommended. And there are some other compilers such as the standard clang compiler, which might also work [here](./other_wasm_compilers.md).
 
-To install WASI SDK, please download the [wasi-sdk release](https://github.com/CraneStation/wasi-sdk/releases) and extract the archive to default path `/opt/wasi-sdk`.
+To install WASI SDK, please download the [wasi-sdk release](https://github.com/WebAssembly/wasi-sdk/releases) and extract the archive to default path `/opt/wasi-sdk`.
 
 The official *wasi-sdk release* doesn't fully support *latest 128-bit SIMD spec* yet. WAMR provides a script in [build-wasi-sdk](../test-tools/build-wasi-sdk/) to generate
 another wasi-sdk with *llvm-15* from source code and installs it at *../test-tools/wasi-sdk*. If you plan to build WASM applications with *latest 128-bit SIMD*, please use it instead of the official release.

--- a/samples/file/README.md
+++ b/samples/file/README.md
@@ -5,7 +5,7 @@ This sample can also demonstrate the SGX IPFS (Intel Protected File System), ena
 
 ## Preparation
 
-Please install WASI SDK, download the [wasi-sdk release](https://github.com/CraneStation/wasi-sdk/releases) and extract the archive to default path `/opt/wasi-sdk`.
+Please install WASI SDK, download the [wasi-sdk release](https://github.com/WebAssembly/wasi-sdk/releases) and extract the archive to default path `/opt/wasi-sdk`.
 For testing with SGX IPFS, follow the instructions in [the documentation of SGX for WAMR](../../doc/linux_sgx.md#sgx-intel-protected-file-system).
 
 ## Build the sample

--- a/samples/native-lib/README.md
+++ b/samples/native-lib/README.md
@@ -29,7 +29,7 @@ get_native_lib(char **p_module_name, NativeSymbol **p_native_symbols)
 
 ## Preparation
 
-Please install WASI SDK, download the [wasi-sdk release](https://github.com/CraneStation/wasi-sdk/releases) and extract the archive to default path `/opt/wasi-sdk`.
+Please install WASI SDK, download the [wasi-sdk release](https://github.com/WebAssembly/wasi-sdk/releases) and extract the archive to default path `/opt/wasi-sdk`.
 
 ## Build the sample
 

--- a/samples/socket-api/README.md
+++ b/samples/socket-api/README.md
@@ -6,7 +6,7 @@ how they communicate with each other.
 
 ## Preparation
 
-Please install WASI SDK, download the [wasi-sdk release](https://github.com/CraneStation/wasi-sdk/releases) and extract the archive to default path `/opt/wasi-sdk`.
+Please install WASI SDK, download the [wasi-sdk release](https://github.com/WebAssembly/wasi-sdk/releases) and extract the archive to default path `/opt/wasi-sdk`.
 And install wabt, download the [wabt release](https://github.com/WebAssembly/wabt/releases) and extract the archive to default path `/opt/wabt`
 
 ## Build the sample

--- a/tests/benchmarks/coremark/README.md
+++ b/tests/benchmarks/coremark/README.md
@@ -10,7 +10,7 @@ Please build iwasm and wamrc, refer to:
 - [Build iwasm on Linux](../../../doc/build_wamr.md#linux), or [Build iwasm on MacOS](../../../doc/build_wamr.md#macos)
 - [Build wamrc AOT compiler](../../../README.md#build-wamrc-aot-compiler)
 
-And install WASI SDK, please download the [wasi-sdk release](https://github.com/CraneStation/wasi-sdk/releases) and extract the archive to default path `/opt/wasi-sdk`.
+And install WASI SDK, please download the [wasi-sdk release](https://github.com/WebAssembly/wasi-sdk/releases) and extract the archive to default path `/opt/wasi-sdk`.
 
 And then run `./build.sh` to build the source code, file `coremark.exe`, `coremark.wasm` and `coremark.aot` will be generated.
 

--- a/tests/benchmarks/polybench/README.md
+++ b/tests/benchmarks/polybench/README.md
@@ -10,7 +10,7 @@ Please build iwasm and wamrc, refer to:
 - [Build iwasm on Linux](../../../doc/build_wamr.md#linux), or [Build iwasm on MacOS](../../../doc/build_wamr.md#macos)
 - [Build wamrc AOT compiler](../../../README.md#build-wamrc-aot-compiler)
 
-And install WASI SDK, please download the [wasi-sdk release](https://github.com/CraneStation/wasi-sdk/releases) and extract the archive to default path `/opt/wasi-sdk`.
+And install WASI SDK, please download the [wasi-sdk release](https://github.com/WebAssembly/wasi-sdk/releases) and extract the archive to default path `/opt/wasi-sdk`.
 
 And then run `./build.sh` to build the source code, the folder `out` will be created and files will be generated under it.
 

--- a/tests/benchmarks/sightglass/README.md
+++ b/tests/benchmarks/sightglass/README.md
@@ -10,7 +10,7 @@ Please build iwasm and wamrc, refer to:
 - [Build iwasm on Linux](../../../doc/build_wamr.md#linux), or [Build iwasm on MacOS](../../../doc/build_wamr.md#macos)
 - [Build wamrc AOT compiler](../../../README.md#build-wamrc-aot-compiler)
 
-And install WASI SDK, please download the [wasi-sdk release](https://github.com/CraneStation/wasi-sdk/releases) and extract the archive to default path `/opt/wasi-sdk`.
+And install WASI SDK, please download the [wasi-sdk release](https://github.com/WebAssembly/wasi-sdk/releases) and extract the archive to default path `/opt/wasi-sdk`.
 
 And then run `./build.sh` to build the source code, the folder `out` will be created and files will be generated under it.
 

--- a/wamr-sdk/README.md
+++ b/wamr-sdk/README.md
@@ -8,7 +8,7 @@ Usually there are two tasks for integrating the WAMR into a particular project:
 The **[WAMR SDK](./wamr-sdk)** tools is helpful to finish the two tasks quickly. It supports menu configuration for selecting WAMR components and builds the WAMR to a SDK package that includes **runtime SDK** and **APP SDK**. The runtime SDK is used for building the native application and the APP SDK should be shipped to WASM application developers.
 
 
-**Note**: [WASI-SDK](https://github.com/CraneStation/wasi-sdk/releases) version 7 and above should be installed before building the WAMR SDK. 
+**Note**: [WASI-SDK](https://github.com/WebAssembly/wasi-sdk/releases) version 7 and above should be installed before building the WAMR SDK.
 
 
 


### PR DESCRIPTION
The wasi-sdk repo moved from CraneStation to the WebAssembly org on GitHub.