### PR TITLE
Rollup fixes for release/1.3.x

### DIFF
--- a/core/iwasm/common/wasm_memory.c
+++ b/core/iwasm/common/wasm_memory.c
@@ -96,6 +96,10 @@ static inline bool
 is_bounds_checks_enabled(WASMModuleInstanceCommon *module_inst)
 {
 #if WASM_CONFIGURABLE_BOUNDS_CHECKS != 0
+    if (!module_inst) {
+        return true;
+    }
+
     return wasm_runtime_is_bounds_checks_enabled(module_inst);
 #else
     return true;

--- a/core/iwasm/compilation/aot_emit_function.c
+++ b/core/iwasm/compilation/aot_emit_function.c
@@ -1088,10 +1088,6 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             goto fail;
         }
 
-        /* Set calling convention for the call with the func's calling
-           convention */
-        LLVMSetInstructionCallConv(value_ret, LLVMGetFunctionCallConv(func));
-
         if (tail_call)
             LLVMSetTailCall(value_ret, true);
 

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -728,7 +728,7 @@ trunc_f64_to_int(WASMModuleInstance *module, uint32 *frame_sp, float64 src_min,
         addr = POP_I32();                                            \
                                                                      \
         if (opcode == WASM_OP_ATOMIC_RMW_I32_##OP_NAME##8_U) {       \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);     \
+            CHECK_MEMORY_OVERFLOW(1);                                \
             CHECK_ATOMIC_MEMORY_ACCESS();                            \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -737,7 +737,7 @@ trunc_f64_to_int(WASMModuleInstance *module, uint32 *frame_sp, float64 src_min,
             shared_memory_unlock(memory);                            \
         }                                                            \
         else if (opcode == WASM_OP_ATOMIC_RMW_I32_##OP_NAME##16_U) { \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);     \
+            CHECK_MEMORY_OVERFLOW(2);                                \
             CHECK_ATOMIC_MEMORY_ACCESS();                            \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -746,7 +746,7 @@ trunc_f64_to_int(WASMModuleInstance *module, uint32 *frame_sp, float64 src_min,
             shared_memory_unlock(memory);                            \
         }                                                            \
         else {                                                       \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);     \
+            CHECK_MEMORY_OVERFLOW(4);                                \
             CHECK_ATOMIC_MEMORY_ACCESS();                            \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -768,7 +768,7 @@ trunc_f64_to_int(WASMModuleInstance *module, uint32 *frame_sp, float64 src_min,
         addr = POP_I32();                                            \
                                                                      \
         if (opcode == WASM_OP_ATOMIC_RMW_I64_##OP_NAME##8_U) {       \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);     \
+            CHECK_MEMORY_OVERFLOW(1);                                \
             CHECK_ATOMIC_MEMORY_ACCESS();                            \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -777,7 +777,7 @@ trunc_f64_to_int(WASMModuleInstance *module, uint32 *frame_sp, float64 src_min,
             shared_memory_unlock(memory);                            \
         }                                                            \
         else if (opcode == WASM_OP_ATOMIC_RMW_I64_##OP_NAME##16_U) { \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);     \
+            CHECK_MEMORY_OVERFLOW(2);                                \
             CHECK_ATOMIC_MEMORY_ACCESS();                            \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -786,7 +786,7 @@ trunc_f64_to_int(WASMModuleInstance *module, uint32 *frame_sp, float64 src_min,
             shared_memory_unlock(memory);                            \
         }                                                            \
         else if (opcode == WASM_OP_ATOMIC_RMW_I64_##OP_NAME##32_U) { \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);     \
+            CHECK_MEMORY_OVERFLOW(4);                                \
             CHECK_ATOMIC_MEMORY_ACCESS();                            \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -796,7 +796,7 @@ trunc_f64_to_int(WASMModuleInstance *module, uint32 *frame_sp, float64 src_min,
         }                                                            \
         else {                                                       \
             uint64 op_result;                                        \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 8, maddr);     \
+            CHECK_MEMORY_OVERFLOW(8);                                \
             CHECK_ATOMIC_MEMORY_ACCESS();                            \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -3864,7 +3864,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
                         notify_count = POP_I32();
                         addr = POP_I32();
-                        CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                        CHECK_MEMORY_OVERFLOW(4);
                         CHECK_ATOMIC_MEMORY_ACCESS();
 
                         ret = wasm_runtime_atomic_notify(
@@ -3884,7 +3884,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         timeout = POP_I64();
                         expect = POP_I32();
                         addr = POP_I32();
-                        CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                        CHECK_MEMORY_OVERFLOW(4);
                         CHECK_ATOMIC_MEMORY_ACCESS();
 
                         ret = wasm_runtime_atomic_wait(
@@ -3908,7 +3908,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         timeout = POP_I64();
                         expect = POP_I64();
                         addr = POP_I32();
-                        CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 8, maddr);
+                        CHECK_MEMORY_OVERFLOW(8);
                         CHECK_ATOMIC_MEMORY_ACCESS();
 
                         ret = wasm_runtime_atomic_wait(
@@ -3941,21 +3941,21 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
 
                         if (opcode == WASM_OP_ATOMIC_I32_LOAD8_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);
+                            CHECK_MEMORY_OVERFLOW(1);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             readv = (uint32)(*(uint8 *)maddr);
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_I32_LOAD16_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);
+                            CHECK_MEMORY_OVERFLOW(2);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             readv = (uint32)LOAD_U16(maddr);
                             shared_memory_unlock(memory);
                         }
                         else {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                            CHECK_MEMORY_OVERFLOW(4);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             readv = LOAD_I32(maddr);
@@ -3976,28 +3976,28 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
 
                         if (opcode == WASM_OP_ATOMIC_I64_LOAD8_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);
+                            CHECK_MEMORY_OVERFLOW(1);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             readv = (uint64)(*(uint8 *)maddr);
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_I64_LOAD16_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);
+                            CHECK_MEMORY_OVERFLOW(2);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             readv = (uint64)LOAD_U16(maddr);
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_I64_LOAD32_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                            CHECK_MEMORY_OVERFLOW(4);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             readv = (uint64)LOAD_U32(maddr);
                             shared_memory_unlock(memory);
                         }
                         else {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 8, maddr);
+                            CHECK_MEMORY_OVERFLOW(8);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             readv = LOAD_I64(maddr);
@@ -4018,21 +4018,21 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
 
                         if (opcode == WASM_OP_ATOMIC_I32_STORE8) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);
+                            CHECK_MEMORY_OVERFLOW(1);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             *(uint8 *)maddr = (uint8)sval;
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_I32_STORE16) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);
+                            CHECK_MEMORY_OVERFLOW(2);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             STORE_U16(maddr, (uint16)sval);
                             shared_memory_unlock(memory);
                         }
                         else {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                            CHECK_MEMORY_OVERFLOW(4);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             STORE_U32(maddr, sval);
@@ -4052,28 +4052,28 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
 
                         if (opcode == WASM_OP_ATOMIC_I64_STORE8) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);
+                            CHECK_MEMORY_OVERFLOW(1);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             *(uint8 *)maddr = (uint8)sval;
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_I64_STORE16) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);
+                            CHECK_MEMORY_OVERFLOW(2);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             STORE_U16(maddr, (uint16)sval);
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_I64_STORE32) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                            CHECK_MEMORY_OVERFLOW(4);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             STORE_U32(maddr, (uint32)sval);
                             shared_memory_unlock(memory);
                         }
                         else {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 8, maddr);
