### PR TITLE
Fix nightly run CI and disable building llvm in CodeQL CI

### DIFF
--- a/.github/workflows/codeql_buildscript.sh
+++ b/.github/workflows/codeql_buildscript.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 
-sudo apt install -y build-essential cmake g++-multilib libgcc-12-dev lib32gcc-12-dev ccache ninja-build ccache
+sudo apt update
+
+sudo apt install -y build-essential cmake g++-multilib libgcc-11-dev lib32gcc-11-dev ccache ninja-build ccache
 
 WAMR_DIR=${PWD}
 
+# TODO: use pre-built llvm binary to build wamrc to
+#       avoid static code analysing for llvm
+: '
 # build wamrc
 cd ${WAMR_DIR}/wamr-compiler
 ./build_llvm.sh
@@ -14,6 +19,7 @@ if [[ $? != 0 ]]; then
     echo "Failed to build wamrc!"
     exit 1;
 fi
+'
 
 # build iwasm with default features enabled
 cd ${WAMR_DIR}/product-mini/platforms/linux
@@ -146,26 +152,6 @@ if [[ $? != 0 ]]; then
     exit 1;
 fi
 
-# build iwasm with llvm jit lazy mode enabled
-cd ${WAMR_DIR}/product-mini/platforms/linux
-rm -rf build && mkdir build && cd build
-cmake .. -DCMAKE_BUILD_TYPE=Debug -DWAMR_BUILD_JIT=1
-make -j
-if [[ $? != 0 ]]; then
-    echo "Failed to build llvm jit lazy mode enabled!"
-    exit 1;
-fi
-
-# build iwasm with llvm jit eager mode enabled
-cd ${WAMR_DIR}/product-mini/platforms/linux
-rm -rf build && mkdir build && cd build
-cmake .. -DCMAKE_BUILD_TYPE=Debug -DWAMR_BUILD_JIT=1 -DWAMR_BUILD_LAZY_JIT=0
-make -j
-if [[ $? != 0 ]]; then
-    echo "Failed to build llvm jit eager mode enabled!"
-    exit 1;
-fi
-
 # build iwasm with fast jit lazy mode enabled
 cd ${WAMR_DIR}/product-mini/platforms/linux
 rm -rf build && mkdir build && cd build
@@ -186,6 +172,28 @@ if [[ $? != 0 ]]; then
     exit 1;
 fi
 
+# TODO: use pre-built llvm binary to build llvm-jit and multi-tier-jit
+: '
+# build iwasm with llvm jit lazy mode enabled
+cd ${WAMR_DIR}/product-mini/platforms/linux
+rm -rf build && mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Debug -DWAMR_BUILD_JIT=1
+make -j
+if [[ $? != 0 ]]; then
+    echo "Failed to build llvm jit lazy mode enabled!"
+    exit 1;
+fi
+
+# build iwasm with llvm jit eager mode enabled
+cd ${WAMR_DIR}/product-mini/platforms/linux
+rm -rf build && mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Debug -DWAMR_BUILD_JIT=1 -DWAMR_BUILD_LAZY_JIT=0
+make -j
+if [[ $? != 0 ]]; then
+    echo "Failed to build llvm jit eager mode enabled!"
+    exit 1;
+fi
+
 # build iwasm with multi-tier jit enabled
 cd ${WAMR_DIR}/product-mini/platforms/linux
 rm -rf build && mkdir build && cd build
@@ -196,6 +204,7 @@ if [[ $? != 0 ]]; then
     echo "Failed to build iwasm with multi-tier jit enabled!"
     exit 1;
 fi
+'
 
 # build iwasm with wasm mini-loader enabled
 cd ${WAMR_DIR}/product-mini/platforms/linux

--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -188,10 +188,16 @@ jobs:
             make_options_feature: "-DWAMR_BUILD_MINI_LOADER=1"
           - make_options_run_mode: $MULTI_TIER_JIT_BUILD_OPTIONS
             make_options_feature: "-DWAMR_BUILD_MINI_LOADER=1"
-          # Fast-JIT and Multi-Tier-JIT mode don't support android(X86-32)
+          # Fast-JIT and Multi-Tier-JIT mode don't support android
           - make_options_run_mode: $FAST_JIT_BUILD_OPTIONS
             platform: android
           - make_options_run_mode: $MULTI_TIER_JIT_BUILD_OPTIONS
+            platform: android
+          # LLVM JIT pre-built binary wasn't compiled by Android NDK
+          # and isn't available for android
+          - make_options_run_mode: $LLVM_LAZY_JIT_BUILD_OPTIONS
+            platform: android
+          - make_options_run_mode: $LLVM_EAGER_JIT_BUILD_OPTIONS
             platform: android
         include:
           - os: ubuntu-20.04
@@ -219,10 +225,20 @@ jobs:
         if: endsWith(matrix.make_options_run_mode, '_JIT_BUILD_OPTIONS') && (steps.retrieve_llvm_libs.outputs.cache-hit != 'true')
         run: echo "::error::can not get prebuilt llvm libraries" && exit 1
 
-      - name: Build iwasm
+      - name: Build iwasm for linux
+        if: matrix.platform == 'linux'
         run: |
           mkdir build && cd build
           cmake .. ${{ matrix.make_options_run_mode }} ${{ matrix.make_options_feature }}
+          cmake --build . --config Release --parallel 4
+        working-directory: product-mini/platforms/${{ matrix.platform }}
+
+      - name: Build iwasm for android
+        if: matrix.platform == 'android'
+        run: |
+          mkdir build && cd build
+          cmake .. ${{ matrix.make_options_run_mode }} ${{ matrix.make_options_feature }} \
+                -DWAMR_BUILD_TARGET=X86_64
           cmake --build . --config Release --parallel 4
         working-directory: product-mini/platforms/${{ matrix.platform }}
 


### PR DESCRIPTION
- Fix nightly run CI failure which was introduced by PR #3239 and
  now it must set WAMR_BUILD_TARGET when building iwasm for Android platform
- Remove building llvm, wamrc and jit in CodeQL CI, since it will
  do static code analyzing for llvm project and cause CodeQL run
  failed: `Oops! A fatal internal error occurred.
  This particular kind of error most often happens as a side effect of running out of
  disk space.`