### PR TITLE
Allow overwriting max memory on module instantiation

### DIFF
--- a/.github/workflows/compilation_on_macos.yml
+++ b/.github/workflows/compilation_on_macos.yml
@@ -242,7 +242,7 @@ jobs:
         run: |
           cmake -S . -B build ${{ matrix.make_options }}
           cmake --build build --config Release --parallel 4
-          ctest --test-dir build
+          ctest --test-dir build --output-on-failure
         working-directory: samples/wasm-c-api
 
   build_samples_others:

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -790,7 +790,8 @@ memory_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
     uint32 num_bytes_per_page = memory->num_bytes_per_page;
     uint32 init_page_count = memory->mem_init_page_count;
     uint32 max_page_count =
-        max_memory_pages == 0 ? memory->mem_max_page_count : max_memory_pages;
+        wasm_runtime_get_max_mem(max_memory_pages, memory->mem_init_page_count,
+                                 memory->mem_max_page_count);
     uint32 inc_page_count, aux_heap_base, global_idx;
     uint32 bytes_of_last_page, bytes_to_page_end;
     uint32 heap_offset = num_bytes_per_page * init_page_count;

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -783,12 +783,14 @@ static AOTMemoryInstance *
 memory_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
                    AOTModule *module, AOTMemoryInstance *memory_inst,
                    AOTMemory *memory, uint32 memory_idx, uint32 heap_size,
