### PR TITLE
Refactor APIs and data structures as preliminary work for Memory64

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -2430,8 +2430,9 @@ load_init_data_section(const uint8 *buf, const uint8 *buf_end,
     read_uint64(p, p_end, module->aux_stack_bottom);
     read_uint32(p, p_end, module->aux_stack_size);
 
-    if (module->aux_data_end > UINT32_MAX || module->aux_heap_base > UINT32_MAX
-        || module->aux_stack_bottom > UINT32_MAX) {
+    if (module->aux_data_end >= MAX_LINEAR_MEMORY_SIZE
+        || module->aux_heap_base >= MAX_LINEAR_MEMORY_SIZE
+        || module->aux_stack_bottom >= MAX_LINEAR_MEMORY_SIZE) {
         set_error_buf(
             error_buf, error_buf_size,
             "invalid range of aux_date_end/aux_heap_base/aux_stack_bottom");

--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -2423,12 +2423,20 @@ load_init_data_section(const uint8 *buf, const uint8 *buf_end,
     }
 
     read_uint32(p, p_end, module->aux_data_end_global_index);
-    read_uint32(p, p_end, module->aux_data_end);
+    read_uint64(p, p_end, module->aux_data_end);
     read_uint32(p, p_end, module->aux_heap_base_global_index);
-    read_uint32(p, p_end, module->aux_heap_base);
+    read_uint64(p, p_end, module->aux_heap_base);
     read_uint32(p, p_end, module->aux_stack_top_global_index);
-    read_uint32(p, p_end, module->aux_stack_bottom);
+    read_uint64(p, p_end, module->aux_stack_bottom);
     read_uint32(p, p_end, module->aux_stack_size);
+
+    if (module->aux_data_end > UINT32_MAX || module->aux_heap_base > UINT32_MAX
+        || module->aux_stack_bottom > UINT32_MAX) {
+        set_error_buf(
+            error_buf, error_buf_size,
+            "invalid range of aux_date_end/aux_heap_base/aux_stack_bottom");
+        return false;
+    }
 
     if (!load_object_data_sections_info(&p, p_end, module,
                                         is_load_from_file_buf, error_buf,

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -2649,16 +2649,17 @@ aot_module_dup_data(AOTModuleInstance *module_inst, const char *src,
                     uint64 size)
 {
     char *buffer;
-    uint64 buffer_offset =
-        aot_module_malloc(module_inst, size, (void **)&buffer);
+    uint64 buffer_offset;
 
     /* TODO: Memory64 size check based on memory idx type */
     bh_assert(size <= UINT32_MAX);
 
+    buffer_offset = aot_module_malloc(module_inst, size, (void **)&buffer);
+
     if (buffer_offset != 0) {
         buffer = wasm_runtime_addr_app_to_native(
             (WASMModuleInstanceCommon *)module_inst, buffer_offset);
-        bh_memcpy_s(buffer, size, src, size);
+        bh_memcpy_s(buffer, (uint32)size, src, (uint32)size);
     }
     return buffer_offset;
 }
@@ -3016,7 +3017,7 @@ aot_memory_init(AOTModuleInstance *module_inst, uint32 seg_index, uint32 offset,
         (WASMModuleInstanceCommon *)module_inst, (uint64)dst);
 
     SHARED_MEMORY_LOCK(memory_inst);
-    bh_memcpy_s(maddr, (uint32)memory_inst->memory_data_size - dst,
+    bh_memcpy_s(maddr, (uint32)(memory_inst->memory_data_size - dst),
                 data + offset, len);
     SHARED_MEMORY_UNLOCK(memory_inst);
     return true;

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -50,7 +50,7 @@ bh_static_assert(offsetof(AOTModuleInstance, cur_exception)
 bh_static_assert(offsetof(AOTModuleInstance, global_table_data)
                  == 13 * sizeof(uint64) + 128 + 11 * sizeof(uint64));
 
-bh_static_assert(sizeof(AOTMemoryInstance) == 104);
+bh_static_assert(sizeof(AOTMemoryInstance) == 112);
 bh_static_assert(offsetof(AOTTableInstance, elems) == 24);
 
 bh_static_assert(offsetof(AOTModuleInstanceExtra, stack_sizes) == 0);
@@ -792,9 +792,9 @@ memory_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
     uint32 max_page_count =
         wasm_runtime_get_max_mem(max_memory_pages, memory->mem_init_page_count,
                                  memory->mem_max_page_count);
-    uint32 inc_page_count, aux_heap_base, global_idx;
+    uint32 inc_page_count, global_idx;
     uint32 bytes_of_last_page, bytes_to_page_end;
-    uint32 heap_offset = num_bytes_per_page * init_page_count;
+    uint64 aux_heap_base, heap_offset = num_bytes_per_page * init_page_count;
     uint64 memory_data_size, max_memory_data_size;
     uint8 *p = NULL, *global_addr;
 
@@ -869,7 +869,7 @@ memory_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
                          - module->import_global_count;
             global_addr = module_inst->global_data
                           + module->globals[global_idx].data_offset;
-            *(uint32 *)global_addr = aux_heap_base;
+            *(uint32 *)global_addr = (uint32)aux_heap_base;
             LOG_VERBOSE("Reset __heap_base global to %u", aux_heap_base);
         }
         else {
@@ -889,18 +889,8 @@ memory_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
                           "try using `--heap-size=0` option");
             return NULL;
         }
-        else if (init_page_count == DEFAULT_MAX_PAGES) {
-            num_bytes_per_page = UINT32_MAX;
-            init_page_count = max_page_count = 1;
-        }
         if (max_page_count > DEFAULT_MAX_PAGES)
             max_page_count = DEFAULT_MAX_PAGES;
-    }
-    else { /* heap_size == 0 */
-        if (init_page_count == DEFAULT_MAX_PAGES) {
-            num_bytes_per_page = UINT32_MAX;
-            init_page_count = max_page_count = 1;
-        }
     }
 
     LOG_VERBOSE("Memory instantiate:");
@@ -911,7 +901,7 @@ memory_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
     LOG_VERBOSE("  heap offset: %u, heap size: %d\n", heap_offset, heap_size);
 
     max_memory_data_size = (uint64)num_bytes_per_page * max_page_count;
-    bh_assert(max_memory_data_size <= 4 * (uint64)BH_GB);
+    bh_assert(max_memory_data_size <= MAX_LINEAR_MEMORY_SIZE);
     (void)max_memory_data_size;
 
     if (wasm_allocate_linear_memory(&p, is_shared_memory, num_bytes_per_page,
@@ -927,11 +917,11 @@ memory_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
     memory_inst->num_bytes_per_page = num_bytes_per_page;
     memory_inst->cur_page_count = init_page_count;
     memory_inst->max_page_count = max_page_count;
-    memory_inst->memory_data_size = (uint32)memory_data_size;
+    memory_inst->memory_data_size = memory_data_size;
 
     /* Init memory info */
     memory_inst->memory_data = p;
-    memory_inst->memory_data_end = p + (uint32)memory_data_size;
+    memory_inst->memory_data_end = p + memory_data_size;
 
     /* Initialize heap info */
     memory_inst->heap_data = p + heap_offset;
@@ -1098,7 +1088,7 @@ memories_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
 
         if (memory_inst->memory_data) {
             bh_memcpy_s((uint8 *)memory_inst->memory_data + base_offset,
-                        memory_inst->memory_data_size - base_offset,
+                        (uint32)memory_inst->memory_data_size - base_offset,
                         data_seg->bytes, length);
         }
     }
@@ -2472,9 +2462,9 @@ execute_free_function(AOTModuleInstance *module_inst, WASMExecEnv *exec_env,
     return ret;
 }
 
-uint32
+uint64
 aot_module_malloc_internal(AOTModuleInstance *module_inst,
-                           WASMExecEnv *exec_env, uint32 size,
+                           WASMExecEnv *exec_env, uint64 size,
                            void **p_native_addr)
 {
     AOTMemoryInstance *memory_inst = aot_get_default_memory(module_inst);
@@ -2482,13 +2472,16 @@ aot_module_malloc_internal(AOTModuleInstance *module_inst,
     uint8 *addr = NULL;
     uint32 offset = 0;
 
+    /* TODO: Memory64 size check based on memory idx type */
+    bh_assert(size <= UINT32_MAX);
+
     if (!memory_inst) {
         aot_set_exception(module_inst, "uninitialized memory");
         return 0;
     }
 
     if (memory_inst->heap_handle) {
-        addr = mem_allocator_malloc(memory_inst->heap_handle, size);
+        addr = mem_allocator_malloc(memory_inst->heap_handle, (uint32)size);
     }
     else if (module->malloc_func_index != (uint32)-1
              && module->free_func_index != (uint32)-1) {
@@ -2513,7 +2506,7 @@ aot_module_malloc_internal(AOTModuleInstance *module_inst,
 
         if (!malloc_func
             || !execute_malloc_function(module_inst, exec_env, malloc_func,
-                                        retain_func, size, &offset)) {
+                                        retain_func, (uint32)size, &offset)) {
             return 0;
         }
         addr = offset ? (uint8 *)memory_inst->memory_data + offset : NULL;
@@ -2532,16 +2525,20 @@ aot_module_malloc_internal(AOTModuleInstance *module_inst,
     }
     if (p_native_addr)
         *p_native_addr = addr;
-    return (uint32)(addr - memory_inst->memory_data);
+    return (uint64)(addr - memory_inst->memory_data);
 }
 
-uint32
+uint64
 aot_module_realloc_internal(AOTModuleInstance *module_inst,
-                            WASMExecEnv *exec_env, uint32 ptr, uint32 size,
+                            WASMExecEnv *exec_env, uint64 ptr, uint64 size,
                             void **p_native_addr)
 {
     AOTMemoryInstance *memory_inst = aot_get_default_memory(module_inst);
     uint8 *addr = NULL;
+
+    /* TODO: Memory64 ptr and size check based on memory idx type */
+    bh_assert(ptr <= UINT32_MAX);
+    bh_assert(size <= UINT32_MAX);
 
     if (!memory_inst) {
         aot_set_exception(module_inst, "uninitialized memory");
@@ -2551,7 +2548,8 @@ aot_module_realloc_internal(AOTModuleInstance *module_inst,
     if (memory_inst->heap_handle) {
         addr = mem_allocator_realloc(
             memory_inst->heap_handle,
-            ptr ? memory_inst->memory_data + ptr : NULL, size);
+            (uint32)ptr ? memory_inst->memory_data + (uint32)ptr : NULL,
+            (uint32)size);
     }
 
     /* Only support realloc in WAMR's app heap */
@@ -2570,12 +2568,12 @@ aot_module_realloc_internal(AOTModuleInstance *module_inst,
 
     if (p_native_addr)
         *p_native_addr = addr;
-    return (uint32)(addr - memory_inst->memory_data);
+    return (uint64)(addr - memory_inst->memory_data);
 }
 
 void
 aot_module_free_internal(AOTModuleInstance *module_inst, WASMExecEnv *exec_env,
-                         uint32 ptr)
+                         uint64 ptr)
 {
     AOTMemoryInstance *memory_inst = aot_get_default_memory(module_inst);
     AOTModule *module = (AOTModule *)module_inst->module;
@@ -2584,8 +2582,11 @@ aot_module_free_internal(AOTModuleInstance *module_inst, WASMExecEnv *exec_env,
         return;
     }
 
+    /* TODO: Memory64 ptr and size check based on memory idx type */
+    bh_assert(ptr <= UINT32_MAX);
+
     if (ptr) {
-        uint8 *addr = memory_inst->memory_data + ptr;
+        uint8 *addr = memory_inst->memory_data + (uint32)ptr;
         uint8 *memory_data_end;
 
         /* memory->memory_data_end may be changed in memory grow */
@@ -2616,20 +2617,21 @@ aot_module_free_internal(AOTModuleInstance *module_inst, WASMExecEnv *exec_env,
                 free_func = aot_lookup_function(module_inst, "__unpin", "(i)i");
 
             if (free_func)
-                execute_free_function(module_inst, exec_env, free_func, ptr);
+                execute_free_function(module_inst, exec_env, free_func,
+                                      (uint32)ptr);
         }
     }
 }
 
-uint32
-aot_module_malloc(AOTModuleInstance *module_inst, uint32 size,
+uint64
+aot_module_malloc(AOTModuleInstance *module_inst, uint64 size,
                   void **p_native_addr)
 {
     return aot_module_malloc_internal(module_inst, NULL, size, p_native_addr);
 }
 
-uint32
-aot_module_realloc(AOTModuleInstance *module_inst, uint32 ptr, uint32 size,
+uint64
+aot_module_realloc(AOTModuleInstance *module_inst, uint64 ptr, uint64 size,
                    void **p_native_addr)
 {
     return aot_module_realloc_internal(module_inst, NULL, ptr, size,
@@ -2637,18 +2639,21 @@ aot_module_realloc(AOTModuleInstance *module_inst, uint32 ptr, uint32 size,
 }
 
 void
-aot_module_free(AOTModuleInstance *module_inst, uint32 ptr)
+aot_module_free(AOTModuleInstance *module_inst, uint64 ptr)
 {
     aot_module_free_internal(module_inst, NULL, ptr);
 }
 
-uint32
+uint64
 aot_module_dup_data(AOTModuleInstance *module_inst, const char *src,
-                    uint32 size)
+                    uint64 size)
 {
     char *buffer;
-    uint32 buffer_offset =
+    uint64 buffer_offset =
         aot_module_malloc(module_inst, size, (void **)&buffer);
+
+    /* TODO: Memory64 size check based on memory idx type */
+    bh_assert(size <= UINT32_MAX);
 
     if (buffer_offset != 0) {
         buffer = wasm_runtime_addr_app_to_native(
@@ -2935,7 +2940,7 @@ fail:
 
 bool
 aot_check_app_addr_and_convert(AOTModuleInstance *module_inst, bool is_str,
-                               uint32 app_buf_addr, uint32 app_buf_size,
+                               uint64 app_buf_addr, uint64 app_buf_size,
                                void **p_native_addr)
 {
     bool ret;
@@ -2999,7 +3004,7 @@ aot_memory_init(AOTModuleInstance *module_inst, uint32 seg_index, uint32 offset,
     }
 
     if (!wasm_runtime_validate_app_addr((WASMModuleInstanceCommon *)module_inst,
-                                        dst, len))
+                                        (uint64)dst, (uint64)len))
         return false;
 
     if ((uint64)offset + (uint64)len > seg_len) {
@@ -3008,10 +3013,11 @@ aot_memory_init(AOTModuleInstance *module_inst, uint32 seg_index, uint32 offset,
     }
 
     maddr = wasm_runtime_addr_app_to_native(
-        (WASMModuleInstanceCommon *)module_inst, dst);
+        (WASMModuleInstanceCommon *)module_inst, (uint64)dst);
 
     SHARED_MEMORY_LOCK(memory_inst);
-    bh_memcpy_s(maddr, memory_inst->memory_data_size - dst, data + offset, len);
+    bh_memcpy_s(maddr, (uint32)memory_inst->memory_data_size - dst,
+                data + offset, len);
     SHARED_MEMORY_UNLOCK(memory_inst);
     return true;
 }
@@ -3030,14 +3036,14 @@ aot_data_drop(AOTModuleInstance *module_inst, uint32 seg_index)
 
 #if WASM_ENABLE_THREAD_MGR != 0
 bool
-aot_set_aux_stack(WASMExecEnv *exec_env, uint32 start_offset, uint32 size)
+aot_set_aux_stack(WASMExecEnv *exec_env, uint64 start_offset, uint32 size)
 {
     AOTModuleInstance *module_inst = (AOTModuleInstance *)exec_env->module_inst;
     AOTModule *module = (AOTModule *)module_inst->module;
 
     uint32 stack_top_idx = module->aux_stack_top_global_index;
-    uint32 data_end = module->aux_data_end;
-    uint32 stack_bottom = module->aux_stack_bottom;
+    uint64 data_end = module->aux_data_end;
+    uint64 stack_bottom = module->aux_stack_bottom;
     bool is_stack_before_data = stack_bottom < data_end ? true : false;
 
     /* Check the aux stack space, currently we don't allocate space in heap */
@@ -3050,12 +3056,13 @@ aot_set_aux_stack(WASMExecEnv *exec_env, uint32 start_offset, uint32 size)
             set the initial value for the global */
         uint32 global_offset = module->globals[stack_top_idx].data_offset;
         uint8 *global_addr = module_inst->global_data + global_offset;
-        *(int32 *)global_addr = start_offset;
+        /* TODO: Memory64 the type i32/i64 depends on memory idx type*/
+        *(int32 *)global_addr = (uint32)start_offset;
 
         /* The aux stack boundary is a constant value,
             set the value to exec_env */
-        exec_env->aux_stack_boundary.boundary = start_offset - size;
-        exec_env->aux_stack_bottom.bottom = start_offset;
+        exec_env->aux_stack_boundary = (uintptr_t)start_offset - size;
+        exec_env->aux_stack_bottom = (uintptr_t)start_offset;
         return true;
     }
 
@@ -3063,14 +3070,14 @@ aot_set_aux_stack(WASMExecEnv *exec_env, uint32 start_offset, uint32 size)
 }
 
 bool
-aot_get_aux_stack(WASMExecEnv *exec_env, uint32 *start_offset, uint32 *size)
+aot_get_aux_stack(WASMExecEnv *exec_env, uint64 *start_offset, uint32 *size)
 {
     AOTModuleInstance *module_inst = (AOTModuleInstance *)exec_env->module_inst;
     AOTModule *module = (AOTModule *)module_inst->module;
 
     /* The aux stack information is resolved in loader
         and store in module */
-    uint32 stack_bottom = module->aux_stack_bottom;
+    uint64 stack_bottom = module->aux_stack_bottom;
     uint32 total_aux_stack_size = module->aux_stack_size;
 
     if (stack_bottom != 0 && total_aux_stack_size != 0) {

--- a/core/iwasm/aot/aot_runtime.h
+++ b/core/iwasm/aot/aot_runtime.h
@@ -246,19 +246,19 @@ typedef struct AOTModule {
        -1 means unexported */
     uint32 aux_data_end_global_index;
     /* auxiliary __data_end exported by wasm app */
-    uint32 aux_data_end;
+    uint64 aux_data_end;
 
     /* the index of auxiliary __heap_base global,
        -1 means unexported */
     uint32 aux_heap_base_global_index;
     /* auxiliary __heap_base exported by wasm app */
-    uint32 aux_heap_base;
+    uint64 aux_heap_base;
 
     /* the index of auxiliary stack top global,
        -1 means unexported */
     uint32 aux_stack_top_global_index;
     /* auxiliary stack bottom resolved */
-    uint32 aux_stack_bottom;
+    uint64 aux_stack_bottom;
     /* auxiliary stack size resolved */
     uint32 aux_stack_size;
 
@@ -558,32 +558,32 @@ aot_get_exception(AOTModuleInstance *module_inst);
 bool
 aot_copy_exception(AOTModuleInstance *module_inst, char *exception_buf);
 
-uint32
+uint64
 aot_module_malloc_internal(AOTModuleInstance *module_inst, WASMExecEnv *env,
-                           uint32 size, void **p_native_addr);
+                           uint64 size, void **p_native_addr);
 
-uint32
+uint64
 aot_module_realloc_internal(AOTModuleInstance *module_inst, WASMExecEnv *env,
-                            uint32 ptr, uint32 size, void **p_native_addr);
+                            uint64 ptr, uint64 size, void **p_native_addr);
 
 void
 aot_module_free_internal(AOTModuleInstance *module_inst, WASMExecEnv *env,
-                         uint32 ptr);
+                         uint64 ptr);
 
-uint32
-aot_module_malloc(AOTModuleInstance *module_inst, uint32 size,
+uint64
+aot_module_malloc(AOTModuleInstance *module_inst, uint64 size,
                   void **p_native_addr);
 
-uint32
-aot_module_realloc(AOTModuleInstance *module_inst, uint32 ptr, uint32 size,
+uint64
+aot_module_realloc(AOTModuleInstance *module_inst, uint64 ptr, uint64 size,
                    void **p_native_addr);
 
 void
-aot_module_free(AOTModuleInstance *module_inst, uint32 ptr);
+aot_module_free(AOTModuleInstance *module_inst, uint64 ptr);
 
-uint32
+uint64
 aot_module_dup_data(AOTModuleInstance *module_inst, const char *src,
-                    uint32 size);
+                    uint64 size);
 
 bool
 aot_enlarge_memory(AOTModuleInstance *module_inst, uint32 inc_page_count);
@@ -605,7 +605,7 @@ aot_call_indirect(WASMExecEnv *exec_env, uint32 tbl_idx, uint32 table_elem_idx,
  */
 bool
 aot_check_app_addr_and_convert(AOTModuleInstance *module_inst, bool is_str,
-                               uint32 app_buf_addr, uint32 app_buf_size,
+                               uint64 app_buf_addr, uint64 app_buf_size,
                                void **p_native_addr);
 
 uint32
@@ -634,10 +634,10 @@ aot_data_drop(AOTModuleInstance *module_inst, uint32 seg_index);
 
 #if WASM_ENABLE_THREAD_MGR != 0
 bool
-aot_set_aux_stack(WASMExecEnv *exec_env, uint32 start_offset, uint32 size);
+aot_set_aux_stack(WASMExecEnv *exec_env, uint64 start_offset, uint32 size);
 
 bool
-aot_get_aux_stack(WASMExecEnv *exec_env, uint32 *start_offset, uint32 *size);
+aot_get_aux_stack(WASMExecEnv *exec_env, uint64 *start_offset, uint32 *size);
 #endif
 
 void

--- a/core/iwasm/common/wasm_application.c
+++ b/core/iwasm/common/wasm_application.c
@@ -97,7 +97,7 @@ execute_main(WASMModuleInstanceCommon *module_inst, int32 argc, char *argv[])
     uint32 argc1 = 0, argv1[2] = { 0 };
     uint32 total_argv_size = 0;
     uint64 total_size;
-    uint32 argv_buf_offset = 0;
+    uint64 argv_buf_offset = 0;
     int32 i;
     char *argv_buf, *p, *p_end;
     uint32 *argv_offsets, module_type;
@@ -202,7 +202,7 @@ execute_main(WASMModuleInstanceCommon *module_inst, int32 argc, char *argv[])
 
         if (total_size >= UINT32_MAX
             || !(argv_buf_offset = wasm_runtime_module_malloc(
-                     module_inst, (uint32)total_size, (void **)&argv_buf))) {
+                     module_inst, total_size, (void **)&argv_buf))) {
             wasm_runtime_set_exception(module_inst, "allocate memory failed");
             return false;
         }
@@ -214,12 +214,13 @@ execute_main(WASMModuleInstanceCommon *module_inst, int32 argc, char *argv[])
         for (i = 0; i < argc; i++) {
             bh_memcpy_s(p, (uint32)(p_end - p), argv[i],
                         (uint32)(strlen(argv[i]) + 1));
-            argv_offsets[i] = argv_buf_offset + (uint32)(p - argv_buf);
+            argv_offsets[i] = (uint32)argv_buf_offset + (uint32)(p - argv_buf);
             p += strlen(argv[i]) + 1;
         }
 
         argc1 = 2;
         argv1[0] = (uint32)argc;
+        /* TODO: memory64 uint64 when the memory idx is i64 */
         argv1[1] =
             (uint32)wasm_runtime_addr_native_to_app(module_inst, argv_offsets);
     }

--- a/core/iwasm/common/wasm_exec_env.c
+++ b/core/iwasm/common/wasm_exec_env.c
@@ -149,8 +149,6 @@ wasm_exec_env_create(struct WASMModuleInstanceCommon *module_inst,
     /* Set the aux_stack_boundary and aux_stack_bottom */
     if (module_inst->module_type == Wasm_Module_Bytecode) {
         WASMModule *module = ((WASMModuleInstance *)module_inst)->module;
-        /* TODO: only assert when it's not memory64 */
-        bh_assert(module->aux_stack_bottom < UINT32_MAX);
         exec_env->aux_stack_bottom = (uintptr_t)module->aux_stack_bottom;
         exec_env->aux_stack_boundary =
             (uintptr_t)module->aux_stack_bottom - module->aux_stack_size;
@@ -165,8 +163,6 @@ wasm_exec_env_create(struct WASMModuleInstanceCommon *module_inst,
     if (module_inst->module_type == Wasm_Module_AoT) {
         AOTModule *module =
             (AOTModule *)((AOTModuleInstance *)module_inst)->module;
-        /* TODO: only assert when it's not memory64 */
-        bh_assert(module->aux_stack_bottom < UINT32_MAX);
         exec_env->aux_stack_bottom = (uintptr_t)module->aux_stack_bottom;
         exec_env->aux_stack_boundary =
             (uintptr_t)module->aux_stack_bottom - module->aux_stack_size;

--- a/core/iwasm/common/wasm_exec_env.c
+++ b/core/iwasm/common/wasm_exec_env.c
@@ -149,9 +149,11 @@ wasm_exec_env_create(struct WASMModuleInstanceCommon *module_inst,
     /* Set the aux_stack_boundary and aux_stack_bottom */
     if (module_inst->module_type == Wasm_Module_Bytecode) {
         WASMModule *module = ((WASMModuleInstance *)module_inst)->module;
-        exec_env->aux_stack_bottom.bottom = module->aux_stack_bottom;
-        exec_env->aux_stack_boundary.boundary =
-            module->aux_stack_bottom - module->aux_stack_size;
+        /* TODO: only assert when it's not memory64 */
+        bh_assert(module->aux_stack_bottom < UINT32_MAX);
+        exec_env->aux_stack_bottom = (uintptr_t)module->aux_stack_bottom;
+        exec_env->aux_stack_boundary =
+            (uintptr_t)module->aux_stack_bottom - module->aux_stack_size;
 #if WASM_ENABLE_GC != 0
         gc_heap_handle =
             ((WASMModuleInstance *)module_inst)->e->common.gc_heap_pool;
@@ -163,9 +165,11 @@ wasm_exec_env_create(struct WASMModuleInstanceCommon *module_inst,
     if (module_inst->module_type == Wasm_Module_AoT) {
         AOTModule *module =
             (AOTModule *)((AOTModuleInstance *)module_inst)->module;
-        exec_env->aux_stack_bottom.bottom = module->aux_stack_bottom;
-        exec_env->aux_stack_boundary.boundary =
-            module->aux_stack_bottom - module->aux_stack_size;
+        /* TODO: only assert when it's not memory64 */
+        bh_assert(module->aux_stack_bottom < UINT32_MAX);
+        exec_env->aux_stack_bottom = (uintptr_t)module->aux_stack_bottom;
+        exec_env->aux_stack_boundary =
+            (uintptr_t)module->aux_stack_bottom - module->aux_stack_size;
 #if WASM_ENABLE_GC != 0
         gc_heap_handle =
             ((AOTModuleInstanceExtra *)((AOTModuleInstance *)module_inst)->e)

--- a/core/iwasm/common/wasm_exec_env.h
+++ b/core/iwasm/common/wasm_exec_env.h
@@ -62,16 +62,10 @@ typedef struct WASMExecEnv {
     WASMSuspendFlags suspend_flags;
 
     /* Auxiliary stack boundary */
-    union {
-        uint32 boundary;
-        uintptr_t __padding__;
-    } aux_stack_boundary;
+    uintptr_t aux_stack_boundary;
 
     /* Auxiliary stack bottom */
-    union {
-        uint32 bottom;
-        uintptr_t __padding__;
-    } aux_stack_bottom;
+    uintptr_t aux_stack_bottom;
 
 #if WASM_ENABLE_AOT != 0
     /* Native symbol list, reserved */
@@ -195,8 +189,7 @@ wasm_exec_env_destroy(WASMExecEnv *exec_env);
 static inline bool
 wasm_exec_env_is_aux_stack_managed_by_runtime(WASMExecEnv *exec_env)
 {
-    return exec_env->aux_stack_boundary.boundary != 0
-           || exec_env->aux_stack_bottom.bottom != 0;
+    return exec_env->aux_stack_boundary != 0 || exec_env->aux_stack_bottom != 0;
 }
 
 /**

--- a/core/iwasm/common/wasm_memory.h
+++ b/core/iwasm/common/wasm_memory.h
@@ -20,7 +20,7 @@ extern "C" {
     BH_ATOMIC_64_LOAD(memory->memory_data_size)
 #define SET_LINEAR_MEMORY_SIZE(memory, size) \
     BH_ATOMIC_64_STORE(memory->memory_data_size, size)
-#else
+#elif WASM_ENABLE_SHARED_MEMORY != 0
 static inline uint64
 GET_LINEAR_MEMORY_SIZE(const WASMMemoryInstance *memory)
 {
@@ -36,6 +36,9 @@ SET_LINEAR_MEMORY_SIZE(WASMMemoryInstance *memory, uint64 size)
     BH_ATOMIC_64_STORE(memory->memory_data_size, size);
     SHARED_MEMORY_UNLOCK(memory);
 }
+#else
+#define GET_LINEAR_MEMORY_SIZE(memory) memory->memory_data_size
+#define SET_LINEAR_MEMORY_SIZE(memory, size) memory->memory_data_size = size
 #endif
 
 bool

--- a/core/iwasm/common/wasm_memory.h
+++ b/core/iwasm/common/wasm_memory.h
@@ -9,19 +9,33 @@
 #include "bh_common.h"
 #include "../include/wasm_export.h"
 #include "../interpreter/wasm_runtime.h"
+#include "../common/wasm_shared_memory.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#if WASM_ENABLE_SHARED_MEMORY != 0
+#if WASM_ENABLE_SHARED_MEMORY != 0 && BH_ATOMIC_64_IS_ATOMIC != 0
 #define GET_LINEAR_MEMORY_SIZE(memory) \
     BH_ATOMIC_64_LOAD(memory->memory_data_size)
 #define SET_LINEAR_MEMORY_SIZE(memory, size) \
     BH_ATOMIC_64_STORE(memory->memory_data_size, size)
 #else
-#define GET_LINEAR_MEMORY_SIZE(memory) memory->memory_data_size
-#define SET_LINEAR_MEMORY_SIZE(memory, size) memory->memory_data_size = size
+static inline uint64
+GET_LINEAR_MEMORY_SIZE(const WASMMemoryInstance *memory)
+{
+    SHARED_MEMORY_LOCK(memory);
+    uint64 memory_data_size = BH_ATOMIC_64_LOAD(memory->memory_data_size);
+    SHARED_MEMORY_UNLOCK(memory);
+    return memory_data_size;
+}
+static inline void
+SET_LINEAR_MEMORY_SIZE(WASMMemoryInstance *memory, uint64 size)
+{
+    SHARED_MEMORY_LOCK(memory);
+    BH_ATOMIC_64_STORE(memory->memory_data_size, size);
+    SHARED_MEMORY_UNLOCK(memory);
+}
 #endif
 
 bool

--- a/core/iwasm/common/wasm_memory.h
+++ b/core/iwasm/common/wasm_memory.h
@@ -16,9 +16,9 @@ extern "C" {
 
 #if WASM_ENABLE_SHARED_MEMORY != 0
 #define GET_LINEAR_MEMORY_SIZE(memory) \
-    BH_ATOMIC_32_LOAD(memory->memory_data_size)
+    BH_ATOMIC_64_LOAD(memory->memory_data_size)
 #define SET_LINEAR_MEMORY_SIZE(memory, size) \
-    BH_ATOMIC_32_STORE(memory->memory_data_size, size)
+    BH_ATOMIC_64_STORE(memory->memory_data_size, size)
 #else
 #define GET_LINEAR_MEMORY_SIZE(memory) memory->memory_data_size
 #define SET_LINEAR_MEMORY_SIZE(memory, size) memory->memory_data_size = size

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -2772,9 +2772,9 @@ wasm_runtime_is_bounds_checks_enabled(WASMModuleInstanceCommon *module_inst)
 }
 #endif
 
-uint32
+uint64
 wasm_runtime_module_malloc_internal(WASMModuleInstanceCommon *module_inst,
-                                    WASMExecEnv *exec_env, uint32 size,
+                                    WASMExecEnv *exec_env, uint64 size,
                                     void **p_native_addr)
 {
 #if WASM_ENABLE_INTERP != 0
@@ -2790,10 +2790,10 @@ wasm_runtime_module_malloc_internal(WASMModuleInstanceCommon *module_inst,
     return 0;
 }
 
-uint32
+uint64
 wasm_runtime_module_realloc_internal(WASMModuleInstanceCommon *module_inst,
-                                     WASMExecEnv *exec_env, uint32 ptr,
-                                     uint32 size, void **p_native_addr)
+                                     WASMExecEnv *exec_env, uint64 ptr,
+                                     uint64 size, void **p_native_addr)
 {
 #if WASM_ENABLE_INTERP != 0
     if (module_inst->module_type == Wasm_Module_Bytecode)
@@ -2810,7 +2810,7 @@ wasm_runtime_module_realloc_internal(WASMModuleInstanceCommon *module_inst,
 
 void
 wasm_runtime_module_free_internal(WASMModuleInstanceCommon *module_inst,
-                                  WASMExecEnv *exec_env, uint32 ptr)
+                                  WASMExecEnv *exec_env, uint64 ptr)
 {
 #if WASM_ENABLE_INTERP != 0
     if (module_inst->module_type == Wasm_Module_Bytecode) {
@@ -2847,7 +2847,7 @@ wasm_runtime_module_malloc(WASMModuleInstanceCommon *module_inst, uint64 size,
 
 uint64
 wasm_runtime_module_realloc(WASMModuleInstanceCommon *module_inst, uint64 ptr,
-                            uint size, void **p_native_addr)
+                            uint64 size, void **p_native_addr)
 {
 #if WASM_ENABLE_INTERP != 0
     if (module_inst->module_type == Wasm_Module_Bytecode)

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -1190,7 +1190,7 @@ wasm_runtime_is_built_in_module(const char *module_name)
 
 #if WASM_ENABLE_THREAD_MGR != 0
 bool
-wasm_exec_env_set_aux_stack(WASMExecEnv *exec_env, uint32 start_offset,
+wasm_exec_env_set_aux_stack(WASMExecEnv *exec_env, uint64 start_offset,
                             uint32 size)
 {
     WASMModuleInstanceCommon *module_inst =
@@ -1209,7 +1209,7 @@ wasm_exec_env_set_aux_stack(WASMExecEnv *exec_env, uint32 start_offset,
 }
 
 bool
-wasm_exec_env_get_aux_stack(WASMExecEnv *exec_env, uint32 *start_offset,
+wasm_exec_env_get_aux_stack(WASMExecEnv *exec_env, uint64 *start_offset,
                             uint32 *size)
 {
     WASMModuleInstanceCommon *module_inst =
@@ -2828,8 +2828,8 @@ wasm_runtime_module_free_internal(WASMModuleInstanceCommon *module_inst,
 #endif
 }
 
-uint32
-wasm_runtime_module_malloc(WASMModuleInstanceCommon *module_inst, uint32 size,
+uint64
+wasm_runtime_module_malloc(WASMModuleInstanceCommon *module_inst, uint64 size,
                            void **p_native_addr)
 {
 #if WASM_ENABLE_INTERP != 0
@@ -2845,9 +2845,9 @@ wasm_runtime_module_malloc(WASMModuleInstanceCommon *module_inst, uint32 size,
     return 0;
 }
 
-uint32
-wasm_runtime_module_realloc(WASMModuleInstanceCommon *module_inst, uint32 ptr,
-                            uint32 size, void **p_native_addr)
+uint64
+wasm_runtime_module_realloc(WASMModuleInstanceCommon *module_inst, uint64 ptr,
+                            uint size, void **p_native_addr)
 {
 #if WASM_ENABLE_INTERP != 0
     if (module_inst->module_type == Wasm_Module_Bytecode)
@@ -2863,7 +2863,7 @@ wasm_runtime_module_realloc(WASMModuleInstanceCommon *module_inst, uint32 ptr,
 }
 
 void
-wasm_runtime_module_free(WASMModuleInstanceCommon *module_inst, uint32 ptr)
+wasm_runtime_module_free(WASMModuleInstanceCommon *module_inst, uint64 ptr)
 {
 #if WASM_ENABLE_INTERP != 0
     if (module_inst->module_type == Wasm_Module_Bytecode) {
@@ -2879,9 +2879,9 @@ wasm_runtime_module_free(WASMModuleInstanceCommon *module_inst, uint32 ptr)
 #endif
 }
 
-uint32
+uint64
 wasm_runtime_module_dup_data(WASMModuleInstanceCommon *module_inst,
-                             const char *src, uint32 size)
+                             const char *src, uint64 size)
 {
 #if WASM_ENABLE_INTERP != 0
     if (module_inst->module_type == Wasm_Module_Bytecode) {
@@ -3702,23 +3702,23 @@ wasm_runtime_invoke_native_raw(WASMExecEnv *exec_env, void *func_ptr,
                             /* pointer without length followed */
                             ptr_len = 1;
 
-                        if (!wasm_runtime_validate_app_addr(module, arg_i32,
-                                                            ptr_len))
+                        if (!wasm_runtime_validate_app_addr(
+                                module, (uint64)arg_i32, (uint64)ptr_len))
                             goto fail;
 
                         *(uintptr_t *)argv_dst =
-                            (uintptr_t)wasm_runtime_addr_app_to_native(module,
-                                                                       arg_i32);
+                            (uintptr_t)wasm_runtime_addr_app_to_native(
+                                module, (uint64)arg_i32);
                     }
                     else if (signature[i + 1] == '$') {
                         /* param is a string */
-                        if (!wasm_runtime_validate_app_str_addr(module,
-                                                                arg_i32))
+                        if (!wasm_runtime_validate_app_str_addr(
+                                module, (uint64)arg_i32))
                             goto fail;
 
                         *(uintptr_t *)argv_dst =
-                            (uintptr_t)wasm_runtime_addr_app_to_native(module,
-                                                                       arg_i32);
+                            (uintptr_t)wasm_runtime_addr_app_to_native(
+                                module, (uint64)arg_i32);
                     }
                 }
                 break;
@@ -4124,21 +4124,21 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
                             /* pointer without length followed */
                             ptr_len = 1;
 
-                        if (!wasm_runtime_validate_app_addr(module, arg_i32,
-                                                            ptr_len))
+                        if (!wasm_runtime_validate_app_addr(
+                                module, (uint64)arg_i32, (uint64)ptr_len))
                             goto fail;
 
                         arg_i32 = (uintptr_t)wasm_runtime_addr_app_to_native(
-                            module, arg_i32);
+                            module, (uint64)arg_i32);
                     }
                     else if (signature[i + 1] == '$') {
                         /* param is a string */
-                        if (!wasm_runtime_validate_app_str_addr(module,
-                                                                arg_i32))
+                        if (!wasm_runtime_validate_app_str_addr(
+                                module, (uint64)arg_i32))
                             goto fail;
 
                         arg_i32 = (uintptr_t)wasm_runtime_addr_app_to_native(
-                            module, arg_i32);
+                            module, (uint64)arg_i32);
                     }
                 }
 
@@ -4499,21 +4499,21 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
                             /* pointer without length followed */
                             ptr_len = 1;
 
-                        if (!wasm_runtime_validate_app_addr(module, arg_i32,
-                                                            ptr_len))
+                        if (!wasm_runtime_validate_app_addr(
+                                module, (uint64)arg_i32, (uint64)ptr_len))
                             goto fail;
 
                         arg_i32 = (uintptr_t)wasm_runtime_addr_app_to_native(
-                            module, arg_i32);
+                            module, (uint64)arg_i32);
                     }
                     else if (signature[i + 1] == '$') {
                         /* param is a string */
-                        if (!wasm_runtime_validate_app_str_addr(module,
-                                                                arg_i32))
+                        if (!wasm_runtime_validate_app_str_addr(
+                                module, (uint64)arg_i32))
                             goto fail;
 
                         arg_i32 = (uintptr_t)wasm_runtime_addr_app_to_native(
-                            module, arg_i32);
+                            module, (uint64)arg_i32);
                     }
                 }
 
@@ -4814,21 +4814,21 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
                             /* pointer without length followed */
                             ptr_len = 1;
 
-                        if (!wasm_runtime_validate_app_addr(module, arg_i32,
-                                                            ptr_len))
+                        if (!wasm_runtime_validate_app_addr(
+                                module, (uint64)arg_i32, (uint64)ptr_len))
                             goto fail;
 
                         arg_i64 = (uintptr_t)wasm_runtime_addr_app_to_native(
-                            module, arg_i32);
+                            module, (uint64)arg_i32);
                     }
                     else if (signature[i + 1] == '$') {
                         /* param is a string */
-                        if (!wasm_runtime_validate_app_str_addr(module,
-                                                                arg_i32))
+                        if (!wasm_runtime_validate_app_str_addr(
+                                module, (uint64)arg_i32))
                             goto fail;
 
                         arg_i64 = (uintptr_t)wasm_runtime_addr_app_to_native(
-                            module, arg_i32);
+                            module, (uint64)arg_i32);
                     }
                 }
                 if (n_ints < MAX_REG_INTS)

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -1611,11 +1611,11 @@ wasm_runtime_dump_module_inst_mem_consumption(
     }
 #endif
 
-    os_printf("WASM module inst memory consumption, total size: %u\n",
+    os_printf("WASM module inst memory consumption, total size: %lu\n",
               mem_conspn.total_size);
     os_printf("    module inst struct size: %u\n",
               mem_conspn.module_inst_struct_size);
-    os_printf("    memories size: %u\n", mem_conspn.memories_size);
+    os_printf("    memories size: %lu\n", mem_conspn.memories_size);
     os_printf("        app heap size: %u\n", mem_conspn.app_heap_size);
     os_printf("    tables size: %u\n", mem_conspn.tables_size);
     os_printf("    functions size: %u\n", mem_conspn.functions_size);
@@ -1650,8 +1650,9 @@ wasm_runtime_dump_mem_consumption(WASMExecEnv *exec_env)
     WASMModuleInstanceCommon *module_inst_common;
     WASMModuleCommon *module_common = NULL;
     void *heap_handle = NULL;
-    uint32 total_size = 0, app_heap_peak_size = 0;
+    uint32 app_heap_peak_size = 0;
     uint32 max_aux_stack_used = -1;
+    uint64 total_size = 0;
 
     module_inst_common = exec_env->module_inst;
 #if WASM_ENABLE_INTERP != 0
@@ -3691,6 +3692,8 @@ wasm_runtime_invoke_native_raw(WASMExecEnv *exec_env, void *func_ptr,
             case VALUE_TYPE_FUNCREF:
 #endif
             {
+                /* TODO: memory64 the data type of ptr_len and argc depends on
+                 * mem idx type */
                 *(uint32 *)argv_dst = arg_i32 = *argv_src++;
                 if (signature) {
                     if (signature[i + 1] == '*') {
@@ -4114,6 +4117,8 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
             {
                 arg_i32 = *argv_src++;
 
+                /* TODO: memory64 the data type of ptr_len and argc depends on
+                 * mem idx type */
                 if (signature) {
                     if (signature[i + 1] == '*') {
                         /* param is a pointer */
@@ -4489,6 +4494,8 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
             {
                 arg_i32 = *argv++;
 
+                /* TODO: memory64 the data type of ptr_len and argc depends on
+                 * mem idx type */
                 if (signature) {
                     if (signature[i + 1] == '*') {
                         /* param is a pointer */
@@ -4804,6 +4811,8 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
             {
                 arg_i32 = *argv_src++;
                 arg_i64 = arg_i32;
+                /* TODO: memory64 the data type of ptr_len and argc depends on
+                 * mem idx type */
                 if (signature) {
                     if (signature[i + 1] == '*') {
                         /* param is a pointer */

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -770,21 +770,21 @@ WASM_RUNTIME_API_EXTERN void *
 wasm_runtime_get_custom_data(WASMModuleInstanceCommon *module_inst);
 
 /* Internal API */
-uint32
+uint64
 wasm_runtime_module_malloc_internal(WASMModuleInstanceCommon *module_inst,
-                                    WASMExecEnv *exec_env, uint32 size,
+                                    WASMExecEnv *exec_env, uint64 size,
                                     void **p_native_addr);
 
 /* Internal API */
-uint32
+uint64
 wasm_runtime_module_realloc_internal(WASMModuleInstanceCommon *module_inst,
-                                     WASMExecEnv *exec_env, uint32 ptr,
-                                     uint32 size, void **p_native_addr);
+                                     WASMExecEnv *exec_env, uint64 ptr,
+                                     uint64 size, void **p_native_addr);
 
 /* Internal API */
 void
 wasm_runtime_module_free_internal(WASMModuleInstanceCommon *module_inst,
-                                  WASMExecEnv *exec_env, uint32 ptr);
+                                  WASMExecEnv *exec_env, uint64 ptr);
 
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN uint64

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -787,49 +787,49 @@ wasm_runtime_module_free_internal(WASMModuleInstanceCommon *module_inst,
                                   WASMExecEnv *exec_env, uint32 ptr);
 
 /* See wasm_export.h for description */
-WASM_RUNTIME_API_EXTERN uint32
-wasm_runtime_module_malloc(WASMModuleInstanceCommon *module_inst, uint32 size,
+WASM_RUNTIME_API_EXTERN uint64
+wasm_runtime_module_malloc(WASMModuleInstanceCommon *module_inst, uint64 size,
                            void **p_native_addr);
 
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN void
-wasm_runtime_module_free(WASMModuleInstanceCommon *module_inst, uint32 ptr);
+wasm_runtime_module_free(WASMModuleInstanceCommon *module_inst, uint64 ptr);
 
 /* See wasm_export.h for description */
-WASM_RUNTIME_API_EXTERN uint32
+WASM_RUNTIME_API_EXTERN uint64
 wasm_runtime_module_dup_data(WASMModuleInstanceCommon *module_inst,
-                             const char *src, uint32 size);
+                             const char *src, uint64 size);
 
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_validate_app_addr(WASMModuleInstanceCommon *module_inst,
-                               uint32 app_offset, uint32 size);
+                               uint64 app_offset, uint64 size);
 
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_validate_app_str_addr(WASMModuleInstanceCommon *module_inst,
-                                   uint32 app_str_offset);
+                                   uint64 app_str_offset);
 
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_validate_native_addr(WASMModuleInstanceCommon *module_inst,
-                                  void *native_ptr, uint32 size);
+                                  void *native_ptr, uint64 size);
 
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN void *
 wasm_runtime_addr_app_to_native(WASMModuleInstanceCommon *module_inst,
-                                uint32 app_offset);
+                                uint64 app_offset);
 
 /* See wasm_export.h for description */
-WASM_RUNTIME_API_EXTERN uint32
+WASM_RUNTIME_API_EXTERN uint64
 wasm_runtime_addr_native_to_app(WASMModuleInstanceCommon *module_inst,
                                 void *native_ptr);
 
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_get_app_addr_range(WASMModuleInstanceCommon *module_inst,
-                                uint32 app_offset, uint32 *p_app_start_offset,
-                                uint32 *p_app_end_offset);
+                                uint64 app_offset, uint64 *p_app_start_offset,
+                                uint64 *p_app_end_offset);
 
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN bool
@@ -916,11 +916,11 @@ wasm_runtime_is_built_in_module(const char *module_name);
 
 #if WASM_ENABLE_THREAD_MGR != 0
 bool
-wasm_exec_env_get_aux_stack(WASMExecEnv *exec_env, uint32 *start_offset,
+wasm_exec_env_get_aux_stack(WASMExecEnv *exec_env, uint64 *start_offset,
                             uint32 *size);
 
 bool
-wasm_exec_env_set_aux_stack(WASMExecEnv *exec_env, uint32 start_offset,
+wasm_exec_env_set_aux_stack(WASMExecEnv *exec_env, uint64 start_offset,
                             uint32 size);
 #endif
 

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -413,10 +413,10 @@ typedef struct WASMModuleMemConsumption {
 } WASMModuleMemConsumption;
 
 typedef struct WASMModuleInstMemConsumption {
-    uint32 total_size;
+    uint64 total_size;
     uint32 module_inst_struct_size;
-    uint32 memories_size;
     uint32 app_heap_size;
+    uint64 memories_size;
     uint32 tables_size;
     uint32 globals_size;
     uint32 functions_size;

--- a/core/iwasm/compilation/aot.h
+++ b/core/iwasm/compilation/aot.h
@@ -316,11 +316,11 @@ typedef struct AOTCompData {
     uint32 retain_func_index;
 
     uint32 aux_data_end_global_index;
-    uint32 aux_data_end;
+    uint64 aux_data_end;
     uint32 aux_heap_base_global_index;
-    uint32 aux_heap_base;
+    uint64 aux_heap_base;
     uint32 aux_stack_top_global_index;
-    uint32 aux_stack_bottom;
+    uint64 aux_stack_bottom;
     uint32 aux_stack_size;
 
 #if WASM_ENABLE_STRINGREF != 0

--- a/core/iwasm/compilation/aot_emit_aot_file.c
+++ b/core/iwasm/compilation/aot_emit_aot_file.c
@@ -850,7 +850,7 @@ get_init_data_section_size(AOTCompContext *comp_ctx, AOTCompData *comp_data,
     size += (uint32)sizeof(uint32) * 2;
 
     /* aux data/heap/stack data */
-    size += sizeof(uint32) * 7;
+    size += sizeof(uint32) * 10;
 
     size += get_object_data_section_info_size(comp_ctx, obj_data);
     return size;
@@ -2428,11 +2428,11 @@ aot_emit_init_data_section(uint8 *buf, uint8 *buf_end, uint32 *p_offset,
     EMIT_U32(comp_data->start_func_index);
 
     EMIT_U32(comp_data->aux_data_end_global_index);
-    EMIT_U32(comp_data->aux_data_end);
+    EMIT_U64(comp_data->aux_data_end);
     EMIT_U32(comp_data->aux_heap_base_global_index);
-    EMIT_U32(comp_data->aux_heap_base);
+    EMIT_U64(comp_data->aux_heap_base);
     EMIT_U32(comp_data->aux_stack_top_global_index);
-    EMIT_U32(comp_data->aux_stack_bottom);
+    EMIT_U64(comp_data->aux_stack_bottom);
     EMIT_U32(comp_data->aux_stack_size);
 
     if (!aot_emit_object_data_section_info(buf, buf_end, &offset, comp_ctx,

--- a/core/iwasm/compilation/aot_emit_function.c
+++ b/core/iwasm/compilation/aot_emit_function.c
@@ -1560,13 +1560,13 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                               comp_ctx->builder, native_addr_size, I64_TYPE,
                               "native_addr_size_i64"))) {
                         aot_set_last_error("llvm build zextOrBitCast failed.");
-                        return false;
+                        goto fail;
                     }
                     if (!(param_values[j] = LLVMBuildZExtOrBitCast(
                               comp_ctx->builder, param_values[j], I64_TYPE,
                               "native_addr_i64"))) {
                         aot_set_last_error("llvm build zextOrBitCast failed.");
-                        return false;
+                        goto fail;
                     }
                     if (!check_app_addr_and_convert(
                             comp_ctx, func_ctx, false, param_values[j],
@@ -1581,7 +1581,7 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                               comp_ctx->builder, param_values[j], I64_TYPE,
                               "native_addr_i64"))) {
                         aot_set_last_error("llvm build zextOrBitCast failed.");
-                        return false;
+                        goto fail;
                     }
                     if (!check_app_addr_and_convert(
                             comp_ctx, func_ctx, true, param_values[j],

--- a/core/iwasm/compilation/aot_emit_function.c
+++ b/core/iwasm/compilation/aot_emit_function.c
@@ -1154,6 +1154,7 @@ free_frame_for_aot_func(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
  * Check whether the app address and its buffer are inside the linear memory,
  * if no, throw exception
  */
+/* TODO: type changes */
 static bool
 check_app_addr_and_convert(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                            bool is_str_arg, LLVMValueRef app_addr,

--- a/core/iwasm/compilation/aot_emit_memory.c
+++ b/core/iwasm/compilation/aot_emit_memory.c
@@ -919,7 +919,7 @@ check_bulk_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             comp_ctx->comp_data->memories[0].num_bytes_per_page;
         uint32 init_page_count =
             comp_ctx->comp_data->memories[0].mem_init_page_count;
-        uint32 mem_data_size = num_bytes_per_page * init_page_count;
+        uint64 mem_data_size = (uint64)num_bytes_per_page * init_page_count;
         if (mem_data_size > 0 && mem_offset + mem_len <= mem_data_size) {
             /* inside memory space */
             /* maddr = mem_base_addr + moffset */
@@ -938,7 +938,7 @@ check_bulk_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     }
     else {
         if (!(mem_size = LLVMBuildLoad2(
-                  comp_ctx->builder, I32_TYPE,
+                  comp_ctx->builder, I64_TYPE,
                   func_ctx->mem_info[0].mem_data_size_addr, "mem_size"))) {
             aot_set_last_error("llvm build load failed.");
             goto fail;

--- a/core/iwasm/compilation/aot_emit_memory.c
+++ b/core/iwasm/compilation/aot_emit_memory.c
@@ -951,8 +951,6 @@ check_bulk_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     offset =
         LLVMBuildZExt(comp_ctx->builder, offset, I64_TYPE, "extend_offset");
     bytes = LLVMBuildZExt(comp_ctx->builder, bytes, I64_TYPE, "extend_len");
-    mem_size =
-        LLVMBuildZExt(comp_ctx->builder, mem_size, I64_TYPE, "extend_size");
 
     BUILD_OP(Add, offset, bytes, max_addr, "max_addr");
     BUILD_ICMP(LLVMIntUGT, max_addr, mem_size, cmp, "cmp_max_mem_addr");

--- a/core/iwasm/compilation/aot_emit_variable.c
+++ b/core/iwasm/compilation/aot_emit_variable.c
@@ -271,6 +271,8 @@ compile_global(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             LLVMMoveBasicBlockAfter(check_underflow_succ, check_overflow_succ);
 
             /* Check aux stack overflow */
+
+            /* TODO: memory64 cast to mem idx type */
             if (!(aux_stack_bound = LLVMBuildTruncOrBitCast(
                       comp_ctx->builder, func_ctx->aux_stack_bound,
                       TO_LLVM_TYPE(global_type), "aux_stack_bound"))) {
@@ -289,9 +291,11 @@ compile_global(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
             /* Check aux stack underflow */
             LLVMPositionBuilderAtEnd(comp_ctx->builder, check_overflow_succ);
+
+            /* TODO: memory64 cast to mem idx type */
             if (!(aux_stack_bottom = LLVMBuildTruncOrBitCast(
                       comp_ctx->builder, func_ctx->aux_stack_bottom,
-                      TO_LLVM_TYPE(global_type), "aux_stack_bound"))) {
+                      TO_LLVM_TYPE(global_type), "aux_stack_bottom"))) {
                 aot_set_last_error("llvm build truncOrBitCast failed.");
                 return false;
             }

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -1365,7 +1365,7 @@ create_memory_info(const AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     }
     if (!(func_ctx->mem_info[0].mem_data_size_addr = LLVMBuildBitCast(
               comp_ctx->builder, func_ctx->mem_info[0].mem_data_size_addr,
-              INT32_PTR_TYPE, "mem_data_size_ptr"))) {
+              INT64_PTR_TYPE, "mem_data_size_ptr"))) {
         aot_set_last_error("llvm build bit cast failed");
         return false;
     }
@@ -1384,7 +1384,7 @@ create_memory_info(const AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
             return false;
         }
         if (!(func_ctx->mem_info[0].mem_data_size_addr = LLVMBuildLoad2(
-                  comp_ctx->builder, I32_TYPE,
+                  comp_ctx->builder, I64_TYPE,
                   func_ctx->mem_info[0].mem_data_size_addr, "mem_data_size"))) {
             aot_set_last_error("llvm build load failed");
             return false;

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -1015,10 +1015,9 @@ create_aux_stack_info(const AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
         aot_set_last_error("llvm build load failed");
         return false;
     }
-    /* TODO: Memory64 the actual type depends on mem_idx type */
-    if (!(func_ctx->aux_stack_bound = LLVMBuildTruncOrBitCast(
-              comp_ctx->builder, func_ctx->aux_stack_bound, I32_TYPE,
-              "aux_stack_bound_mem_idx_type"))) {
+    if (!(func_ctx->aux_stack_bound =
+              LLVMBuildZExt(comp_ctx->builder, func_ctx->aux_stack_bound,
+                            I64_TYPE, "aux_stack_bound_i64"))) {
         aot_set_last_error("llvm build truncOrBitCast failed.");
         return false;
     }
@@ -1044,10 +1043,9 @@ create_aux_stack_info(const AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
         aot_set_last_error("llvm build load failed");
         return false;
     }
-    /* TODO: Memory64 the actual type depends on mem_idx type */
-    if (!(func_ctx->aux_stack_bottom = LLVMBuildTruncOrBitCast(
-              comp_ctx->builder, func_ctx->aux_stack_bottom, I32_TYPE,
-              "aux_stack_bottom_mem_idx_type"))) {
+    if (!(func_ctx->aux_stack_bottom =
+              LLVMBuildZExt(comp_ctx->builder, func_ctx->aux_stack_bottom,
+                            I64_TYPE, "aux_stack_bottom_i64"))) {
         aot_set_last_error("llvm build truncOrBitCast failed.");
         return false;
     }

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -992,10 +992,7 @@ static bool
 create_aux_stack_info(const AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 {
     LLVMValueRef aux_stack_bound_offset = I32_SIX, aux_stack_bound_addr;
-    LLVMValueRef aux_stack_bottom_offset =
-                     comp_ctx->pointer_size == sizeof(uint64) ? I32_EIGHT
-                                                              : I32_SEVEN,
-                 aux_stack_bottom_addr;
+    LLVMValueRef aux_stack_bottom_offset = I32_SEVEN, aux_stack_bottom_addr;
 
     /* Get aux stack boundary address */
     if (!(aux_stack_bound_addr = LLVMBuildInBoundsGEP2(

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -992,7 +992,10 @@ static bool
 create_aux_stack_info(const AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 {
     LLVMValueRef aux_stack_bound_offset = I32_SIX, aux_stack_bound_addr;
-    LLVMValueRef aux_stack_bottom_offset = I32_SEVEN, aux_stack_bottom_addr;
+    LLVMValueRef aux_stack_bottom_offset =
+                     comp_ctx->pointer_size == sizeof(uint64) ? I32_EIGHT
+                                                              : I32_SEVEN,
+                 aux_stack_bottom_addr;
 
     /* Get aux stack boundary address */
     if (!(aux_stack_bound_addr = LLVMBuildInBoundsGEP2(
@@ -1004,14 +1007,14 @@ create_aux_stack_info(const AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 
     if (!(aux_stack_bound_addr =
               LLVMBuildBitCast(comp_ctx->builder, aux_stack_bound_addr,
-                               INT32_PTR_TYPE, "aux_stack_bound_ptr"))) {
+                               INTPTR_T_PTR_TYPE, "aux_stack_bound_ptr"))) {
         aot_set_last_error("llvm build bit cast failed");
         return false;
     }
 
     if (!(func_ctx->aux_stack_bound =
-              LLVMBuildLoad2(comp_ctx->builder, I32_TYPE, aux_stack_bound_addr,
-                             "aux_stack_bound"))) {
+              LLVMBuildLoad2(comp_ctx->builder, INTPTR_T_TYPE,
+                             aux_stack_bound_addr, "aux_stack_bound"))) {
         aot_set_last_error("llvm build load failed");
         return false;
     }
@@ -1026,13 +1029,13 @@ create_aux_stack_info(const AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 
     if (!(aux_stack_bottom_addr =
               LLVMBuildBitCast(comp_ctx->builder, aux_stack_bottom_addr,
-                               INT32_PTR_TYPE, "aux_stack_bottom_ptr"))) {
+                               INTPTR_T_PTR_TYPE, "aux_stack_bottom_ptr"))) {
         aot_set_last_error("llvm build bit cast failed");
         return false;
     }
     if (!(func_ctx->aux_stack_bottom =
-              LLVMBuildLoad2(comp_ctx->builder, I32_TYPE, aux_stack_bottom_addr,
-                             "aux_stack_bottom"))) {
+              LLVMBuildLoad2(comp_ctx->builder, INTPTR_T_TYPE,
+                             aux_stack_bottom_addr, "aux_stack_bottom"))) {
         aot_set_last_error("llvm build load failed");
         return false;
     }

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -1011,8 +1011,15 @@ create_aux_stack_info(const AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 
     if (!(func_ctx->aux_stack_bound =
               LLVMBuildLoad2(comp_ctx->builder, INTPTR_T_TYPE,
-                             aux_stack_bound_addr, "aux_stack_bound"))) {
+                             aux_stack_bound_addr, "aux_stack_bound_intptr"))) {
         aot_set_last_error("llvm build load failed");
+        return false;
+    }
+    /* TODO: Memory64 the actual type depends on mem_idx type */
+    if (!(func_ctx->aux_stack_bound = LLVMBuildTruncOrBitCast(
+              comp_ctx->builder, func_ctx->aux_stack_bound, I32_TYPE,
+              "aux_stack_bound_mem_idx_type"))) {
+        aot_set_last_error("llvm build truncOrBitCast failed.");
         return false;
     }
 
@@ -1030,10 +1037,18 @@ create_aux_stack_info(const AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
         aot_set_last_error("llvm build bit cast failed");
         return false;
     }
+
     if (!(func_ctx->aux_stack_bottom =
               LLVMBuildLoad2(comp_ctx->builder, INTPTR_T_TYPE,
                              aux_stack_bottom_addr, "aux_stack_bottom"))) {
         aot_set_last_error("llvm build load failed");
+        return false;
+    }
+    /* TODO: Memory64 the actual type depends on mem_idx type */
+    if (!(func_ctx->aux_stack_bottom = LLVMBuildTruncOrBitCast(
+              comp_ctx->builder, func_ctx->aux_stack_bottom, I32_TYPE,
+              "aux_stack_bottom_mem_idx_type"))) {
+        aot_set_last_error("llvm build truncOrBitCast failed.");
         return false;
     }
 

--- a/core/iwasm/fast-jit/fe/jit_emit_function.c
+++ b/core/iwasm/fast-jit/fe/jit_emit_function.c
@@ -331,12 +331,13 @@ jit_compile_op_call(JitCompContext *cc, uint32 func_idx, bool tail_call)
                 func_params[1] = NEW_CONST(I32, false); /* is_str = false */
                 func_params[2] = argvs[i];
                 if (signature[i + 2] == '~') {
+                    func_params[3] = jit_cc_new_reg_I64(cc);
                     /* pointer with length followed */
-                    func_params[3] = argvs[i + 1];
+                    GEN_INSN(I32TOI64, func_params[3], argvs[i + 1]);
                 }
                 else {
                     /* pointer with length followed */
-                    func_params[3] = NEW_CONST(I32, 1);
+                    func_params[3] = NEW_CONST(I64, 1);
                 }
             }
             else if (signature[i + 1] == '$') {
@@ -344,10 +345,15 @@ jit_compile_op_call(JitCompContext *cc, uint32 func_idx, bool tail_call)
                 is_pointer_arg = true;
                 func_params[1] = NEW_CONST(I32, true); /* is_str = true */
                 func_params[2] = argvs[i];
-                func_params[3] = NEW_CONST(I32, 1);
+                func_params[3] = NEW_CONST(I64, 1);
             }
 
             if (is_pointer_arg) {
+                JitReg native_addr_64 = jit_cc_new_reg_I64(cc);
+                /* TODO: Memory64 no need to convert if mem idx type is i64 */
+                GEN_INSN(I32TOI64, native_addr_64, func_params[2]);
+                func_params[2] = native_addr_64;
+
                 if (!jit_emit_callnative(cc, jit_check_app_addr_and_convert,
                                          ret, func_params, 5)) {
                     goto fail;

--- a/core/iwasm/fast-jit/fe/jit_emit_function.c
+++ b/core/iwasm/fast-jit/fe/jit_emit_function.c
@@ -331,6 +331,7 @@ jit_compile_op_call(JitCompContext *cc, uint32 func_idx, bool tail_call)
                 func_params[1] = NEW_CONST(I32, false); /* is_str = false */
                 func_params[2] = argvs[i];
                 if (signature[i + 2] == '~') {
+                    /* TODO: Memory64 no need to convert if mem idx type i64 */
                     func_params[3] = jit_cc_new_reg_I64(cc);
                     /* pointer with length followed */
                     GEN_INSN(I32TOI64, func_params[3], argvs[i + 1]);
@@ -350,7 +351,7 @@ jit_compile_op_call(JitCompContext *cc, uint32 func_idx, bool tail_call)
 
             if (is_pointer_arg) {
                 JitReg native_addr_64 = jit_cc_new_reg_I64(cc);
-                /* TODO: Memory64 no need to convert if mem idx type is i64 */
+                /* TODO: Memory64 no need to convert if mem idx type i64 */
                 GEN_INSN(I32TOI64, native_addr_64, func_params[2]);
                 func_params[2] = native_addr_64;
 

--- a/core/iwasm/fast-jit/fe/jit_emit_memory.c
+++ b/core/iwasm/fast-jit/fe/jit_emit_memory.c
@@ -630,7 +630,7 @@ wasm_init_memory(WASMModuleInstance *inst, uint32 mem_idx, uint32 seg_idx,
 {
     WASMMemoryInstance *mem_inst;
     WASMDataSeg *data_segment;
-    uint32 mem_size;
+    uint64 mem_size;
     uint8 *mem_addr, *data_addr;
     uint32 seg_len;
 

--- a/core/iwasm/fast-jit/fe/jit_emit_memory.c
+++ b/core/iwasm/fast-jit/fe/jit_emit_memory.c
@@ -655,7 +655,7 @@ wasm_init_memory(WASMModuleInstance *inst, uint32 mem_idx, uint32 seg_idx,
         goto out_of_bounds;
 
     mem_addr = mem_inst->memory_data + mem_offset;
-    bh_memcpy_s(mem_addr, mem_size - mem_offset, data_addr, len);
+    bh_memcpy_s(mem_addr, (uint32)mem_size - mem_offset, data_addr, len);
 
     return 0;
 out_of_bounds:
@@ -719,7 +719,7 @@ wasm_copy_memory(WASMModuleInstance *inst, uint32 src_mem_idx,
                  uint32 dst_offset)
 {
     WASMMemoryInstance *src_mem, *dst_mem;
-    uint32 src_mem_size, dst_mem_size;
+    uint64 src_mem_size, dst_mem_size;
     uint8 *src_addr, *dst_addr;
 
     src_mem = inst->memories[src_mem_idx];
@@ -738,7 +738,7 @@ wasm_copy_memory(WASMModuleInstance *inst, uint32 src_mem_idx,
     src_addr = src_mem->memory_data + src_offset;
     dst_addr = dst_mem->memory_data + dst_offset;
     /* allowing the destination and source to overlap */
-    bh_memmove_s(dst_addr, dst_mem_size - dst_offset, src_addr, len);
+    bh_memmove_s(dst_addr, (uint32)(dst_mem_size - dst_offset), src_addr, len);
 
     return 0;
 out_of_bounds:
@@ -784,7 +784,7 @@ wasm_fill_memory(WASMModuleInstance *inst, uint32 mem_idx, uint32 len,
                  uint32 val, uint32 dst)
 {
     WASMMemoryInstance *mem_inst;
-    uint32 mem_size;
+    uint64 mem_size;
     uint8 *dst_addr;
 
     mem_inst = inst->memories[mem_idx];

--- a/core/iwasm/fast-jit/fe/jit_emit_memory.c
+++ b/core/iwasm/fast-jit/fe/jit_emit_memory.c
@@ -655,7 +655,7 @@ wasm_init_memory(WASMModuleInstance *inst, uint32 mem_idx, uint32 seg_idx,
         goto out_of_bounds;
 
     mem_addr = mem_inst->memory_data + mem_offset;
-    bh_memcpy_s(mem_addr, (uint32)mem_size - mem_offset, data_addr, len);
+    bh_memcpy_s(mem_addr, (uint32)(mem_size - mem_offset), data_addr, len);
 
     return 0;
 out_of_bounds:

--- a/core/iwasm/fast-jit/fe/jit_emit_variable.c
+++ b/core/iwasm/fast-jit/fe/jit_emit_variable.c
@@ -265,10 +265,6 @@ jit_compile_op_set_global(JitCompContext *cc, uint32 global_idx,
                 JitReg aux_stack_bound = get_aux_stack_bound_reg(cc->jit_frame);
                 JitReg aux_stack_bottom =
                     get_aux_stack_bottom_reg(cc->jit_frame);
-#if UINTPTR_MAX == UINT64_MAX
-                GEN_INSN(I64TOI32, aux_stack_bound, aux_stack_bound);
-                GEN_INSN(I64TOI32, aux_stack_bottom, aux_stack_bottom);
-#endif
                 GEN_INSN(CMP, cc->cmp_reg, value, aux_stack_bound);
                 if (!(jit_emit_exception(cc, EXCE_AUX_STACK_OVERFLOW,
                                          JIT_OP_BLEU, cc->cmp_reg, NULL)))

--- a/core/iwasm/fast-jit/fe/jit_emit_variable.c
+++ b/core/iwasm/fast-jit/fe/jit_emit_variable.c
@@ -265,6 +265,10 @@ jit_compile_op_set_global(JitCompContext *cc, uint32 global_idx,
                 JitReg aux_stack_bound = get_aux_stack_bound_reg(cc->jit_frame);
                 JitReg aux_stack_bottom =
                     get_aux_stack_bottom_reg(cc->jit_frame);
+#if UINTPTR_MAX == UINT64_MAX
+                GEN_INSN(I64TOI32, aux_stack_bound, aux_stack_bound);
+                GEN_INSN(I64TOI32, aux_stack_bottom, aux_stack_bottom);
+#endif
                 GEN_INSN(CMP, cc->cmp_reg, value, aux_stack_bound);
                 if (!(jit_emit_exception(cc, EXCE_AUX_STACK_OVERFLOW,
                                          JIT_OP_BLEU, cc->cmp_reg, NULL)))

--- a/core/iwasm/fast-jit/jit_frontend.c
+++ b/core/iwasm/fast-jit/jit_frontend.c
@@ -194,12 +194,19 @@ JitReg
 get_aux_stack_bound_reg(JitFrame *frame)
 {
     JitCompContext *cc = frame->cc;
+#if UINTPTR_MAX == UINT64_MAX
+    JitReg tmp = jit_cc_new_reg_I32(cc);
+#endif
 
     if (!frame->aux_stack_bound_reg) {
         frame->aux_stack_bound_reg = cc->aux_stack_bound_reg;
-        GEN_INSN(
-            LDPTR, frame->aux_stack_bound_reg, cc->exec_env_reg,
-            NEW_CONST(I32, offsetof(WASMExecEnv, aux_stack_boundary)));
+        GEN_INSN(LDPTR, frame->aux_stack_bound_reg, cc->exec_env_reg,
+                 NEW_CONST(I32, offsetof(WASMExecEnv, aux_stack_boundary)));
+#if UINTPTR_MAX == UINT64_MAX
+        /* TODO: Memory64 whether to convert depends on memory idx type */
+        GEN_INSN(I64TOI32, tmp, frame->aux_stack_bound_reg);
+        frame->aux_stack_bound_reg = tmp;
+#endif
     }
     return frame->aux_stack_bound_reg;
 }
@@ -208,12 +215,19 @@ JitReg
 get_aux_stack_bottom_reg(JitFrame *frame)
 {
     JitCompContext *cc = frame->cc;
+#if UINTPTR_MAX == UINT64_MAX
+    JitReg tmp = jit_cc_new_reg_I32(cc);
+#endif
 
     if (!frame->aux_stack_bottom_reg) {
         frame->aux_stack_bottom_reg = cc->aux_stack_bottom_reg;
-        GEN_INSN(
-            LDPTR, frame->aux_stack_bottom_reg, cc->exec_env_reg,
-            NEW_CONST(I32, offsetof(WASMExecEnv, aux_stack_bottom)));
+        GEN_INSN(LDPTR, frame->aux_stack_bottom_reg, cc->exec_env_reg,
+                 NEW_CONST(I32, offsetof(WASMExecEnv, aux_stack_bottom)));
+#if UINTPTR_MAX == UINT64_MAX
+        /* TODO: Memory64 whether to convert depends on memory idx type */
+        GEN_INSN(I64TOI32, tmp, frame->aux_stack_bottom_reg);
+        frame->aux_stack_bottom_reg = tmp;
+#endif
     }
     return frame->aux_stack_bottom_reg;
 }

--- a/core/iwasm/fast-jit/jit_frontend.c
+++ b/core/iwasm/fast-jit/jit_frontend.c
@@ -198,8 +198,8 @@ get_aux_stack_bound_reg(JitFrame *frame)
     if (!frame->aux_stack_bound_reg) {
         frame->aux_stack_bound_reg = cc->aux_stack_bound_reg;
         GEN_INSN(
-            LDI32, frame->aux_stack_bound_reg, cc->exec_env_reg,
-            NEW_CONST(I32, offsetof(WASMExecEnv, aux_stack_boundary.boundary)));
+            LDPTR, frame->aux_stack_bound_reg, cc->exec_env_reg,
+            NEW_CONST(I32, offsetof(WASMExecEnv, aux_stack_boundary)));
     }
     return frame->aux_stack_bound_reg;
 }
@@ -212,8 +212,8 @@ get_aux_stack_bottom_reg(JitFrame *frame)
     if (!frame->aux_stack_bottom_reg) {
         frame->aux_stack_bottom_reg = cc->aux_stack_bottom_reg;
         GEN_INSN(
-            LDI32, frame->aux_stack_bottom_reg, cc->exec_env_reg,
-            NEW_CONST(I32, offsetof(WASMExecEnv, aux_stack_bottom.bottom)));
+            LDPTR, frame->aux_stack_bottom_reg, cc->exec_env_reg,
+            NEW_CONST(I32, offsetof(WASMExecEnv, aux_stack_bottom)));
     }
     return frame->aux_stack_bottom_reg;
 }
@@ -915,8 +915,9 @@ create_fixed_virtual_regs(JitCompContext *cc)
     cc->import_func_ptrs_reg = jit_cc_new_reg_ptr(cc);
     cc->fast_jit_func_ptrs_reg = jit_cc_new_reg_ptr(cc);
     cc->func_type_indexes_reg = jit_cc_new_reg_ptr(cc);
-    cc->aux_stack_bound_reg = jit_cc_new_reg_I32(cc);
-    cc->aux_stack_bottom_reg = jit_cc_new_reg_I32(cc);
+    // uintptr type
+    cc->aux_stack_bound_reg = jit_cc_new_reg_ptr(cc);
+    cc->aux_stack_bottom_reg = jit_cc_new_reg_ptr(cc);
 
     count = module->import_memory_count + module->memory_count;
     if (count > 0) {

--- a/core/iwasm/fast-jit/jit_frontend.c
+++ b/core/iwasm/fast-jit/jit_frontend.c
@@ -194,19 +194,15 @@ JitReg
 get_aux_stack_bound_reg(JitFrame *frame)
 {
     JitCompContext *cc = frame->cc;
-#if UINTPTR_MAX == UINT64_MAX
     JitReg tmp = jit_cc_new_reg_I32(cc);
-#endif
 
     if (!frame->aux_stack_bound_reg) {
         frame->aux_stack_bound_reg = cc->aux_stack_bound_reg;
         GEN_INSN(LDPTR, frame->aux_stack_bound_reg, cc->exec_env_reg,
                  NEW_CONST(I32, offsetof(WASMExecEnv, aux_stack_boundary)));
-#if UINTPTR_MAX == UINT64_MAX
         /* TODO: Memory64 whether to convert depends on memory idx type */
         GEN_INSN(I64TOI32, tmp, frame->aux_stack_bound_reg);
         frame->aux_stack_bound_reg = tmp;
-#endif
     }
     return frame->aux_stack_bound_reg;
 }
@@ -215,19 +211,15 @@ JitReg
 get_aux_stack_bottom_reg(JitFrame *frame)
 {
     JitCompContext *cc = frame->cc;
-#if UINTPTR_MAX == UINT64_MAX
     JitReg tmp = jit_cc_new_reg_I32(cc);
-#endif
 
     if (!frame->aux_stack_bottom_reg) {
         frame->aux_stack_bottom_reg = cc->aux_stack_bottom_reg;
         GEN_INSN(LDPTR, frame->aux_stack_bottom_reg, cc->exec_env_reg,
                  NEW_CONST(I32, offsetof(WASMExecEnv, aux_stack_bottom)));
-#if UINTPTR_MAX == UINT64_MAX
         /* TODO: Memory64 whether to convert depends on memory idx type */
         GEN_INSN(I64TOI32, tmp, frame->aux_stack_bottom_reg);
         frame->aux_stack_bottom_reg = tmp;
-#endif
     }
     return frame->aux_stack_bottom_reg;
 }
@@ -929,7 +921,6 @@ create_fixed_virtual_regs(JitCompContext *cc)
     cc->import_func_ptrs_reg = jit_cc_new_reg_ptr(cc);
     cc->fast_jit_func_ptrs_reg = jit_cc_new_reg_ptr(cc);
     cc->func_type_indexes_reg = jit_cc_new_reg_ptr(cc);
-    // uintptr type
     cc->aux_stack_bound_reg = jit_cc_new_reg_ptr(cc);
     cc->aux_stack_bottom_reg = jit_cc_new_reg_ptr(cc);
 

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -1031,8 +1031,8 @@ wasm_runtime_is_bounds_checks_enabled(
  *         it is not an absolute address.
  *         Return non-zero if success, zero if failed.
  */
-WASM_RUNTIME_API_EXTERN uint32_t
-wasm_runtime_module_malloc(wasm_module_inst_t module_inst, uint32_t size,
+WASM_RUNTIME_API_EXTERN uint64_t
+wasm_runtime_module_malloc(wasm_module_inst_t module_inst, uint64_t size,
                            void **p_native_addr);
 
 /**
@@ -1042,7 +1042,7 @@ wasm_runtime_module_malloc(wasm_module_inst_t module_inst, uint32_t size,
  * @param ptr the pointer to free
  */
 WASM_RUNTIME_API_EXTERN void
-wasm_runtime_module_free(wasm_module_inst_t module_inst, uint32_t ptr);
+wasm_runtime_module_free(wasm_module_inst_t module_inst, uint64_t ptr);
 
 /**
  * Allocate memory from the heap of WASM module instance and initialize
@@ -1057,9 +1057,9 @@ wasm_runtime_module_free(wasm_module_inst_t module_inst, uint32_t ptr);
  *         it is not an absolute address.
  *         Return non-zero if success, zero if failed.
  */
-WASM_RUNTIME_API_EXTERN uint32_t
+WASM_RUNTIME_API_EXTERN uint64_t
 wasm_runtime_module_dup_data(wasm_module_inst_t module_inst,
-                             const char *src, uint32_t size);
+                             const char *src, uint64_t size);
 
 /**
  * Validate the app address, check whether it belongs to WASM module
@@ -1074,7 +1074,7 @@ wasm_runtime_module_dup_data(wasm_module_inst_t module_inst,
  */
 WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_validate_app_addr(wasm_module_inst_t module_inst,
-                               uint32_t app_offset, uint32_t size);
+                               uint64_t app_offset, uint64_t size);
 
 /**
  * Similar to wasm_runtime_validate_app_addr(), except that the size parameter
@@ -1096,7 +1096,7 @@ wasm_runtime_validate_app_addr(wasm_module_inst_t module_inst,
  */
 WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_validate_app_str_addr(wasm_module_inst_t module_inst,
-                                   uint32_t app_str_offset);
+                                   uint64_t app_str_offset);
 
 /**
  * Validate the native address, check whether it belongs to WASM module
@@ -1112,7 +1112,7 @@ wasm_runtime_validate_app_str_addr(wasm_module_inst_t module_inst,
  */
 WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_validate_native_addr(wasm_module_inst_t module_inst,
-                                  void *native_ptr, uint32_t size);
+                                  void *native_ptr, uint64_t size);
 
 /**
  * Convert app address(relative address) to native address(absolute address)
@@ -1128,7 +1128,7 @@ wasm_runtime_validate_native_addr(wasm_module_inst_t module_inst,
  */
 WASM_RUNTIME_API_EXTERN void *
 wasm_runtime_addr_app_to_native(wasm_module_inst_t module_inst,
-                                uint32_t app_offset);
+                                uint64_t app_offset);
 
 /**
  * Convert native address(absolute address) to app address(relative address)
@@ -1138,7 +1138,7 @@ wasm_runtime_addr_app_to_native(wasm_module_inst_t module_inst,
  *
  * @return the app address converted
  */
-WASM_RUNTIME_API_EXTERN uint32_t
+WASM_RUNTIME_API_EXTERN uint64_t
 wasm_runtime_addr_native_to_app(wasm_module_inst_t module_inst,
                                 void *native_ptr);
 
@@ -1154,9 +1154,9 @@ wasm_runtime_addr_native_to_app(wasm_module_inst_t module_inst,
  */
 WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_get_app_addr_range(wasm_module_inst_t module_inst,
-                                uint32_t app_offset,
-                                uint32_t *p_app_start_offset,
-                                uint32_t *p_app_end_offset);
+                                uint64_t app_offset,
+                                uint64_t *p_app_start_offset,
+                                uint64_t *p_app_end_offset);
 
 /**
  * Get the native address range (absolute address) that a native address

--- a/core/iwasm/interpreter/wasm.h
+++ b/core/iwasm/interpreter/wasm.h
@@ -94,7 +94,7 @@ extern "C" {
 #define DEFAULT_MAX_PAGES 65536
 
 /* Max size of linear memory */
-#define MAX_LINEAR_MEMORY_SIZE 4 * (uint64)BH_GB
+#define MAX_LINEAR_MEMORY_SIZE (4 * (uint64)BH_GB)
 
 #if WASM_ENABLE_GC == 0
 typedef uintptr_t table_elem_type_t;
@@ -1091,6 +1091,21 @@ inline static unsigned
 align_uint(unsigned v, unsigned b)
 {
     unsigned m = b - 1;
+    return (v + m) & ~m;
+}
+
+/**
+ * Align an 64 bit unsigned value on a alignment boundary.
+ *
+ * @param v the value to be aligned
+ * @param b the alignment boundary (2, 4, 8, ...)
+ *
+ * @return the aligned value
+ */
+inline static uint64
+align_uint64(uint64 v, uint64 b)
+{
+    uint64 m = b - 1;
     return (v + m) & ~m;
 }
 

--- a/core/iwasm/interpreter/wasm.h
+++ b/core/iwasm/interpreter/wasm.h
@@ -93,6 +93,9 @@ extern "C" {
 #define DEFAULT_NUM_BYTES_PER_PAGE 65536
 #define DEFAULT_MAX_PAGES 65536
 
+/* Max size of linear memory */
+#define MAX_LINEAR_MEMORY_SIZE 4 * (uint64)BH_GB
+
 #if WASM_ENABLE_GC == 0
 typedef uintptr_t table_elem_type_t;
 #define NULL_REF (0xFFFFFFFF)
@@ -870,19 +873,19 @@ struct WASMModule {
        -1 means unexported */
     uint32 aux_data_end_global_index;
     /* auxiliary __data_end exported by wasm app */
-    uint32 aux_data_end;
+    uint64 aux_data_end;
 
     /* the index of auxiliary __heap_base global,
        -1 means unexported */
     uint32 aux_heap_base_global_index;
     /* auxiliary __heap_base exported by wasm app */
-    uint32 aux_heap_base;
+    uint64 aux_heap_base;
 
     /* the index of auxiliary stack top global,
        -1 means unexported */
     uint32 aux_stack_top_global_index;
     /* auxiliary stack bottom resolved */
-    uint32 aux_stack_bottom;
+    uint64 aux_stack_bottom;
     /* auxiliary stack size resolved */
     uint32 aux_stack_size;
 

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -4088,6 +4088,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 bh_assert(global_idx < module->e->global_count);
                 global = globals + global_idx;
                 global_addr = get_global_addr(global_data, global);
+                /* TODO: Memory64 the data type depends on mem idx type */
                 aux_stack_top = (uint64)(*(uint32 *)(frame_sp - 1));
                 if (aux_stack_top <= (uint64)exec_env->aux_stack_boundary) {
                     wasm_set_exception(module, "wasm auxiliary stack overflow");
@@ -5488,8 +5489,8 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 #endif
 
                         /* allowing the destination and source to overlap */
-                        bh_memmove_s(mdst, (uint32)linear_mem_size - dst, msrc,
-                                     len);
+                        bh_memmove_s(mdst, (uint32)(linear_mem_size - dst),
+                                     msrc, len);
                         break;
                     }
                     case WASM_OP_MEMORY_FILL:

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -1209,8 +1209,8 @@ wasm_interp_call_func_import(WASMModuleInstance *module_inst,
     uint8 *ip = prev_frame->ip;
     char buf[128];
     WASMExecEnv *sub_module_exec_env = NULL;
-    uint32 aux_stack_origin_boundary = 0;
-    uint32 aux_stack_origin_bottom = 0;
+    uintptr_t aux_stack_origin_boundary = 0;
+    uintptr_t aux_stack_origin_bottom = 0;
 
     if (!sub_func_inst) {
         snprintf(buf, sizeof(buf),
@@ -1233,13 +1233,11 @@ wasm_interp_call_func_import(WASMModuleInstance *module_inst,
     wasm_exec_env_set_module_inst(exec_env,
                                   (WASMModuleInstanceCommon *)sub_module_inst);
     /* - aux_stack_boundary */
-    aux_stack_origin_boundary = exec_env->aux_stack_boundary.boundary;
-    exec_env->aux_stack_boundary.boundary =
-        sub_module_exec_env->aux_stack_boundary.boundary;
+    aux_stack_origin_boundary = exec_env->aux_stack_boundary;
+    exec_env->aux_stack_boundary = sub_module_exec_env->aux_stack_boundary;
     /* - aux_stack_bottom */
-    aux_stack_origin_bottom = exec_env->aux_stack_bottom.bottom;
-    exec_env->aux_stack_bottom.bottom =
-        sub_module_exec_env->aux_stack_bottom.bottom;
+    aux_stack_origin_bottom = exec_env->aux_stack_bottom;
+    exec_env->aux_stack_bottom = sub_module_exec_env->aux_stack_bottom;
 
     /* set ip NULL to make call_func_bytecode return after executing
        this function */
@@ -1251,8 +1249,8 @@ wasm_interp_call_func_import(WASMModuleInstance *module_inst,
 
     /* restore ip and other replaced */
     prev_frame->ip = ip;
-    exec_env->aux_stack_boundary.boundary = aux_stack_origin_boundary;
-    exec_env->aux_stack_bottom.bottom = aux_stack_origin_bottom;
+    exec_env->aux_stack_boundary = aux_stack_origin_boundary;
+    exec_env->aux_stack_bottom = aux_stack_origin_bottom;
     wasm_exec_env_restore_module_inst(exec_env,
                                       (WASMModuleInstanceCommon *)module_inst);
 }
@@ -1463,10 +1461,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 goto got_exception;
             }
 
-            HANDLE_OP(WASM_OP_NOP)
-            {
-                HANDLE_OP_END();
-            }
+            HANDLE_OP(WASM_OP_NOP) { HANDLE_OP_END(); }
 
 #if WASM_ENABLE_EXCE_HANDLING != 0
             HANDLE_OP(WASM_OP_RETHROW)
@@ -4087,18 +4082,18 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
             HANDLE_OP(WASM_OP_SET_GLOBAL_AUX_STACK)
             {
-                uint32 aux_stack_top;
+                uint64 aux_stack_top;
 
                 read_leb_uint32(frame_ip, frame_ip_end, global_idx);
                 bh_assert(global_idx < module->e->global_count);
                 global = globals + global_idx;
                 global_addr = get_global_addr(global_data, global);
-                aux_stack_top = *(uint32 *)(frame_sp - 1);
-                if (aux_stack_top <= exec_env->aux_stack_boundary) {
+                aux_stack_top = (uint64)(*(uint32 *)(frame_sp - 1));
+                if (aux_stack_top <= (uint64)exec_env->aux_stack_boundary) {
                     wasm_set_exception(module, "wasm auxiliary stack overflow");
                     goto got_exception;
                 }
-                if (aux_stack_top > exec_env->aux_stack_bottom) {
+                if (aux_stack_top > (uint64)exec_env->aux_stack_bottom) {
                     wasm_set_exception(module,
                                        "wasm auxiliary stack underflow");
                     goto got_exception;
@@ -4107,8 +4102,9 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 frame_sp--;
 #if WASM_ENABLE_MEMORY_PROFILING != 0
                 if (module->module->aux_stack_top_global_index != (uint32)-1) {
-                    uint32 aux_stack_used = module->module->aux_stack_bottom
-                                            - *(uint32 *)global_addr;
+                    uint32 aux_stack_used =
+                        (uint32)(module->module->aux_stack_bottom
+                                 - *(uint32 *)global_addr);
                     if (aux_stack_used > module->e->max_aux_stack_used)
                         module->e->max_aux_stack_used = aux_stack_used;
                 }
@@ -5330,10 +5326,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
             HANDLE_OP(WASM_OP_I32_REINTERPRET_F32)
             HANDLE_OP(WASM_OP_I64_REINTERPRET_F64)
             HANDLE_OP(WASM_OP_F32_REINTERPRET_I32)
-            HANDLE_OP(WASM_OP_F64_REINTERPRET_I64)
-            {
-                HANDLE_OP_END();
-            }
+            HANDLE_OP(WASM_OP_F64_REINTERPRET_I64) { HANDLE_OP_END(); }
 
             HANDLE_OP(WASM_OP_I32_EXTEND8_S)
             {

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -39,16 +39,15 @@ typedef float64 CellType_F64;
 
 #if !defined(OS_ENABLE_HW_BOUND_CHECK) \
     || WASM_CPU_SUPPORTS_UNALIGNED_ADDR_ACCESS == 0
-#define CHECK_MEMORY_OVERFLOW(bytes)                             \
-    do {                                                         \
-        uint64 offset1 = (uint64)offset + (uint64)addr;          \
-        if (disable_bounds_checks                                \
-            || offset1 + bytes <= (uint64)get_linear_mem_size()) \
-            /* If offset1 is in valid range, maddr must also     \
-                be in valid range, no need to check it again. */ \
-            maddr = memory->memory_data + offset1;               \
-        else                                                     \
-            goto out_of_bounds;                                  \
+#define CHECK_MEMORY_OVERFLOW(bytes)                                           \
+    do {                                                                       \
+        uint64 offset1 = (uint64)offset + (uint64)addr;                        \
+        if (disable_bounds_checks || offset1 + bytes <= get_linear_mem_size()) \
+            /* If offset1 is in valid range, maddr must also                   \
+                be in valid range, no need to check it again. */               \
+            maddr = memory->memory_data + offset1;                             \
+        else                                                                   \
+            goto out_of_bounds;                                                \
     } while (0)
 
 #define CHECK_BULK_MEMORY_OVERFLOW(start, bytes, maddr)                        \
@@ -1444,7 +1443,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 #if !defined(OS_ENABLE_HW_BOUND_CHECK)              \
     || WASM_CPU_SUPPORTS_UNALIGNED_ADDR_ACCESS == 0 \
     || WASM_ENABLE_BULK_MEMORY != 0
-    uint32 linear_mem_size = 0;
+    uint64 linear_mem_size = 0;
     if (memory)
 #if WASM_ENABLE_THREAD_MGR == 0
         linear_mem_size = memory->memory_data_size;
@@ -3527,18 +3526,18 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
             HANDLE_OP(WASM_OP_SET_GLOBAL_AUX_STACK)
             {
-                uint32 aux_stack_top;
+                uint64 aux_stack_top;
 
                 global_idx = read_uint32(frame_ip);
                 bh_assert(global_idx < module->e->global_count);
                 global = globals + global_idx;
                 global_addr = get_global_addr(global_data, global);
-                aux_stack_top = frame_lp[GET_OFFSET()];
-                if (aux_stack_top <= exec_env->aux_stack_boundary.boundary) {
+                aux_stack_top = (uint64)frame_lp[GET_OFFSET()];
+                if (aux_stack_top <= (uint64)exec_env->aux_stack_boundary) {
                     wasm_set_exception(module, "wasm auxiliary stack overflow");
                     goto got_exception;
                 }
-                if (aux_stack_top > exec_env->aux_stack_bottom.bottom) {
+                if (aux_stack_top > (uint64)exec_env->aux_stack_bottom) {
                     wasm_set_exception(module,
                                        "wasm auxiliary stack underflow");
                     goto got_exception;
@@ -4968,8 +4967,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 #ifndef OS_ENABLE_HW_BOUND_CHECK
                         CHECK_BULK_MEMORY_OVERFLOW(addr, bytes, maddr);
 #else
-                        if ((uint64)(uint32)addr + bytes
-                            > (uint64)linear_mem_size)
+                        if ((uint64)(uint32)addr + bytes > linear_mem_size)
                             goto out_of_bounds;
                         maddr = memory->memory_data + (uint32)addr;
 #endif
@@ -4987,7 +4985,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         if (offset + bytes > seg_len)
                             goto out_of_bounds;
 
-                        bh_memcpy_s(maddr, linear_mem_size - addr,
+                        bh_memcpy_s(maddr, (uint32)(linear_mem_size - addr),
                                     data + offset, (uint32)bytes);
                         break;
                     }
@@ -5017,17 +5015,18 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         CHECK_BULK_MEMORY_OVERFLOW(src, len, msrc);
                         CHECK_BULK_MEMORY_OVERFLOW(dst, len, mdst);
 #else
-                        if ((uint64)(uint32)src + len > (uint64)linear_mem_size)
+                        if ((uint64)(uint32)src + len > linear_mem_size)
                             goto out_of_bounds;
                         msrc = memory->memory_data + (uint32)src;
 
-                        if ((uint64)(uint32)dst + len > (uint64)linear_mem_size)
+                        if ((uint64)(uint32)dst + len > linear_mem_size)
                             goto out_of_bounds;
                         mdst = memory->memory_data + (uint32)dst;
 #endif
 
                         /* allowing the destination and source to overlap */
-                        bh_memmove_s(mdst, linear_mem_size - dst, msrc, len);
+                        bh_memmove_s(mdst, (uint32)(linear_mem_size - dst),
+                                     msrc, len);
                         break;
                     }
                     case WASM_OP_MEMORY_FILL:
@@ -5046,7 +5045,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 #ifndef OS_ENABLE_HW_BOUND_CHECK
                         CHECK_BULK_MEMORY_OVERFLOW(dst, len, mdst);
 #else
-                        if ((uint64)(uint32)dst + len > (uint64)linear_mem_size)
+                        if ((uint64)(uint32)dst + len > linear_mem_size)
                             goto out_of_bounds;
                         mdst = memory->memory_data + (uint32)dst;
 #endif

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -3530,6 +3530,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 bh_assert(global_idx < module->e->global_count);
                 global = globals + global_idx;
                 global_addr = get_global_addr(global_data, global);
+                /* TODO: Memory64 the data type depends on mem idx type */
                 aux_stack_top = (uint64)frame_lp[GET_OFFSET()];
                 if (aux_stack_top <= (uint64)exec_env->aux_stack_boundary) {
                     wasm_set_exception(module, "wasm auxiliary stack overflow");

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -5597,8 +5597,9 @@ load_from_sections(WASMModule *module, WASMSection *sections,
                                 *buf_func = NULL, *buf_func_end = NULL;
     WASMGlobal *aux_data_end_global = NULL, *aux_heap_base_global = NULL;
     WASMGlobal *aux_stack_top_global = NULL, *global;
-    uint32 aux_data_end = (uint32)-1, aux_heap_base = (uint32)-1;
-    uint32 aux_stack_top = (uint32)-1, global_index, func_index, i;
+    uint64 aux_data_end = (uint64)-1, aux_heap_base = (uint64)-1,
+           aux_stack_top = (uint64)-1;
+    uint32 global_index, func_index, i;
     uint32 aux_data_end_global_index = (uint32)-1;
     uint32 aux_heap_base_global_index = (uint32)-1;
     WASMFuncType *func_type;
@@ -5735,7 +5736,7 @@ load_from_sections(WASMModule *module, WASMSection *sections,
                     && global->init_expr.init_expr_type
                            == INIT_EXPR_TYPE_I32_CONST) {
                     aux_heap_base_global = global;
-                    aux_heap_base = global->init_expr.u.i32;
+                    aux_heap_base = (uint64)(uint32)global->init_expr.u.i32;
                     aux_heap_base_global_index = export->index;
                     LOG_VERBOSE("Found aux __heap_base global, value: %d",
                                 aux_heap_base);
@@ -5748,7 +5749,7 @@ load_from_sections(WASMModule *module, WASMSection *sections,
                     && global->init_expr.init_expr_type
                            == INIT_EXPR_TYPE_I32_CONST) {
                     aux_data_end_global = global;
-                    aux_data_end = global->init_expr.u.i32;
+                    aux_data_end = (uint64)(uint32)global->init_expr.u.i32;
                     aux_data_end_global_index = export->index;
                     LOG_VERBOSE("Found aux __data_end global, value: %d",
                                 aux_data_end);
@@ -5789,9 +5790,10 @@ load_from_sections(WASMModule *module, WASMSection *sections,
                         && global->type == VALUE_TYPE_I32
                         && global->init_expr.init_expr_type
                                == INIT_EXPR_TYPE_I32_CONST
-                        && (uint32)global->init_expr.u.i32 <= aux_heap_base) {
+                        && (uint64)(uint32)global->init_expr.u.i32
+                               <= aux_heap_base) {
                         aux_stack_top_global = global;
-                        aux_stack_top = (uint32)global->init_expr.u.i32;
+                        aux_stack_top = (uint64)(uint32)global->init_expr.u.i32;
                         module->aux_stack_top_global_index =
                             module->import_global_count + global_index;
                         module->aux_stack_bottom = aux_stack_top;
@@ -5939,7 +5941,7 @@ load_from_sections(WASMModule *module, WASMSection *sections,
         if (aux_data_end_global && aux_heap_base_global
             && aux_stack_top_global) {
             uint64 init_memory_size;
-            uint32 shrunk_memory_size = align_uint(aux_heap_base, 8);
+            uint32 shrunk_memory_size = align_uint((uint32)aux_heap_base, 8);
 
             if (module->import_memory_count) {
                 memory_import = &module->import_memories[0].u.memory;

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -5754,7 +5754,7 @@ load_from_sections(WASMModule *module, WASMSection *sections,
                     LOG_VERBOSE("Found aux __data_end global, value: %d",
                                 aux_data_end);
 
-                    aux_data_end = align_uint(aux_data_end, 16);
+                    aux_data_end = align_uint((uint32)aux_data_end, 16);
                 }
             }
 
@@ -5799,8 +5799,8 @@ load_from_sections(WASMModule *module, WASMSection *sections,
                         module->aux_stack_bottom = aux_stack_top;
                         module->aux_stack_size =
                             aux_stack_top > aux_data_end
-                                ? aux_stack_top - aux_data_end
-                                : aux_stack_top;
+                                ? (uint32)(aux_stack_top - aux_data_end)
+                                : (uint32)aux_stack_top;
                         LOG_VERBOSE("Found aux stack top global, value: %d, "
                                     "global index: %d, stack size: %d",
                                     aux_stack_top, global_index,

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -2542,8 +2542,9 @@ load_from_sections(WASMModule *module, WASMSection *sections,
                                 *buf_func = NULL, *buf_func_end = NULL;
     WASMGlobal *aux_data_end_global = NULL, *aux_heap_base_global = NULL;
     WASMGlobal *aux_stack_top_global = NULL, *global;
-    uint32 aux_data_end = (uint32)-1, aux_heap_base = (uint32)-1;
-    uint32 aux_stack_top = (uint32)-1, global_index, func_index, i;
+    uint64 aux_data_end = (uint64)-1, aux_heap_base = (uint64)-1,
+           aux_stack_top = (uint64)-1;
+    uint32 global_index, func_index, i;
     uint32 aux_data_end_global_index = (uint32)-1;
     uint32 aux_heap_base_global_index = (uint32)-1;
     WASMFuncType *func_type;
@@ -2661,7 +2662,7 @@ load_from_sections(WASMModule *module, WASMSection *sections,
                     && global->init_expr.init_expr_type
                            == INIT_EXPR_TYPE_I32_CONST) {
                     aux_heap_base_global = global;
-                    aux_heap_base = global->init_expr.u.i32;
+                    aux_heap_base = (uint64)(uint32)global->init_expr.u.i32;
                     aux_heap_base_global_index = export->index;
                     LOG_VERBOSE("Found aux __heap_base global, value: %d",
                                 aux_heap_base);
@@ -2674,12 +2675,11 @@ load_from_sections(WASMModule *module, WASMSection *sections,
                     && global->init_expr.init_expr_type
                            == INIT_EXPR_TYPE_I32_CONST) {
                     aux_data_end_global = global;
-                    aux_data_end = global->init_expr.u.i32;
+                    aux_data_end = (uint64)(uint32)global->init_expr.u.i32;
                     aux_data_end_global_index = export->index;
                     LOG_VERBOSE("Found aux __data_end global, value: %d",
                                 aux_data_end);
-
-                    aux_data_end = align_uint(aux_data_end, 16);
+                    aux_data_end = align_uint64(aux_data_end, 16);
                 }
             }
 
@@ -2715,16 +2715,17 @@ load_from_sections(WASMModule *module, WASMSection *sections,
                         && global->type == VALUE_TYPE_I32
                         && global->init_expr.init_expr_type
                                == INIT_EXPR_TYPE_I32_CONST
-                        && (uint32)global->init_expr.u.i32 <= aux_heap_base) {
+                        && (uint64)(uint32)global->init_expr.u.i32
+                               <= aux_heap_base) {
                         aux_stack_top_global = global;
-                        aux_stack_top = (uint32)global->init_expr.u.i32;
+                        aux_stack_top = (uint64)(uint32)global->init_expr.u.i32;
                         module->aux_stack_top_global_index =
                             module->import_global_count + global_index;
                         module->aux_stack_bottom = aux_stack_top;
                         module->aux_stack_size =
                             aux_stack_top > aux_data_end
-                                ? aux_stack_top - aux_data_end
-                                : aux_stack_top;
+                                ? (uint32)(aux_stack_top - aux_data_end)
+                                : (uint32)aux_stack_top;
                         LOG_VERBOSE("Found aux stack top global, value: %d, "
                                     "global index: %d, stack size: %d",
                                     aux_stack_top, global_index,
@@ -2862,60 +2863,62 @@ load_from_sections(WASMModule *module, WASMSection *sections,
         if (aux_data_end_global && aux_heap_base_global
             && aux_stack_top_global) {
             uint64 init_memory_size;
-            uint32 shrunk_memory_size = align_uint(aux_heap_base, 8);
+            uint64 shrunk_memory_size = align_uint64(aux_heap_base, 8);
 
-            if (module->import_memory_count) {
-                memory_import = &module->import_memories[0].u.memory;
-                init_memory_size = (uint64)memory_import->num_bytes_per_page
-                                   * memory_import->init_page_count;
-                if (shrunk_memory_size <= init_memory_size) {
-                    /* Reset memory info to decrease memory usage */
-                    memory_import->num_bytes_per_page = shrunk_memory_size;
-                    memory_import->init_page_count = 1;
-                    LOG_VERBOSE("Shrink import memory size to %d",
-                                shrunk_memory_size);
+            /* Only resize(shrunk) the memory size if num_bytes_per_page is in
+             * valid range of uint32 */
+            if (shrunk_memory_size <= UINT32_MAX) {
+                if (module->import_memory_count) {
+                    memory_import = &module->import_memories[0].u.memory;
+                    init_memory_size = (uint64)memory_import->num_bytes_per_page
+                                       * memory_import->init_page_count;
+                    if (shrunk_memory_size <= init_memory_size) {
+                        /* Reset memory info to decrease memory usage */
+                        memory_import->num_bytes_per_page = shrunk_memory_size;
+                        memory_import->init_page_count = 1;
+                        LOG_VERBOSE("Shrink import memory size to %d",
+                                    shrunk_memory_size);
+                    }
                 }
-            }
-            if (module->memory_count) {
-                memory = &module->memories[0];
-                init_memory_size = (uint64)memory->num_bytes_per_page
-                                   * memory->init_page_count;
-                if (shrunk_memory_size <= init_memory_size) {
-                    /* Reset memory info to decrease memory usage */
-                    memory->num_bytes_per_page = shrunk_memory_size;
-                    memory->init_page_count = 1;
-                    LOG_VERBOSE("Shrink memory size to %d", shrunk_memory_size);
+
+                if (module->memory_count) {
+                    memory = &module->memories[0];
+                    init_memory_size = (uint64)memory->num_bytes_per_page
+                                       * memory->init_page_count;
+                    if (shrunk_memory_size <= init_memory_size) {
+                        /* Reset memory info to decrease memory usage */
+                        memory->num_bytes_per_page = shrunk_memory_size;
+                        memory->init_page_count = 1;
+                        LOG_VERBOSE("Shrink memory size to %d",
+                                    shrunk_memory_size);
+                    }
                 }
             }
         }
 
         if (module->import_memory_count) {
             memory_import = &module->import_memories[0].u.memory;
-            if (memory_import->init_page_count < DEFAULT_MAX_PAGES)
+            if (memory_import->init_page_count < DEFAULT_MAX_PAGES) {
                 memory_import->num_bytes_per_page *=
                     memory_import->init_page_count;
-            else
-                memory_import->num_bytes_per_page = UINT32_MAX;
-
-            if (memory_import->init_page_count > 0)
-                memory_import->init_page_count = memory_import->max_page_count =
-                    1;
-            else
-                memory_import->init_page_count = memory_import->max_page_count =
-                    0;
+                if (memory_import->init_page_count > 0)
+                    memory_import->init_page_count =
+                        memory_import->max_page_count = 1;
+                else
+                    memory_import->init_page_count =
+                        memory_import->max_page_count = 0;
+            }
         }
 
         if (module->memory_count) {
             memory = &module->memories[0];
-            if (memory->init_page_count < DEFAULT_MAX_PAGES)
+            if (memory->init_page_count < DEFAULT_MAX_PAGES) {
                 memory->num_bytes_per_page *= memory->init_page_count;
-            else
-                memory->num_bytes_per_page = UINT32_MAX;
-
-            if (memory->init_page_count > 0)
-                memory->init_page_count = memory->max_page_count = 1;
-            else
-                memory->init_page_count = memory->max_page_count = 0;
+                if (memory->init_page_count > 0)
+                    memory->init_page_count = memory->max_page_count = 1;
+                else
+                    memory->init_page_count = memory->max_page_count = 0;
+            }
         }
     }
 

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -3417,11 +3417,12 @@ wasm_module_dup_data(WASMModuleInstance *module_inst, const char *src,
                      uint64 size)
 {
     char *buffer;
-    uint64 buffer_offset =
-        wasm_module_malloc(module_inst, size, (void **)&buffer);
+    uint64 buffer_offset;
 
     /* TODO: Memory64 size check based on memory idx type */
     bh_assert(size <= UINT32_MAX);
+
+    buffer_offset = wasm_module_malloc(module_inst, size, (void **)&buffer);
 
     if (buffer_offset != 0) {
         buffer = wasm_runtime_addr_app_to_native(
@@ -3684,7 +3685,8 @@ void
 wasm_get_module_inst_mem_consumption(const WASMModuleInstance *module_inst,
                                      WASMModuleInstMemConsumption *mem_conspn)
 {
-    uint32 i, size;
+    uint32 i;
+    uint64 size;
 
     memset(mem_conspn, 0, sizeof(*mem_conspn));
 

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -3964,7 +3964,7 @@ jit_set_exception_with_id(WASMModuleInstance *module_inst, uint32 id)
 
 bool
 jit_check_app_addr_and_convert(WASMModuleInstance *module_inst, bool is_str,
-                               uint32 app_buf_addr, uint32 app_buf_size,
+                               uint64 app_buf_addr, uint64 app_buf_size,
                                void **p_native_addr)
 {
     bool ret = wasm_check_app_addr_and_convert(

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -103,7 +103,7 @@ struct WASMMemoryInstance {
     /* Whether the memory is shared */
     uint8 is_shared_memory;
 
-    /* TODO: Memory64 whether the memory is 64-bit memory addresses */
+    /* TODO: Memory64 whether the memory has 64-bit memory addresses */
     uint8 is_memory64;
 
     /* Reference count of the memory instance:

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -110,8 +110,9 @@ struct WASMMemoryInstance {
          0: non-shared memory, > 0: shared memory */
     bh_atomic_16_t ref_count;
 
-    /* Four bytes Paddings */
-    uint32 padding;
+    /* Four-byte paddings to ensure the layout of WASMMemoryInstance is the same
+     * in both 64-bit and 32-bit */
+    uint8 __paddings[4];
 
     /* Number bytes per page */
     uint32 num_bytes_per_page;

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -731,7 +731,7 @@ jit_set_exception_with_id(WASMModuleInstance *module_inst, uint32 id);
  */
 bool
 jit_check_app_addr_and_convert(WASMModuleInstance *module_inst, bool is_str,
-                               uint32 app_buf_addr, uint32 app_buf_size,
+                               uint64 app_buf_addr, uint64 app_buf_size,
                                void **p_native_addr);
 #endif /* end of WASM_ENABLE_FAST_JIT != 0 || WASM_ENABLE_JIT != 0 \
           || WASM_ENABLE_WAMR_COMPILER != 0 */

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -103,12 +103,15 @@ struct WASMMemoryInstance {
     /* Whether the memory is shared */
     uint8 is_shared_memory;
 
-    /* One byte padding */
-    uint8 __padding__;
+    /* TODO: Memory64 whether the memory is 64-bit memory addresses */
+    uint8 is_memory64;
 
     /* Reference count of the memory instance:
          0: non-shared memory, > 0: shared memory */
     bh_atomic_16_t ref_count;
+
+    /* Four bytes Paddings */
+    uint32 padding;
 
     /* Number bytes per page */
     uint32 num_bytes_per_page;
@@ -117,7 +120,7 @@ struct WASMMemoryInstance {
     /* Maximum page count */
     uint32 max_page_count;
     /* Memory data size */
-    uint32 memory_data_size;
+    uint64 memory_data_size;
     /**
      * Memory data begin address, Note:
      *   the app-heap might be inserted in to the linear memory,
@@ -175,7 +178,8 @@ struct WASMGlobalInstance {
     uint8 type;
     /* mutable or constant */
     bool is_mutable;
-    /* data offset to base_addr of WASMMemoryInstance */
+    /* data offset to the address of initial_value, started from the end of
+     * WASMMemoryInstance(start of WASMGlobalInstance)*/
     uint32 data_offset;
     /* initial value */
     WASMValue initial_value;
@@ -577,34 +581,34 @@ wasm_get_exception(WASMModuleInstance *module);
 bool
 wasm_copy_exception(WASMModuleInstance *module_inst, char *exception_buf);
 
-uint32
+uint64
 wasm_module_malloc_internal(WASMModuleInstance *module_inst,
-                            WASMExecEnv *exec_env, uint32 size,
+                            WASMExecEnv *exec_env, uint64 size,
                             void **p_native_addr);
 
-uint32
+uint64
 wasm_module_realloc_internal(WASMModuleInstance *module_inst,
-                             WASMExecEnv *exec_env, uint32 ptr, uint32 size,
+                             WASMExecEnv *exec_env, uint64 ptr, uint64 size,
                              void **p_native_addr);
 
 void
 wasm_module_free_internal(WASMModuleInstance *module_inst,
-                          WASMExecEnv *exec_env, uint32 ptr);
+                          WASMExecEnv *exec_env, uint64 ptr);
 
-uint32
-wasm_module_malloc(WASMModuleInstance *module_inst, uint32 size,
+uint64
+wasm_module_malloc(WASMModuleInstance *module_inst, uint64 size,
                    void **p_native_addr);
 
-uint32
-wasm_module_realloc(WASMModuleInstance *module_inst, uint32 ptr, uint32 size,
+uint64
+wasm_module_realloc(WASMModuleInstance *module_inst, uint64 ptr, uint64 size,
                     void **p_native_addr);
 
 void
-wasm_module_free(WASMModuleInstance *module_inst, uint32 ptr);
+wasm_module_free(WASMModuleInstance *module_inst, uint64 ptr);
 
-uint32
+uint64
 wasm_module_dup_data(WASMModuleInstance *module_inst, const char *src,
-                     uint32 size);
+                     uint64 size);
 
 /**
  * Check whether the app address and the buf is inside the linear memory,
@@ -612,7 +616,7 @@ wasm_module_dup_data(WASMModuleInstance *module_inst, const char *src,
  */
 bool
 wasm_check_app_addr_and_convert(WASMModuleInstance *module_inst, bool is_str,
-                                uint32 app_buf_addr, uint32 app_buf_size,
+                                uint64 app_buf_addr, uint64 app_buf_size,
                                 void **p_native_addr);
 
 WASMMemoryInstance *
@@ -627,10 +631,10 @@ wasm_call_indirect(WASMExecEnv *exec_env, uint32 tbl_idx, uint32 elem_idx,
 
 #if WASM_ENABLE_THREAD_MGR != 0
 bool
-wasm_set_aux_stack(WASMExecEnv *exec_env, uint32 start_offset, uint32 size);
+wasm_set_aux_stack(WASMExecEnv *exec_env, uint64 start_offset, uint32 size);
 
 bool
-wasm_get_aux_stack(WASMExecEnv *exec_env, uint32 *start_offset, uint32 *size);
+wasm_get_aux_stack(WASMExecEnv *exec_env, uint64 *start_offset, uint32 *size);
 #endif
 
 void

--- a/core/iwasm/libraries/debug-engine/debug_engine.c
+++ b/core/iwasm/libraries/debug-engine/debug_engine.c
@@ -409,7 +409,7 @@ wasm_debug_instance_create(WASMCluster *cluster, int32 port)
      * expressions */
     instance->exec_mem_info.size = DEBUG_EXECUTION_MEMORY_SIZE;
     instance->exec_mem_info.start_offset = wasm_runtime_module_malloc(
-        module_inst, instance->exec_mem_info.size, NULL);
+        module_inst, (uint64)instance->exec_mem_info.size, NULL);
     if (instance->exec_mem_info.start_offset == 0) {
         LOG_WARNING(
             "WASM Debug Engine warning: failed to allocate linear memory for "

--- a/core/iwasm/libraries/debug-engine/debug_engine.c
+++ b/core/iwasm/libraries/debug-engine/debug_engine.c
@@ -1393,7 +1393,7 @@ wasm_debug_instance_mmap(WASMDebugInstance *instance, uint32 size,
         return 0;
     }
 
-    if ((uint64)instance->exec_mem_info.current_pos
+    if (instance->exec_mem_info.current_pos
             - instance->exec_mem_info.start_offset + size
         <= (uint64)instance->exec_mem_info.size) {
         offset = instance->exec_mem_info.current_pos;

--- a/core/iwasm/libraries/debug-engine/debug_engine.h
+++ b/core/iwasm/libraries/debug-engine/debug_engine.h
@@ -53,9 +53,9 @@ typedef enum debug_state_t {
 } debug_state_t;
 
 typedef struct WASMDebugExecutionMemory {
-    uint32 start_offset;
+    uint64 start_offset;
+    uint64 current_pos;
     uint32 size;
-    uint32 current_pos;
 } WASMDebugExecutionMemory;
 
 struct WASMDebugInstance {

--- a/core/iwasm/libraries/lib-pthread/lib_pthread_wrapper.c
+++ b/core/iwasm/libraries/lib-pthread/lib_pthread_wrapper.c
@@ -558,7 +558,8 @@ pthread_create_wrapper(wasm_exec_env_t exec_env,
     ThreadRoutineArgs *routine_args = NULL;
     uint32 thread_handle;
     uint32 stack_size = 8192;
-    uint32 aux_stack_start = 0, aux_stack_size;
+    uint32 aux_stack_size;
+    uint64 aux_stack_start = 0;
     int32 ret = -1;
 
     bh_assert(module);
@@ -669,14 +670,14 @@ pthread_join_wrapper(wasm_exec_env_t exec_env, uint32 thread,
 
     /* validate addr, we can use current thread's
        module instance here as the memory is shared */
-    if (!validate_app_addr(retval_offset, sizeof(int32))) {
+    if (!validate_app_addr((uint64)retval_offset, (uint64)sizeof(int32))) {
         /* Join failed, but we don't want to terminate all threads,
            do not spread exception here */
         wasm_runtime_set_exception(module_inst, NULL);
         return -1;
     }
 
-    retval = (void **)addr_app_to_native(retval_offset);
+    retval = (void **)addr_app_to_native((uint64)retval_offset);
 
     node = get_thread_info(exec_env, thread);
     if (!node) {
@@ -1263,7 +1264,7 @@ sem_getvalue_wrapper(wasm_exec_env_t exec_env, uint32 sem, int32 *sval)
     (void)exec_env;
     SemCallbackArgs args = { sem, NULL };
 
-    if (validate_native_addr(sval, sizeof(int32))) {
+    if (validate_native_addr(sval, (uint64)sizeof(int32))) {
 
         bh_hash_map_traverse(sem_info_map, sem_fetch_cb, &args);
 

--- a/core/iwasm/libraries/libc-builtin/libc_builtin_wrapper.c
+++ b/core/iwasm/libraries/libc-builtin/libc_builtin_wrapper.c
@@ -233,7 +233,7 @@ _vprintf_wa(out_func_t out, void *ctx, const char *fmt, _va_list ap,
                         return false;
                     }
 
-                    s = start = addr_app_to_native(s_offset);
+                    s = start = addr_app_to_native((uint64)s_offset);
 
                     str_len = (uint32)strlen(start);
                     if (str_len >= UINT32_MAX - 64) {
@@ -401,7 +401,7 @@ printf_wrapper(wasm_exec_env_t exec_env, const char *format, _va_list va_args)
     struct str_context ctx = { NULL, 0, 0 };
 
     /* format has been checked by runtime */
-    if (!validate_native_addr(va_args, sizeof(int32)))
+    if (!validate_native_addr(va_args, (uint64)sizeof(int32)))
         return 0;
 
     if (!_vprintf_wa((out_func_t)printf_out, &ctx, format, va_args,
@@ -420,7 +420,7 @@ sprintf_wrapper(wasm_exec_env_t exec_env, char *str, const char *format,
     struct str_context ctx;
 
     /* str and format have been checked by runtime */
-    if (!validate_native_addr(va_args, sizeof(uint32)))
+    if (!validate_native_addr(va_args, (uint64)sizeof(uint32)))
         return 0;
 
     if (!wasm_runtime_get_native_addr_range(module_inst, (uint8 *)str, NULL,
@@ -452,7 +452,7 @@ snprintf_wrapper(wasm_exec_env_t exec_env, char *str, uint32 size,
     struct str_context ctx;
 
     /* str and format have been checked by runtime */
-    if (!validate_native_addr(va_args, sizeof(uint32)))
+    if (!validate_native_addr(va_args, (uint64)sizeof(uint32)))
         return 0;
 
     ctx.str = str;
@@ -499,7 +499,7 @@ strdup_wrapper(wasm_exec_env_t exec_env, const char *str)
     if (str) {
         len = (uint32)strlen(str) + 1;
 
-        str_ret_offset = module_malloc(len, (void **)&str_ret);
+        str_ret_offset = (uint32)module_malloc((uint64)len, (void **)&str_ret);
         if (str_ret_offset) {
             bh_memcpy_s(str_ret, len, str, len);
         }
@@ -521,7 +521,7 @@ memcmp_wrapper(wasm_exec_env_t exec_env, const void *s1, const void *s2,
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
 
     /* s2 has been checked by runtime */
-    if (!validate_native_addr((void *)s1, size))
+    if (!validate_native_addr((void *)s1, (uint64)size))
         return 0;
 
     return memcmp(s1, s2, size);
@@ -532,13 +532,13 @@ memcpy_wrapper(wasm_exec_env_t exec_env, void *dst, const void *src,
                uint32 size)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
-    uint32 dst_offset = addr_native_to_app(dst);
+    uint32 dst_offset = (uint32)addr_native_to_app(dst);
 
     if (size == 0)
         return dst_offset;
 
     /* src has been checked by runtime */
-    if (!validate_native_addr(dst, size))
+    if (!validate_native_addr(dst, (uint64)size))
         return dst_offset;
 
     bh_memcpy_s(dst, size, src, size);
@@ -549,13 +549,13 @@ static uint32
 memmove_wrapper(wasm_exec_env_t exec_env, void *dst, void *src, uint32 size)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
-    uint32 dst_offset = addr_native_to_app(dst);
+    uint32 dst_offset = (uint32)addr_native_to_app(dst);
 
     if (size == 0)
         return dst_offset;
 
     /* src has been checked by runtime */
-    if (!validate_native_addr(dst, size))
+    if (!validate_native_addr(dst, (uint64)size))
         return dst_offset;
 
     memmove(dst, src, size);
@@ -566,9 +566,9 @@ static uint32
 memset_wrapper(wasm_exec_env_t exec_env, void *s, int32 c, uint32 size)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
-    uint32 s_offset = addr_native_to_app(s);
+    uint32 s_offset = (uint32)addr_native_to_app(s);
 
-    if (!validate_native_addr(s, size))
+    if (!validate_native_addr(s, (uint64)size))
         return s_offset;
 
     memset(s, c, size);
@@ -583,7 +583,7 @@ strchr_wrapper(wasm_exec_env_t exec_env, const char *s, int32 c)
 
     /* s has been checked by runtime */
     ret = strchr(s, c);
-    return ret ? addr_native_to_app(ret) : 0;
+    return ret ? (uint32)addr_native_to_app(ret) : 0;
 }
 
 static int32
@@ -602,7 +602,7 @@ strncmp_wrapper(wasm_exec_env_t exec_env, const char *s1, const char *s2,
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
 
     /* s2 has been checked by runtime */
-    if (!validate_native_addr((void *)s1, size))
+    if (!validate_native_addr((void *)s1, (uint64)size))
         return 0;
 
     return strncmp(s1, s2, size);
@@ -615,7 +615,7 @@ strcpy_wrapper(wasm_exec_env_t exec_env, char *dst, const char *src)
     uint32 len = (uint32)strlen(src) + 1;
 
     /* src has been checked by runtime */
-    if (!validate_native_addr(dst, len))
+    if (!validate_native_addr(dst, (uint64)len))
         return 0;
 
 #ifndef BH_PLATFORM_WINDOWS
@@ -623,7 +623,7 @@ strcpy_wrapper(wasm_exec_env_t exec_env, char *dst, const char *src)
 #else
     strncpy_s(dst, len, src, len);
 #endif
-    return addr_native_to_app(dst);
+    return (uint32)addr_native_to_app(dst);
 }
 
 static uint32
@@ -633,7 +633,7 @@ strncpy_wrapper(wasm_exec_env_t exec_env, char *dst, const char *src,
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
 
     /* src has been checked by runtime */
-    if (!validate_native_addr(dst, size))
+    if (!validate_native_addr(dst, (uint64)size))
         return 0;
 
 #ifndef BH_PLATFORM_WINDOWS
@@ -641,7 +641,7 @@ strncpy_wrapper(wasm_exec_env_t exec_env, char *dst, const char *src,
 #else
     strncpy_s(dst, size, src, size);
 #endif
-    return addr_native_to_app(dst);
+    return (uint32)addr_native_to_app(dst);
 }
 
 static uint32
@@ -657,7 +657,7 @@ static uint32
 malloc_wrapper(wasm_exec_env_t exec_env, uint32 size)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
-    return module_malloc(size, NULL);
+    return (uint32)module_malloc((uint64)size, NULL);
 }
 
 static uint32
@@ -671,7 +671,7 @@ calloc_wrapper(wasm_exec_env_t exec_env, uint32 nmemb, uint32 size)
     if (total_size >= UINT32_MAX)
         return 0;
 
-    ret_offset = module_malloc((uint32)total_size, (void **)&ret_ptr);
+    ret_offset = (uint32)module_malloc(total_size, (void **)&ret_ptr);
     if (ret_offset) {
         memset(ret_ptr, 0, (uint32)total_size);
     }
@@ -692,7 +692,7 @@ free_wrapper(wasm_exec_env_t exec_env, void *ptr)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
 
-    if (!validate_native_addr(ptr, sizeof(uint32)))
+    if (!validate_native_addr(ptr, (uint64)sizeof(uint32)))
         return;
 
     module_free(addr_native_to_app(ptr));
@@ -723,11 +723,11 @@ strtol_wrapper(wasm_exec_env_t exec_env, const char *nptr, char **endptr,
     int32 num = 0;
 
     /* nptr has been checked by runtime */
-    if (!validate_native_addr(endptr, sizeof(uint32)))
+    if (!validate_native_addr(endptr, (uint64)sizeof(uint32)))
         return 0;
 
     num = (int32)strtol(nptr, endptr, base);
-    *(uint32 *)endptr = addr_native_to_app(*endptr);
+    *(uint32 *)endptr = (uint32)addr_native_to_app(*endptr);
 
     return num;
 }
@@ -740,11 +740,11 @@ strtoul_wrapper(wasm_exec_env_t exec_env, const char *nptr, char **endptr,
     uint32 num = 0;
 
     /* nptr has been checked by runtime */
-    if (!validate_native_addr(endptr, sizeof(uint32)))
+    if (!validate_native_addr(endptr, (uint64)sizeof(uint32)))
         return 0;
 
     num = (uint32)strtoul(nptr, endptr, base);
-    *(uint32 *)endptr = addr_native_to_app(*endptr);
+    *(uint32 *)endptr = (uint32)addr_native_to_app(*endptr);
 
     return num;
 }
@@ -755,11 +755,11 @@ memchr_wrapper(wasm_exec_env_t exec_env, const void *s, int32 c, uint32 n)
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     void *res;
 
-    if (!validate_native_addr((void *)s, n))
+    if (!validate_native_addr((void *)s, (uint64)n))
         return 0;
 
     res = memchr(s, c, n);
-    return addr_native_to_app(res);
+    return (uint32)addr_native_to_app(res);
 }
 
 static int32
@@ -796,7 +796,7 @@ strstr_wrapper(wasm_exec_env_t exec_env, const char *s, const char *find)
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     /* s and find have been checked by runtime */
     char *res = strstr(s, find);
-    return addr_native_to_app(res);
+    return (uint32)addr_native_to_app(res);
 }
 
 static int32
@@ -884,10 +884,10 @@ emscripten_memcpy_big_wrapper(wasm_exec_env_t exec_env, void *dst,
                               const void *src, uint32 size)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
-    uint32 dst_offset = addr_native_to_app(dst);
+    uint32 dst_offset = (uint32)addr_native_to_app(dst);
 
     /* src has been checked by runtime */
-    if (!validate_native_addr(dst, size))
+    if (!validate_native_addr(dst, (uint64)size))
         return dst_offset;
 
     bh_memcpy_s(dst, size, src, size);
@@ -925,7 +925,7 @@ static uint32
 __cxa_allocate_exception_wrapper(wasm_exec_env_t exec_env, uint32 thrown_size)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
-    uint32 exception = module_malloc(thrown_size, NULL);
+    uint32 exception = (uint32)module_malloc((uint64)thrown_size, NULL);
     if (!exception)
         return 0;
 
@@ -968,7 +968,7 @@ clock_gettime_wrapper(wasm_exec_env_t exec_env, uint32 clk_id,
 
     (void)clk_id;
 
-    if (!validate_native_addr(ts_app, sizeof(struct timespec_app)))
+    if (!validate_native_addr(ts_app, (uint64)sizeof(struct timespec_app)))
         return (uint32)-1;
 
     time = os_time_get_boot_us();

--- a/core/iwasm/libraries/libc-emcc/libc_emcc_wrapper.c
+++ b/core/iwasm/libraries/libc-emcc/libc_emcc_wrapper.c
@@ -184,7 +184,8 @@ __sys_stat64_wrapper(wasm_exec_env_t exec_env, const char *pathname,
     int ret;
     struct stat statbuf;
 
-    if (!validate_native_addr((void *)statbuf_app, sizeof(struct stat_emcc)))
+    if (!validate_native_addr((void *)statbuf_app,
+                              (uint64)sizeof(struct stat_emcc)))
         return -1;
 
     if (pathname == NULL)
@@ -204,7 +205,8 @@ __sys_fstat64_wrapper(wasm_exec_env_t exec_env, int fd,
     int ret;
     struct stat statbuf;
 
-    if (!validate_native_addr((void *)statbuf_app, sizeof(struct stat_emcc)))
+    if (!validate_native_addr((void *)statbuf_app,
+                              (uint64)sizeof(struct stat_emcc)))
         return -1;
 
     if (fd <= 0)
@@ -225,7 +227,7 @@ mmap_wrapper(wasm_exec_env_t exec_env, void *addr, int length, int prot,
     char *buf;
     int size_read;
 
-    buf_offset = module_malloc(length, (void **)&buf);
+    buf_offset = module_malloc((uint64)length, (void **)&buf);
     if (buf_offset == 0)
         return -1;
 
@@ -244,7 +246,7 @@ static int
 munmap_wrapper(wasm_exec_env_t exec_env, uint32 buf_offset, int length)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
-    module_free(buf_offset);
+    module_free((uint64)buf_offset);
     return 0;
 }
 
@@ -422,7 +424,7 @@ __sys_getcwd_wrapper(wasm_exec_env_t exec_env, char *buf, uint32 size)
         return -1;
 
     ret = getcwd(buf, size);
-    return ret ? addr_native_to_app(ret) : 0;
+    return ret ? (uint32)addr_native_to_app(ret) : 0;
 }
 
 #include <sys/utsname.h>
@@ -443,7 +445,7 @@ __sys_uname_wrapper(wasm_exec_env_t exec_env, struct utsname_app *uname_app)
     struct utsname uname_native = { 0 };
     uint32 length;
 
-    if (!validate_native_addr(uname_app, sizeof(struct utsname_app)))
+    if (!validate_native_addr(uname_app, (uint64)sizeof(struct utsname_app)))
         return -1;
 
     if (uname(&uname_native) != 0) {

--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -146,7 +146,7 @@ wasm_cluster_allocate_aux_stack(WASMExecEnv *exec_env, uint64 *p_start,
 #if WASM_ENABLE_HEAP_AUX_STACK_ALLOCATION != 0
     WASMModuleInstanceCommon *module_inst =
         wasm_exec_env_get_module_inst(exec_env);
-    uint32 stack_end;
+    uint64 stack_end;
 
     stack_end = wasm_runtime_module_malloc_internal(module_inst, exec_env,
                                                     cluster->stack_size, NULL);

--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -604,7 +604,8 @@ wasm_cluster_destroy_spawned_exec_env(WASMExecEnv *exec_env)
     }
 
     /* Free aux stack space */
-    wasm_cluster_free_aux_stack(exec_env_tls, (uint64)exec_env->aux_stack_bottom);
+    wasm_cluster_free_aux_stack(exec_env_tls,
+                                (uint64)exec_env->aux_stack_bottom);
 
     os_mutex_lock(&cluster->lock);
 

--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -281,7 +281,7 @@ wasm_cluster_create(WASMExecEnv *exec_env)
 
 #if WASM_ENABLE_HEAP_AUX_STACK_ALLOCATION == 0
     if (cluster_max_thread_num != 0) {
-        uint64 total_size = cluster_max_thread_num * sizeof(uint32);
+        uint64 total_size = cluster_max_thread_num * sizeof(uint64);
         uint32 i;
         if (total_size >= UINT32_MAX
             || !(cluster->stack_tops =

--- a/core/iwasm/libraries/thread-mgr/thread_manager.h
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.h
@@ -30,7 +30,7 @@ struct WASMCluster {
     /* The aux stack of a module with shared memory will be
         divided into several segments. This array store the
         stack top of different segments */
-    uint32 *stack_tops;
+    uint64 *stack_tops;
     /* Record which segments are occupied */
     bool *stack_segment_occupied;
 #endif
@@ -89,7 +89,7 @@ wasm_cluster_dup_c_api_imports(WASMModuleInstanceCommon *module_inst_dst,
 int32
 wasm_cluster_create_thread(WASMExecEnv *exec_env,
                            wasm_module_inst_t module_inst,
-                           bool is_aux_stack_allocated, uint32 aux_stack_start,
+                           bool is_aux_stack_allocated, uint64 aux_stack_start,
                            uint32 aux_stack_size,
                            void *(*thread_routine)(void *), void *arg);
 
@@ -231,11 +231,11 @@ void
 wasm_cluster_traverse_unlock(WASMExecEnv *exec_env);
 
 bool
-wasm_cluster_allocate_aux_stack(WASMExecEnv *exec_env, uint32 *p_start,
+wasm_cluster_allocate_aux_stack(WASMExecEnv *exec_env, uint64 *p_start,
                                 uint32 *p_size);
 
 bool
-wasm_cluster_free_aux_stack(WASMExecEnv *exec_env, uint32 start);
+wasm_cluster_free_aux_stack(WASMExecEnv *exec_env, uint64 start);
 
 #ifdef __cplusplus
 }

--- a/core/iwasm/libraries/wasi-nn/src/utils/wasi_nn_app_native.c
+++ b/core/iwasm/libraries/wasi-nn/src/utils/wasi_nn_app_native.c
@@ -10,14 +10,15 @@ graph_builder_app_native(wasm_module_inst_t instance,
                          graph_builder_wasm *builder_wasm,
                          graph_builder *builder)
 {
-    if (!wasm_runtime_validate_app_addr(instance, builder_wasm->buf_offset,
-                                        builder_wasm->size * sizeof(uint8_t))) {
+    if (!wasm_runtime_validate_app_addr(
+            instance, (uint64)builder_wasm->buf_offset,
+            (uint64)builder_wasm->size * sizeof(uint8_t))) {
         NN_ERR_PRINTF("builder_wasm->buf_offset is invalid");
         return invalid_argument;
     }
 
     builder->buf = (uint8_t *)wasm_runtime_addr_app_to_native(
-        instance, builder_wasm->buf_offset);
+        instance, (uint64)builder_wasm->buf_offset);
     builder->size = builder_wasm->size;
     return success;
 }
@@ -27,8 +28,9 @@ graph_builder_array_app_native(wasm_module_inst_t instance,
                                graph_builder_array_wasm *builder_array_wasm,
                                graph_builder_array *builder_array)
 {
-    if (!wasm_runtime_validate_native_addr(instance, builder_array_wasm,
-                                           sizeof(graph_builder_array_wasm))) {
+    if (!wasm_runtime_validate_native_addr(
+            instance, builder_array_wasm,
+            (uint64)sizeof(graph_builder_array_wasm))) {
         NN_ERR_PRINTF("builder_array_wasm is invalid");
         return invalid_argument;
     }
@@ -37,15 +39,15 @@ graph_builder_array_app_native(wasm_module_inst_t instance,
                   builder_array_wasm->size);
 
     if (!wasm_runtime_validate_app_addr(
-            instance, builder_array_wasm->buf_offset,
-            builder_array_wasm->size * sizeof(graph_builder_wasm))) {
+            instance, (uint64)builder_array_wasm->buf_offset,
+            (uint64)builder_array_wasm->size * sizeof(graph_builder_wasm))) {
         NN_ERR_PRINTF("builder_array_wasm->buf_offset is invalid");
         return invalid_argument;
     }
 
     graph_builder_wasm *builder_wasm =
         (graph_builder_wasm *)wasm_runtime_addr_app_to_native(
-            instance, builder_array_wasm->buf_offset);
+            instance, (uint64)builder_array_wasm->buf_offset);
 
     graph_builder *builder = (graph_builder *)wasm_runtime_malloc(
         builder_array_wasm->size * sizeof(graph_builder));
@@ -74,13 +76,14 @@ static error
 tensor_data_app_native(wasm_module_inst_t instance, uint32_t total_elements,
                        tensor_wasm *input_tensor_wasm, tensor_data *data)
 {
-    if (!wasm_runtime_validate_app_addr(
-            instance, input_tensor_wasm->data_offset, total_elements)) {
+    if (!wasm_runtime_validate_app_addr(instance,
+                                        (uint64)input_tensor_wasm->data_offset,
+                                        (uint64)total_elements)) {
         NN_ERR_PRINTF("input_tensor_wasm->data_offset is invalid");
         return invalid_argument;
     }
     *data = (tensor_data)wasm_runtime_addr_app_to_native(
-        instance, input_tensor_wasm->data_offset);
+        instance, (uint64)input_tensor_wasm->data_offset);
     return success;
 }
 
@@ -89,19 +92,20 @@ tensor_dimensions_app_native(wasm_module_inst_t instance,
                              tensor_wasm *input_tensor_wasm,
                              tensor_dimensions **dimensions)
 {
-    if (!wasm_runtime_validate_app_addr(instance,
-                                        input_tensor_wasm->dimensions_offset,
-                                        sizeof(tensor_dimensions_wasm))) {
+    if (!wasm_runtime_validate_app_addr(
+            instance, (uint64)input_tensor_wasm->dimensions_offset,
+            (uint64)sizeof(tensor_dimensions_wasm))) {
         NN_ERR_PRINTF("input_tensor_wasm->dimensions_offset is invalid");
         return invalid_argument;
     }
 
     tensor_dimensions_wasm *dimensions_wasm =
         (tensor_dimensions_wasm *)wasm_runtime_addr_app_to_native(
-            instance, input_tensor_wasm->dimensions_offset);
+            instance, (uint64)input_tensor_wasm->dimensions_offset);
 
-    if (!wasm_runtime_validate_app_addr(instance, dimensions_wasm->buf_offset,
-                                        sizeof(tensor_dimensions))) {
+    if (!wasm_runtime_validate_app_addr(instance,
+                                        (uint64)dimensions_wasm->buf_offset,
+                                        (uint64)sizeof(tensor_dimensions))) {
         NN_ERR_PRINTF("dimensions_wasm->buf_offset is invalid");
         return invalid_argument;
     }
@@ -113,7 +117,7 @@ tensor_dimensions_app_native(wasm_module_inst_t instance,
 
     (*dimensions)->size = dimensions_wasm->size;
     (*dimensions)->buf = (uint32_t *)wasm_runtime_addr_app_to_native(
-        instance, dimensions_wasm->buf_offset);
+        instance, (uint64)dimensions_wasm->buf_offset);
 
     NN_DBG_PRINTF("Number of dimensions: %d", (*dimensions)->size);
     return success;
@@ -125,7 +129,7 @@ tensor_app_native(wasm_module_inst_t instance, tensor_wasm *input_tensor_wasm,
 {
     NN_DBG_PRINTF("Converting tensor_wasm to tensor");
     if (!wasm_runtime_validate_native_addr(instance, input_tensor_wasm,
-                                           sizeof(tensor_wasm))) {
+                                           (uint64)sizeof(tensor_wasm))) {
         NN_ERR_PRINTF("input_tensor_wasm is invalid");
         return invalid_argument;
     }

--- a/core/iwasm/libraries/wasi-nn/src/wasi_nn.c
+++ b/core/iwasm/libraries/wasi-nn/src/wasi_nn.c
@@ -211,7 +211,8 @@ wasi_nn_load(wasm_exec_env_t exec_env, graph_builder_array_wasm *builder,
                                                  &builder_native)))
         return res;
 
-    if (!wasm_runtime_validate_native_addr(instance, g, sizeof(graph))) {
+    if (!wasm_runtime_validate_native_addr(instance, g,
+                                           (uint64)sizeof(graph))) {
         NN_ERR_PRINTF("graph is invalid");
         res = invalid_argument;
         goto fail;
@@ -248,8 +249,8 @@ wasi_nn_init_execution_context(wasm_exec_env_t exec_env, graph g,
     if (success != (res = is_model_initialized(wasi_nn_ctx)))
         return res;
 
-    if (!wasm_runtime_validate_native_addr(instance, ctx,
-                                           sizeof(graph_execution_context))) {
+    if (!wasm_runtime_validate_native_addr(
+            instance, ctx, (uint64)sizeof(graph_execution_context))) {
         NN_ERR_PRINTF("ctx is invalid");
         return invalid_argument;
     }
@@ -331,7 +332,7 @@ wasi_nn_get_output(wasm_exec_env_t exec_env, graph_execution_context ctx,
         return res;
 
     if (!wasm_runtime_validate_native_addr(instance, output_tensor_size,
-                                           sizeof(uint32_t))) {
+                                           (uint64)sizeof(uint32_t))) {
         NN_ERR_PRINTF("output_tensor_size is invalid");
         return invalid_argument;
     }

--- a/core/shared/platform/common/posix/posix_memmap.c
+++ b/core/shared/platform/common/posix/posix_memmap.c
@@ -134,7 +134,7 @@ os_mmap(void *hint, size_t size, int prot, int flags, os_file_handle file)
     }
 #endif /* end of BUILD_TARGET_RISCV64_LP64D || BUILD_TARGET_RISCV64_LP64 */
 
-    /* memory has't been mapped or was mapped failed previously */
+    /* memory hasn't been mapped or was mapped failed previously */
     if (addr == MAP_FAILED) {
         /* try 5 times */
         for (i = 0; i < 5; i++) {

--- a/core/shared/utils/bh_atomic.h
+++ b/core/shared/utils/bh_atomic.h
@@ -53,6 +53,10 @@ typedef uint16 bh_atomic_16_t;
  * If left undefined, it will be automatically defined
  * according to the platform.
  */
+#ifdef WASM_UINT64_IS_ATOMIC
+#define BH_ATOMIC_64_IS_ATOMIC WASM_UINT64_IS_ATOMIC
+#endif /* WASM_UINT64_IS_ATOMIC */
+
 #ifdef WASM_UINT32_IS_ATOMIC
 #define BH_ATOMIC_32_IS_ATOMIC WASM_UINT32_IS_ATOMIC
 #endif /* WASM_UINT32_IS_ATOMIC */

--- a/core/shared/utils/bh_atomic.h
+++ b/core/shared/utils/bh_atomic.h
@@ -97,18 +97,20 @@ typedef uint16 bh_atomic_16_t;
 #endif
 #endif
 
-/* Force disable atomic 16-bit operations on bare-metal RISC-V
- * because the 16-bit atomic operations is emulated by 32-bit
+/* Force disable atomic 16/64-bit operations on bare-metal RISC-V
+ * because the 16/64-bit atomic operations is emulated by 32-bit
  * atomic operations, which has linkage problem on current toolchain:
  * in function `shared_memory_inc_reference':
  * wasm_shared_memory.c:85:(.text.shared_memory_inc_reference+0x10): undefined
- * reference to `__atomic_fetch_add_2'
+ * reference to `__atomic_fetch_add_2/8'
  */
 #ifndef WASM_UINT16_IS_ATOMIC
 #if !defined(__linux__) && !defined(__FreeBSD__) && !defined(__NetBSD__) \
     && !defined(__OpenBSD__) && defined(__riscv)
 #undef BH_ATOMIC_16_IS_ATOMIC
 #define BH_ATOMIC_16_IS_ATOMIC 0
+#undef BH_ATOMIC_64_IS_ATOMIC
+#define BH_ATOMIC_64_IS_ATOMIC 0
 #endif
 #endif
 

--- a/core/shared/utils/bh_atomic.h
+++ b/core/shared/utils/bh_atomic.h
@@ -87,7 +87,7 @@ typedef uint16 bh_atomic_16_t;
 #endif
 #else
 #ifndef BH_ATOMIC_64_IS_ATOMIC
-#define BH_ATOMIC_64_IS_ATOMIC 1
+#define BH_ATOMIC_64_IS_ATOMIC 0
 #endif
 #ifndef BH_ATOMIC_32_IS_ATOMIC
 #define BH_ATOMIC_32_IS_ATOMIC 0

--- a/core/shared/utils/bh_atomic.h
+++ b/core/shared/utils/bh_atomic.h
@@ -112,9 +112,12 @@ typedef uint16 bh_atomic_16_t;
 #endif
 #endif
 
-/* On 32-bit platform, disable 64-bit atomic opeartions */
+/* On some 32-bit platform, disable 64-bit atomic operations, otherwise
+ * undefined reference to `__atomic_load_8' */
 #ifndef WASM_UINT64_IS_ATOMIC
-#if UINT32_MAX == UINTPTR_MAX
+#if !defined(__linux__) && !defined(__FreeBSD__) && !defined(__NetBSD__) \
+    && !defined(__OpenBSD__) && (defined(__riscv) || defined(__arm__))   \
+    && UINT32_MAX == UINTPTR_MAX
 #undef BH_ATOMIC_64_IS_ATOMIC
 #define BH_ATOMIC_64_IS_ATOMIC 0
 #endif

--- a/core/shared/utils/bh_atomic.h
+++ b/core/shared/utils/bh_atomic.h
@@ -97,18 +97,24 @@ typedef uint16 bh_atomic_16_t;
 #endif
 #endif
 
-/* Force disable atomic 16/64-bit operations on bare-metal RISC-V
- * because the 16/64-bit atomic operations is emulated by 32-bit
+/* Force disable atomic 16-bit operations on bare-metal RISC-V
+ * because the 16-bit atomic operations is emulated by 32-bit
  * atomic operations, which has linkage problem on current toolchain:
  * in function `shared_memory_inc_reference':
  * wasm_shared_memory.c:85:(.text.shared_memory_inc_reference+0x10): undefined
- * reference to `__atomic_fetch_add_2/8'
+ * reference to `__atomic_fetch_add_2'
  */
 #ifndef WASM_UINT16_IS_ATOMIC
 #if !defined(__linux__) && !defined(__FreeBSD__) && !defined(__NetBSD__) \
     && !defined(__OpenBSD__) && defined(__riscv)
 #undef BH_ATOMIC_16_IS_ATOMIC
 #define BH_ATOMIC_16_IS_ATOMIC 0
+#endif
+#endif
+
+/* On 32-bit platform, disable 64-bit atomic opeartions */
+#ifndef WASM_UINT64_IS_ATOMIC
+#if UINT32_MAX == UINTPTR_MAX
 #undef BH_ATOMIC_64_IS_ATOMIC
 #define BH_ATOMIC_64_IS_ATOMIC 0
 #endif

--- a/doc/embed_wamr.md
+++ b/doc/embed_wamr.md
@@ -211,9 +211,9 @@ There are two runtime APIs available for this purpose.
  * p_native_addr: return the native address of allocated memory
  * size: the buffer size to allocate
  */
-uint32_t
+uint64_t
 wasm_runtime_module_malloc(wasm_module_inst_t module_inst,
-                           uint32_t size, void **p_native_addr);
+                           uint64_t size, void **p_native_addr);
 
 /**
  * malloc a buffer from instance's private memory space,
@@ -223,28 +223,28 @@ wasm_runtime_module_malloc(wasm_module_inst_t module_inst,
  * src: the native buffer address
  * size: the size of buffer to be allocated and copy data
  */
-uint32_t
+uint64_t
 wasm_runtime_module_dup_data(wasm_module_inst_t module_inst,
-                             const char *src, uint32_t size);
+                             const char *src, uint64_t size);
 
 /* free the memory allocated from module memory space */
 void
-wasm_runtime_module_free(wasm_module_inst_t module_inst, uint32_t ptr);
+wasm_runtime_module_free(wasm_module_inst_t module_inst, uint64_t ptr);
 ```
 
 Usage sample:
 
 ```c
 char * buffer = NULL;
-uint32_t buffer_for_wasm;
+uint64_t buffer_for_wasm;
 
 buffer_for_wasm = wasm_runtime_module_malloc(module_inst, 100, &buffer);
 if (buffer_for_wasm != 0) {
-    uint32 argv[2];
+    uint32 argv[3];
     strncpy(buffer, "hello", 100); /* use native address for accessing in runtime */
     argv[0] = buffer_for_wasm;     /* pass the buffer address for WASM space */
-    argv[1] = 100;                 /* the size of buffer */
-    wasm_runtime_call_wasm(exec_env, func, 2, argv);
+    argv[2] = 100;                 /* the size of buffer */
+    wasm_runtime_call_wasm(exec_env, func, 3, argv);
 
     /* it is runtime embedder's responsibility to release the memory,
        unless the WASM app will free the passed pointer in its code */

--- a/doc/export_native_api.md
+++ b/doc/export_native_api.md
@@ -170,12 +170,12 @@ void foo2(wasm_exec_env_t exec_env,
     if (!wasm_runtime_validate_app_str_add(msg_offset))
         return 0;
     
-    if (!wasm_runtime_validate_app_addr(buffer_offset, buf_len))
+    if (!wasm_runtime_validate_app_addr((uint64)buffer_offset, (uint64)buf_len))
         return;
 
     // do address conversion
-    buffer = wasm_runtime_addr_app_to_native(buffer_offset);
-    msg = wasm_runtime_addr_app_to_native(msg_offset);
+    buffer = wasm_runtime_addr_app_to_native((uint64)buffer_offset);
+    msg = wasm_runtime_addr_app_to_native((uint64)msg_offset);
 
     strncpy(buffer, msg, buf_len);
 }

--- a/language-bindings/go/wamr/instance.go
+++ b/language-bindings/go/wamr/instance.go
@@ -309,62 +309,62 @@ func (self *Instance) GetException() string {
 }
 
 /* Allocate memory from the heap of the instance */
-func (self Instance) ModuleMalloc(size uint32) (uint32, *uint8) {
-    var offset C.uint32_t
+func (self Instance) ModuleMalloc(size uint64) (uint64, *uint8) {
+    var offset C.uint64_t
     native_addrs := make([]*uint8, 1, 1)
     ptr := unsafe.Pointer(&native_addrs[0])
-    offset = C.wasm_runtime_module_malloc(self._instance, (C.uint32_t)(size),
+    offset = C.wasm_runtime_module_malloc(self._instance, (C.uint64_t)(size),
                                           (*unsafe.Pointer)(ptr))
-    return (uint32)(offset), native_addrs[0]
+    return (uint64)(offset), native_addrs[0]
 }
 
 /* Free memory to the heap of the instance */
-func (self Instance) ModuleFree(offset uint32) {
-    C.wasm_runtime_module_free(self._instance, (C.uint32_t)(offset))
+func (self Instance) ModuleFree(offset uint64) {
+    C.wasm_runtime_module_free(self._instance, (C.uint64_t)(offset))
 }
 
-func (self Instance) ValidateAppAddr(app_offset uint32, size uint32) bool {
+func (self Instance) ValidateAppAddr(app_offset uint64, size uint64) bool {
     ret := C.wasm_runtime_validate_app_addr(self._instance,
-                                            (C.uint32_t)(app_offset),
-                                            (C.uint32_t)(size))
+                                            (C.uint64_t)(app_offset),
+                                            (C.uint64_t)(size))
     return (bool)(ret)
 }
 
-func (self Instance) ValidateStrAddr(app_str_offset uint32) bool {
+func (self Instance) ValidateStrAddr(app_str_offset uint64) bool {
     ret := C.wasm_runtime_validate_app_str_addr(self._instance,
-                                                (C.uint32_t)(app_str_offset))
+                                                (C.uint64_t)(app_str_offset))
     return (bool)(ret)
 }
 
-func (self Instance) ValidateNativeAddr(native_ptr *uint8, size uint32) bool {
+func (self Instance) ValidateNativeAddr(native_ptr *uint8, size uint64) bool {
     native_ptr_C := (unsafe.Pointer)(native_ptr)
     ret := C.wasm_runtime_validate_native_addr(self._instance,
                                                native_ptr_C,
-                                               (C.uint32_t)(size))
+                                               (C.uint64_t)(size))
     return (bool)(ret)
 }
 
-func (self Instance) AddrAppToNative(app_offset uint32) *uint8 {
+func (self Instance) AddrAppToNative(app_offset uint64) *uint8 {
     native_ptr := C.wasm_runtime_addr_app_to_native(self._instance,
-                                                    (C.uint32_t)(app_offset))
+                                                    (C.uint64_t)(app_offset))
     return (*uint8)(native_ptr)
 }
 
-func (self Instance) AddrNativeToApp(native_ptr *uint8) uint32 {
+func (self Instance) AddrNativeToApp(native_ptr *uint8) uint64 {
     native_ptr_C := (unsafe.Pointer)(native_ptr)
     offset := C.wasm_runtime_addr_native_to_app(self._instance,
                                                 native_ptr_C)
-    return (uint32)(offset)
+    return (uint64)(offset)
 }
 
-func (self Instance) GetAppAddrRange(app_offset uint32) (bool,
-                                                         uint32,
-                                                         uint32) {
-    var start_offset, end_offset C.uint32_t
+func (self Instance) GetAppAddrRange(app_offset uint64) (bool,
+                                                         uint64,
+                                                         uint64) {
+    var start_offset, end_offset C.uint64_t
     ret := C.wasm_runtime_get_app_addr_range(self._instance,
-                                             (C.uint32_t)(app_offset),
+                                             (C.uint64_t)(app_offset),
                                              &start_offset, &end_offset)
-    return (bool)(ret), (uint32)(start_offset), (uint32)(end_offset)
+    return (bool)(ret), (uint64)(start_offset), (uint64)(end_offset)
 }
 
 func (self Instance) GetNativeAddrRange(native_ptr *uint8) (bool,

--- a/language-bindings/python/src/wamr/wamrapi/wamr.py
+++ b/language-bindings/python/src/wamr/wamrapi/wamr.py
@@ -6,6 +6,7 @@ from ctypes import addressof
 from ctypes import c_char
 from ctypes import c_uint
 from ctypes import c_uint8
+from ctypes import c_uint64
 from ctypes import c_void_p
 from ctypes import cast
 from ctypes import create_string_buffer
@@ -167,7 +168,7 @@ class Instance:
             raise Exception("Error while creating module instance")
         return module_inst
 
-    def malloc(self, nbytes: int, native_handler) -> c_uint:
+    def malloc(self, nbytes: int, native_handler) -> c_uint64:
         return wasm_runtime_module_malloc(self.module_inst, nbytes, native_handler)
 
     def free(self, wasm_handler) -> None:

--- a/samples/basic/src/main.c
+++ b/samples/basic/src/main.c
@@ -61,7 +61,7 @@ main(int argc, char *argv_main[])
     wasm_function_inst_t func = NULL;
     wasm_function_inst_t func2 = NULL;
     char *native_buffer = NULL;
-    uint32_t wasm_buffer = 0;
+    uint64_t wasm_buffer = 0;
 
     RuntimeInitArgs init_args;
     memset(&init_args, 0, sizeof(RuntimeInitArgs));
@@ -176,7 +176,7 @@ main(int argc, char *argv_main[])
            ret_val);
 
     // Next we will pass a buffer to the WASM function
-    uint32 argv2[4];
+    uint32 argv2[5];
 
     // must allocate buffer from wasm instance memory space (never use pointer
     // from host runtime)
@@ -185,8 +185,8 @@ main(int argc, char *argv_main[])
 
     memcpy(argv2, &ret_val, sizeof(float)); // the first argument
     argv2[1] = wasm_buffer; // the second argument is the wasm buffer address
-    argv2[2] = 100;         //  the third argument is the wasm buffer size
-    argv2[3] = 3; //  the last argument is the digits after decimal point for
+    argv2[3] = 100;         //  the third argument is the wasm buffer size
+    argv2[4] = 3; //  the last argument is the digits after decimal point for
                   //  converting float to string
 
     if (!(func2 = wasm_runtime_lookup_function(module_inst, "float_to_string",
@@ -231,7 +231,7 @@ fail:
         wasm_runtime_destroy_exec_env(exec_env);
     if (module_inst) {
         if (wasm_buffer)
-            wasm_runtime_module_free(module_inst, wasm_buffer);
+            wasm_runtime_module_free(module_inst, (uint64)wasm_buffer);
         wasm_runtime_deinstantiate(module_inst);
     }
     if (module)

--- a/samples/native-lib/test_hello2.c
+++ b/samples/native-lib/test_hello2.c
@@ -30,12 +30,14 @@ test_hello2_wrapper(wasm_exec_env_t exec_env, uint32_t nameaddr,
     wasm_runtime_free(p);
 
     wasm_module_inst_t inst = wasm_runtime_get_module_inst(exec_env);
-    if (!wasm_runtime_validate_app_str_addr(inst, nameaddr)
-        || !wasm_runtime_validate_app_addr(inst, resultaddr, resultlen)) {
+    if (!wasm_runtime_validate_app_str_addr(inst, (uint64_t)nameaddr)
+        || !wasm_runtime_validate_app_addr(inst, (uint64_t)resultaddr,
+                                           (uint64_t)resultlen)) {
         return -1;
     }
-    const char *name = wasm_runtime_addr_app_to_native(inst, nameaddr);
-    char *result = wasm_runtime_addr_app_to_native(inst, resultaddr);
+    const char *name =
+        wasm_runtime_addr_app_to_native(inst, (uint64_t)nameaddr);
+    char *result = wasm_runtime_addr_app_to_native(inst, (uint64_t)resultaddr);
     return snprintf(result, resultlen,
                     "Hello, %s. This is %s! Your wasm_module_inst_t is %p.\n",
                     name, __func__, inst);


### PR DESCRIPTION
# Change the data type representing linear memory address from u32 to u64.

## (Export) APIs signature changes

- (Export)`wasm_runtime_module_malloc`
  - `wasm_module_malloc`
    - `wasm_module_malloc_internal`
  - `aot_module_malloc`
    - `aot_module_malloc_internal`

- `wasm_runtime_module_realloc`
  - `wasm_module_realloc`
    - `wasm_module_realloc_internal`
  - `aot_module_realloc`
    - `aot_module_realloc_internal`

- (Export)`wasm_runtime_module_free`
  - `wasm_module_free`
    - `wasm_module_free_internal`
  - `aot_module_malloc`
    - `aot_module_free_internal`

- (Export)`wasm_runtime_module_dup_data`
  - `wasm_module_dup_data`
  - `aot_module_dup_data`

- (Export)`wasm_runtime_validate_app_addr`

- (Export)`wasm_runtime_validate_app_str_addr`

- (Export)`wasm_runtime_validate_native_addr`

- (Export)`wasm_runtime_addr_app_to_native`

- (Export)`wasm_runtime_addr_native_to_app`

- (Export)`wasm_runtime_get_app_addr_range`

- `aot_set_aux_stack`
- `aot_get_aux_stack`

- `wasm_set_aux_stack`
- `wasm_get_aux_stack`

- `aot_check_app_addr_and_convert`/`wasm_check_app_addr_and_convert`/`jit_check_app_addr_and_convert`

- `wasm_exec_env_set_aux_stack`

- `wasm_exec_env_get_aux_stack`

- `wasm_cluster_create_thread`

- `wasm_cluster_allocate_aux_stack`

- `wasm_cluster_free_aux_stack`

## Data structure changes

- For `WASMModule` and `AOTModule`

  - data member: `aux_data_end`, `aux_heap_base`, `aux_stack_bottom`

  will influence wasm loader, aot file emit, aot loader, wasm/aot runtime memory instantiating, and auxiliary stack boundary check. So it will change the AOT ABI

- For `WASMExecEnv`

  - data member: `aux_stack_boundary`, `aux_stack_bottom`
  
  will influence auxiliary stack boundary creating(create_aux_stack_info), accessing(getter/setter) and checking
  Use **uintptr_t* instead of u64 because the many offset calculations in AOT make this assumption, it would be many more modifications if make it u64

- For `AOTCompData`

  - data member: `aux_data_end`, `aux_heap_base`, `aux_stack_bottom`

  will influence aot file emit

- For `WASMMemoryInstance(AOTMemoryInstance)`
  - data member: `memory_data_size`, `__padding`->`is_memory64`

  will influence wasm/aot runtime memory instantiating, memory init/copy. And address converting and checking (check_app_addr_and_convert)

- For `WASMModuleInstMemConsumption`
  - data member: `total_size` and `memories_size`

- For `WASMDebugExecutionMemory`
  - data member: `start_offset` and `current_pos`

- For `WASMCluster`
  - data member: `*stack_tops`

  will influence multi-thread aux stack management

## Components that are affected by the APIs and data structure changes:

1. `Libc_builtin`

2. `Libc_emcc`

3. `Libc_uvwasi`

4. `Libc_wasi`

5. `Python` and `Golang` Language Embedding

6. Interpreter Debug engine

7. Multi-thread(Pthread and wasi-thread) wasm cluster aux stack management

