### PR TITLE
Add comments to suppress warning from clang-tidy

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -214,6 +214,8 @@ GET_U16_FROM_ADDR(const uint8 *p)
         p += sizeof(type);                              \
     } while (0)
 
+/* NOLINTBEGIN, disable lint for this region with clang-tidy */
+
 #define read_byte_array(p, p_end, addr, len) \
     do {                                     \
         CHECK_BUF(p, p_end, len);            \
@@ -235,6 +237,8 @@ GET_U16_FROM_ADDR(const uint8 *p)
 #define read_uint16(p, p_end, res) TEMPLATE_READ(p, p_end, res, uint16)
 #define read_uint32(p, p_end, res) TEMPLATE_READ(p, p_end, res, uint32)
 #define read_uint64(p, p_end, res) TEMPLATE_READ(p, p_end, res, uint64)
+
+/* NOLINTEND */
 
 /* Legal values for bin_type */
 #define BIN_TYPE_ELF32L 0 /* 32-bit little endian */

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -1474,7 +1474,7 @@ invoke_native_with_hw_bound_check(WASMExecEnv *exec_env, void *func_ptr,
     (void)jmpbuf_node_pop;
     return ret;
 }
-#define invoke_native_internal invoke_native_with_hw_bound_check
+#define invoke_native_internal invoke_native_with_hw_bound_check /* NOLINT */
 #else /* else of OS_ENABLE_HW_BOUND_CHECK */
 static inline bool
 invoke_native_internal(WASMExecEnv *exec_env, void *func_ptr,

--- a/core/iwasm/common/wasm_application.c
+++ b/core/iwasm/common/wasm_application.c
@@ -46,7 +46,7 @@ static union {
     char b;
 } __ue = { .a = 1 };
 
-#define is_little_endian() (__ue.b == 1)
+#define is_little_endian() (__ue.b == 1) /* NOLINT */
 
 /**
  * Implementation of wasm_application_execute_main()

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -785,6 +785,7 @@ align_ptr(const uint8 *p, uint32 b)
             return false;                                    \
     } while (0)
 
+/* NOLINTNEXTLINE */
 #define read_uint16(p, p_end, res)                 \
     do {                                           \
         p = (uint8 *)align_ptr(p, sizeof(uint16)); \
@@ -793,6 +794,7 @@ align_ptr(const uint8 *p, uint32 b)
         p += sizeof(uint16);                       \
     } while (0)
 
+/* NOLINTNEXTLINE */
 #define read_uint32(p, p_end, res)                 \
     do {                                           \
         p = (uint8 *)align_ptr(p, sizeof(uint32)); \
@@ -3537,7 +3539,7 @@ static union {
     char b;
 } __ue = { .a = 1 };
 
-#define is_little_endian() (__ue.b == 1)
+#define is_little_endian() (__ue.b == 1) /* NOLINT */
 
 bool
 wasm_runtime_register_natives(const char *module_name,
@@ -4446,6 +4448,7 @@ typedef int64 (*Int64FuncPtr)(GenericFunctionPointer, uint64 *, uint64);
 typedef int32 (*Int32FuncPtr)(GenericFunctionPointer, uint64 *, uint64);
 typedef void (*VoidFuncPtr)(GenericFunctionPointer, uint64 *, uint64);
 
+/* NOLINTBEGIN */
 static volatile Float64FuncPtr invokeNative_Float64 =
     (Float64FuncPtr)(uintptr_t)invokeNative;
 static volatile Float32FuncPtr invokeNative_Float32 =
@@ -4461,6 +4464,7 @@ static volatile VoidFuncPtr invokeNative_Void =
 typedef v128 (*V128FuncPtr)(GenericFunctionPointer, uint64 *, uint64);
 static V128FuncPtr invokeNative_V128 = (V128FuncPtr)(uintptr_t)invokeNative;
 #endif
+/* NOLINTEND */
 
 #if defined(_WIN32) || defined(_WIN32_)
 #define MAX_REG_FLOATS 4


### PR DESCRIPTION
Suppress style warnings for macro definition, name of these macros is inconsistent with others (upper case).