### PR TITLE
Small refactor and bug fix

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -48,11 +48,11 @@ bh_static_assert(offsetof(AOTModuleInstance, func_type_indexes)
 bh_static_assert(offsetof(AOTModuleInstance, cur_exception)
                  == 13 * sizeof(uint64));
 bh_static_assert(offsetof(AOTModuleInstance, c_api_func_imports)
-                 == 13 * sizeof(uint64) + 128 + 8 * sizeof(uint64));
+                 == 13 * sizeof(uint64) + 128 + 7 * sizeof(uint64));
 bh_static_assert(offsetof(AOTModuleInstance, global_table_data)
                  == 13 * sizeof(uint64) + 128 + 14 * sizeof(uint64));
 
-bh_static_assert(sizeof(AOTMemoryInstance) == 112);
+bh_static_assert(sizeof(AOTMemoryInstance) == 120);
 bh_static_assert(offsetof(AOTTableInstance, elems) == 24);
 
 bh_static_assert(offsetof(AOTModuleInstanceExtra, stack_sizes) == 0);

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -138,6 +138,8 @@ struct WASMMemoryInstance {
     DefPointer(uint8 *, heap_data_end);
     /* The heap created */
     DefPointer(void *, heap_handle);
+    /* TODO: use it replace the g_shared_memory_lock */
+    DefPointer(korp_mutex *, shared_memory_lock);
 
 #if WASM_ENABLE_FAST_JIT != 0 || WASM_ENABLE_JIT != 0 \
     || WASM_ENABLE_WAMR_COMPILER != 0 || WASM_ENABLE_AOT != 0
@@ -405,8 +407,6 @@ struct WASMModuleInstance {
        it denotes `AOTModule *` */
     DefPointer(WASMModule *, module);
 
-    DefPointer(void *, used_to_be_wasi_ctx); /* unused */
-
     DefPointer(WASMExecEnv *, exec_env_singleton);
     /* Array of function pointers to import functions,
        not available in AOTModuleInstance */
@@ -434,7 +434,7 @@ struct WASMModuleInstance {
 
     /* Default WASM operand stack size */
     uint32 default_wasm_stack_size;
-    uint32 reserved[5];
+    uint32 reserved[7];
 
     /*
      * +------------------------------+ <-- memories

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -138,7 +138,7 @@ struct WASMMemoryInstance {
     DefPointer(uint8 *, heap_data_end);
     /* The heap created */
     DefPointer(void *, heap_handle);
-    /* TODO: use it replace the g_shared_memory_lock */
+    /* TODO: use it to replace the g_shared_memory_lock */
     DefPointer(korp_mutex *, shared_memory_lock);
 
 #if WASM_ENABLE_FAST_JIT != 0 || WASM_ENABLE_JIT != 0 \

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -139,7 +139,7 @@ struct WASMMemoryInstance {
     /* The heap created */
     DefPointer(void *, heap_handle);
     /* TODO: use it to replace the g_shared_memory_lock */
-    DefPointer(korp_mutex *, shared_memory_lock);
+    DefPointer(korp_mutex *, memory_lock);
 
 #if WASM_ENABLE_FAST_JIT != 0 || WASM_ENABLE_JIT != 0 \
     || WASM_ENABLE_WAMR_COMPILER != 0 || WASM_ENABLE_AOT != 0

--- a/language-bindings/go/wamr/module.go
+++ b/language-bindings/go/wamr/module.go
@@ -117,8 +117,8 @@ func (self *Module) SetWasiArgsEx(dirList [][]byte, mapDirList [][]byte,
     C.wasm_runtime_set_wasi_args_ex(self.module, dirPtr, dirCount,
                                     mapDirPtr, mapDirCount,
                                     envPtr, envCount, argvPtr, argc,
-                                    C.int(stdinfd), C.int(stdoutfd),
-                                    C.int(stderrfd))
+                                    C.long(stdinfd), C.long(stdoutfd),
+                                    C.long(stderrfd))
 }
 
 /* Set module's wasi network address pool */

--- a/language-bindings/python/README.md
+++ b/language-bindings/python/README.md
@@ -4,7 +4,7 @@ The WAMR Python package contains a set of high-level bindings for WAMR API and W
 
 ## Installation
 
-* **Notice**: This python package need python >= `3.9`.
+* **Notice**: This python package need python >= `3.10`.
 
 To Install from local source tree in _development mode_ run the following command,
 

--- a/language-bindings/python/setup.py
+++ b/language-bindings/python/setup.py
@@ -62,5 +62,5 @@ setup(
         'install': PreInstallCommand,
         'egg_info': PreEggInfoCommand,
     },
-    python_requires='>=3.9'
+    python_requires='>=3.10'
 )

--- a/language-bindings/python/wamr-api/README.md
+++ b/language-bindings/python/wamr-api/README.md
@@ -1,6 +1,6 @@
 # WARM API
 
-* **Notice**: The python package `wamr.wamrapi.wamr` need python >= `3.9`.
+* **Notice**: The python package `wamr.wamrapi.wamr` need python >= `3.10`.
 
 ## Setup
 
@@ -8,7 +8,7 @@
 
 Install requirements,
 
-```
+```shell
 pip install -r requirements.txt
 ```
 
@@ -17,6 +17,7 @@ pip install -r requirements.txt
 The following command builds the iwasm library and generates the Python bindings,
 
 ```sh
+# In WAMR root directory
 bash language-bindings/python/utils/create_lib.sh
 ```
 


### PR DESCRIPTION
- go binding: type error(https://github.com/bytecodealliance/wasm-micro-runtime/issues/3220)
- python binding: type annotation uses the union operator "|", which requires Python version >=3.10
- merged unused field `used_to_be_wasi_ctx` in `AOTModuleInstance` into `reserved` area
- added field  `DefPointer(korp_mutex *, memory_lock);` in `WASMMemoryInstance` for future refactor