+                            CHECK_MEMORY_OVERFLOW(8);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
                             PUT_I64_TO_ADDR((uint32 *)maddr, sval);
@@ -4093,7 +4093,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
 
                         if (opcode == WASM_OP_ATOMIC_RMW_I32_CMPXCHG8_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);
+                            CHECK_MEMORY_OVERFLOW(1);
                             CHECK_ATOMIC_MEMORY_ACCESS();
 
                             expect = (uint8)expect;
@@ -4104,7 +4104,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_RMW_I32_CMPXCHG16_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);
+                            CHECK_MEMORY_OVERFLOW(2);
                             CHECK_ATOMIC_MEMORY_ACCESS();
 
                             expect = (uint16)expect;
@@ -4115,7 +4115,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                             shared_memory_unlock(memory);
                         }
                         else {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                            CHECK_MEMORY_OVERFLOW(4);
                             CHECK_ATOMIC_MEMORY_ACCESS();
 
                             shared_memory_lock(memory);
@@ -4139,7 +4139,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
 
                         if (opcode == WASM_OP_ATOMIC_RMW_I64_CMPXCHG8_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);
+                            CHECK_MEMORY_OVERFLOW(1);
                             CHECK_ATOMIC_MEMORY_ACCESS();
 
                             expect = (uint8)expect;
@@ -4150,7 +4150,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_RMW_I64_CMPXCHG16_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);
+                            CHECK_MEMORY_OVERFLOW(2);
                             CHECK_ATOMIC_MEMORY_ACCESS();
 
                             expect = (uint16)expect;
