### PR TITLE
Fix build on MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ if (WAMR_BUILD_WASM_CACHE EQUAL 1)
 endif ()
 
 if (MINGW)
-  target_link_libraries (iwasm_shared -lWs2_32)
+  target_link_libraries (iwasm_shared INTERFACE -lWs2_32 -lwsock32)
 endif ()
 
 install (TARGETS iwasm_shared LIBRARY DESTINATION lib)


### PR DESCRIPTION
PR fixes two errors:

1 - Usage of CMake target_link_libraries()

```
Make Error at CMakeLists.txt:154 (target_link_libraries):
  The keyword signature for target_link_libraries has already been used with
  the target "iwasm_shared".  All uses of target_link_libraries with a target
  must be either all-keyword or all-plain.

  The uses of the keyword signature are here:

   * CMakeLists.txt:148 (target_link_libraries)
```
See https://stackoverflow.com/questions/47737558/uses-of-target-link-libraries-must-be-either-all-keyword-or-all-plain

Fixed by adding keyword INTERFACE

2 - Undefined symbols during linkage, fixed by adding -lwsock32.