### PR TITLE
Classic and fast interpreter threads opcodes boundary check fix 

### DIFF
--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -728,7 +728,7 @@ trunc_f64_to_int(WASMModuleInstance *module, uint32 *frame_sp, float64 src_min,
         addr = POP_I32();                                            \
                                                                      \
         if (opcode == WASM_OP_ATOMIC_RMW_I32_##OP_NAME##8_U) {       \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);     \
+            CHECK_MEMORY_OVERFLOW(1);                                \
             CHECK_ATOMIC_MEMORY_ACCESS();                            \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -737,7 +737,7 @@ trunc_f64_to_int(WASMModuleInstance *module, uint32 *frame_sp, float64 src_min,
             shared_memory_unlock(memory);                            \
         }                                                            \
         else if (opcode == WASM_OP_ATOMIC_RMW_I32_##OP_NAME##16_U) { \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);     \
+            CHECK_MEMORY_OVERFLOW(2);                                \
             CHECK_ATOMIC_MEMORY_ACCESS();                            \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -746,7 +746,7 @@ trunc_f64_to_int(WASMModuleInstance *module, uint32 *frame_sp, float64 src_min,
             shared_memory_unlock(memory);                            \
         }                                                            \
         else {                                                       \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);     \
+            CHECK_MEMORY_OVERFLOW(4);                                \
             CHECK_ATOMIC_MEMORY_ACCESS();                            \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -768,7 +768,7 @@ trunc_f64_to_int(WASMModuleInstance *module, uint32 *frame_sp, float64 src_min,
         addr = POP_I32();                                            \
                                                                      \
         if (opcode == WASM_OP_ATOMIC_RMW_I64_##OP_NAME##8_U) {       \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);     \
+            CHECK_MEMORY_OVERFLOW(1);                                \
             CHECK_ATOMIC_MEMORY_ACCESS();                            \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -777,7 +777,7 @@ trunc_f64_to_int(WASMModuleInstance *module, uint32 *frame_sp, float64 src_min,
             shared_memory_unlock(memory);                            \
         }                                                            \
         else if (opcode == WASM_OP_ATOMIC_RMW_I64_##OP_NAME##16_U) { \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);     \
+            CHECK_MEMORY_OVERFLOW(2);                                \
             CHECK_ATOMIC_MEMORY_ACCESS();                            \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -786,7 +786,7 @@ trunc_f64_to_int(WASMModuleInstance *module, uint32 *frame_sp, float64 src_min,
             shared_memory_unlock(memory);                            \
         }                                                            \
         else if (opcode == WASM_OP_ATOMIC_RMW_I64_##OP_NAME##32_U) { \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);     \
+            CHECK_MEMORY_OVERFLOW(4);                                \
             CHECK_ATOMIC_MEMORY_ACCESS();                            \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -796,7 +796,7 @@ trunc_f64_to_int(WASMModuleInstance *module, uint32 *frame_sp, float64 src_min,
         }                                                            \
         else {                                                       \
             uint64 op_result;                                        \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 8, maddr);     \
+            CHECK_MEMORY_OVERFLOW(8);                                \
             CHECK_ATOMIC_MEMORY_ACCESS();                            \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -3864,7 +3864,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
                         notify_count = POP_I32();
                         addr = POP_I32();
-                        CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                        CHECK_MEMORY_OVERFLOW(4);
                         CHECK_ATOMIC_MEMORY_ACCESS();
 
                         ret = wasm_runtime_atomic_notify(
@@ -3884,7 +3884,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         timeout = POP_I64();
                         expect = POP_I32();
                         addr = POP_I32();
-                        CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                        CHECK_MEMORY_OVERFLOW(4);
                         CHECK_ATOMIC_MEMORY_ACCESS();
 
                         ret = wasm_runtime_atomic_wait(
@@ -3908,7 +3908,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         timeout = POP_I64();
                         expect = POP_I64();
                         addr = POP_I32();
-                        CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 8, maddr);
+                        CHECK_MEMORY_OVERFLOW(8);
                         CHECK_ATOMIC_MEMORY_ACCESS();
 
                         ret = wasm_runtime_atomic_wait(
@@ -3941,21 +3941,21 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
 
                         if (opcode == WASM_OP_ATOMIC_I32_LOAD8_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);
+                            CHECK_MEMORY_OVERFLOW(1);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             readv = (uint32)(*(uint8 *)maddr);
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_I32_LOAD16_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);
+                            CHECK_MEMORY_OVERFLOW(2);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             readv = (uint32)LOAD_U16(maddr);
                             shared_memory_unlock(memory);
                         }
                         else {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                            CHECK_MEMORY_OVERFLOW(4);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             readv = LOAD_I32(maddr);
@@ -3976,28 +3976,28 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
 
                         if (opcode == WASM_OP_ATOMIC_I64_LOAD8_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);
+                            CHECK_MEMORY_OVERFLOW(1);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             readv = (uint64)(*(uint8 *)maddr);
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_I64_LOAD16_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);
+                            CHECK_MEMORY_OVERFLOW(2);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             readv = (uint64)LOAD_U16(maddr);
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_I64_LOAD32_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                            CHECK_MEMORY_OVERFLOW(4);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             readv = (uint64)LOAD_U32(maddr);
                             shared_memory_unlock(memory);
                         }
                         else {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 8, maddr);
+                            CHECK_MEMORY_OVERFLOW(8);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             readv = LOAD_I64(maddr);
@@ -4018,21 +4018,21 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
 
                         if (opcode == WASM_OP_ATOMIC_I32_STORE8) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);
+                            CHECK_MEMORY_OVERFLOW(1);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             *(uint8 *)maddr = (uint8)sval;
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_I32_STORE16) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);
+                            CHECK_MEMORY_OVERFLOW(2);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             STORE_U16(maddr, (uint16)sval);
                             shared_memory_unlock(memory);
                         }
                         else {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                            CHECK_MEMORY_OVERFLOW(4);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             STORE_U32(maddr, sval);
@@ -4052,28 +4052,28 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
 
                         if (opcode == WASM_OP_ATOMIC_I64_STORE8) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);
+                            CHECK_MEMORY_OVERFLOW(1);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             *(uint8 *)maddr = (uint8)sval;
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_I64_STORE16) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);
+                            CHECK_MEMORY_OVERFLOW(2);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             STORE_U16(maddr, (uint16)sval);
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_I64_STORE32) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                            CHECK_MEMORY_OVERFLOW(4);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             STORE_U32(maddr, (uint32)sval);
                             shared_memory_unlock(memory);
                         }
                         else {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 8, maddr);
