### PR TITLE
Small llvm-jit/aot bug fix

### DIFF
--- a/core/iwasm/compilation/aot_compiler.h
+++ b/core/iwasm/compilation/aot_compiler.h
@@ -569,6 +569,10 @@ set_local_gc_ref(AOTCompFrame *frame, int n, LLVMValueRef value, uint8 ref_type)
         memset(aot_value, 0, sizeof(AOTValue));                           \
         if (comp_ctx->enable_gc && aot_is_type_gc_reftype(value_type))    \
             aot_value->type = VALUE_TYPE_GC_REF;                          \
+        else if (comp_ctx->enable_ref_types                               \
+                 && (value_type == VALUE_TYPE_FUNCREF                     \
+                     || value_type == VALUE_TYPE_EXTERNREF))              \
+            aot_value->type = VALUE_TYPE_I32;                             \
         else                                                              \
             aot_value->type = value_type;                                 \
         aot_value->value = llvm_value;                                    \

--- a/core/iwasm/fast-jit/fe/jit_emit_control.c
+++ b/core/iwasm/fast-jit/fe/jit_emit_control.c
@@ -1102,7 +1102,7 @@ jit_compile_op_br_if(JitCompContext *cc, uint32 br_depth,
         }
     }
 
-    /* Only opy parameters or results when their count > 0 and
+    /* Only copy parameters or results when their count > 0 and
        the src/dst addr are different */
     copy_arities = check_copy_arities(block_dst, jit_frame);
 


### PR DESCRIPTION
When dealing with non-gc enabled funcref/externref, need to make sure to push them as i32 type