### PR TITLE
freertos: thread exit more common

### DIFF
--- a/core/shared/platform/common/freertos/freertos_thread.c
+++ b/core/shared/platform/common/freertos/freertos_thread.c
@@ -204,7 +204,7 @@ os_thread_wrapper(void *arg)
     thread_data_list_add(thread_data);
 
     thread_data->start_routine(thread_data->arg);
-    os_thread_cleanup();
+    os_thread_exit(NULL);
 }
 
 int


### PR DESCRIPTION
in native side,  even not call `os_thread_exit` at end of thread code, also can exit correctly