### PR TITLE
aot_compile_op_call: stop setting calling convention explicitly

### DIFF
--- a/core/iwasm/compilation/aot_emit_function.c
+++ b/core/iwasm/compilation/aot_emit_function.c
@@ -1088,10 +1088,6 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             goto fail;
         }
 
-        /* Set calling convention for the call with the func's calling
-           convention */
-        LLVMSetInstructionCallConv(value_ret, LLVMGetFunctionCallConv(func));
-
         if (tail_call)
             LLVMSetTailCall(value_ret, true);
 


### PR DESCRIPTION
The current logic doesn't work for some cases.
cf. https://github.com/bytecodealliance/wasm-micro-runtime/issues/3138

It's unclear why we are setting the calling convention explicitly here at all. In many cases, the default just seems working.