### PR TITLE
wasi: apply wasm_runtime_begin_blocking_op to poll as well

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/blocking_op.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/blocking_op.h
@@ -51,3 +51,9 @@ blocking_op_openat(wasm_exec_env_t exec_env, os_file_handle handle,
                    const char *path, __wasi_oflags_t oflags,
                    __wasi_fdflags_t fd_flags, __wasi_lookupflags_t lookup_flags,
                    wasi_libc_file_access_mode access_mode, os_file_handle *out);
+
+#ifndef BH_PLATFORM_WINDOWS
+__wasi_errno_t
+blocking_op_poll(wasm_exec_env_t exec_env, struct pollfd *pfds, nfds_t nfds,
+                 int timeout, int *retp);
+#endif

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -2230,11 +2230,10 @@ wasmtime_ssp_poll_oneoff(wasm_exec_env_t exec_env, struct fd_table *curfds,
         timeout = -1;
     }
 
-    int ret = poll(pfds, nsubscriptions, timeout);
-
-    __wasi_errno_t error = 0;
-    if (ret == -1) {
-        error = convert_errno(errno);
+    int ret;
+    int error = blocking_op_poll(exec_env, pfds, nsubscriptions, timeout, &ret);
+    if (error != 0) {
+        /* got an error */
     }
     else if (ret == 0 && *nevents == 0 && clock_subscription != NULL) {
         // No events triggered. Trigger the clock event.


### PR DESCRIPTION
While we used a different approach for poll_oneoff [1], the implementation works only when the poll list includes an absolute clock event. That is, if we have a thread which is polling on descriptors without a timeout, we fail to terminate the thread.

This commit fixes it by applying wasm_runtime_begin_blocking_op to poll as well.

[1] https://github.com/bytecodealliance/wasm-micro-runtime/pull/1951