+                            CHECK_MEMORY_OVERFLOW(8);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             PUT_I64_TO_ADDR((uint32 *)maddr, sval);
@@ -4093,7 +4093,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
 
                         if (opcode == WASM_OP_ATOMIC_RMW_I32_CMPXCHG8_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);
+                            CHECK_MEMORY_OVERFLOW(1);
                             CHECK_ATOMIC_MEMORY_ACCESS();
 
                             expect = (uint8)expect;
@@ -4104,7 +4104,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_RMW_I32_CMPXCHG16_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);
+                            CHECK_MEMORY_OVERFLOW(2);
                             CHECK_ATOMIC_MEMORY_ACCESS();
 
                             expect = (uint16)expect;
@@ -4115,7 +4115,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                             shared_memory_unlock(memory);
                         }
                         else {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                            CHECK_MEMORY_OVERFLOW(4);
                             CHECK_ATOMIC_MEMORY_ACCESS();
 
                             shared_memory_lock(memory);
@@ -4139,7 +4139,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
 
                         if (opcode == WASM_OP_ATOMIC_RMW_I64_CMPXCHG8_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);
+                            CHECK_MEMORY_OVERFLOW(1);
                             CHECK_ATOMIC_MEMORY_ACCESS();
 
                             expect = (uint8)expect;
@@ -4150,7 +4150,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_RMW_I64_CMPXCHG16_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);
+                            CHECK_MEMORY_OVERFLOW(2);
                             CHECK_ATOMIC_MEMORY_ACCESS();
 
                             expect = (uint16)expect;