@@ -4161,7 +4161,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_RMW_I64_CMPXCHG32_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                            CHECK_MEMORY_OVERFLOW(4);
                             CHECK_ATOMIC_MEMORY_ACCESS();
 
                             expect = (uint32)expect;
@@ -4172,7 +4172,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                             shared_memory_unlock(memory);
                         }
                         else {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 8, maddr);
+                            CHECK_MEMORY_OVERFLOW(8);
                             CHECK_ATOMIC_MEMORY_ACCESS();
 
                             shared_memory_lock(memory);

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -479,7 +479,7 @@ LOAD_PTR(void *addr)
         addr = POP_I32();                                            \
                                                                      \
         if (opcode == WASM_OP_ATOMIC_RMW_I32_##OP_NAME##8_U) {       \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);     \
+            CHECK_MEMORY_OVERFLOW(1);                                \
             CHECK_ATOMIC_MEMORY_ACCESS(1);                           \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -488,7 +488,7 @@ LOAD_PTR(void *addr)
             shared_memory_unlock(memory);                            \
         }                                                            \
         else if (opcode == WASM_OP_ATOMIC_RMW_I32_##OP_NAME##16_U) { \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);     \
+            CHECK_MEMORY_OVERFLOW(2);                                \
             CHECK_ATOMIC_MEMORY_ACCESS(2);                           \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -497,7 +497,7 @@ LOAD_PTR(void *addr)
             shared_memory_unlock(memory);                            \
         }                                                            \
         else {                                                       \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);     \
+            CHECK_MEMORY_OVERFLOW(4);                                \
             CHECK_ATOMIC_MEMORY_ACCESS(4);                           \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -519,7 +519,7 @@ LOAD_PTR(void *addr)
         addr = POP_I32();                                            \
                                                                      \
         if (opcode == WASM_OP_ATOMIC_RMW_I64_##OP_NAME##8_U) {       \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);     \
+            CHECK_MEMORY_OVERFLOW(1);                                \
             CHECK_ATOMIC_MEMORY_ACCESS(1);                           \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -528,7 +528,7 @@ LOAD_PTR(void *addr)
             shared_memory_unlock(memory);                            \
         }                                                            \
         else if (opcode == WASM_OP_ATOMIC_RMW_I64_##OP_NAME##16_U) { \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);     \
+            CHECK_MEMORY_OVERFLOW(2);                                \
             CHECK_ATOMIC_MEMORY_ACCESS(2);                           \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -537,7 +537,7 @@ LOAD_PTR(void *addr)
             shared_memory_unlock(memory);                            \
         }                                                            \
         else if (opcode == WASM_OP_ATOMIC_RMW_I64_##OP_NAME##32_U) { \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);     \
+            CHECK_MEMORY_OVERFLOW(4);                                \
             CHECK_ATOMIC_MEMORY_ACCESS(4);                           \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -547,7 +547,7 @@ LOAD_PTR(void *addr)
         }                                                            \
         else {                                                       \
             uint64 op_result;                                        \
-            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 8, maddr);     \
+            CHECK_MEMORY_OVERFLOW(8);                                \
             CHECK_ATOMIC_MEMORY_ACCESS(8);                           \
                                                                      \
             shared_memory_lock(memory);                              \
