### PR TITLE
fast-interp: Fix GC opcode ref.as_non_null

### DIFF
--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -686,10 +686,12 @@ aot_add_llvm_func(AOTCompContext *comp_ctx, LLVMModuleRef module,
 
     bh_assert(func_index < comp_ctx->func_ctx_count);
     bh_assert(LLVMGetReturnType(func_type) == ret_type);
+
     const char *prefix = AOT_FUNC_PREFIX;
     const bool need_precheck =
         comp_ctx->enable_stack_bound_check || comp_ctx->enable_stack_estimation;
-    LLVMValueRef precheck_func;
+    LLVMValueRef precheck_func = NULL;
+
     if (need_precheck) {
         precheck_func = aot_add_llvm_func1(comp_ctx, module, func_index,
                                            aot_func_type->param_count,

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -2437,11 +2437,12 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
             HANDLE_OP(WASM_OP_REF_AS_NON_NULL)
             {
-                gc_obj = GET_REF_FROM_ADDR(frame_sp - REF_CELL_NUM);
+                gc_obj = POP_REF();
                 if (gc_obj == NULL_REF) {
                     wasm_set_exception(module, "null reference");
                     goto got_exception;
                 }
+                PUSH_REF(gc_obj);
                 HANDLE_OP_END();
             }
 

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -1967,12 +1967,12 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
             }
             HANDLE_OP(WASM_OP_REF_AS_NON_NULL)
             {
-                opnd_off = GET_OFFSET();
-                gc_obj = GET_REF_FROM_ADDR(frame_lp + opnd_off);
+                gc_obj = POP_REF();
                 if (gc_obj == NULL_REF) {
                     wasm_set_exception(module, "null reference");
                     goto got_exception;
                 }
+                PUSH_REF(gc_obj);
                 HANDLE_OP_END();
             }
             HANDLE_OP(WASM_OP_REF_EQ)

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -12251,11 +12251,10 @@ re_scan:
                                                  error_buf, error_buf_size))) {
                         goto fail;
                     }
-                }
-
 #if WASM_ENABLE_FAST_INTERP != 0
-                disable_emit = true;
+                    disable_emit = true;
 #endif
+                }
 
                 /* PUSH the converted (ref ht) */
                 if (type != VALUE_TYPE_ANY) {


### PR DESCRIPTION
The issue was found in https://github.com/bytecodealliance/wasm-micro-runtime/issues/3151.