@@ -4161,7 +4161,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_RMW_I64_CMPXCHG32_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                            CHECK_MEMORY_OVERFLOW(4);
                             CHECK_ATOMIC_MEMORY_ACCESS();
 
                             expect = (uint32)expect;
@@ -4172,7 +4172,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                             shared_memory_unlock(memory);
                         }
                         else {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 8, maddr);
+                            CHECK_MEMORY_OVERFLOW(8);
                             CHECK_ATOMIC_MEMORY_ACCESS();
 
                             shared_memory_lock(memory);

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -479,7 +479,7 @@ LOAD_PTR(void *addr)
         addr = POP_I32();                                            \
                                                                      \
         if (opcode == WASM_OP_ATOMIC_RMW_I32_##OP_NAME##8_U) {       \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);     \
+            CHECK_MEMORY_OVERFLOW(1);                                \
             CHECK_ATOMIC_MEMORY_ACCESS(1);                           \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -488,7 +488,7 @@ LOAD_PTR(void *addr)
             shared_memory_unlock(memory);                            \
         }                                                            \
         else if (opcode == WASM_OP_ATOMIC_RMW_I32_##OP_NAME##16_U) { \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);     \
+            CHECK_MEMORY_OVERFLOW(2);                                \
             CHECK_ATOMIC_MEMORY_ACCESS(2);                           \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -497,7 +497,7 @@ LOAD_PTR(void *addr)
             shared_memory_unlock(memory);                            \
         }                                                            \
         else {                                                       \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);     \
+            CHECK_MEMORY_OVERFLOW(4);                                \
             CHECK_ATOMIC_MEMORY_ACCESS(4);                           \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -519,7 +519,7 @@ LOAD_PTR(void *addr)
         addr = POP_I32();                                            \
                                                                      \
         if (opcode == WASM_OP_ATOMIC_RMW_I64_##OP_NAME##8_U) {       \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);     \
+            CHECK_MEMORY_OVERFLOW(1);                                \
             CHECK_ATOMIC_MEMORY_ACCESS(1);                           \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -528,7 +528,7 @@ LOAD_PTR(void *addr)
             shared_memory_unlock(memory);                            \
         }                                                            \
         else if (opcode == WASM_OP_ATOMIC_RMW_I64_##OP_NAME##16_U) { \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);     \
+            CHECK_MEMORY_OVERFLOW(2);                                \
             CHECK_ATOMIC_MEMORY_ACCESS(2);                           \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -537,7 +537,7 @@ LOAD_PTR(void *addr)
             shared_memory_unlock(memory);                            \
         }                                                            \
         else if (opcode == WASM_OP_ATOMIC_RMW_I64_##OP_NAME##32_U) { \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);     \
+            CHECK_MEMORY_OVERFLOW(4);                                \
             CHECK_ATOMIC_MEMORY_ACCESS(4);                           \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -547,7 +547,7 @@ LOAD_PTR(void *addr)
         }                                                            \
         else {                                                       \
             uint64 op_result;                                        \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 8, maddr);     \
+            CHECK_MEMORY_OVERFLOW(8);                                \
             CHECK_ATOMIC_MEMORY_ACCESS(8);                           \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -3303,7 +3303,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
                         notify_count = POP_I32();
                         addr = POP_I32();
