### PR TITLE
API and data structure refactor 

### DIFF
--- a/core/iwasm/aot/aot_runtime.h
+++ b/core/iwasm/aot/aot_runtime.h
@@ -499,14 +499,12 @@ aot_deinstantiate(AOTModuleInstance *module_inst, bool is_sub_inst);
  *
  * @param module_inst the module instance
  * @param name the name of the function
- * @param signature the signature of the function, use "i32"/"i64"/"f32"/"f64"
- *        to represent the type of i32/i64/f32/f64, e.g. "(i32i64)" "(i32)f32"
  *
  * @return the function instance found
  */
 AOTFunctionInstance *
-aot_lookup_function(const AOTModuleInstance *module_inst, const char *name,
-                    const char *signature);
+aot_lookup_function(const AOTModuleInstance *module_inst, const char *name);
+
 /**
  * Call the given AOT function of a AOT module instance with
  * arguments.

--- a/core/iwasm/common/wasm_application.c
+++ b/core/iwasm/common/wasm_application.c
@@ -147,10 +147,10 @@ execute_main(WASMModuleInstanceCommon *module_inst, int32 argc, char *argv[])
     }
 #endif /* end of WASM_ENABLE_LIBC_WASI */
 
-    if (!(func = wasm_runtime_lookup_function(module_inst, "main", NULL))
-        && !(func = wasm_runtime_lookup_function(module_inst,
-                                                 "__main_argc_argv", NULL))
-        && !(func = wasm_runtime_lookup_function(module_inst, "_main", NULL))) {
+    if (!(func = wasm_runtime_lookup_function(module_inst, "main"))
+        && !(func =
+                 wasm_runtime_lookup_function(module_inst, "__main_argc_argv"))
+        && !(func = wasm_runtime_lookup_function(module_inst, "_main"))) {
 #if WASM_ENABLE_LIBC_WASI != 0
         wasm_runtime_set_exception(
             module_inst, "lookup the entry point symbol (like _start, main, "
@@ -337,8 +337,7 @@ execute_func(WASMModuleInstanceCommon *module_inst, const char *name,
     bh_assert(argc >= 0);
     LOG_DEBUG("call a function \"%s\" with %d arguments", name, argc);
 
-    if (!(target_func =
-              wasm_runtime_lookup_function(module_inst, name, NULL))) {
+    if (!(target_func = wasm_runtime_lookup_function(module_inst, name))) {
         snprintf(buf, sizeof(buf), "lookup function %s failed", name);
         wasm_runtime_set_exception(module_inst, buf);
         goto fail;

--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -4939,19 +4939,17 @@ wasm_instance_new_with_args_ex(wasm_store_t *store, const wasm_module_t *module,
     /* create the c-api func import list */
 #if WASM_ENABLE_INTERP != 0
     if (instance->inst_comm_rt->module_type == Wasm_Module_Bytecode) {
-        WASMModuleInstanceExtra *e =
-            ((WASMModuleInstance *)instance->inst_comm_rt)->e;
-        p_func_imports = &(e->common.c_api_func_imports);
+        WASMModuleInstance *wasm_module_inst =
+            (WASMModuleInstance *)instance->inst_comm_rt;
+        p_func_imports = &(wasm_module_inst->c_api_func_imports);
         import_func_count = MODULE_INTERP(module)->import_function_count;
     }
 #endif
 #if WASM_ENABLE_AOT != 0
     if (instance->inst_comm_rt->module_type == Wasm_Module_AoT) {
-        AOTModuleInstanceExtra *e =
-            (AOTModuleInstanceExtra *)((AOTModuleInstance *)
-                                           instance->inst_comm_rt)
-                ->e;
-        p_func_imports = &(e->common.c_api_func_imports);
+        AOTModuleInstance *aot_module_inst =
+            (AOTModuleInstance *)instance->inst_comm_rt;
+        p_func_imports = &(aot_module_inst->c_api_func_imports);
         import_func_count = MODULE_AOT(module)->import_func_count;
     }
 #endif
@@ -4965,7 +4963,7 @@ wasm_instance_new_with_args_ex(wasm_store_t *store, const wasm_module_t *module,
         goto failed;
     }
 
-    /* fill in module_inst->e->c_api_func_imports */
+    /* fill in module_inst->c_api_func_imports */
     for (i = 0; imports && i < imports->num_elems; i++) {
         wasm_func_t *func_host = NULL;
         wasm_extern_t *in = imports->data[i];

--- a/core/iwasm/common/wasm_memory.c
+++ b/core/iwasm/common/wasm_memory.c
@@ -825,13 +825,11 @@ return_func:
 
 #if WASM_ENABLE_INTERP != 0
         if (module->module_type == Wasm_Module_Bytecode)
-            exec_env =
-                ((WASMModuleInstanceExtra *)module->e)->common.cur_exec_env;
+            exec_env = ((WASMModuleInstance *)module)->cur_exec_env;
 #endif
 #if WASM_ENABLE_AOT != 0
         if (module->module_type == Wasm_Module_AoT)
-            exec_env =
-                ((AOTModuleInstanceExtra *)module->e)->common.cur_exec_env;
+            exec_env = ((AOTModuleInstance *)module)->cur_exec_env;
 #endif
 
         enlarge_memory_error_cb(inc_page_count, total_size_old, 0,

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -1853,17 +1853,17 @@ wasm_runtime_get_function_type(const WASMFunctionInstanceCommon *function,
 
 WASMFunctionInstanceCommon *
 wasm_runtime_lookup_function(WASMModuleInstanceCommon *const module_inst,
-                             const char *name, const char *signature)
+                             const char *name)
 {
 #if WASM_ENABLE_INTERP != 0
     if (module_inst->module_type == Wasm_Module_Bytecode)
         return (WASMFunctionInstanceCommon *)wasm_lookup_function(
-            (const WASMModuleInstance *)module_inst, name, signature);
+            (const WASMModuleInstance *)module_inst, name);
 #endif
 #if WASM_ENABLE_AOT != 0
     if (module_inst->module_type == Wasm_Module_AoT)
         return (WASMFunctionInstanceCommon *)aot_lookup_function(
-            (const AOTModuleInstance *)module_inst, name, signature);
+            (const AOTModuleInstance *)module_inst, name);
 #endif
     return NULL;
 }

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -611,7 +611,7 @@ wasm_runtime_get_module(WASMModuleInstanceCommon *module_inst);
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN WASMFunctionInstanceCommon *
 wasm_runtime_lookup_function(WASMModuleInstanceCommon *const module_inst,
-                             const char *name, const char *signature);
+                             const char *name);
 
 /* Internal API */
 WASMFuncType *

--- a/core/iwasm/compilation/aot_emit_function.c
+++ b/core/iwasm/compilation/aot_emit_function.c
@@ -329,13 +329,9 @@ call_aot_invoke_c_api_native(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
     param_values[0] = func_ctx->aot_inst;
 
-    /* Get module_inst->e->common.c_api_func_imports */
-    offset_c_api_func_imports =
-        get_module_inst_extra_offset(comp_ctx)
-        + (comp_ctx->is_jit_mode
-               ? offsetof(WASMModuleInstanceExtra, common.c_api_func_imports)
-               /* offsetof(AOTModuleInstanceExtra, common.c_api_func_imports) */
-               : sizeof(uint64));
+    /* Get module_inst->c_api_func_imports, jit mode WASMModuleInstance is the
+     * same layout with AOTModuleInstance */
+    offset_c_api_func_imports = offsetof(AOTModuleInstance, c_api_func_imports);
     offset = I32_CONST(offset_c_api_func_imports);
     CHECK_LLVM_CONST(offset);
     c_api_func_imports =

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -124,7 +124,7 @@ create_basic_func_context(const AOTCompContext *comp_ctx,
 {
     LLVMValueRef aot_inst_offset = I32_TWO, aot_inst_addr;
 
-    /* Save the pameters for fast access */
+    /* Save the parameters for fast access */
     func_ctx->exec_env = LLVMGetParam(func_ctx->func, 0);
 
     /* Get aot inst address, the layout of exec_env is:

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -616,13 +616,12 @@ wasm_runtime_get_wasi_exit_code(wasm_module_inst_t module_inst);
  *
  * @param module_inst the module instance
  * @param name the name of the function
- * @param signature the signature of the function, ignored currently
  *
  * @return the function instance found, NULL if not found
  */
 WASM_RUNTIME_API_EXTERN wasm_function_inst_t
 wasm_runtime_lookup_function(wasm_module_inst_t const module_inst,
-                             const char *name, const char *signature);
+                             const char *name);
 
 /**
  * Get parameter count of the function instance

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -5426,8 +5426,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 #ifndef OS_ENABLE_HW_BOUND_CHECK
                         CHECK_BULK_MEMORY_OVERFLOW(addr, bytes, maddr);
 #else
-                        if ((uint64)(uint32)addr + bytes
-                            > (uint64)linear_mem_size)
+                        if ((uint64)(uint32)addr + bytes > linear_mem_size)
                             goto out_of_bounds;
                         maddr = memory->memory_data + (uint32)addr;
 #endif
@@ -5446,7 +5445,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         if (offset + bytes > seg_len)
                             goto out_of_bounds;
 
-                        bh_memcpy_s(maddr, linear_mem_size - addr,
+                        bh_memcpy_s(maddr, (uint32)(linear_mem_size - addr),
                                     data + offset, (uint32)bytes);
                         break;
                     }
@@ -5478,11 +5477,11 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         CHECK_BULK_MEMORY_OVERFLOW(src, len, msrc);
                         CHECK_BULK_MEMORY_OVERFLOW(dst, len, mdst);
 #else
-                        if ((uint64)(uint32)src + len > (uint64)linear_mem_size)
+                        if ((uint64)(uint32)src + len > linear_mem_size)
                             goto out_of_bounds;
                         msrc = memory->memory_data + (uint32)src;
 
-                        if ((uint64)(uint32)dst + len > (uint64)linear_mem_size)
+                        if ((uint64)(uint32)dst + len > linear_mem_size)
                             goto out_of_bounds;
                         mdst = memory->memory_data + (uint32)dst;
 #endif

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -1106,9 +1106,8 @@ wasm_interp_call_func_native(WASMModuleInstance *module_inst,
     if (!func_import->call_conv_wasm_c_api) {
         native_func_pointer = module_inst->import_func_ptrs[cur_func_index];
     }
-    else if (module_inst->e->common.c_api_func_imports) {
-        c_api_func_import =
-            module_inst->e->common.c_api_func_imports + cur_func_index;
+    else if (module_inst->c_api_func_imports) {
+        c_api_func_import = module_inst->c_api_func_imports + cur_func_index;
         native_func_pointer = c_api_func_import->func_ptr_linked;
     }
 

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -1187,9 +1187,8 @@ wasm_interp_call_func_native(WASMModuleInstance *module_inst,
     if (!func_import->call_conv_wasm_c_api) {
         native_func_pointer = module_inst->import_func_ptrs[cur_func_index];
     }
-    else if (module_inst->e->common.c_api_func_imports) {
-        c_api_func_import =
-            module_inst->e->common.c_api_func_imports + cur_func_index;
+    else if (module_inst->c_api_func_imports) {
+        c_api_func_import = module_inst->c_api_func_imports + cur_func_index;
         native_func_pointer = c_api_func_import->func_ptr_linked;
     }
 

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -297,10 +297,9 @@ typedef struct CApiFuncImport {
 
 /* The common part of WASMModuleInstanceExtra and AOTModuleInstanceExtra */
 typedef struct WASMModuleInstanceExtraCommon {
-    CApiFuncImport *c_api_func_imports;
+#if WASM_ENABLE_MODULE_INST_CONTEXT != 0
     void *contexts[WASM_MAX_INSTANCE_CONTEXTS];
-    /* pointer to the exec env currently used */
-    WASMExecEnv *cur_exec_env;
+#endif
 #if WASM_CONFIGURABLE_BOUNDS_CHECKS != 0
     /* Disable bounds checks or not */
     bool disable_bounds_checks;
@@ -426,13 +425,16 @@ struct WASMModuleInstance {
     /* Function performance profiling info list, only available
        in AOTModuleInstance */
     DefPointer(struct AOTFuncPerfProfInfo *, func_perf_profilings);
+    DefPointer(CApiFuncImport *, c_api_func_imports);
+    /* Pointer to the exec env currently used */
+    DefPointer(WASMExecEnv *, cur_exec_env);
     /* WASM/AOT module extra info, for AOTModuleInstance,
        it denotes `AOTModuleInstanceExtra *` */
     DefPointer(WASMModuleInstanceExtra *, e);
 
     /* Default WASM operand stack size */
     uint32 default_wasm_stack_size;
-    uint32 reserved[3];
+    uint32 reserved[5];
 
     /*
      * +------------------------------+ <-- memories
@@ -539,8 +541,7 @@ wasm_set_running_mode(WASMModuleInstance *module_inst,
                       RunningMode running_mode);
 
 WASMFunctionInstance *
-wasm_lookup_function(const WASMModuleInstance *module_inst, const char *name,
-                     const char *signature);
+wasm_lookup_function(const WASMModuleInstance *module_inst, const char *name);
 
 #if WASM_ENABLE_MULTI_MODULE != 0
 WASMGlobalInstance *

--- a/core/iwasm/libraries/lib-wasi-threads/lib_wasi_threads_wrapper.c
+++ b/core/iwasm/libraries/lib-wasi-threads/lib_wasi_threads_wrapper.c
@@ -98,8 +98,8 @@ thread_spawn_wrapper(wasm_exec_env_t exec_env, uint32 start_arg)
 
     wasm_native_inherit_contexts(new_module_inst, module_inst);
 
-    start_func = wasm_runtime_lookup_function(new_module_inst,
-                                              THREAD_START_FUNCTION, NULL);
+    start_func =
+        wasm_runtime_lookup_function(new_module_inst, THREAD_START_FUNCTION);
     if (!start_func) {
         LOG_ERROR("Failed to find thread start function %s",
                   THREAD_START_FUNCTION);

--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -781,10 +781,10 @@ wasm_cluster_dup_c_api_imports(WASMModuleInstanceCommon *module_inst_dst,
 
 #if WASM_ENABLE_INTERP != 0
     if (module_inst_src->module_type == Wasm_Module_Bytecode) {
-        new_c_api_func_imports = &(((WASMModuleInstance *)module_inst_dst)
-                                       ->e->common.c_api_func_imports);
-        c_api_func_imports = ((const WASMModuleInstance *)module_inst_src)
-                                 ->e->common.c_api_func_imports;
+        new_c_api_func_imports =
+            &(((WASMModuleInstance *)module_inst_dst)->c_api_func_imports);
+        c_api_func_imports =
+            ((const WASMModuleInstance *)module_inst_src)->c_api_func_imports;
         import_func_count =
             ((WASMModule *)(((const WASMModuleInstance *)module_inst_src)
                                 ->module))
@@ -793,13 +793,10 @@ wasm_cluster_dup_c_api_imports(WASMModuleInstanceCommon *module_inst_dst,
 #endif
 #if WASM_ENABLE_AOT != 0
     if (module_inst_src->module_type == Wasm_Module_AoT) {
-        AOTModuleInstanceExtra *e =
-            (AOTModuleInstanceExtra *)((AOTModuleInstance *)module_inst_dst)->e;
-        new_c_api_func_imports = &(e->common.c_api_func_imports);
-
-        e = (AOTModuleInstanceExtra *)((AOTModuleInstance *)module_inst_src)->e;
-        c_api_func_imports = e->common.c_api_func_imports;
-
+        new_c_api_func_imports =
+            &(((AOTModuleInstance *)module_inst_dst)->c_api_func_imports);
+        c_api_func_imports =
+            ((const AOTModuleInstance *)module_inst_src)->c_api_func_imports;
         import_func_count =
             ((AOTModule *)(((AOTModuleInstance *)module_inst_src)->module))
                 ->import_func_count;

--- a/doc/embed_wamr.md
+++ b/doc/embed_wamr.md
@@ -100,7 +100,7 @@ After a module is instantiated, the runtime embedder can lookup the target WASM 
 ```c
   /* lookup a WASM function by its name
      The function signature can NULL here */
-  func = wasm_runtime_lookup_function(module_inst, "fib", NULL);
+  func = wasm_runtime_lookup_function(module_inst, "fib");
 
   /* creat an execution environment to execute the WASM functions */
   exec_env = wasm_runtime_create_exec_env(module_inst, stack_size);

--- a/doc/multi_module.md
+++ b/doc/multi_module.md
@@ -62,8 +62,7 @@ WAMR hopes that the native host or embedding environment loads/unloads the modul
 ```c
 wasm_function_inst_t
 wasm_runtime_lookup_function(wasm_module_inst_t const module_inst,
-                             const char *name,
-                             const char *signature);
+                             const char *name);
 ```
 
 Multi-module allows one to look up an exported function of a submodule. There are two ways to indicate the function _name_:

--- a/doc/perf_tune.md
+++ b/doc/perf_tune.md
@@ -288,7 +288,7 @@ And in the host embedder:
     bool ret;
 
     argv[0] = *(uint32 *)&arg_f32;
-    func = wasm_runtime_lookup_function(module_inst, "foo1", NULL);
+    func = wasm_runtime_lookup_function(module_inst, "foo1");
     ret = wasm_runtime_call_wasm(exec_env, func, 1, argv);
     if (!ret) {
         /* handle exception */

--- a/language-bindings/go/wamr/instance.go
+++ b/language-bindings/go/wamr/instance.go
@@ -129,8 +129,7 @@ func (self *Instance) CallFunc(funcName string,
         cName := C.CString(funcName)
         defer C.free(unsafe.Pointer(cName))
 
-        _func = C.wasm_runtime_lookup_function(self._instance,
-                                               cName, (*C.char)(C.NULL))
+        _func = C.wasm_runtime_lookup_function(self._instance, cName)
         if _func == nil {
             return fmt.Errorf("CallFunc error: lookup function failed")
         }
@@ -170,8 +169,7 @@ func (self *Instance) CallFuncV(funcName string,
         cName := C.CString(funcName)
         defer C.free(unsafe.Pointer(cName))
 
-        _func = C.wasm_runtime_lookup_function(self._instance,
-                                               cName, (*C.char)(C.NULL))
+        _func = C.wasm_runtime_lookup_function(self._instance, cName)
         if _func == nil {
             return fmt.Errorf("CallFunc error: lookup function failed")
         }

--- a/language-bindings/python/src/wamr/wamrapi/wamr.py
+++ b/language-bindings/python/src/wamr/wamrapi/wamr.py
@@ -175,7 +175,7 @@ class Instance:
         wasm_runtime_module_free(self.module_inst, wasm_handler)
 
     def lookup_function(self, name: str) -> wasm_function_inst_t:
-        func = wasm_runtime_lookup_function(self.module_inst, name, None)
+        func = wasm_runtime_lookup_function(self.module_inst, name)
         if not func:
             raise Exception("Error while looking-up function")
         return func

--- a/product-mini/platforms/zephyr/simple/src/main.c
+++ b/product-mini/platforms/zephyr/simple/src/main.c
@@ -65,14 +65,12 @@ app_instance_main(wasm_module_inst_t module_inst)
     wasm_exec_env_t exec_env;
     unsigned argv[2] = { 0 };
 
-    if (wasm_runtime_lookup_function(module_inst, "main", NULL)
-        || wasm_runtime_lookup_function(module_inst, "__main_argc_argv",
-                                        NULL)) {
+    if (wasm_runtime_lookup_function(module_inst, "main")
+        || wasm_runtime_lookup_function(module_inst, "__main_argc_argv")) {
         LOG_VERBOSE("Calling main function\n");
         wasm_application_execute_main(module_inst, app_argc, app_argv);
     }
-    else if ((func = wasm_runtime_lookup_function(module_inst, "app_main",
-                                                  NULL))) {
+    else if ((func = wasm_runtime_lookup_function(module_inst, "app_main"))) {
         exec_env =
             wasm_runtime_create_exec_env(module_inst, CONFIG_APP_HEAP_SIZE);
         if (!exec_env) {

--- a/samples/basic/src/main.c
+++ b/samples/basic/src/main.c
@@ -149,8 +149,7 @@ main(int argc, char *argv_main[])
         goto fail;
     }
 
-    if (!(func = wasm_runtime_lookup_function(module_inst, "generate_float",
-                                              NULL))) {
+    if (!(func = wasm_runtime_lookup_function(module_inst, "generate_float"))) {
         printf("The generate_float wasm function is not found.\n");
         goto fail;
     }
@@ -189,8 +188,8 @@ main(int argc, char *argv_main[])
     argv2[4] = 3; //  the last argument is the digits after decimal point for
                   //  converting float to string
 
-    if (!(func2 = wasm_runtime_lookup_function(module_inst, "float_to_string",
-                                               NULL))) {
+    if (!(func2 =
+              wasm_runtime_lookup_function(module_inst, "float_to_string"))) {
         printf(
             "The wasm function float_to_string wasm function is not found.\n");
         goto fail;
@@ -208,7 +207,7 @@ main(int argc, char *argv_main[])
     }
 
     wasm_function_inst_t func3 =
-        wasm_runtime_lookup_function(module_inst, "calculate", NULL);
+        wasm_runtime_lookup_function(module_inst, "calculate");
     if (!func3) {
         printf("The wasm function calculate is not found.\n");
         goto fail;

--- a/samples/inst-context/src/main.c
+++ b/samples/inst-context/src/main.c
@@ -128,7 +128,7 @@ main(int argc, char *argv_main[])
     }
 
     wasm_function_inst_t func3 =
-        wasm_runtime_lookup_function(module_inst, "calculate", NULL);
+        wasm_runtime_lookup_function(module_inst, "calculate");
     if (!func3) {
         printf("The wasm function calculate is not found.\n");
         goto fail;

--- a/samples/ref-types/src/hello.c
+++ b/samples/ref-types/src/hello.c
@@ -234,19 +234,19 @@ main(int argc, char *argv[])
 
     /* lookup function instance */
     if (!(wasm_cmp_externref_ptr = wasm_runtime_lookup_function(
-              wasm_module_inst, "cmp-externref", NULL))) {
+              wasm_module_inst, "cmp-externref"))) {
         printf("%s\n", "lookup function cmp-externref failed");
         goto fail;
     }
 
     if (!(wasm_get_externref_ptr = wasm_runtime_lookup_function(
-              wasm_module_inst, "get-externref", NULL))) {
+              wasm_module_inst, "get-externref"))) {
         printf("%s\n", "lookup function get-externref failed");
         goto fail;
     }
 
     if (!(wasm_set_externref_ptr = wasm_runtime_lookup_function(
-              wasm_module_inst, "set-externref", NULL))) {
+              wasm_module_inst, "set-externref"))) {
         printf("%s\n", "lookup function set-externref failed");
         goto fail;
     }

--- a/samples/shared-module/src/main.c
+++ b/samples/shared-module/src/main.c
@@ -104,15 +104,15 @@ main(int argc, char *argv_main[])
             goto fail;
         }
 
-        func_test_data_drop[i] = wasm_runtime_lookup_function(
-            module_inst[i], name_test_data_drop, NULL);
+        func_test_data_drop[i] =
+            wasm_runtime_lookup_function(module_inst[i], name_test_data_drop);
         if (!func_test_data_drop[i]) {
             printf("The wasm function %s is not found.\n", name_test_data_drop);
             goto fail;
         }
 
-        func_test_elem_drop[i] = wasm_runtime_lookup_function(
-            module_inst[i], name_test_elem_drop, NULL);
+        func_test_elem_drop[i] =
+            wasm_runtime_lookup_function(module_inst[i], name_test_elem_drop);
         if (!func_test_elem_drop[i]) {
             printf("The wasm function %s is not found.\n", name_test_elem_drop);
             goto fail;

--- a/samples/spawn-thread/src/main.c
+++ b/samples/spawn-thread/src/main.c
@@ -29,7 +29,7 @@ thread(void *arg)
         return NULL;
     }
 
-    func = wasm_runtime_lookup_function(module_inst, "sum", NULL);
+    func = wasm_runtime_lookup_function(module_inst, "sum");
     if (!func) {
         printf("failed to lookup function sum");
         wasm_runtime_destroy_thread_env();
@@ -57,7 +57,7 @@ wamr_thread_cb(wasm_exec_env_t exec_env, void *arg)
     wasm_function_inst_t func;
     uint32 argv[2];
 
-    func = wasm_runtime_lookup_function(module_inst, "sum", NULL);
+    func = wasm_runtime_lookup_function(module_inst, "sum");
     if (!func) {
         printf("failed to lookup function sum");
         return NULL;
@@ -133,7 +133,7 @@ main(int argc, char *argv[])
         goto fail4;
     }
 
-    func = wasm_runtime_lookup_function(wasm_module_inst, "sum", NULL);
+    func = wasm_runtime_lookup_function(wasm_module_inst, "sum");
     if (!func) {
         printf("failed to lookup function sum");
         goto fail5;

--- a/samples/terminate/src/main.c
+++ b/samples/terminate/src/main.c
@@ -39,7 +39,7 @@ runner_with_spawn_exec_env(void *vp)
     wasm_function_inst_t func;
     bool ok = wasm_runtime_init_thread_env();
     assert(ok);
-    func = wasm_runtime_lookup_function(inst, "block_forever", NULL);
+    func = wasm_runtime_lookup_function(inst, "block_forever");
     assert(func != NULL);
     wasm_runtime_call_wasm(env, func, 0, NULL);
     wasm_runtime_destroy_spawned_exec_env(env);


### PR DESCRIPTION
- remove parameter 'signature' from `wasm_runtime_lookup_function`
- move common data members `c_api_func_imports` and `cur_exec_env` from `WASMModuleInstanceExtraCommon` to `WASMModuleInstance`
- In `WASMModuleInstance` enlarge reserved[3] to reserved[5] in case add more data member in the future