### PR TITLE
Add esp32c6 support

### DIFF
--- a/build-scripts/esp-idf/wamr/CMakeLists.txt
+++ b/build-scripts/esp-idf/wamr/CMakeLists.txt
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # Set WAMR's build options
-if("${IDF_TARGET}" STREQUAL "esp32c3")
-    set(WAMR_BUILD_TARGET "RISCV32")
-else()
+if("${IDF_TARGET}" STREQUAL "esp32")
     set(WAMR_BUILD_TARGET "XTENSA")
+else()
+    set(WAMR_BUILD_TARGET "RISCV32")
 endif()
 
 set(WAMR_BUILD_PLATFORM "esp-idf")

--- a/build-scripts/esp-idf/wamr/CMakeLists.txt
+++ b/build-scripts/esp-idf/wamr/CMakeLists.txt
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # Set WAMR's build options
-if("${IDF_TARGET}" STREQUAL "esp32")
-    set(WAMR_BUILD_TARGET "XTENSA")
-else()
+if("${IDF_TARGET}" STREQUAL "esp32c3" OR "${IDF_TARGET}" STREQUAL "esp32c6")
     set(WAMR_BUILD_TARGET "RISCV32")
+else()
+    set(WAMR_BUILD_TARGET "XTENSA")
 endif()
 
 set(WAMR_BUILD_PLATFORM "esp-idf")

--- a/product-mini/platforms/esp-idf/build_and_run.sh
+++ b/product-mini/platforms/esp-idf/build_and_run.sh
@@ -6,6 +6,7 @@
 ESP32_TARGET="esp32"
 ESP32C3_TARGET="esp32c3"
 ESP32S3_TARGET="esp32s3"
+ESP32C6_TARGET="esp32c6"
 
 usage ()
 {
@@ -15,6 +16,7 @@ usage ()
         echo "        $0 $ESP32_TARGET"
         echo "        $0 $ESP32C3_TARGET"
         echo "        $0 $ESP32S3_TARGET"
+        echo "        $0 $ESP32C6_TARGET"
         exit 1
 }
 


### PR DESCRIPTION
This commit adds support for ESP32 C6, which has been mentioned in #3208

Testing output is shown as 
![Screenshot from 2024-03-15 17-55-23](https://github.com/bytecodealliance/wasm-micro-runtime/assets/114033626/3626348b-56ea-4d97-bd8c-06642d8a5ce1)
