### PR TITLE
Fix nightly run tsan ASLR issue

### DIFF
--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -626,7 +626,9 @@ jobs:
         run: echo "TEST_ON_X86_32=true" >> $GITHUB_ENV
 
       - name: set additional tsan options
-        run: echo "TSAN_OPTIONS=suppressions=$PWD/tsan_suppressions.txt" >> $GITHUB_ENV
+        run: |
+          echo "TSAN_OPTIONS=suppressions=$PWD/tsan_suppressions.txt" >> $GITHUB_ENV
+          sudo sysctl vm.mmap_rnd_bits=28
         working-directory: tests/wamr-test-suites
 
       #only download llvm libraries in jit and aot mode


### PR DESCRIPTION
Adopt method mentioned in this [post](https://stackoverflow.com/questions/77850769/fatal-threadsanitizer-unexpected-memory-mapping-when-running-on-linux-kernels), tsan test should not randomly failing now