### PR TITLE
Clarify how to verify SGX evidence without an Intel SGX-enabled platform

### DIFF
--- a/core/iwasm/libraries/lib-rats/lib_rats_common.h
+++ b/core/iwasm/libraries/lib-rats/lib_rats_common.h
@@ -15,6 +15,22 @@
 extern "C" {
 #endif
 
+/* Enclave Flags Bit Masks */
+/* If set, then the enclave is initialized */
+#define SGX_FLAGS_INITTED 0x001ULL
+/* If set, then the enclave is debug */
+#define SGX_FLAGS_DEBUG 0x002ULL
+/* If set, then the enclave is 64 bit */
+#define SGX_FLAGS_MODE64BIT 0x004ULL
+/* If set, then the enclave has access to provision key */
+#define SGX_FLAGS_PROVISION_KEY 0x010ULL
+/* If set, then the enclave has access to EINITTOKEN key */
+#define SGX_FLAGS_EINITTOKEN_KEY 0x020ULL
+/* If set, then the enclave uses KSS */
+#define SGX_FLAGS_KSS 0x080ULL
+/* If set, then the enclave enables AEX Notify */
+#define SGX_FLAGS_AEX_NOTIFY 0x400ULL
+
 #define SGX_QUOTE_MAX_SIZE 8192
 #define SGX_USER_DATA_SIZE 64
 #define SGX_MEASUREMENT_SIZE 32

--- a/samples/sgx-ra/README.md
+++ b/samples/sgx-ra/README.md
@@ -245,7 +245,9 @@ $ pip3 install -r requirements.txt
 
 ### Validation of the quotes
 The Wasm application can then be modified to validate precomputed quotes using the exposed function `librats_verify`.
+
 Alternatively, the underlying library `librats` may be directly used if the non-SGX platforms do not execute WebAssembly code (without WAMR).
+Examples are provided in the directory [non-sgx-verify/](non-sgx-verify/).
 
 ### Claims validation
 Once the runtime has validated the signature of the quote, the application must also check the other claims embedded in the quote to ensure they match their expected value.

--- a/samples/sgx-ra/README.md
+++ b/samples/sgx-ra/README.md
@@ -18,6 +18,7 @@ The following commands are an example of the SGX environment installation on Ubu
 # https://download.01.org/intel-sgx/latest/linux-latest/distro
 $ cd $HOME
 $ OS_PLATFORM=ubuntu20.04
+$ OS_CODE_NAME=`lsb_release -sc`
 $ SGX_PLATFORM=$OS_PLATFORM-server
 $ SGX_RELEASE_VERSION=1.17
 $ SGX_DRIVER_VERSION=1.41
@@ -39,7 +40,7 @@ $ chmod +x sgx_linux_x64_sdk_$SGX_SDK_VERSION.bin
 $ sudo ./sgx_linux_x64_sdk_$SGX_SDK_VERSION.bin --prefix /opt/intel
 
 # install SGX DCAP Library
-$ echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+$ echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu $OS_CODE_NAME main" | sudo tee /etc/apt/sources.list.d/intel-sgx.list
 $ wget -O - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add
 $ sudo apt-get update
 $ sudo apt-get install -y libsgx-epid libsgx-quote-ex libsgx-dcap-ql libsgx-enclave-common-dev libsgx-dcap-ql-dev libsgx-dcap-default-qpl-dev libsgx-dcap-quote-verify-dev
@@ -86,9 +87,9 @@ Intel provides an implementation of the cache mechanism.
 The following commands set up Intel PCCS.
 ```shell
 # install Node.js
+$ sudo apt install -y curl cracklib-runtime
 $ curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash - && sudo apt-get install -y nodejs
 # install PCCS software
-$ sudo apt-get install -y cracklib-runtime
 $ sudo apt-get install -y sgx-dcap-pccs
 ```
 
@@ -140,7 +141,7 @@ Do you want to generate insecure HTTPS key and cert for PCCS service? [Y] (Y/N)
 
 Answer "Y" to this question.
 
-### Provisioning a system into Intel PCCS
+### Provisioning the current system's Intel SGX collateral into the PCCS
 
 Now that the PCCS is up and running, it's time to provision an Intel SGX-enabled platform.
 We use the tool `PCKIDRetrievalTool` to get the attestation collateral of the current machine.
@@ -195,8 +196,73 @@ $ ./iwasm wasm-app/test.wasm
 
 The sample will print the evidence in JSON and the message: *Evidence is trusted.*
 
+In case of validation issues expressed as a value of `0xeXXX`, the corresponding error reason is explained in [this header file](https://github.com/intel/SGXDataCenterAttestationPrimitives/blob/master/QuoteGeneration/quote_wrapper/common/inc/sgx_ql_lib_common.h).
+
+## Validate quotes on non-SGX platforms
+Quotes created on an Intel SGX platform can also be verified on systems that do not support SGX (e.g., a different CPU architecture).
+This scenario typically arises when deploying trusted applications in a cloud environment, which provides confidential computing.
+
+For that purpose, we are required to install a subset of Intel SGX libraries to support quote validation.
+The steps below highlight how to set up such an environment.
+
+
+### Intel SGX dependencies
+```shell
+$ OS_CODE_NAME=`lsb_release -sc`
+# install SGX DCAP Library
+$ echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu $OS_CODE_NAME main" | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+$ wget -O - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add
+$ sudo apt-get update
+$ sudo apt-get install -y libsgx-quote-ex libsgx-dcap-ql libsgx-dcap-quote-verify libsgx-dcap-default-qpl
+```
+
+### Set up the Intel Provisioning Certification Caching Service (Intel PCCS)
+Follow the steps described in the section _Set up the Intel Provisioning Certification Caching Service (Intel PCCS)_.
+
+### Runtime configuration
+Follow the steps described in the section _Runtime configuration_.
+
+### Provisioning all the Intel SGX collateral into the PCCS
+We must finally fetch and configure the SGX collaterals into the PCCS for all the SGX-enabled CPUs.
+
+```shell
+# Set up the Intel PCCS administration tool
+$ git clone https://github.com/intel/SGXDataCenterAttestationPrimitives.git
+$ cd SGXDataCenterAttestationPrimitives/tools/PccsAdminTool
+$ sudo apt-get install -y python3 python3-pip
+$ pip3 install -r requirements.txt
+
+# Configuring the Intel PCCS. Input the PCS/PCCS password as requested.
+# 1. Get registration data from PCCS service
+./pccsadmin.py get
+# 2. Fetch platform collateral data from Intel PCS based on the registration data
+./pccsadmin.py fetch
+# 3. Put platform collateral data or appraisal policy files to PCCS cache db
+./pccsadmin.py put
+# 4. Request PCCS to refresh certificates or collateral in cache database
+./pccsadmin.py refresh
+```
+
+### Validation of the quotes
+The Wasm application can then be modified to validate precomputed quotes using the exposed function `librats_verify`.
+Alternatively, the underlying library `librats` may be directly used if the non-SGX platforms do not execute WebAssembly code (without WAMR).
+
+### Claims validation
+Once the runtime has validated the signature of the quote, the application must also check the other claims embedded in the quote to ensure they match their expected value.
+
+The documentation _Data Center Attestation Primitives: Library API_ describes in Section _3.8 Enclave Identity Checking_ defines the claims for the user to check.
+Here is a summary of them:
+
+- **Enclave Identity Checking**: either check the hash _MRENCLAVE_ (the enclave identity) or _MRSIGNER_ and the _product id_ (the software provider identity).
+- **Verify Attributes**: production enclaves should not have the _Debug_ flag set to 1.
+- **Verify SSA Frame extended feature set**
+- **Verify the ISV_SVN level of the enclave**: whenever there is a security update to an enclave, the ISV_SVN value should be increased to reflect the higher security level.
+- **Verify that the ReportData contains the expected value**: This can be used to provide specific data from the enclave or it can be used to hold a hash of a larger block of data which is provided with the quote. Note that the verification of the quote signature confirms the integrity of the report data (and the rest of the REPORT body). 
+
+
 ## Further readings
 
 - [Intel SGX Software Installation Guide For Linux OS](https://download.01.org/intel-sgx/latest/dcap-latest/linux/docs/Intel_SGX_SW_Installation_Guide_for_Linux.pdf)
-- [Intel Software Guard Extensions (Intel® SGX) Data Center Attestation Primitives: Library API ](https://download.01.org/intel-sgx/latest/dcap-latest/linux/docs/Intel_SGX_ECDSA_QuoteLibReference_DCAP_API.pdf)
+- [Intel Software Guard Extensions (Intel® SGX) Data Center Attestation Primitives: Library API](https://download.01.org/intel-sgx/latest/dcap-latest/linux/docs/Intel_SGX_ECDSA_QuoteLibReference_DCAP_API.pdf)
 - [Remote Attestation for Multi-Package Platforms using Intel SGX Datacenter Attestation Primitives (DCAP)](https://download.01.org/intel-sgx/latest/dcap-latest/linux/docs/Intel_SGX_DCAP_Multipackage_SW.pdf)
+- [Documentation of the PCCS administration tool](https://github.com/intel/SGXDataCenterAttestationPrimitives/blob/master/tools/PccsAdminTool/README.txt)

--- a/samples/sgx-ra/non-sgx-verify/README.md
+++ b/samples/sgx-ra/non-sgx-verify/README.md
@@ -1,0 +1,5 @@
+# Examples of evidence verification without Intel SGX
+Intel SGX evidence generated using WAMR can be validated on trusted plaforms without Intel SGX, or an Intel processors.
+
+## Using C#
+The sample [csharp/](csharp/) demonstrates such validation using C# as a managed language.

--- a/samples/sgx-ra/non-sgx-verify/csharp/.gitignore
+++ b/samples/sgx-ra/non-sgx-verify/csharp/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+bin/
+obj/

--- a/samples/sgx-ra/non-sgx-verify/csharp/Program.cs
+++ b/samples/sgx-ra/non-sgx-verify/csharp/Program.cs
@@ -1,0 +1,108 @@
+﻿/*
+ * Copyright (C) 2024 Intel Corporation.
+ * Copyright (C) 2024 University of Neuchatel, Switzerland.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+// Set the reference values below
+byte[] mrEnclaveReference =
+{
+    0xDA, 0xE0, 0xDA, 0x2F, 0x8A, 0x53, 0xA0, 0xB4, 0x8F, 0x92, 0x6A, 0x3B, 0xC0, 0x48, 0xD6, 0xA9, 
+    0x67, 0xD4, 0x7C, 0x86, 0x19, 0x86, 0x76, 0x6F, 0x8F, 0x5A, 0xB1, 0xC0, 0xA8, 0xD8, 0x8E, 0x44
+};
+byte[] mrSignerReference =
+{
+    0x83, 0xD7, 0x19, 0xE7, 0x7D, 0xEA, 0xCA, 0x14, 0x70, 0xF6, 0xBA, 0xF6, 0x2A, 0x4D, 0x77, 0x43, 
+    0x03, 0xC8, 0x99, 0xDB, 0x69, 0x02, 0x0F, 0x9C, 0x70, 0xEE, 0x1D, 0xFC, 0x08, 0xC7, 0xCE, 0x9E
+};
+const ushort securityVersionReference = 0;
+const ushort productIdReference = 0;
+string nonce = "This is a sample.\0"; // Notice the \0 at the end, which is mandatory as C-strings are terminated with this char
+string evidenceAsString = """{"type":"sgx_ecdsa","report_base64":"[..]","report_len":[..]}""";
+string wasmFilePath = "../build/wasm-app/test.wasm";
+
+// Parse and compute the claims
+EvidenceJson? evidenceAsJson = JsonSerializer.Deserialize<EvidenceJson>(evidenceAsString, new JsonSerializerOptions
+{
+    PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+});
+Debug.Assert(evidenceAsJson != null, "The evidence cannot be parsed.");
+
+byte[] wasmFileContent = await File.ReadAllBytesAsync(wasmFilePath);
+byte[] nonceAsBytes = Encoding.UTF8.GetBytes(nonce);
+byte[] computedUserData = await ComputeUserData(wasmFileContent, nonceAsBytes);
+byte[] evidenceAsBytes = Convert.FromBase64String(evidenceAsJson.ReportBase64);
+Evidence evidence = new(evidenceAsBytes);
+int libRatsReturnValue = LibRats.VerifyEvidenceFromJson(evidenceAsString, await ComputeUserData(wasmFileContent, nonceAsBytes));
+
+// Compare and display the results
+Console.WriteLine($"User data, evidence: {BitConverter.ToString(evidence.UserData)}");
+Console.WriteLine($"User Data, computed: {BitConverter.ToString(computedUserData)}");
+Console.WriteLine($"Do the two user data match? {evidence.UserData.SequenceEqual(computedUserData)}");
+Console.WriteLine($"MrEnclave: {BitConverter.ToString(evidence.MrEnclave)}");
+Console.WriteLine($"Do the MrEnclave match? {mrEnclaveReference.SequenceEqual(evidence.MrEnclave)}");
+Console.WriteLine($"MrSigner: {BitConverter.ToString(evidence.MrSigner)}");
+Console.WriteLine($"Do the MrSigner match? {mrSignerReference.SequenceEqual(evidence.MrSigner)}");
+Console.WriteLine($"Security Version: {evidence.SecurityVersion}, expected: {securityVersionReference}");
+Console.WriteLine($"Product ID: {evidence.ProductId}, expected: {productIdReference}");
+Console.WriteLine($"VerifyJsonUsingLibrats returned: {libRatsReturnValue:X}");
+
+// Compute the user data as computed by WAMR
+static async ValueTask<byte[]> ComputeUserData(byte[] wasmFileContent, byte[] nonce)
+{
+    using var sha256 = SHA256.Create();
+    var wasmFileContentHash = sha256.ComputeHash(wasmFileContent);
+            
+    using MemoryStream stream = new();
+    await stream.WriteAsync(wasmFileContentHash);
+    await stream.WriteAsync(nonce);
+    stream.Position = 0;    
+
+    byte[] computedUserData = await sha256.ComputeHashAsync(stream);
+    return computedUserData;
+}
+
+/// <summary>
+/// The layout of the JSON is given by librats.
+/// </summary>
+class EvidenceJson
+{
+    public required string Type { get; init; }
+    public required string ReportBase64 { get; init; }
+    public required int ReportLen { get; init; }
+}
+
+/// <summary>
+/// The start of the _report_body_t struct from Intel SGX is at offset 0x30.
+/// </summary>
+/// <remarks>
+/// _report_body_t struct: https://github.com/intel/linux-sgx/blob/a1eeccba5a72b3b9b342569d2cc469ece106d3e9/common/inc/sgx_report.h#L93-L111
+/// Attestation flow: https://www.intel.com/content/www/us/en/developer/articles/code-sample/software-guard-extensions-remote-attestation-end-to-end-example.html
+/// </remarks>
+class Evidence(byte[] evidenceAsBytes)
+{
+    public byte[] MrEnclave => evidenceAsBytes[0x70..0x90];
+    public byte[] MrSigner => evidenceAsBytes[0xB0..0xD0];
+    public ushort ProductId => BitConverter.ToUInt16(evidenceAsBytes.AsSpan(0x130, 2));
+    public ushort SecurityVersion => BitConverter.ToUInt16(evidenceAsBytes.AsSpan(0x132, 2));
+    public byte[] UserData => evidenceAsBytes[0x170..0x190];
+}
+
+static class LibRats
+{
+    /// <summary>
+    /// Verifies the evidence using librats native function.
+    /// </summary>
+    /// <remarks>
+    /// Original signature: int librats_verify_evidence_from_json(const char *json_string, const uint8_t *hash);
+    /// </remarks>
+    [DllImport("/usr/local/lib/librats/librats_lib.so", EntryPoint = "librats_verify_evidence_from_json")]
+    public static extern int VerifyEvidenceFromJson(string json, byte[] hash);
+}

--- a/samples/sgx-ra/non-sgx-verify/csharp/README.md
+++ b/samples/sgx-ra/non-sgx-verify/csharp/README.md
@@ -1,0 +1,18 @@
+# Examples of evidence verification without Intel SGX using C#
+This sample demonstrates how to validate WAMR-generated evidence without using an Intel SGX-enabled platform.
+A typical use case is a Web service hosted on trusted premises.
+
+## Prerequisites
+ - [dotnet-sdk](https://learn.microsoft.com/en-us/dotnet/core/install/linux) (8+)
+ - [librats](https://github.com/inclavare-containers/librats)
+ - Intel infrastructure for validating evidence, [see here](../../README.md#validate-quotes-on-non-sgx-platforms)
+
+This sample has been tested on Linux Ubuntu 20.04+.
+Any other Linux platforms should be supported.
+This sample should also work on other OS, provided librats can be compiled on those other OS.
+
+## How to use
+ - Supply the reference values to consider trustworthy in [Program.cs](Program.cs#L15-L27).
+ - Generate a valid JSON evidence using WAMR on an Intel SGX-enabled platform.
+ - Fill in the JSON evidence in [Program.cs](Program.cs#L28).
+ - Run the command `dotnet run` in this directory.

--- a/samples/sgx-ra/non-sgx-verify/csharp/VerifyEvidence.csproj
+++ b/samples/sgx-ra/non-sgx-verify/csharp/VerifyEvidence.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/samples/sgx-ra/wasm-app/main.c
+++ b/samples/sgx-ra/wasm-app/main.c
@@ -90,10 +90,24 @@ main(int argc, char **argv)
     hex_dump("User Data", evidence->user_data, SGX_USER_DATA_SIZE, 32);
     hex_dump("MRENCLAVE", evidence->mr_enclave, SGX_MEASUREMENT_SIZE, 32);
     hex_dump("MRSIGNER", evidence->mr_signer, SGX_MEASUREMENT_SIZE, 32);
-    printf("\n\tProduct ID:\t\t%u\n", evidence->product_id);
-    printf("\tSecurity Version:\t%u\n", evidence->security_version);
-    printf("\tAttributes.flags:\t%llu\n", evidence->att_flags);
-    printf("\tAttribute.xfrm:\t\t%llu\n", evidence->att_xfrm);
+    printf("\n\tProduct ID:\t\t\t\t%u\n", evidence->product_id);
+    printf("\tSecurity Version:\t\t\t%u\n", evidence->security_version);
+    printf("\tAttributes.flags:\t\t\t%llu\n", evidence->att_flags);
+    printf("\tAttributes.flags[INITTED]:\t\t%d\n",
+           (evidence->att_flags & SGX_FLAGS_INITTED) != 0);
+    printf("\tAttributes.flags[DEBUG]:\t\t%d\n",
+           (evidence->att_flags & SGX_FLAGS_DEBUG) != 0);
+    printf("\tAttributes.flags[MODE64BIT]:\t\t%d\n",
+           (evidence->att_flags & SGX_FLAGS_MODE64BIT) != 0);
+    printf("\tAttributes.flags[PROVISION_KEY]:\t%d\n",
+           (evidence->att_flags & SGX_FLAGS_PROVISION_KEY) != 0);
+    printf("\tAttributes.flags[EINITTOKEN_KEY]:\t%d\n",
+           (evidence->att_flags & SGX_FLAGS_EINITTOKEN_KEY) != 0);
+    printf("\tAttributes.flags[KSS]:\t\t\t%d\n",
+           (evidence->att_flags & SGX_FLAGS_KSS) != 0);
+    printf("\tAttributes.flags[AEX_NOTIFY]:\t\t%d\n",
+           (evidence->att_flags & SGX_FLAGS_AEX_NOTIFY) != 0);
+    printf("\tAttribute.xfrm:\t\t\t\t%llu\n", evidence->att_xfrm);
 
     rats_err = librats_verify((const char *)evidence_json, evidence->user_data);
     if (rats_err != 0) {


### PR DESCRIPTION
Dear Developers,

Today, I provide a PR that encompasses two complementing purposes:

 - A documentation on verifying an Intel SGX evidence as produced by WAMR, including a guide for verification without an Intel SGX-enabled platform. This also contains a small addition to the RA sample to extract specific information, such as whether the enclave is running in debug mode.
 - A C# sample to verify evidence on trusted premises (and without Intel SGX). Evidence is generated on untrusted environments, using Intel SGX.

I stay at your disposal to bring eventual changes for this PR if needed.
Cheers,
Jämes