### PR TITLE
Correct validation for SIMD sub opcode

### DIFF
--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -9836,8 +9836,7 @@ re_scan:
             {
                 uint32 opcode1;
 
-                CHECK_BUF(p, p_end, 1);
-                opcode1 = read_uint8(p);
+                read_leb_uint32(p, p_end, opcode1);
                 /* follow the order of enum WASMSimdEXTOpcode in wasm_opcode.h
                  */
                 switch (opcode1) {


### PR DESCRIPTION
The sub opcode for SIMD opcode is a u32 number encoded using leb format( https://webassembly.github.io/spec/core/binary/instructions.html#vector-instructions). We were simply reading one byte from the buffer before, this can't capture some of the malformed cases that have more than one byte sub opcode