### PR TITLE
Change from `long` to `longlong`

### DIFF
--- a/language-bindings/go/samples/test.go
+++ b/language-bindings/go/samples/test.go
@@ -87,7 +87,7 @@ func main() {
     var instance *wamr.Instance
     var argv []uint32
     var results []interface{}
-    var offset uint32
+    var offset uint64
     var native_addr *uint8
     var err error
 

--- a/language-bindings/go/wamr/module.go
+++ b/language-bindings/go/wamr/module.go
@@ -117,8 +117,8 @@ func (self *Module) SetWasiArgsEx(dirList [][]byte, mapDirList [][]byte,
     C.wasm_runtime_set_wasi_args_ex(self.module, dirPtr, dirCount,
                                     mapDirPtr, mapDirCount,
                                     envPtr, envCount, argvPtr, argc,
-                                    C.longlong(stdinfd), C.longlong(stdoutfd),
-                                    C.longlong(stderrfd))
+                                    C.int64_t(stdinfd), C.int64_t(stdoutfd),
+                                    C.int64_t(stderrfd))
 }
 
 /* Set module's wasi network address pool */

--- a/language-bindings/go/wamr/module.go
+++ b/language-bindings/go/wamr/module.go
@@ -117,8 +117,8 @@ func (self *Module) SetWasiArgsEx(dirList [][]byte, mapDirList [][]byte,
     C.wasm_runtime_set_wasi_args_ex(self.module, dirPtr, dirCount,
                                     mapDirPtr, mapDirCount,
                                     envPtr, envCount, argvPtr, argc,
-                                    C.long(stdinfd), C.long(stdoutfd),
-                                    C.long(stderrfd))
+                                    C.longlong(stdinfd), C.longlong(stdoutfd),
+                                    C.longlong(stderrfd))
 }
 
 /* Set module's wasi network address pool */


### PR DESCRIPTION
- go binding: type error(https://github.com/bytecodealliance/wasm-micro-runtime/issues/3220)
- change from long to longlong due to error:
```sh
./module.go:119:64: cannot use _Ctype_long(stdinfd) (value of type _Ctype_long) as _Ctype_longlong value in variable declaration
./module.go:120:43: cannot use _Ctype_long(stdoutfd) (value of type _Ctype_long) as _Ctype_longlong value in variable declaration
./module.go:120:60: cannot use _Ctype_long(stderrfd) (value of type _Ctype_long) as _Ctype_longlong value in variable declaration
```
- change from `uint32` to `uint64` due to casting error