### PR TITLE
Fix null pointer access in fast interpreter mode  when configurable software bound check is enabled

### DIFF
--- a/core/iwasm/common/wasm_memory.c
+++ b/core/iwasm/common/wasm_memory.c
@@ -104,6 +104,10 @@ static inline bool
 is_bounds_checks_enabled(WASMModuleInstanceCommon *module_inst)
 {
 #if WASM_CONFIGURABLE_BOUNDS_CHECKS != 0
+    if (!module_inst) {
+        return true;
+    }
+
     return wasm_runtime_is_bounds_checks_enabled(module_inst);
 #else
     return true;


### PR DESCRIPTION
The wasm_interp_call_func_bytecode is called for the first time with the empty module / exec_env to generate a global_handle_table. Before that happens though, the function checks if the module instance has bounds check enabled. Because the module instance is null, the program crashes. I added an extra check to prevent the crashes.