@@ -2881,8 +2881,8 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
             {
                 addr1 = GET_OFFSET();
                 addr2 = GET_OFFSET();
-                frame_lp[addr2] = frame_lp[addr1];
-                frame_lp[addr2 + 1] = frame_lp[addr1 + 1];
+                PUT_I64_TO_ADDR(frame_lp + addr2,
+                                GET_I64_FROM_ADDR(frame_lp + addr1));
                 HANDLE_OP_END();
             }
 
@@ -3017,7 +3017,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         offset = (uint64)(uint32)POP_I32();
                         addr = POP_I32();
 
-#if WASM_ENABLE_THREAD_MGR
+#if WASM_ENABLE_THREAD_MGR != 0
                         linear_mem_size = get_linear_mem_size();
 #endif
 
@@ -3065,7 +3065,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         src = POP_I32();
                         dst = POP_I32();
 
-#if WASM_ENABLE_THREAD_MGR
+#if WASM_ENABLE_THREAD_MGR != 0
                         linear_mem_size = get_linear_mem_size();
 #endif
 
@@ -3095,7 +3095,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         fill_val = POP_I32();
                         dst = POP_I32();
 
-#if WASM_ENABLE_THREAD_MGR
+#if WASM_ENABLE_THREAD_MGR != 0
                         linear_mem_size = get_linear_mem_size();
 #endif
 
@@ -3303,7 +3303,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
                         notify_count = POP_I32();
                         addr = POP_I32();
-                        CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                        CHECK_MEMORY_OVERFLOW(4);
                         CHECK_ATOMIC_MEMORY_ACCESS(4);
 
                         ret = wasm_runtime_atomic_notify(
@@ -3323,7 +3323,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         timeout = POP_I64();
                         expect = POP_I32();
                         addr = POP_I32();
-                        CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                        CHECK_MEMORY_OVERFLOW(4);
                         CHECK_ATOMIC_MEMORY_ACCESS(4);
 
                         ret = wasm_runtime_atomic_wait(
@@ -3347,7 +3347,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         timeout = POP_I64();
                         expect = POP_I64();
                         addr = POP_I32();
-                        CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 8, maddr);
+                        CHECK_MEMORY_OVERFLOW(8);
                         CHECK_ATOMIC_MEMORY_ACCESS(8);
 
                         ret = wasm_runtime_atomic_wait(
@@ -3378,21 +3378,21 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
 
                         if (opcode == WASM_OP_ATOMIC_I32_LOAD8_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);
+                            CHECK_MEMORY_OVERFLOW(1);
                             CHECK_ATOMIC_MEMORY_ACCESS(1);
                             shared_memory_lock(memory);
                             readv = (uint32)(*(uint8 *)maddr);
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_I32_LOAD16_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);
+                            CHECK_MEMORY_OVERFLOW(2);
                             CHECK_ATOMIC_MEMORY_ACCESS(2);
                             shared_memory_lock(memory);
                             readv = (uint32)LOAD_U16(maddr);
                             shared_memory_unlock(memory);
                         }
                         else {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                            CHECK_MEMORY_OVERFLOW(4);
                             CHECK_ATOMIC_MEMORY_ACCESS(4);
                             shared_memory_lock(memory);
                             readv = LOAD_I32(maddr);
@@ -3413,28 +3413,28 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
 
                         if (opcode == WASM_OP_ATOMIC_I64_LOAD8_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);
+                            CHECK_MEMORY_OVERFLOW(1);
                             CHECK_ATOMIC_MEMORY_ACCESS(1);
                             shared_memory_lock(memory);
                             readv = (uint64)(*(uint8 *)maddr);
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_I64_LOAD16_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);
+                            CHECK_MEMORY_OVERFLOW(2);
                             CHECK_ATOMIC_MEMORY_ACCESS(2);
                             shared_memory_lock(memory);
                             readv = (uint64)LOAD_U16(maddr);
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_I64_LOAD32_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                            CHECK_MEMORY_OVERFLOW(4);
                             CHECK_ATOMIC_MEMORY_ACCESS(4);
                             shared_memory_lock(memory);
                             readv = (uint64)LOAD_U32(maddr);
                             shared_memory_unlock(memory);
                         }
                         else {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 8, maddr);
