### PR TITLE
zephyr: use zephyr sys_cache instead of CMSIS

### DIFF
--- a/core/shared/platform/zephyr/platform_internal.h
+++ b/core/shared/platform/zephyr/platform_internal.h
@@ -50,6 +50,12 @@
 #include <zephyr/net/net_context.h>
 #endif /* end of KERNEL_VERSION_NUMBER < 0x030200 */
 
+#if KERNEL_VERSION_NUMBER >= 0x030300 /* version 3.3.0 */
+#if defined(CONFIG_CPU_CORTEX_M7) && defined(CONFIG_ARM_MPU)
+#include <zephyr/cache.h>
+#endif
+#endif /* end of KERNEL_VERSION_NUMBER > 0x030300 */
+
 #ifdef CONFIG_ARM_MPU
 #if KERNEL_VERSION_NUMBER < 0x030200 /* version 3.2.0 */
 #include <arch/arm/aarch32/cortex_m/cmsis.h>

--- a/core/shared/platform/zephyr/zephyr_platform.c
+++ b/core/shared/platform/zephyr/zephyr_platform.c
@@ -202,10 +202,14 @@ void
 os_dcache_flush()
 {
 #if defined(CONFIG_CPU_CORTEX_M7) && defined(CONFIG_ARM_MPU)
+#if KERNEL_VERSION_NUMBER < 0x030300 /* version 3.3.0 */
     uint32 key;
     key = irq_lock();
     SCB_CleanDCache();
     irq_unlock(key);
+#else
+    sys_cache_data_flush_all();
+#endif
 #elif defined(CONFIG_SOC_CVF_EM7D) && defined(CONFIG_ARC_MPU) \
     && defined(CONFIG_CACHE_FLUSHING)
     __asm__ __volatile__("sync");
@@ -216,7 +220,11 @@ os_dcache_flush()
 
 void
 os_icache_flush(void *start, size_t len)
-{}
+{
+#if KERNEL_VERSION_NUMBER >= 0x030300 /* version 3.3.0 */
+    sys_cache_instr_flush_range(start, len);
+#endif
+}
 
 void
 set_exec_mem_alloc_func(exec_mem_alloc_func_t alloc_func,


### PR DESCRIPTION
when running AOT code in Zephyr on STM32H743VIT6 without `CONFIG_CACHE_MANAGEMENT=y`, a hard fault occurs, which leads to `SCB_CleanDCache()`.

I think it’s better to use the functions built into Zephyr