### PR TITLE
zephyr: include math only with minimal libc

### DIFF
--- a/core/shared/platform/zephyr/platform_internal.h
+++ b/core/shared/platform/zephyr/platform_internal.h
@@ -102,7 +102,8 @@ void abort(void);
 size_t strspn(const char *s, const char *accept);
 size_t strcspn(const char *s, const char *reject);
 
-/* math functions which are not provided by os */
+/* math functions which are not provided by os with minimal libc */
+#if defined(CONFIG_MINIMAL_LIBC)
 double atan(double x);
 double atan2(double y, double x);
 double sqrt(double x);
@@ -129,6 +130,10 @@ double scalbn(double x, int n);
 unsigned long long int strtoull(const char *nptr, char **endptr, int base);
 double strtod(const char *nptr, char **endptr);
 float strtof(const char *nptr, char **endptr);
+#else
+#include <math.h>
+#endif /* CONFIG_MINIMAL_LIBC */
+
 /* clang-format on */
 
 #if KERNEL_VERSION_NUMBER >= 0x030100 /* version 3.1.0 */

--- a/core/shared/platform/zephyr/shared_platform.cmake
+++ b/core/shared/platform/zephyr/shared_platform.cmake
@@ -8,7 +8,9 @@ add_definitions(-DBH_PLATFORM_ZEPHYR)
 include_directories(${PLATFORM_SHARED_DIR})
 include_directories(${PLATFORM_SHARED_DIR}/../include)
 
-include (${CMAKE_CURRENT_LIST_DIR}/../common/math/platform_api_math.cmake)
+if(${CONFIG_MINIMAL_LIBC})
+    include (${CMAKE_CURRENT_LIST_DIR}/../common/math/platform_api_math.cmake)
+endif()
 
 file (GLOB_RECURSE source_all ${PLATFORM_SHARED_DIR}/*.c)
 


### PR DESCRIPTION
use math functions, only with `CONFIG_MINIMAL_LIBC=y`.

`CONFIG_PICOLIBC=y` or `CONFIG_NEWLIB_LIBC=y` provide math functions that are used by wasm, and compilation fails when they are selected.