+                            CHECK_MEMORY_OVERFLOW(8);
                             CHECK_ATOMIC_MEMORY_ACCESS(8);
                             shared_memory_lock(memory);
                             readv = LOAD_I64(maddr);
@@ -3454,21 +3454,21 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
 
                         if (opcode == WASM_OP_ATOMIC_I32_STORE8) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);
+                            CHECK_MEMORY_OVERFLOW(1);
                             CHECK_ATOMIC_MEMORY_ACCESS(1);
                             shared_memory_lock(memory);
                             *(uint8 *)maddr = (uint8)sval;
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_I32_STORE16) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);
+                            CHECK_MEMORY_OVERFLOW(2);
                             CHECK_ATOMIC_MEMORY_ACCESS(2);
                             shared_memory_lock(memory);
                             STORE_U16(maddr, (uint16)sval);
                             shared_memory_unlock(memory);
                         }
                         else {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                            CHECK_MEMORY_OVERFLOW(4);
                             CHECK_ATOMIC_MEMORY_ACCESS(4);
                             shared_memory_lock(memory);
                             STORE_U32(maddr, sval);
@@ -3488,28 +3488,28 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
 
                         if (opcode == WASM_OP_ATOMIC_I64_STORE8) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);
+                            CHECK_MEMORY_OVERFLOW(1);
                             CHECK_ATOMIC_MEMORY_ACCESS(1);
                             shared_memory_lock(memory);
                             *(uint8 *)maddr = (uint8)sval;
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_I64_STORE16) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);
+                            CHECK_MEMORY_OVERFLOW(2);
                             CHECK_ATOMIC_MEMORY_ACCESS(2);
                             shared_memory_lock(memory);
                             STORE_U16(maddr, (uint16)sval);
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_I64_STORE32) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                            CHECK_MEMORY_OVERFLOW(4);
                             CHECK_ATOMIC_MEMORY_ACCESS(4);
                             shared_memory_lock(memory);
                             STORE_U32(maddr, (uint32)sval);
                             shared_memory_unlock(memory);
                         }
                         else {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 8, maddr);
+                            CHECK_MEMORY_OVERFLOW(8);
                             CHECK_ATOMIC_MEMORY_ACCESS(8);
                             shared_memory_lock(memory);
                             STORE_I64(maddr, sval);
@@ -3529,7 +3529,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
 
                         if (opcode == WASM_OP_ATOMIC_RMW_I32_CMPXCHG8_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);
+                            CHECK_MEMORY_OVERFLOW(1);
                             CHECK_ATOMIC_MEMORY_ACCESS(1);
 
                             expect = (uint8)expect;
@@ -3540,7 +3540,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_RMW_I32_CMPXCHG16_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);
+                            CHECK_MEMORY_OVERFLOW(2);
                             CHECK_ATOMIC_MEMORY_ACCESS(2);
 
                             expect = (uint16)expect;