-                        CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                        CHECK_MEMORY_OVERFLOW(4);
                         CHECK_ATOMIC_MEMORY_ACCESS(4);
 
                         ret = wasm_runtime_atomic_notify(
@@ -3323,7 +3323,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         timeout = POP_I64();
                         expect = POP_I32();
                         addr = POP_I32();
-                        CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                        CHECK_MEMORY_OVERFLOW(4);
                         CHECK_ATOMIC_MEMORY_ACCESS(4);
 
                         ret = wasm_runtime_atomic_wait(
@@ -3347,7 +3347,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         timeout = POP_I64();
                         expect = POP_I64();
                         addr = POP_I32();
-                        CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 8, maddr);
+                        CHECK_MEMORY_OVERFLOW(8);
                         CHECK_ATOMIC_MEMORY_ACCESS(8);
 
                         ret = wasm_runtime_atomic_wait(
@@ -3378,21 +3378,21 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
 
                         if (opcode == WASM_OP_ATOMIC_I32_LOAD8_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);
+                            CHECK_MEMORY_OVERFLOW(1);
                             CHECK_ATOMIC_MEMORY_ACCESS(1);
                             shared_memory_lock(memory);
                             readv = (uint32)(*(uint8 *)maddr);
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_I32_LOAD16_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);
+                            CHECK_MEMORY_OVERFLOW(2);
                             CHECK_ATOMIC_MEMORY_ACCESS(2);
                             shared_memory_lock(memory);
                             readv = (uint32)LOAD_U16(maddr);
                             shared_memory_unlock(memory);
                         }
                         else {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                            CHECK_MEMORY_OVERFLOW(4);
                             CHECK_ATOMIC_MEMORY_ACCESS(4);
                             shared_memory_lock(memory);
                             readv = LOAD_I32(maddr);
@@ -3413,28 +3413,28 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
 
                         if (opcode == WASM_OP_ATOMIC_I64_LOAD8_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);
+                            CHECK_MEMORY_OVERFLOW(1);
                             CHECK_ATOMIC_MEMORY_ACCESS(1);
                             shared_memory_lock(memory);
                             readv = (uint64)(*(uint8 *)maddr);
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_I64_LOAD16_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);
+                            CHECK_MEMORY_OVERFLOW(2);
                             CHECK_ATOMIC_MEMORY_ACCESS(2);
                             shared_memory_lock(memory);
                             readv = (uint64)LOAD_U16(maddr);
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_I64_LOAD32_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                            CHECK_MEMORY_OVERFLOW(4);
                             CHECK_ATOMIC_MEMORY_ACCESS(4);
                             shared_memory_lock(memory);
                             readv = (uint64)LOAD_U32(maddr);
                             shared_memory_unlock(memory);
                         }
                         else {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 8, maddr);
+                            CHECK_MEMORY_OVERFLOW(8);
                             CHECK_ATOMIC_MEMORY_ACCESS(8);
                             shared_memory_lock(memory);
                             readv = LOAD_I64(maddr);
@@ -3454,21 +3454,21 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
 
                         if (opcode == WASM_OP_ATOMIC_I32_STORE8) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);
+                            CHECK_MEMORY_OVERFLOW(1);
                             CHECK_ATOMIC_MEMORY_ACCESS(1);
                             shared_memory_lock(memory);
                             *(uint8 *)maddr = (uint8)sval;
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_I32_STORE16) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);
+                            CHECK_MEMORY_OVERFLOW(2);
                             CHECK_ATOMIC_MEMORY_ACCESS(2);
                             shared_memory_lock(memory);
                             STORE_U16(maddr, (uint16)sval);
                             shared_memory_unlock(memory);
                         }
                         else {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                            CHECK_MEMORY_OVERFLOW(4);
                             CHECK_ATOMIC_MEMORY_ACCESS(4);
                             shared_memory_lock(memory);
                             STORE_U32(maddr, sval);
@@ -3488,28 +3488,28 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
 
                         if (opcode == WASM_OP_ATOMIC_I64_STORE8) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);
