### PR TITLE
Fix AOT compilation on MacOS

### DIFF
--- a/core/shared/platform/common/posix/posix_memmap.c
+++ b/core/shared/platform/common/posix/posix_memmap.c
@@ -7,6 +7,7 @@
 
 #if defined(__APPLE__) || defined(__MACH__)
 #include <libkern/OSCacheControl.h>
+#include <TargetConditionals.h>
 #endif
 
 #ifndef BH_ENABLE_TRACE_MMAP

--- a/core/shared/platform/common/posix/posix_thread.c
+++ b/core/shared/platform/common/posix/posix_thread.c
@@ -9,6 +9,10 @@
 #include "platform_api_vmcore.h"
 #include "platform_api_extension.h"
 
+#if defined(__APPLE__) || defined(__MACH__)
+#include <TargetConditionals.h>
+#endif
+
 typedef struct {
     thread_start_routine_t start;
     void *arg;


### PR DESCRIPTION
After #2995, AOT stopped working properly on my arm MacOS:
```bash
[10:31:34:240 - 206309B40]: /Users/eloparco/dev/forks/wasm-micro-runtime/core/iwasm/common/wasm_runtime_common.c, line 1270, WASM module load failed
AOT module load failed: mmap memory failed
```

That's because, without `#include <TargetConditionals.h>`, `TARGET_OS_OSX` is undefined (since it's definition is in that header file).

I wanted to setup a step in CI for MacOS to avoid things to break again in the future, but in CI AOT seems to work even without (I guess because there we use an Intel MacOS node, not ARM).