-                   char *error_buf, uint32 error_buf_size)
+                   uint32 max_memory_pages, char *error_buf,
+                   uint32 error_buf_size)
 {
     void *heap_handle;
     uint32 num_bytes_per_page = memory->num_bytes_per_page;
     uint32 init_page_count = memory->mem_init_page_count;
-    uint32 max_page_count = memory->mem_max_page_count;
+    uint32 max_page_count =
+        max_memory_pages == 0 ? memory->mem_max_page_count : max_memory_pages;
     uint32 inc_page_count, aux_heap_base, global_idx;
     uint32 bytes_of_last_page, bytes_to_page_end;
     uint32 heap_offset = num_bytes_per_page * init_page_count;
@@ -984,7 +986,8 @@ aot_get_default_memory(AOTModuleInstance *module_inst)
 
 static bool
 memories_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
-                     AOTModule *module, uint32 heap_size, char *error_buf,
+                     AOTModule *module, uint32 heap_size,
+                     uint32 max_memory_pages, char *error_buf,
                      uint32 error_buf_size)
 {
     uint32 global_index, global_data_offset, base_offset, length;
@@ -1002,9 +1005,9 @@ memories_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
 
     memories = module_inst->global_table_data.memory_instances;
     for (i = 0; i < memory_count; i++, memories++) {
-        memory_inst = memory_instantiate(module_inst, parent, module, memories,
-                                         &module->memories[i], i, heap_size,
-                                         error_buf, error_buf_size);
+        memory_inst = memory_instantiate(
+            module_inst, parent, module, memories, &module->memories[i], i,
+            heap_size, max_memory_pages, error_buf, error_buf_size);
         if (!memory_inst) {
             return false;
         }
@@ -1461,7 +1464,7 @@ check_linked_symbol(AOTModule *module, char *error_buf, uint32 error_buf_size)
 AOTModuleInstance *
 aot_instantiate(AOTModule *module, AOTModuleInstance *parent,
                 WASMExecEnv *exec_env_main, uint32 stack_size, uint32 heap_size,
-                char *error_buf, uint32 error_buf_size)
+                uint32 max_memory_pages, char *error_buf, uint32 error_buf_size)
 {
     AOTModuleInstance *module_inst;
 #if WASM_ENABLE_BULK_MEMORY != 0 || WASM_ENABLE_REF_TYPES != 0
@@ -1551,7 +1554,7 @@ aot_instantiate(AOTModule *module, AOTModuleInstance *parent,
         &((AOTModuleInstanceExtra *)module_inst->e)->sub_module_inst_list_head;
     ret = wasm_runtime_sub_module_instantiate(
         (WASMModuleCommon *)module, (WASMModuleInstanceCommon *)module_inst,
-        stack_size, heap_size, error_buf, error_buf_size);
+        stack_size, heap_size, max_memory_pages, error_buf, error_buf_size);
     if (!ret) {
         LOG_DEBUG("build a sub module list failed");
         goto fail;
@@ -1613,8 +1616,8 @@ aot_instantiate(AOTModule *module, AOTModuleInstance *parent,
         goto fail;
 
     /* Initialize memory space */
-    if (!memories_instantiate(module_inst, parent, module, heap_size, error_buf,
-                              error_buf_size))
+    if (!memories_instantiate(module_inst, parent, module, heap_size,
+                              max_memory_pages, error_buf, error_buf_size))
         goto fail;
 
     /* Initialize function pointers */

--- a/core/iwasm/aot/aot_runtime.h
+++ b/core/iwasm/aot/aot_runtime.h
@@ -482,7 +482,8 @@ aot_unload(AOTModule *module);
 AOTModuleInstance *
 aot_instantiate(AOTModule *module, AOTModuleInstance *parent,
                 WASMExecEnv *exec_env_main, uint32 stack_size, uint32 heap_size,
-                char *error_buf, uint32 error_buf_size);
+                uint32 max_memory_pages, char *error_buf,
+                uint32 error_buf_size);
 
 /**
  * Deinstantiate a AOT module instance, destroy the resources.

--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -4873,17 +4873,18 @@ wasm_instance_new_with_args(wasm_store_t *store, const wasm_module_t *module,
                             own wasm_trap_t **trap, const uint32 stack_size,
                             const uint32 heap_size)
 {
+    InstantiationArgs inst_args = { 0 };
+    inst_args.default_stack_size = stack_size;
+    inst_args.host_managed_heap_size = heap_size;
     return wasm_instance_new_with_args_ex(store, module, imports, trap,
-                                          stack_size, heap_size, 0);
+                                          &inst_args);
 }
 
 wasm_instance_t *
 wasm_instance_new_with_args_ex(wasm_store_t *store, const wasm_module_t *module,
                                const wasm_extern_vec_t *imports,
                                own wasm_trap_t **trap,
-                               const uint32_t stack_size,
-                               const uint32_t heap_size,
-                               const uint32_t max_memory_pages)
+                               const InstantiationArgs *inst_args)
 {
     char sub_error_buf[128] = { 0 };
     char error_buf[256] = { 0 };
@@ -4924,8 +4925,7 @@ wasm_instance_new_with_args_ex(wasm_store_t *store, const wasm_module_t *module,
      */
 
     instance->inst_comm_rt = wasm_runtime_instantiate_ex(
-        *module, stack_size, heap_size, max_memory_pages, sub_error_buf,
-        sizeof(sub_error_buf));
+        *module, inst_args, sub_error_buf, sizeof(sub_error_buf));
     if (!instance->inst_comm_rt) {
         goto failed;
     }

--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -4873,6 +4873,18 @@ wasm_instance_new_with_args(wasm_store_t *store, const wasm_module_t *module,
                             own wasm_trap_t **trap, const uint32 stack_size,
                             const uint32 heap_size)
 {
+    return wasm_instance_new_with_args_ex(store, module, imports, trap,
+                                          stack_size, heap_size, 0);
+}
+
+wasm_instance_t *
+wasm_instance_new_with_args_ex(wasm_store_t *store, const wasm_module_t *module,
+                               const wasm_extern_vec_t *imports,
+                               own wasm_trap_t **trap,
+                               const uint32_t stack_size,
+                               const uint32_t heap_size,
+                               const uint32_t max_memory_pages)
+{
     char sub_error_buf[128] = { 0 };
     char error_buf[256] = { 0 };
     wasm_instance_t *instance = NULL;
@@ -4911,8 +4923,9 @@ wasm_instance_new_with_args(wasm_store_t *store, const wasm_module_t *module,
      * will do the linking result check at the end of wasm_runtime_instantiate
      */
 
-    instance->inst_comm_rt = wasm_runtime_instantiate(
-        *module, stack_size, heap_size, sub_error_buf, sizeof(sub_error_buf));
+    instance->inst_comm_rt = wasm_runtime_instantiate_ex(
+        *module, stack_size, heap_size, max_memory_pages, sub_error_buf,
+        sizeof(sub_error_buf));
     if (!instance->inst_comm_rt) {
         goto failed;
     }

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -1361,20 +1361,20 @@ WASMModuleInstanceCommon *
 wasm_runtime_instantiate_internal(WASMModuleCommon *module,
                                   WASMModuleInstanceCommon *parent,
                                   WASMExecEnv *exec_env_main, uint32 stack_size,
-                                  uint32 heap_size, char *error_buf,
-                                  uint32 error_buf_size)
+                                  uint32 heap_size, uint32 max_memory_pages,
+                                  char *error_buf, uint32 error_buf_size)
 {
 #if WASM_ENABLE_INTERP != 0
     if (module->module_type == Wasm_Module_Bytecode)
         return (WASMModuleInstanceCommon *)wasm_instantiate(
             (WASMModule *)module, (WASMModuleInstance *)parent, exec_env_main,
-            stack_size, heap_size, error_buf, error_buf_size);
+            stack_size, heap_size, max_memory_pages, error_buf, error_buf_size);
 #endif
 #if WASM_ENABLE_AOT != 0
     if (module->module_type == Wasm_Module_AoT)
         return (WASMModuleInstanceCommon *)aot_instantiate(
             (AOTModule *)module, (AOTModuleInstance *)parent, exec_env_main,
-            stack_size, heap_size, error_buf, error_buf_size);
+            stack_size, heap_size, max_memory_pages, error_buf, error_buf_size);
 #endif
     set_error_buf(error_buf, error_buf_size,
                   "Instantiate module failed, invalid module type");
@@ -1386,8 +1386,19 @@ wasm_runtime_instantiate(WASMModuleCommon *module, uint32 stack_size,
                          uint32 heap_size, char *error_buf,
                          uint32 error_buf_size)
 {
-    return wasm_runtime_instantiate_internal(
-        module, NULL, NULL, stack_size, heap_size, error_buf, error_buf_size);
+    return wasm_runtime_instantiate_internal(module, NULL, NULL, stack_size,
+                                             heap_size, 0, error_buf,
+                                             error_buf_size);
+}
+
+WASMModuleInstanceCommon *
+wasm_runtime_instantiate_ex(WASMModuleCommon *module, uint32 stack_size,
+                            uint32 heap_size, uint32 max_memory_pages,
+                            char *error_buf, uint32 error_buf_size)
+{
+    return wasm_runtime_instantiate_internal(module, NULL, NULL, stack_size,
+                                             heap_size, max_memory_pages,
+                                             error_buf, error_buf_size);
 }
 
 void
@@ -6403,7 +6414,8 @@ bool
 wasm_runtime_sub_module_instantiate(WASMModuleCommon *module,
                                     WASMModuleInstanceCommon *module_inst,
                                     uint32 stack_size, uint32 heap_size,
-                                    char *error_buf, uint32 error_buf_size)
+                                    uint32 max_memory_pages, char *error_buf,
+                                    uint32 error_buf_size)
 {
     bh_list *sub_module_inst_list = NULL;
     WASMRegisteredModule *sub_module_list_node = NULL;
@@ -6431,8 +6443,8 @@ wasm_runtime_sub_module_instantiate(WASMModuleCommon *module,
         WASMModuleCommon *sub_module = sub_module_list_node->module;
         WASMModuleInstanceCommon *sub_module_inst = NULL;
         sub_module_inst = wasm_runtime_instantiate_internal(
-            sub_module, NULL, NULL, stack_size, heap_size, error_buf,
-            error_buf_size);
+            sub_module, NULL, NULL, stack_size, heap_size, max_memory_pages,
+            error_buf, error_buf_size);
         if (!sub_module_inst) {
             LOG_DEBUG("instantiate %s failed",
                       sub_module_list_node->module_name);

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -566,8 +566,8 @@ WASMModuleInstanceCommon *
 wasm_runtime_instantiate_internal(WASMModuleCommon *module,
                                   WASMModuleInstanceCommon *parent,
                                   WASMExecEnv *exec_env_main, uint32 stack_size,
-                                  uint32 heap_size, char *error_buf,
-                                  uint32 error_buf_size);
+                                  uint32 heap_size, uint32 max_memory_pages,
+                                  char *error_buf, uint32 error_buf_size);
 
 /* Internal API */
 void
@@ -579,6 +579,12 @@ WASM_RUNTIME_API_EXTERN WASMModuleInstanceCommon *
 wasm_runtime_instantiate(WASMModuleCommon *module, uint32 default_stack_size,
                          uint32 host_managed_heap_size, char *error_buf,
                          uint32 error_buf_size);
+
+/* See wasm_export.h for description */
+WASM_RUNTIME_API_EXTERN WASMModuleInstanceCommon *
+wasm_runtime_instantiate_ex(WASMModuleCommon *module, uint32 stack_size,
+                            uint32 heap_size, uint32 max_memory_pages,
+                            char *error_buf, uint32 error_buf_size);
 
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN bool
@@ -887,7 +893,8 @@ bool
 wasm_runtime_sub_module_instantiate(WASMModuleCommon *module,
                                     WASMModuleInstanceCommon *module_inst,
                                     uint32 stack_size, uint32 heap_size,
-                                    char *error_buf, uint32 error_buf_size);
+                                    uint32 max_memory_pages, char *error_buf,
+                                    uint32 error_buf_size);
 void
 wasm_runtime_sub_module_deinstantiate(WASMModuleInstanceCommon *module_inst);
 #endif

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -562,6 +562,11 @@ WASM_RUNTIME_API_EXTERN void
 wasm_runtime_unload(WASMModuleCommon *module);
 
 /* Internal API */
+uint32
+wasm_runtime_get_max_mem(uint32 max_memory_pages, uint32 module_init_page_count,
+                         uint32 module_max_page_count);
+
+/* Internal API */
 WASMModuleInstanceCommon *
 wasm_runtime_instantiate_internal(WASMModuleCommon *module,
                                   WASMModuleInstanceCommon *parent,
@@ -582,9 +587,9 @@ wasm_runtime_instantiate(WASMModuleCommon *module, uint32 default_stack_size,
 
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN WASMModuleInstanceCommon *
-wasm_runtime_instantiate_ex(WASMModuleCommon *module, uint32 stack_size,
-                            uint32 heap_size, uint32 max_memory_pages,
-                            char *error_buf, uint32 error_buf_size);
+wasm_runtime_instantiate_ex(WASMModuleCommon *module,
+                            const InstantiationArgs *args, char *error_buf,
+                            uint32 error_buf_size);
 
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN bool

--- a/core/iwasm/include/wasm_c_api.h
+++ b/core/iwasm/include/wasm_c_api.h
@@ -644,6 +644,12 @@ WASM_API_EXTERN own wasm_instance_t* wasm_instance_new_with_args(
   own wasm_trap_t** trap, const uint32_t stack_size, const uint32_t heap_size
 );
 
+// please refer to wasm_runtime_instantiate_ex(...) in core/iwasm/include/wasm_export.h
+WASM_API_EXTERN own wasm_instance_t* wasm_instance_new_with_args_ex(
+  wasm_store_t*, const wasm_module_t*, const wasm_extern_vec_t *imports,
+  own wasm_trap_t** trap, const uint32_t stack_size, const uint32_t heap_size, const uint32_t max_memory_pages
+);
+
 WASM_API_EXTERN void wasm_instance_exports(const wasm_instance_t*, own wasm_extern_vec_t* out);
 
 

--- a/core/iwasm/include/wasm_c_api.h
+++ b/core/iwasm/include/wasm_c_api.h
@@ -186,6 +186,16 @@ struct wasm_config_t {
     /*TODO: wasi args*/
 };
 
+#ifndef INSTANTIATION_ARGS_OPTION_DEFINED
+#define INSTANTIATION_ARGS_OPTION_DEFINED
+/* WASM module instantiation arguments */
+typedef struct InstantiationArgs {
+    uint32_t default_stack_size;
+    uint32_t host_managed_heap_size;
+    uint32_t max_memory_pages;
+} InstantiationArgs;
+#endif /* INSTANTIATION_ARGS_OPTION_DEFINED */
+
 /*
  * by default:
  * - mem_alloc_type is Alloc_With_System_Allocator
@@ -647,7 +657,7 @@ WASM_API_EXTERN own wasm_instance_t* wasm_instance_new_with_args(
 // please refer to wasm_runtime_instantiate_ex(...) in core/iwasm/include/wasm_export.h
 WASM_API_EXTERN own wasm_instance_t* wasm_instance_new_with_args_ex(
   wasm_store_t*, const wasm_module_t*, const wasm_extern_vec_t *imports,
-  own wasm_trap_t** trap, const uint32_t stack_size, const uint32_t heap_size, const uint32_t max_memory_pages
+  own wasm_trap_t** trap, const InstantiationArgs *inst_args
 );
 
 WASM_API_EXTERN void wasm_instance_exports(const wasm_instance_t*, own wasm_extern_vec_t* out);

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -528,6 +528,32 @@ wasm_runtime_instantiate(const wasm_module_t module,
                          char *error_buf, uint32_t error_buf_size);
 
 /**
+ * Instantiate a WASM module, overwriting maximum memory
+ * 
+ * @param module the WASM module to instantiate
+ * @param default_stack_size the default stack size of the module instance when the
+ *        exec env's operation stack isn't created by user, e.g. API
+ *        wasm_application_execute_main() and wasm_application_execute_func()
+ *        create the operation stack internally with the stack size specified
+ *        here. And API wasm_runtime_create_exec_env() creates the operation
+ *        stack with stack size specified by its parameter, the stack size
+ *        specified here is ignored.
+ * @param host_managed_heap_size the default heap size of the module instance, a heap will
+ *        be created besides the app memory space. Both wasm app and native
+ *        function can allocate memory from the heap.
+ * @param max_memory_pages the number of pages (64k each) to use as maximum memory
+ * @param error_buf buffer to output the error info if failed
+ * @param error_buf_size the size of the error buffer
+ *
+ * @return return the instantiated WASM module instance, NULL if failed
+ */
+WASM_RUNTIME_API_EXTERN wasm_module_inst_t
+wasm_runtime_instantiate_ex(const wasm_module_t module,
+                         uint32_t default_stack_size, uint32_t host_managed_heap_size,
+                         uint32_t max_memory_pages,
+                         char *error_buf, uint32_t error_buf_size);
+
+/**
  * Set the running mode of a WASM module instance, override the
  * default running mode of the runtime. Note that it only makes sense when
  * the input is a wasm bytecode file: for the AOT file, runtime always runs

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -183,6 +183,16 @@ typedef struct RuntimeInitArgs {
     bool enable_linux_perf;
 } RuntimeInitArgs;
 
+#ifndef INSTANTIATION_ARGS_OPTION_DEFINED
+#define INSTANTIATION_ARGS_OPTION_DEFINED
+/* WASM module instantiation arguments */
+typedef struct InstantiationArgs {
+    uint32_t default_stack_size;
+    uint32_t host_managed_heap_size;
+    uint32_t max_memory_pages;
+} InstantiationArgs;
+#endif /* INSTANTIATION_ARGS_OPTION_DEFINED */
+
 #ifndef WASM_VALKIND_T_DEFINED
 #define WASM_VALKIND_T_DEFINED
 typedef uint8_t wasm_valkind_t;
@@ -528,29 +538,13 @@ wasm_runtime_instantiate(const wasm_module_t module,
                          char *error_buf, uint32_t error_buf_size);
 
 /**
- * Instantiate a WASM module, overwriting maximum memory
+ * Instantiate a WASM module, with specified instantiation arguments
  * 
- * @param module the WASM module to instantiate
- * @param default_stack_size the default stack size of the module instance when the
- *        exec env's operation stack isn't created by user, e.g. API
- *        wasm_application_execute_main() and wasm_application_execute_func()
- *        create the operation stack internally with the stack size specified
- *        here. And API wasm_runtime_create_exec_env() creates the operation
- *        stack with stack size specified by its parameter, the stack size
- *        specified here is ignored.
- * @param host_managed_heap_size the default heap size of the module instance, a heap will
- *        be created besides the app memory space. Both wasm app and native
- *        function can allocate memory from the heap.
- * @param max_memory_pages the number of pages (64k each) to use as maximum memory
- * @param error_buf buffer to output the error info if failed
- * @param error_buf_size the size of the error buffer
- *
- * @return return the instantiated WASM module instance, NULL if failed
+ * Same as wasm_runtime_instantiate, but it also allows overwriting maximum memory
  */
 WASM_RUNTIME_API_EXTERN wasm_module_inst_t
 wasm_runtime_instantiate_ex(const wasm_module_t module,
-                         uint32_t default_stack_size, uint32_t host_managed_heap_size,
-                         uint32_t max_memory_pages,
+                         const InstantiationArgs *args,
                          char *error_buf, uint32_t error_buf_size);
 
 /**

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -353,7 +353,8 @@ fail1:
 static WASMMemoryInstance **
 memories_instantiate(const WASMModule *module, WASMModuleInstance *module_inst,
                      WASMModuleInstance *parent, uint32 heap_size,
-                     char *error_buf, uint32 error_buf_size)
+                     uint32 max_memory_pages, char *error_buf,
+                     uint32 error_buf_size)
 {
     WASMImport *import;
     uint32 mem_index = 0, i,
@@ -374,7 +375,9 @@ memories_instantiate(const WASMModule *module, WASMModuleInstance *module_inst,
     for (i = 0; i < module->import_memory_count; i++, import++, memory++) {
         uint32 num_bytes_per_page = import->u.memory.num_bytes_per_page;
         uint32 init_page_count = import->u.memory.init_page_count;
-        uint32 max_page_count = import->u.memory.max_page_count;
+        uint32 max_page_count = max_memory_pages == 0
+                                    ? import->u.memory.max_page_count
+                                    : max_memory_pages;
         uint32 flags = import->u.memory.flags;
         uint32 actual_heap_size = heap_size;
 
@@ -412,12 +415,15 @@ memories_instantiate(const WASMModule *module, WASMModuleInstance *module_inst,
 
     /* instantiate memories from memory section */
     for (i = 0; i < module->memory_count; i++, memory++) {
+        uint32 max_page_count = max_memory_pages == 0
+                                    ? module->memories[i].max_page_count
+                                    : max_memory_pages;
         if (!(memories[mem_index] = memory_instantiate(
                   module_inst, parent, memory, mem_index,
                   module->memories[i].num_bytes_per_page,
-                  module->memories[i].init_page_count,
-                  module->memories[i].max_page_count, heap_size,
-                  module->memories[i].flags, error_buf, error_buf_size))) {
+                  module->memories[i].init_page_count, max_page_count,
+                  heap_size, module->memories[i].flags, error_buf,
+                  error_buf_size))) {
             memories_deinstantiate(module_inst, memories, memory_count);
             return NULL;
         }
@@ -1934,7 +1940,8 @@ wasm_set_running_mode(WASMModuleInstance *module_inst, RunningMode running_mode)
 WASMModuleInstance *
 wasm_instantiate(WASMModule *module, WASMModuleInstance *parent,
                  WASMExecEnv *exec_env_main, uint32 stack_size,
-                 uint32 heap_size, char *error_buf, uint32 error_buf_size)
+                 uint32 heap_size, uint32 max_memory_pages, char *error_buf,
+                 uint32 error_buf_size)
 {
     WASMModuleInstance *module_inst;
     WASMGlobalInstance *globals = NULL, *global;
@@ -2022,7 +2029,7 @@ wasm_instantiate(WASMModule *module, WASMModuleInstance *parent,
         &module_inst->e->sub_module_inst_list_head;
     ret = wasm_runtime_sub_module_instantiate(
         (WASMModuleCommon *)module, (WASMModuleInstanceCommon *)module_inst,
-        stack_size, heap_size, error_buf, error_buf_size);
+        stack_size, heap_size, max_memory_pages, error_buf, error_buf_size);
     if (!ret) {
         LOG_DEBUG("build a sub module list failed");
         goto fail;
@@ -2131,9 +2138,9 @@ wasm_instantiate(WASMModule *module, WASMModuleInstance *parent,
 
     /* Instantiate memories/tables/functions/tags */
     if ((module_inst->memory_count > 0
-         && !(module_inst->memories =
-                  memories_instantiate(module, module_inst, parent, heap_size,
-                                       error_buf, error_buf_size)))
+         && !(module_inst->memories = memories_instantiate(
+                  module, module_inst, parent, heap_size, max_memory_pages,
+                  error_buf, error_buf_size)))
         || (module_inst->table_count > 0
             && !(module_inst->tables =
                      tables_instantiate(module, module_inst, first_table,

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -375,9 +375,9 @@ memories_instantiate(const WASMModule *module, WASMModuleInstance *module_inst,
     for (i = 0; i < module->import_memory_count; i++, import++, memory++) {
         uint32 num_bytes_per_page = import->u.memory.num_bytes_per_page;
         uint32 init_page_count = import->u.memory.init_page_count;
-        uint32 max_page_count = max_memory_pages == 0
-                                    ? import->u.memory.max_page_count
-                                    : max_memory_pages;
+        uint32 max_page_count = wasm_runtime_get_max_mem(
+            max_memory_pages, import->u.memory.init_page_count,
+            import->u.memory.max_page_count);
         uint32 flags = import->u.memory.flags;
         uint32 actual_heap_size = heap_size;
 
@@ -415,9 +415,9 @@ memories_instantiate(const WASMModule *module, WASMModuleInstance *module_inst,
 
     /* instantiate memories from memory section */
     for (i = 0; i < module->memory_count; i++, memory++) {
-        uint32 max_page_count = max_memory_pages == 0
-                                    ? module->memories[i].max_page_count
-                                    : max_memory_pages;
+        uint32 max_page_count = wasm_runtime_get_max_mem(
+            max_memory_pages, module->memories[i].init_page_count,
+            module->memories[i].max_page_count);
         if (!(memories[mem_index] = memory_instantiate(
                   module_inst, parent, memory, mem_index,
                   module->memories[i].num_bytes_per_page,

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -513,7 +513,8 @@ wasm_unload(WASMModule *module);
 WASMModuleInstance *
 wasm_instantiate(WASMModule *module, WASMModuleInstance *parent,
                  WASMExecEnv *exec_env_main, uint32 stack_size,
-                 uint32 heap_size, char *error_buf, uint32 error_buf_size);
+                 uint32 heap_size, uint32 max_memory_pages, char *error_buf,
+                 uint32 error_buf_size);
 
 void
 wasm_dump_perf_profiling(const WASMModuleInstance *module_inst);

--- a/core/iwasm/libraries/lib-pthread/lib_pthread_wrapper.c
+++ b/core/iwasm/libraries/lib-pthread/lib_pthread_wrapper.c
@@ -579,7 +579,7 @@ pthread_create_wrapper(wasm_exec_env_t exec_env,
 #endif
 
     if (!(new_module_inst = wasm_runtime_instantiate_internal(
-              module, module_inst, exec_env, stack_size, 0, NULL, 0)))
+              module, module_inst, exec_env, stack_size, 0, 0, NULL, 0)))
         return -1;
 
     /* Set custom_data to new module instance */

--- a/core/iwasm/libraries/lib-wasi-threads/lib_wasi_threads_wrapper.c
+++ b/core/iwasm/libraries/lib-wasi-threads/lib_wasi_threads_wrapper.c
@@ -87,7 +87,7 @@ thread_spawn_wrapper(wasm_exec_env_t exec_env, uint32 start_arg)
     stack_size = ((WASMModuleInstance *)module_inst)->default_wasm_stack_size;
 
     if (!(new_module_inst = wasm_runtime_instantiate_internal(
-              module, module_inst, exec_env, stack_size, 0, NULL, 0)))
+              module, module_inst, exec_env, stack_size, 0, 0, NULL, 0)))
         return -1;
 
     wasm_runtime_set_custom_data_internal(

--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -504,7 +504,7 @@ wasm_cluster_spawn_exec_env(WASMExecEnv *exec_env)
     }
 
     if (!(new_module_inst = wasm_runtime_instantiate_internal(
-              module, module_inst, exec_env, stack_size, 0, NULL, 0))) {
+              module, module_inst, exec_env, stack_size, 0, 0, NULL, 0))) {
         return NULL;
     }
 

--- a/language-bindings/python/src/wamr/wasmcapi/binding.py
+++ b/language-bindings/python/src/wamr/wasmcapi/binding.py
@@ -2013,6 +2013,12 @@ def wasm_instance_new_with_args(arg0,arg1,arg2,arg3,arg4,arg5):
     _wasm_instance_new_with_args.argtypes = [POINTER(wasm_store_t),POINTER(wasm_module_t),POINTER(wasm_extern_vec_t),POINTER(POINTER(wasm_trap_t)),c_uint32,c_uint32]
     return _wasm_instance_new_with_args(arg0,arg1,arg2,arg3,arg4,arg5)
 
+def wasm_instance_new_with_args_ex(arg0,arg1,arg2,arg3,arg4,arg5,arg6):
+    _wasm_instance_new_with_args_ex = libiwasm.wasm_instance_new_with_args_ex
+    _wasm_instance_new_with_args_ex.restype = POINTER(wasm_instance_t)
+    _wasm_instance_new_with_args_ex.argtypes = [POINTER(wasm_store_t),POINTER(wasm_module_t),POINTER(wasm_extern_vec_t),POINTER(POINTER(wasm_trap_t)),c_uint32,c_uint32,c_uint32]
+    return _wasm_instance_new_with_args_ex(arg0,arg1,arg2,arg3,arg4,arg5,arg6)
+
 def wasm_instance_exports(arg0,arg1):
     _wasm_instance_exports = libiwasm.wasm_instance_exports
     _wasm_instance_exports.restype = None

--- a/language-bindings/python/src/wamr/wasmcapi/binding.py
+++ b/language-bindings/python/src/wamr/wasmcapi/binding.py
@@ -2013,11 +2013,14 @@ def wasm_instance_new_with_args(arg0,arg1,arg2,arg3,arg4,arg5):
     _wasm_instance_new_with_args.argtypes = [POINTER(wasm_store_t),POINTER(wasm_module_t),POINTER(wasm_extern_vec_t),POINTER(POINTER(wasm_trap_t)),c_uint32,c_uint32]
     return _wasm_instance_new_with_args(arg0,arg1,arg2,arg3,arg4,arg5)
 
-def wasm_instance_new_with_args_ex(arg0,arg1,arg2,arg3,arg4,arg5,arg6):
+class InstantiationArgs(Structure):
+    pass
+
+def wasm_instance_new_with_args_ex(arg0,arg1,arg2,arg3,arg4):
     _wasm_instance_new_with_args_ex = libiwasm.wasm_instance_new_with_args_ex
     _wasm_instance_new_with_args_ex.restype = POINTER(wasm_instance_t)
-    _wasm_instance_new_with_args_ex.argtypes = [POINTER(wasm_store_t),POINTER(wasm_module_t),POINTER(wasm_extern_vec_t),POINTER(POINTER(wasm_trap_t)),c_uint32,c_uint32,c_uint32]
-    return _wasm_instance_new_with_args_ex(arg0,arg1,arg2,arg3,arg4,arg5,arg6)
+    _wasm_instance_new_with_args_ex.argtypes = [POINTER(wasm_store_t),POINTER(wasm_module_t),POINTER(wasm_extern_vec_t),POINTER(POINTER(wasm_trap_t)),POINTER(InstantiationArgs)]
+    return _wasm_instance_new_with_args_ex(arg0,arg1,arg2,arg3,arg4)
 
 def wasm_instance_exports(arg0,arg1):
     _wasm_instance_exports = libiwasm.wasm_instance_exports

--- a/language-bindings/python/wasm-c-api/docs/design.md
+++ b/language-bindings/python/wasm-c-api/docs/design.md
@@ -431,130 +431,131 @@ In next phase, we will create OOP APIs. Almost follow the
 
 ## A big list
 
-| WASM Concept | Procedural APIs                | OOP APIs   | OOP APIs methods |
-| ------------ | ------------------------------ | ---------- | ---------------- |
-| XXX_vec      | wasm_xxx_vec_new               |            | list             |
-|              | wasm_xxx_vec_new_uninitialized |            |                  |
-|              | wasm_xxx_vec_new_empty         |            |                  |
-|              | wasm_xxx_vec_copy              |            |                  |
-|              | wasm_xxx_vec_delete            |            |                  |
-| valtype      | wasm_valtype_new               | valtype    | \_\_init\_\_     |
-|              | wasm_valtype_delete            |            | \_\_del\_\_      |
-|              | wasm_valtype_kind              |            | \_\_eq\_\_       |
-|              | wasm_valtype_copy              |            |                  |
-|              | _vector methods_               |            |                  |
-| functype     | wasm_functype_new              | functype   |                  |
-|              | wasm_functype_delete           |            |                  |
-|              | wasm_functype_params           |            |                  |
-|              | wasm_functype_results          |            |                  |
-|              | wasm_functype_copy             |            |                  |
-|              | _vector methods_               |            |                  |
-| globaltype   | wasm_globaltype_new            | globaltype | \_\_init\_\_     |
-|              | wasm_globaltype_delete         |            | \_\_del\_\_      |
-|              | wasm_globaltype_content        |            | \_\_eq\_\_       |
-|              | wasm_globaltype_mutability     |            |                  |
-|              | wasm_globaltype_copy           |            |                  |
-|              | _vector methods_               |            |                  |
-| tabletype    | wasm_tabletype_new             | tabletype  | \_\_init\_\_     |
-|              | wasm_tabletype_delete          |            | \_\_del\_\_      |
-|              | wasm_tabletype_element         |            | \_\_eq\_\_       |
-|              | wasm_tabletype_limits          |            |                  |
-|              | wasm_tabletype_copy            |            |                  |
-|              | _vector methods_               |            |                  |
-| memorytype   | wasm_memorytype_new            | memorytype | \_\_init\_\_     |
-|              | wasm_memorytype_delete         |            | \_\_del\_\_      |
-|              | wasm_memorytype_limits         |            | \_\_eq\_\_       |
-|              | wasm_memorytype_copy           |            |                  |
-|              | _vector methods_               |            |                  |
-| externtype   | wasm_externtype_as_XXX         | externtype |                  |
-|              | wasm_XXX_as_externtype         |            |                  |
-|              | wasm_externtype_copy           |            |                  |
-|              | wasm_externtype_delete         |            |                  |
-|              | wasm_externtype_kind           |            |                  |
-|              | _vector methods_               |            |                  |
-| importtype   | wasm_importtype_new            | importtype |                  |
-|              | wasm_importtype_delete         |            |                  |
-|              | wasm_importtype_module         |            |                  |
-|              | wasm_importtype_name           |            |                  |
-|              | wasm_importtype_type           |            |                  |
-|              | wasm_importtype_copy           |            |                  |
-|              | _vector methods_               |            |                  |
-| exportype    | wasm_exporttype_new            | exporttype |                  |
-|              | wasm_exporttype_delete         |            |                  |
-|              | wasm_exporttype_name           |            |                  |
-|              | wasm_exporttype_type           |            |                  |
-|              | wasm_exporttype_copy           |            |                  |
-|              | _vector methods_               |            |                  |
-| val          | wasm_val_delete                | val        |                  |
-|              | wasm_val_copy                  |            |                  |
-|              | _vector methods_               |            |                  |
-| frame        | wasm_frame_delete              | frame      |                  |
-|              | wasm_frame_instance            |            |                  |
-|              | wasm_frame_func_index          |            |                  |
-|              | wasm_frame_func_offset         |            |                  |
-|              | wasm_frame_module_offset       |            |                  |
-|              | wasm_frame_copy                |            |                  |
-|              | _vector methods_               |            |                  |
-| trap         | wasm_trap_new                  | trap       |                  |
-|              | wasm_trap_delete               |            |                  |
-|              | wasm_trap_message              |            |                  |
-|              | wasm_trap_origin               |            |                  |
-|              | wasm_trap_trace                |            |                  |
-|              | _vector methods_               |            |                  |
-| foreign      | wasm_foreign_new               | foreign    |                  |
-|              | wasm_foreign_delete            |            |                  |
-|              | _vector methods_               |            |                  |
-| engine       | wasm_engine_new                | engine     |                  |
-|              | wasm_engine_new_with_args\*    |            |                  |
-|              | wasm_engine_new_with_config    |            |                  |
-|              | wasm_engine_delete             |            |                  |
-| store        | wasm_store_new                 | store      |                  |
-|              | wasm_store_delete              |            |                  |
-|              | _vector methods_               |            |                  |
-| module       | wasm_module_new                | module     |                  |
-|              | wasm_module_delete             |            |                  |
-|              | wasm_module_validate           |            |                  |
-|              | wasm_module_imports            |            |                  |
-|              | wasm_module_exports            |            |                  |
-| instance     | wasm_instance_new              | instance   |                  |
-|              | wasm_instance_delete           |            |                  |
-|              | wasm_instance_new_with_args\*  |            |                  |
-|              | wasm_instance_exports          |            |                  |
-|              | _vector methods_               |            |                  |
-| func         | wasm_func_new                  | func       |                  |
-|              | wasm_func_new_with_env         |            |                  |
-|              | wasm_func_delete               |            |                  |
-|              | wasm_func_type                 |            |                  |
-|              | wasm_func_call                 |            |                  |
-|              | wasm_func_param_arity          |            |                  |
-|              | wasm_func_result_arity         |            |                  |
-|              | _vector methods_               |            |                  |
-| global       | wasm_global_new                | global     |                  |
-|              | wasm_global_delete             |            |                  |
-|              | wasm_global_type               |            |                  |
-|              | wasm_global_get                |            |                  |
-|              | wasm_global_set                |            |                  |
-|              | _vector methods_               |            |                  |
-| table        | wasm_table_new                 | table      |                  |
-|              | wasm_table_delete              |            |                  |
-|              | wasm_table_type                |            |                  |
-|              | wasm_table_get                 |            |                  |
-|              | wasm_table_set                 |            |                  |
-|              | wasm_table_size                |            |                  |
-|              | _vector methods_               |            |                  |
-| memory       | wasm_memory_new                | memory     |                  |
-|              | wasm_memory_delete             |            |                  |
-|              | wasm_memory_type               |            |                  |
-|              | wasm_memory_data               |            |                  |
-|              | wasm_memory_data_size          |            |                  |
-|              | wasm_memory_size               |            |                  |
-|              | _vector methods_               |            |                  |
-| extern       | wasm_extern_delete             | extern     |                  |
-|              | wasm_extern_as_XXX             |            |                  |
-|              | wasm_XXX_as_extern             |            |                  |
-|              | wasm_extern_kind               |            |                  |
-|              | wasm_extern_type               |            |                  |
-|              | _vector methods_               |            |                  |
+| WASM Concept | Procedural APIs                  | OOP APIs   | OOP APIs methods |
+| ------------ | -------------------------------- | ---------- | ---------------- |
+| XXX_vec      | wasm_xxx_vec_new                 |            | list             |
+|              | wasm_xxx_vec_new_uninitialized   |            |                  |
+|              | wasm_xxx_vec_new_empty           |            |                  |
+|              | wasm_xxx_vec_copy                |            |                  |
+|              | wasm_xxx_vec_delete              |            |                  |
+| valtype      | wasm_valtype_new                 | valtype    | \_\_init\_\_     |
+|              | wasm_valtype_delete              |            | \_\_del\_\_      |
+|              | wasm_valtype_kind                |            | \_\_eq\_\_       |
+|              | wasm_valtype_copy                |            |                  |
+|              | _vector methods_                 |            |                  |
+| functype     | wasm_functype_new                | functype   |                  |
+|              | wasm_functype_delete             |            |                  |
+|              | wasm_functype_params             |            |                  |
+|              | wasm_functype_results            |            |                  |
+|              | wasm_functype_copy               |            |                  |
+|              | _vector methods_                 |            |                  |
+| globaltype   | wasm_globaltype_new              | globaltype | \_\_init\_\_     |
+|              | wasm_globaltype_delete           |            | \_\_del\_\_      |
+|              | wasm_globaltype_content          |            | \_\_eq\_\_       |
+|              | wasm_globaltype_mutability       |            |                  |
+|              | wasm_globaltype_copy             |            |                  |
+|              | _vector methods_                 |            |                  |
+| tabletype    | wasm_tabletype_new               | tabletype  | \_\_init\_\_     |
+|              | wasm_tabletype_delete            |            | \_\_del\_\_      |
+|              | wasm_tabletype_element           |            | \_\_eq\_\_       |
+|              | wasm_tabletype_limits            |            |                  |
+|              | wasm_tabletype_copy              |            |                  |
+|              | _vector methods_                 |            |                  |
+| memorytype   | wasm_memorytype_new              | memorytype | \_\_init\_\_     |
+|              | wasm_memorytype_delete           |            | \_\_del\_\_      |
+|              | wasm_memorytype_limits           |            | \_\_eq\_\_       |
+|              | wasm_memorytype_copy             |            |                  |
+|              | _vector methods_                 |            |                  |
+| externtype   | wasm_externtype_as_XXX           | externtype |                  |
+|              | wasm_XXX_as_externtype           |            |                  |
+|              | wasm_externtype_copy             |            |                  |
+|              | wasm_externtype_delete           |            |                  |
+|              | wasm_externtype_kind             |            |                  |
+|              | _vector methods_                 |            |                  |
+| importtype   | wasm_importtype_new              | importtype |                  |
+|              | wasm_importtype_delete           |            |                  |
+|              | wasm_importtype_module           |            |                  |
+|              | wasm_importtype_name             |            |                  |
+|              | wasm_importtype_type             |            |                  |
+|              | wasm_importtype_copy             |            |                  |
+|              | _vector methods_                 |            |                  |
+| exportype    | wasm_exporttype_new              | exporttype |                  |
+|              | wasm_exporttype_delete           |            |                  |
+|              | wasm_exporttype_name             |            |                  |
+|              | wasm_exporttype_type             |            |                  |
+|              | wasm_exporttype_copy             |            |                  |
+|              | _vector methods_                 |            |                  |
+| val          | wasm_val_delete                  | val        |                  |
+|              | wasm_val_copy                    |            |                  |
+|              | _vector methods_                 |            |                  |
+| frame        | wasm_frame_delete                | frame      |                  |
+|              | wasm_frame_instance              |            |                  |
+|              | wasm_frame_func_index            |            |                  |
+|              | wasm_frame_func_offset           |            |                  |
+|              | wasm_frame_module_offset         |            |                  |
+|              | wasm_frame_copy                  |            |                  |
+|              | _vector methods_                 |            |                  |
+| trap         | wasm_trap_new                    | trap       |                  |
+|              | wasm_trap_delete                 |            |                  |
+|              | wasm_trap_message                |            |                  |
+|              | wasm_trap_origin                 |            |                  |
+|              | wasm_trap_trace                  |            |                  |
+|              | _vector methods_                 |            |                  |
+| foreign      | wasm_foreign_new                 | foreign    |                  |
+|              | wasm_foreign_delete              |            |                  |
+|              | _vector methods_                 |            |                  |
+| engine       | wasm_engine_new                  | engine     |                  |
+|              | wasm_engine_new_with_args\*      |            |                  |
+|              | wasm_engine_new_with_config      |            |                  |
+|              | wasm_engine_delete               |            |                  |
+| store        | wasm_store_new                   | store      |                  |
+|              | wasm_store_delete                |            |                  |
+|              | _vector methods_                 |            |                  |
+| module       | wasm_module_new                  | module     |                  |
+|              | wasm_module_delete               |            |                  |
+|              | wasm_module_validate             |            |                  |
+|              | wasm_module_imports              |            |                  |
+|              | wasm_module_exports              |            |                  |
+| instance     | wasm_instance_new                | instance   |                  |
+|              | wasm_instance_delete             |            |                  |
+|              | wasm_instance_new_with_args\*    |            |                  |
+|              | wasm_instance_new_with_args_ex\* |            |                  |
+|              | wasm_instance_exports            |            |                  |
+|              | _vector methods_                 |            |                  |
+| func         | wasm_func_new                    | func       |                  |
+|              | wasm_func_new_with_env           |            |                  |
+|              | wasm_func_delete                 |            |                  |
+|              | wasm_func_type                   |            |                  |
+|              | wasm_func_call                   |            |                  |
+|              | wasm_func_param_arity            |            |                  |
+|              | wasm_func_result_arity           |            |                  |
+|              | _vector methods_                 |            |                  |
+| global       | wasm_global_new                  | global     |                  |
+|              | wasm_global_delete               |            |                  |
+|              | wasm_global_type                 |            |                  |
+|              | wasm_global_get                  |            |                  |
+|              | wasm_global_set                  |            |                  |
+|              | _vector methods_                 |            |                  |
+| table        | wasm_table_new                   | table      |                  |
+|              | wasm_table_delete                |            |                  |
+|              | wasm_table_type                  |            |                  |
+|              | wasm_table_get                   |            |                  |
+|              | wasm_table_set                   |            |                  |
+|              | wasm_table_size                  |            |                  |
+|              | _vector methods_                 |            |                  |
+| memory       | wasm_memory_new                  | memory     |                  |
+|              | wasm_memory_delete               |            |                  |
+|              | wasm_memory_type                 |            |                  |
+|              | wasm_memory_data                 |            |                  |
+|              | wasm_memory_data_size            |            |                  |
+|              | wasm_memory_size                 |            |                  |
+|              | _vector methods_                 |            |                  |
+| extern       | wasm_extern_delete               | extern     |                  |
+|              | wasm_extern_as_XXX               |            |                  |
+|              | wasm_XXX_as_extern               |            |                  |
+|              | wasm_extern_kind                 |            |                  |
+|              | wasm_extern_type                 |            |                  |
+|              | _vector methods_                 |            |                  |
 
 not supported _functions_
 


### PR DESCRIPTION
This PR adds a `max_memory_pages` parameter to module instantiation APIs, to allow overriding the max memory defined in the WASM module.

Sticking to the max memory defined in the module is quite limiting when using shared memory in production. If targeted devices have different memory constraints, many wasm files have to be generated with different max memory values. And device constraints may not be known in advance.

Being able to set the max memory value during module instantiation allows to reuse the same wasm module, e.g. by retrying instantiation with different max memory value.