@@ -3551,7 +3551,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                             shared_memory_unlock(memory);
                         }
                         else {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                            CHECK_MEMORY_OVERFLOW(4);
                             CHECK_ATOMIC_MEMORY_ACCESS(4);
 
                             shared_memory_lock(memory);
@@ -3575,7 +3575,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
 
                         if (opcode == WASM_OP_ATOMIC_RMW_I64_CMPXCHG8_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 1, maddr);
+                            CHECK_MEMORY_OVERFLOW(1);
                             CHECK_ATOMIC_MEMORY_ACCESS(1);
 
                             expect = (uint8)expect;
@@ -3586,7 +3586,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_RMW_I64_CMPXCHG16_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 2, maddr);
+                            CHECK_MEMORY_OVERFLOW(2);
                             CHECK_ATOMIC_MEMORY_ACCESS(2);
 
                             expect = (uint16)expect;
@@ -3597,7 +3597,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                             shared_memory_unlock(memory);
                         }
                         else if (opcode == WASM_OP_ATOMIC_RMW_I64_CMPXCHG32_U) {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 4, maddr);
+                            CHECK_MEMORY_OVERFLOW(4);
                             CHECK_ATOMIC_MEMORY_ACCESS(4);
 
                             expect = (uint32)expect;
@@ -3608,7 +3608,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                             shared_memory_unlock(memory);
                         }
                         else {
-                            CHECK_BULK_MEMORY_OVERFLOW(addr + offset, 8, maddr);
+                            CHECK_MEMORY_OVERFLOW(8);
                             CHECK_ATOMIC_MEMORY_ACCESS(8);
 
                             shared_memory_lock(memory);

--- a/core/shared/platform/nuttx/nuttx_platform.c
+++ b/core/shared/platform/nuttx/nuttx_platform.c
@@ -94,7 +94,11 @@ os_mmap(void *hint, size_t size, int prot, int flags, os_file_handle file)
 
 #if defined(CONFIG_ARCH_USE_TEXT_HEAP)
     if ((prot & MMAP_PROT_EXEC) != 0) {
-        return up_textheap_memalign(sizeof(void *), size);
+        p = up_textheap_memalign(sizeof(void *), size);
+        if (p) {
+            memset(p, 0, size);
+        }
+        return p;
     }
 #endif
 
@@ -108,7 +112,11 @@ os_mmap(void *hint, size_t size, int prot, int flags, os_file_handle file)
             return NULL;
         }
         i_addr = (void *)((uint8 *)d_addr + MEM_DUAL_BUS_OFFSET);
-        return in_ibus_ext(i_addr) ? i_addr : d_addr;
+        p = in_ibus_ext(i_addr) ? i_addr : d_addr;
+        if (p) {
+            memset(p, 0, size);
+        }
+        return p;
     }
 #endif
     /* Note: aot_loader.c assumes that os_mmap provides large enough
@@ -125,6 +133,10 @@ os_mmap(void *hint, size_t size, int prot, int flags, os_file_handle file)
     if (posix_memalign(&p, 32, size)) {
         return NULL;
     }
+
+    /* Zero the memory which is required by os_mmap */
+    memset(p, 0, size);
+
     return p;
 }
 


### PR DESCRIPTION
Apply patches in branch main for branch `release/1.3.x`:
- Fix loader check_wasi_abi_compatibility (#3126)
- Zero the memory mapped from os_mmap in NuttX (#3132)
- Fix possible integer overflow in loader target block check (#3133)
- Fix locel.set in polymorphic stack (#3135)
- Fix threads opcodes' boundary check in classic-interp and fast-interp (#3136)
- aot_compile_op_call: Stop setting calling convention explicitly (#3140)
- aot compiler: Place precheck wrapper before the corresponding wrapped function (#3141)
- fast-interp: Fix copy_stack_top_i64 overlap issue (#3146)
- fast-interp: Fix frame_offset overflow issue (#3149)
- Fix null pointer access in fast-interp when configurable soft bound check is enabled (#3150)