+                            CHECK_MEMORY_OVERFLOW(1);
                             CHECK_ATOMIC_MEMORY_ACCESS(1);
                             shared_memory_lock(memory);
                             *(uint8 *)maddr = (uint8)sval;
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_I64_STORE16) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);
+                            CHECK_MEMORY_OVERFLOW(2);
                             CHECK_ATOMIC_MEMORY_ACCESS(2);
                             shared_memory_lock(memory);
                             STORE_U16(maddr, (uint16)sval);
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_I64_STORE32) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                            CHECK_MEMORY_OVERFLOW(4);
                             CHECK_ATOMIC_MEMORY_ACCESS(4);
                             shared_memory_lock(memory);
                             STORE_U32(maddr, (uint32)sval);
                             shared_memory_unlock(memory);
                         }
                         else {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 8, maddr);
+                            CHECK_MEMORY_OVERFLOW(8);
                             CHECK_ATOMIC_MEMORY_ACCESS(8);
                             shared_memory_lock(memory);
                             STORE_I64(maddr, sval);
@@ -3529,7 +3529,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
 
                         if (opcode == WASM_OP_ATOMIC_RMW_I32_CMPXCHG8_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);
+                            CHECK_MEMORY_OVERFLOW(1);
                             CHECK_ATOMIC_MEMORY_ACCESS(1);
 
                             expect = (uint8)expect;
@@ -3540,7 +3540,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_RMW_I32_CMPXCHG16_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);
+                            CHECK_MEMORY_OVERFLOW(2);
                             CHECK_ATOMIC_MEMORY_ACCESS(2);
 
                             expect = (uint16)expect;
@@ -3551,7 +3551,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                             shared_memory_unlock(memory);
                         }
                         else {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                            CHECK_MEMORY_OVERFLOW(4);
                             CHECK_ATOMIC_MEMORY_ACCESS(4);
 
                             shared_memory_lock(memory);
@@ -3575,7 +3575,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
 
                         if (opcode == WASM_OP_ATOMIC_RMW_I64_CMPXCHG8_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);
+                            CHECK_MEMORY_OVERFLOW(1);
                             CHECK_ATOMIC_MEMORY_ACCESS(1);
 
                             expect = (uint8)expect;
@@ -3586,7 +3586,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_RMW_I64_CMPXCHG16_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);
+                            CHECK_MEMORY_OVERFLOW(2);
                             CHECK_ATOMIC_MEMORY_ACCESS(2);
 
                             expect = (uint16)expect;
@@ -3597,7 +3597,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_RMW_I64_CMPXCHG32_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                            CHECK_MEMORY_OVERFLOW(4);
                             CHECK_ATOMIC_MEMORY_ACCESS(4);
 
                             expect = (uint32)expect;
@@ -3608,7 +3608,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                             shared_memory_unlock(memory);
                         }
                         else {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 8, maddr);
+                            CHECK_MEMORY_OVERFLOW(8);
                             CHECK_ATOMIC_MEMORY_ACCESS(8);
 
                             shared_memory_lock(memory);

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -3017,7 +3017,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         offset = (uint64)(uint32)POP_I32();
                         addr = POP_I32();
 
-#if WASM_ENABLE_THREAD_MGR
+#if WASM_ENABLE_THREAD_MGR != 0
                         linear_mem_size = get_linear_mem_size();
 #endif
 
@@ -3065,7 +3065,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         src = POP_I32();
                         dst = POP_I32();
 
-#if WASM_ENABLE_THREAD_MGR
+#if WASM_ENABLE_THREAD_MGR != 0
                         linear_mem_size = get_linear_mem_size();
 #endif
 
@@ -3095,7 +3095,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         fill_val = POP_I32();
                         dst = POP_I32();
 
-#if WASM_ENABLE_THREAD_MGR
+#if WASM_ENABLE_THREAD_MGR != 0
                         linear_mem_size = get_linear_mem_size();
 #endif
 


### PR DESCRIPTION
Use CHECK_MEMORY_OVERFLOW instead of CHECK_BULK_MEMORY_OVERFLOW to avoid overflow in threads atomic opcodes boundary check.