### PR TITLE
append `\0` to every name string in aot name section

### DIFF
--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -4923,7 +4923,7 @@ load_user_section(const uint8 *buf, const uint8 *buf_end, WASMModule *module,
     }
 
 #if WASM_ENABLE_CUSTOM_NAME_SECTION != 0
-    if (memcmp(p, "name", 4) == 0) {
+    if (name_len == 4 && memcmp(p, "name", 4) == 0) {
         module->name_section_buf = buf;
         module->name_section_buf_end = buf_end;
         p += name_len;

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -1942,7 +1942,7 @@ load_user_section(const uint8 *buf, const uint8 *buf_end, WASMModule *module,
     bh_assert(name_len > 0 && p + name_len <= p_end);
 
 #if WASM_ENABLE_CUSTOM_NAME_SECTION != 0
-    if (memcmp(p, "name", 4) == 0) {
+    if (name_len == 4 && memcmp(p, "name", 4) == 0) {
         p += name_len;
         handle_name_section(p, p_end, module, is_load_from_file_buf, error_buf,
                             error_buf_size);


### PR DESCRIPTION
Since strings in .name section in .wasm is not c-style, need to append a `\0` to strings in .name section in .aot when emitting.