### PR TITLE
Specify language in the wasi socket ext project

### DIFF
--- a/core/iwasm/libraries/lib-socket/lib_socket_wasi.cmake
+++ b/core/iwasm/libraries/lib-socket/lib_socket_wasi.cmake
@@ -3,7 +3,7 @@
 
 cmake_minimum_required (VERSION 2.8...3.16)
 
-project(socket_wasi_ext)
+project(socket_wasi_ext LANGUAGES C)
 
 add_library(${PROJECT_NAME} STATIC ${CMAKE_CURRENT_LIST_DIR}/src/wasi/wasi_socket_ext.c)
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_LIST_DIR}/inc/)


### PR DESCRIPTION
If the language is not specified, CMake will try to find C++ compiler, even though it is not really needed in that case (as the project is only written in C).