### PR TITLE
cosmopolitan: fix build - use x86_64-unknown-cosmo- to build, update platform_internal.h

### DIFF
--- a/core/shared/platform/cosmopolitan/platform_internal.h
+++ b/core/shared/platform/cosmopolitan/platform_internal.h
@@ -55,6 +55,7 @@ typedef pthread_t korp_tid;
 typedef pthread_mutex_t korp_mutex;
 typedef pthread_cond_t korp_cond;
 typedef pthread_t korp_thread;
+typedef pthread_rwlock_t korp_rwlock;
 typedef sem_t korp_sem;
 
 #define OS_THREAD_MUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER
@@ -66,6 +67,12 @@ typedef sem_t korp_sem;
 typedef int os_file_handle;
 typedef DIR *os_dir_stream;
 typedef int os_raw_file_handle;
+
+static inline os_file_handle
+os_get_invalid_handle()
+{
+    return -1;
+}
 
 #if WASM_DISABLE_WRITE_GS_BASE == 0
 #if defined(BUILD_TARGET_X86_64) || defined(BUILD_TARGET_AMD_64)

--- a/product-mini/README.md
+++ b/product-mini/README.md
@@ -447,12 +447,12 @@ make
 ## Cosmopolitan Libc
 Currently, only x86_64 architecture with interpreter modes is supported.
 
-Clone the Cosmopolitan Libc. Setup `cosmocc` as described in [Getting Started](https://github.com/jart/cosmopolitan/#getting-started) being sure to get it into `PATH`.
+Setup `cosmocc` as described in [Getting Started](https://github.com/jart/cosmopolitan/#getting-started) being sure to get its `bin` directory into `PATH`.
 
 Build iwasm
 ``` Bash
-export CC=cosmocc
-export CXX=cosmoc++
+export CC=x86_64-unknown-cosmo-cc
+export CXX=x86_64-unknown-cosmo-c++
 rm -rf build
 mkdir build
 cmake -DWAMR_BUILD_INTERP=1 -DWAMR_BUILD_FAST_INTERP=1 -B build

--- a/product-mini/platforms/cosmopolitan/build_cosmocc.sh
+++ b/product-mini/platforms/cosmopolitan/build_cosmocc.sh
@@ -2,8 +2,8 @@
 
 # Copyright (C) 2023 Dylibso.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-export CC=cosmocc
-export CXX=cosmoc++
+export CC=x86_64-unknown-cosmo-cc
+export CXX=x86_64-unknown-cosmo-c++
 rm -rf build
 mkdir build
 cmake -DWAMR_BUILD_INTERP=1 -DWAMR_BUILD_FAST_INTERP=1 -B build


### PR DESCRIPTION
This fixes the cosmopolitan platform.

* Switch `build_cosmocc.sh` and platform documentation to explicitly use the x86_64 cosmocc compiler as multi-arch cosmocc won't work here. Older version `cosmocc` just did a x86_64 build.
* Add missing items from `platform_internal.h` to fix build.

Please use my `@dylibso.com` email when merging. 