### PR TITLE
Correct the dirfd argument value that passes to fstatat

### DIFF
--- a/core/shared/platform/common/posix/posix_file.c
+++ b/core/shared/platform/common/posix/posix_file.c
@@ -384,7 +384,7 @@ os_openat(os_file_handle handle, const char *path, __wasi_oflags_t oflags,
         // Linux returns ENXIO instead of EOPNOTSUPP when opening a socket.
         if (openat_errno == ENXIO) {
             struct stat sb;
-            int ret = fstatat(fd, path, &sb,
+            int ret = fstatat(handle, path, &sb,
                               (lookup_flags & __WASI_LOOKUP_SYMLINK_FOLLOW)
                                   ? 0
                                   : AT_SYMLINK_NOFOLLOW);
@@ -396,7 +396,7 @@ os_openat(os_file_handle handle, const char *path, __wasi_oflags_t oflags,
         if (openat_errno == ENOTDIR
             && (open_flags & (O_NOFOLLOW | O_DIRECTORY)) != 0) {
             struct stat sb;
-            int ret = fstatat(fd, path, &sb, AT_SYMLINK_NOFOLLOW);
+            int ret = fstatat(handle, path, &sb, AT_SYMLINK_NOFOLLOW);
             if (S_ISLNK(sb.st_mode)) {
                 return __WASI_ELOOP;
             }


### PR DESCRIPTION
```C
// dirfd: This is the file descriptor of the directory relative to which the pathname is interpreted. 
int openat(int dirfd, const char *pathname, int flags, ...);
```
The value should be directory handle instead of file handle(which is always -1 in this context) return from `openat` 

This PR will fix the random failing test case `nofollow_errors` mentioned in https://github.com/bytecodealliance/wasm-micro-runtime/issues/3222