### PR TITLE
zephyr: include libc utils when building with WASI support

### DIFF
--- a/core/shared/platform/zephyr/shared_platform.cmake
+++ b/core/shared/platform/zephyr/shared_platform.cmake
@@ -12,5 +12,11 @@ include (${CMAKE_CURRENT_LIST_DIR}/../common/math/platform_api_math.cmake)
 
 file (GLOB_RECURSE source_all ${PLATFORM_SHARED_DIR}/*.c)
 
+if (WAMR_BUILD_LIBC_WASI EQUAL 1)
+  list(APPEND source_all ${PLATFORM_SHARED_DIR}/../common/posix/posix_file.c)
+  include (${CMAKE_CURRENT_LIST_DIR}/../common/libc-util/platform_common_libc_util.cmake)
+  set(source_all ${source_all} ${PLATFORM_COMMON_LIBC_UTIL_SOURCE})
+endif ()
+
 set (PLATFORM_SHARED_SOURCE ${source_all} ${PLATFORM_COMMON_MATH_SOURCE})
 


### PR DESCRIPTION
Follows up the change in
https://github.com/bytecodealliance/wasm-micro-runtime/pull/2585 to include libc utils when targeting zephyr, which abstracts posix filesystem functions.

Fixes https://github.com/bytecodealliance/wasm-micro-runtime/issues/2846 (there may be subsequent issues that need to be addressed regarding WASI support on Zephyr)