### PR TITLE
loader: Remove updating ctx->dynamic_offset in emit_br_info

### DIFF
--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -8912,21 +8912,6 @@ wasm_loader_emit_br_info(WASMLoaderContext *ctx, BranchBlock *frame_csp,
             dynamic_offset -= cell;
             emit_operand(ctx, dynamic_offset);
         }
-        /* Update ctx->max_dynamic_offset */
-        if (dynamic_offset > ctx->max_dynamic_offset)
-            ctx->max_dynamic_offset = dynamic_offset;
-        /* Update ctx->dynamic_offset */
-        frame_offset = ctx->frame_offset;
-        for (i = (int32)arity - 1; i >= 0; i--) {
-            cell = (uint8)wasm_value_type_cell_num(types[i]);
-            /* Ensure the frame offset stack won't go underflow */
-            if (frame_offset - cell >= ctx->frame_offset_bottom) {
-                frame_offset -= cell;
-                if (*frame_offset > ctx->start_dynamic_offset
-                    && *frame_offset < ctx->max_dynamic_offset)
-                    ctx->dynamic_offset -= cell;
-            }
-        }
     }
 
     /* Part f */

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -8912,19 +8912,21 @@ wasm_loader_emit_br_info(WASMLoaderContext *ctx, BranchBlock *frame_csp,
             dynamic_offset -= cell;
             emit_operand(ctx, dynamic_offset);
         }
-        /* Update ctx->dynamic_offset and ctx->frame_offset */
+        /* Update ctx->max_dynamic_offset */
+        if (dynamic_offset > ctx->max_dynamic_offset)
+            ctx->max_dynamic_offset = dynamic_offset;
+        /* Update ctx->dynamic_offset */
         frame_offset = ctx->frame_offset;
         for (i = (int32)arity - 1; i >= 0; i--) {
             cell = (uint8)wasm_value_type_cell_num(types[i]);
             /* Ensure the frame offset stack won't go underflow */
-            if (frame_offset - cell < ctx->frame_offset_bottom) {
+            if (frame_offset - cell >= ctx->frame_offset_bottom) {
                 frame_offset -= cell;
                 if (*frame_offset > ctx->start_dynamic_offset
                     && *frame_offset < ctx->max_dynamic_offset)
                     ctx->dynamic_offset -= cell;
             }
         }
-        ctx->frame_offset = frame_offset;
     }
 
     /* Part f */

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -4698,12 +4698,24 @@ wasm_loader_emit_br_info(WASMLoaderContext *ctx, BranchBlock *frame_csp,
         /* Part e */
         dynamic_offset =
             frame_csp->dynamic_offset + wasm_get_cell_num(types, arity);
-        ctx->dynamic_offset = dynamic_offset;
         for (i = (int32)arity - 1; i >= 0; i--) {
             cell = (uint8)wasm_value_type_cell_num(types[i]);
             dynamic_offset -= cell;
             emit_operand(ctx, dynamic_offset);
         }
+        /* Update ctx->dynamic_offset and ctx->frame_offset */
+        frame_offset = ctx->frame_offset;
+        for (i = (int32)arity - 1; i >= 0; i--) {
+            cell = (uint8)wasm_value_type_cell_num(types[i]);
+            /* Ensure the frame offset stack won't go underflow */
+            if (frame_offset - cell < ctx->frame_offset_bottom) {
+                frame_offset -= cell;
+                if (*frame_offset > ctx->start_dynamic_offset
+                    && *frame_offset < ctx->max_dynamic_offset)
+                    ctx->dynamic_offset -= cell;
+            }
+        }
+        ctx->frame_offset = frame_offset;
     }
 
     /* Part f */

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -4703,19 +4703,21 @@ wasm_loader_emit_br_info(WASMLoaderContext *ctx, BranchBlock *frame_csp,
             dynamic_offset -= cell;
             emit_operand(ctx, dynamic_offset);
         }
-        /* Update ctx->dynamic_offset and ctx->frame_offset */
+        /* Update ctx->max_dynamic_offset */
+        if (dynamic_offset > ctx->max_dynamic_offset)
+            ctx->max_dynamic_offset = dynamic_offset;
+        /* Update ctx->dynamic_offset */
         frame_offset = ctx->frame_offset;
         for (i = (int32)arity - 1; i >= 0; i--) {
             cell = (uint8)wasm_value_type_cell_num(types[i]);
             /* Ensure the frame offset stack won't go underflow */
-            if (frame_offset - cell < ctx->frame_offset_bottom) {
+            if (frame_offset - cell >= ctx->frame_offset_bottom) {
                 frame_offset -= cell;
                 if (*frame_offset > ctx->start_dynamic_offset
                     && *frame_offset < ctx->max_dynamic_offset)
                     ctx->dynamic_offset -= cell;
             }
         }
-        ctx->frame_offset = frame_offset;
     }
 
     /* Part f */

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -4703,21 +4703,6 @@ wasm_loader_emit_br_info(WASMLoaderContext *ctx, BranchBlock *frame_csp,
             dynamic_offset -= cell;
             emit_operand(ctx, dynamic_offset);
         }
-        /* Update ctx->max_dynamic_offset */
-        if (dynamic_offset > ctx->max_dynamic_offset)
-            ctx->max_dynamic_offset = dynamic_offset;
-        /* Update ctx->dynamic_offset */
-        frame_offset = ctx->frame_offset;
-        for (i = (int32)arity - 1; i >= 0; i--) {
-            cell = (uint8)wasm_value_type_cell_num(types[i]);
-            /* Ensure the frame offset stack won't go underflow */
-            if (frame_offset - cell >= ctx->frame_offset_bottom) {
-                frame_offset -= cell;
-                if (*frame_offset > ctx->start_dynamic_offset
-                    && *frame_offset < ctx->max_dynamic_offset)
-                    ctx->dynamic_offset -= cell;
-            }
-        }
     }
 
     /* Part f */


### PR DESCRIPTION
Should not update `ctx->dynamic_offset` in emit_br_info, since the `Part e` only
sets the dst offsets, the operand stack should not be changed, e.g., the stack
operands are to be used by the opcodes followed by `br_if` opcode.

Reported in https://github.com/bytecodealliance/wasm-micro-runtime/issues/3210.