### PR TITLE
Allow converting the zero wasm address to native

### DIFF
--- a/core/iwasm/common/wasm_memory.c
+++ b/core/iwasm/common/wasm_memory.c
@@ -419,15 +419,13 @@ wasm_runtime_addr_app_to_native(WASMModuleInstanceCommon *module_inst_comm,
             SHARED_MEMORY_UNLOCK(memory_inst);
             return addr;
         }
-    }
-    /* If bounds checks is disabled, return the address directly */
-    else if (app_offset != 0) {
         SHARED_MEMORY_UNLOCK(memory_inst);
-        return addr;
+        return NULL;
     }
 
+    /* If bounds checks is disabled, return the address directly */
     SHARED_MEMORY_UNLOCK(memory_inst);
-    return NULL;
+    return addr;
 }
 
 uint32


### PR DESCRIPTION
This allows to know the beginning of the wasm address space. At the moment to achieve that, we need to apply a `hack wasm_runtime_addr_app_to_native(X)-X` to get the beginning of WASM memory in the nativ code, but I don't see a good reason why not to allow zero address as a parameter value for this function