### PR TITLE
Implement remaining Windows filesystem functions

### DIFF
--- a/core/shared/platform/windows/win_util.h
+++ b/core/shared/platform/windows/win_util.h
@@ -12,6 +12,9 @@
 __wasi_timestamp_t
 convert_filetime_to_wasi_timestamp(LPFILETIME filetime);
 
+FILETIME
+convert_wasi_timestamp_to_filetime(__wasi_timestamp_t timestamp);
+
 /* Convert a Windows error code to a WASI error code */
 __wasi_errno_t
 convert_windows_error_code(DWORD windows_error_code);

--- a/product-mini/platforms/windows/wasi_filtered_tests.json
+++ b/product-mini/platforms/windows/wasi_filtered_tests.json
@@ -1,34 +1,6 @@
 {
-    "WASI C tests": {
-        "fdopendir-with-access": "Not implemented",
-        "lseek": "Not implemented"
-    },
     "WASI Rust tests": {
-        "dangling_symlink": "Not implemented",
-        "directory_seek": "Not implemented",
-        "dir_fd_op_failures": "Not implemented",
-        "fd_advise": "Not implemented",
-        "fd_fdstat_set_rights": "Not implemented",
-        "fd_filestat_set": "Not implemented",
-        "fd_flags_set": "Not implemented",
-        "fd_readdir": "Not implemented",
-        "file_allocate": "Not implemented",
-        "file_seek_tell": "Not implemented",
-        "file_truncation": "Not implemented",
-        "nofollow_errors": "Not implemented",
-        "path_exists": "Not implemented",
-        "path_filestat": "Not implemented",
-        "path_link": "Not implemented",
-        "path_open_preopen": "Not implemented",
-        "path_rename": "Not implemented",
-        "path_rename_dir_trailing_slashes": "Not implemented",
-        "path_symlink_trailing_slashes": "Not implemented",
-        "poll_oneoff_stdio": "Not implemented",
-        "readlink": "Not implemented (path_symlink)",
-        "symlink_create": "Not implemented",
-        "symlink_filestat": "Not implemented",
-        "symlink_loop": "Not implemented",
-        "truncation_rights": "Not implemented"
+        "poll_oneoff_stdio": "Not implemented"
     },
     "WASI threads proposal": {
         "wasi_threads_exit_main_wasi_read": "Blocking ops not implemented",


### PR DESCRIPTION
Now that the filesystem implementation is now complete, the previous test filters on Windows can be removed. Some of the tests only pass when certain environment variables have been set on Windows so an extra step has been added in the wasi test runner script to modify the test config files before the tests begin.