### PR TITLE
Dev/memory64

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -914,7 +914,7 @@ memory_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
     bh_assert(max_memory_data_size <= MAX_LINEAR_MEMORY_SIZE);
     (void)max_memory_data_size;
 
-    /* TODO: memory64 use is_memory64 flag */
+    /* TODO: memory64 uses is_memory64 flag */
     if (wasm_allocate_linear_memory(&p, is_shared_memory, false,
                                     num_bytes_per_page, init_page_count,
                                     max_page_count, &memory_data_size)

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -914,9 +914,10 @@ memory_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
     bh_assert(max_memory_data_size <= MAX_LINEAR_MEMORY_SIZE);
     (void)max_memory_data_size;
 
-    if (wasm_allocate_linear_memory(&p, is_shared_memory, num_bytes_per_page,
-                                    init_page_count, max_page_count,
-                                    &memory_data_size)
+    /* TODO: memory64 use is_memory64 flag */
+    if (wasm_allocate_linear_memory(&p, is_shared_memory, false,
+                                    num_bytes_per_page, init_page_count,
+                                    max_page_count, &memory_data_size)
         != BHT_OK) {
         set_error_buf(error_buf, error_buf_size,
                       "allocate linear memory failed");

--- a/core/iwasm/common/wasm_application.c
+++ b/core/iwasm/common/wasm_application.c
@@ -227,10 +227,9 @@ execute_main(WASMModuleInstanceCommon *module_inst, int32 argc, char *argv[])
 #if WASM_ENABLE_MEMORY64 != 0
         if (is_memory64) {
             argc1 = 3;
-            uint64_t app_addr =
+            uint64 app_addr =
                 wasm_runtime_addr_native_to_app(module_inst, argv_offsets);
-            bh_memcpy_s(&(argv1[1]), sizeof(uint32) * 2, &app_addr,
-                        sizeof(uint64));
+            PUT_I64_TO_ADDR(&argv[1], app_addr);
         }
         else
 #endif

--- a/core/iwasm/common/wasm_application.c
+++ b/core/iwasm/common/wasm_application.c
@@ -61,7 +61,7 @@ static union {
  * Implementation of wasm_application_execute_main()
  */
 static bool
-check_main_func_type(const WASMFuncType *type)
+check_main_func_type(const WASMFuncType *type, bool is_memory64)
 {
     if (!(type->param_count == 0 || type->param_count == 2)
         || type->result_count > 1) {
@@ -72,7 +72,8 @@ check_main_func_type(const WASMFuncType *type)
 
     if (type->param_count == 2
         && !(type->types[0] == VALUE_TYPE_I32
-             && type->types[1] == VALUE_TYPE_I32)) {
+             && type->types[1]
+                    == (is_memory64 ? VALUE_TYPE_I64 : VALUE_TYPE_I32))) {
         LOG_ERROR(
             "WASM execute application failed: invalid main function type.\n");
         return false;
@@ -94,14 +95,18 @@ execute_main(WASMModuleInstanceCommon *module_inst, int32 argc, char *argv[])
     WASMFunctionInstanceCommon *func;
     WASMFuncType *func_type = NULL;
     WASMExecEnv *exec_env = NULL;
-    uint32 argc1 = 0, argv1[2] = { 0 };
+    uint32 argc1 = 0, argv1[3] = { 0 };
     uint32 total_argv_size = 0;
     uint64 total_size;
     uint64 argv_buf_offset = 0;
     int32 i;
     char *argv_buf, *p, *p_end;
     uint32 *argv_offsets, module_type;
-    bool ret, is_import_func = true;
+    bool ret, is_import_func = true, is_memory64 = false;
+#if WASM_ENABLE_MEMORY64 != 0
+    WASMModuleInstance *wasm_module_inst = (WASMModuleInstance *)module_inst;
+    is_memory64 = wasm_module_inst->memories[0]->is_memory64;
+#endif
 
     exec_env = wasm_runtime_get_exec_env_singleton(module_inst);
     if (!exec_env) {
@@ -187,7 +192,7 @@ execute_main(WASMModuleInstanceCommon *module_inst, int32 argc, char *argv[])
         return false;
     }
 
-    if (!check_main_func_type(func_type)) {
+    if (!check_main_func_type(func_type, is_memory64)) {
         wasm_runtime_set_exception(module_inst,
                                    "invalid function type of main function");
         return false;
@@ -218,11 +223,22 @@ execute_main(WASMModuleInstanceCommon *module_inst, int32 argc, char *argv[])
             p += strlen(argv[i]) + 1;
         }
 
-        argc1 = 2;
         argv1[0] = (uint32)argc;
-        /* TODO: memory64 uint64 when the memory idx is i64 */
-        argv1[1] =
-            (uint32)wasm_runtime_addr_native_to_app(module_inst, argv_offsets);
+#if WASM_ENABLE_MEMORY64 != 0
+        if (is_memory64) {
+            argc1 = 3;
+            uint64_t app_addr =
+                wasm_runtime_addr_native_to_app(module_inst, argv_offsets);
+            argv1[1] = (uint32_t)(app_addr & 0xFFFFFFFF);
+            argv1[2] = (uint32_t)((app_addr >> 32) & 0xFFFFFFFF);
+        }
+        else
+#endif
+        {
+            argc1 = 2;
+            argv1[1] = (uint32)wasm_runtime_addr_native_to_app(module_inst,
+                                                               argv_offsets);
+        }
     }
 
     ret = wasm_runtime_call_wasm(exec_env, func, argc1, argv1);

--- a/core/iwasm/common/wasm_application.c
+++ b/core/iwasm/common/wasm_application.c
@@ -229,8 +229,8 @@ execute_main(WASMModuleInstanceCommon *module_inst, int32 argc, char *argv[])
             argc1 = 3;
             uint64_t app_addr =
                 wasm_runtime_addr_native_to_app(module_inst, argv_offsets);
-            argv1[1] = (uint32_t)(app_addr & 0xFFFFFFFF);
-            argv1[2] = (uint32_t)((app_addr >> 32) & 0xFFFFFFFF);
+            bh_memcpy_s(&(argv1[1]), sizeof(uint32) * 2, &app_addr,
+                        sizeof(uint64));
         }
         else
 #endif

--- a/core/iwasm/common/wasm_memory.c
+++ b/core/iwasm/common/wasm_memory.c
@@ -896,8 +896,9 @@ wasm_deallocate_linear_memory(WASMMemoryInstance *memory_inst)
 
 int
 wasm_allocate_linear_memory(uint8 **data, bool is_shared_memory,
-                            uint64 num_bytes_per_page, uint64 init_page_count,
-                            uint64 max_page_count, uint64 *memory_data_size)
+                            bool is_memory64, uint64 num_bytes_per_page,
+                            uint64 init_page_count, uint64 max_page_count,
+                            uint64 *memory_data_size)
 {
     uint64 map_size, page_size;
 
@@ -926,7 +927,16 @@ wasm_allocate_linear_memory(uint8 **data, bool is_shared_memory,
 
     page_size = os_getpagesize();
     *memory_data_size = init_page_count * num_bytes_per_page;
-    bh_assert(*memory_data_size <= MAX_LINEAR_MEMORY_SIZE);
+
+#if WASM_ENABLE_MEMORY64 != 0
+    if (is_memory64) {
+        bh_assert(*memory_data_size <= MAX_LINEAR_MEM64_MEMORY_SIZE);
+    }
+    else
+#endif
+    {
+        bh_assert(*memory_data_size <= MAX_LINEAR_MEMORY_SIZE);
+    }
     align_as_and_cast(*memory_data_size, page_size);
 
     if (map_size > 0) {

--- a/core/iwasm/common/wasm_memory.h
+++ b/core/iwasm/common/wasm_memory.h
@@ -64,8 +64,9 @@ wasm_deallocate_linear_memory(WASMMemoryInstance *memory_inst);
 
 int
 wasm_allocate_linear_memory(uint8 **data, bool is_shared_memory,
-                            uint64 num_bytes_per_page, uint64 init_page_count,
-                            uint64 max_page_count, uint64 *memory_data_size);
+                            bool is_memory64, uint64 num_bytes_per_page,
+                            uint64 init_page_count, uint64 max_page_count,
+                            uint64 *memory_data_size);
 
 #ifdef __cplusplus
 }

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -3732,7 +3732,8 @@ wasm_runtime_invoke_native_raw(WASMExecEnv *exec_env, void *func_ptr,
             case VALUE_TYPE_I64:
 #if WASM_ENABLE_MEMORY64 != 0
             {
-                PUT_I64_TO_ADDR((uint32 *)argv, GET_I64_FROM_ADDR(argv_src));
+                PUT_I64_TO_ADDR((uint32 *)argv_dst,
+                                GET_I64_FROM_ADDR(argv_src));
                 argv_src += 2;
                 arg_i64 = *argv_dst;
                 if (signature) {

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -3671,6 +3671,9 @@ wasm_runtime_invoke_native_raw(WASMExecEnv *exec_env, void *func_ptr,
     uint64 argv_buf[16] = { 0 }, *argv1 = argv_buf, *argv_dst, size;
     uint32 *argv_src = argv, i, argc1, ptr_len;
     uint32 arg_i32;
+#if WASM_ENABLE_MEMORY64 != 0
+    uint64 arg_i64;
+#endif
     bool ret = false;
 
     argc1 = func_type->param_count;

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -3693,6 +3693,10 @@ wasm_runtime_invoke_native_raw(WASMExecEnv *exec_env, void *func_ptr,
 #endif
             {
                 *(uint32 *)argv_dst = arg_i32 = *argv_src++;
+                /* TODO: memory64 if future there is a way for supporting
+                 * wasm64 and wasm32 in libc at the same time, remove the
+                 * macro control */
+#if WASM_ENABLE_MEMORY64 == 0
                 if (signature) {
                     if (signature[i + 1] == '*') {
                         /* param is a pointer */
@@ -3722,13 +3726,13 @@ wasm_runtime_invoke_native_raw(WASMExecEnv *exec_env, void *func_ptr,
                                 module, (uint64)arg_i32);
                     }
                 }
+#endif
                 break;
             }
             case VALUE_TYPE_I64:
 #if WASM_ENABLE_MEMORY64 != 0
             {
-                bh_memcpy_s(argv_dst, sizeof(uint64), argv_src,
-                            sizeof(uint32) * 2);
+                PUT_I64_TO_ADDR((uint32 *)argv, GET_I64_FROM_ADDR(argv_src));
                 argv_src += 2;
                 arg_i64 = *argv_dst;
                 if (signature) {
@@ -4847,6 +4851,10 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
             {
                 arg_i32 = *argv_src++;
                 arg_i64 = arg_i32;
+                /* TODO: memory64 if future there is a way for supporting
+                 * wasm64 and wasm32 in libc at the same time, remove the
+                 * macro control */
+#if WASM_ENABLE_MEMORY64 == 0
                 if (signature) {
                     if (signature[i + 1] == '*') {
                         /* param is a pointer */
@@ -4874,6 +4882,7 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
                             module, (uint64)arg_i32);
                     }
                 }
+#endif
                 if (n_ints < MAX_REG_INTS)
                     ints[n_ints++] = arg_i64;
                 else
@@ -4883,7 +4892,7 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
             case VALUE_TYPE_I64:
 #if WASM_ENABLE_MEMORY64 != 0
             {
-                arg_i64 = *(uint64 *)argv_src;
+                arg_i64 = GET_I64_FROM_ADDR(argv_src);
                 argv_src += 2;
                 if (signature) {
                     /* TODO: memory64 pointer with length need a new symbol

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -1510,7 +1510,11 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 #endif
 #endif
 #if WASM_ENABLE_MEMORY64 != 0
+    /* TODO: multi-memories for now assuming the memory idx type is consistent
+     * across multi-memories */
     bool is_memory64 = false;
+    if (memory)
+        is_memory64 = memory->is_memory64;
 #endif
 
 #if WASM_ENABLE_DEBUG_INTERP != 0
@@ -4170,7 +4174,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 global = globals + global_idx;
                 global_addr = get_global_addr(global_data, global);
 #if WASM_ENABLE_MEMORY64 != 0
-                if (module->memories[0]->is_memory64) {
+                if (is_memory64) {
                     aux_stack_top = *(uint64 *)(frame_sp - 2);
                 }
                 else
@@ -4188,7 +4192,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     goto got_exception;
                 }
 #if WASM_ENABLE_MEMORY64 != 0
-                if (module->memories[0]->is_memory64) {
+                if (is_memory64) {
                     *(uint64 *)global_addr = aux_stack_top;
                     frame_sp -= 2;
                 }
@@ -4228,9 +4232,6 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 mem_offset_t offset, addr;
 
                 read_leb_uint32(frame_ip, frame_ip_end, flags);
-#if WASM_ENABLE_MEMORY64 != 0
-                is_memory64 = module->memories[0]->is_memory64;
-#endif
                 read_leb_mem_offset(frame_ip, frame_ip_end, offset);
                 addr = POP_MEM_OFFSET();
                 CHECK_MEMORY_OVERFLOW(4);
@@ -4247,9 +4248,6 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 mem_offset_t offset, addr;
 
                 read_leb_uint32(frame_ip, frame_ip_end, flags);
-#if WASM_ENABLE_MEMORY64 != 0
-                is_memory64 = module->memories[0]->is_memory64;
-#endif
                 read_leb_mem_offset(frame_ip, frame_ip_end, offset);
                 addr = POP_MEM_OFFSET();
                 CHECK_MEMORY_OVERFLOW(8);
@@ -4265,9 +4263,6 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 mem_offset_t offset, addr;
 
                 read_leb_uint32(frame_ip, frame_ip_end, flags);
-#if WASM_ENABLE_MEMORY64 != 0
-                is_memory64 = module->memories[0]->is_memory64;
-#endif
                 read_leb_mem_offset(frame_ip, frame_ip_end, offset);
                 addr = POP_MEM_OFFSET();
                 CHECK_MEMORY_OVERFLOW(1);
@@ -4283,9 +4278,6 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 mem_offset_t offset, addr;
 
                 read_leb_uint32(frame_ip, frame_ip_end, flags);
-#if WASM_ENABLE_MEMORY64 != 0
-                is_memory64 = module->memories[0]->is_memory64;
-#endif
                 read_leb_mem_offset(frame_ip, frame_ip_end, offset);
                 addr = POP_MEM_OFFSET();
                 CHECK_MEMORY_OVERFLOW(1);
@@ -4301,9 +4293,6 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 mem_offset_t offset, addr;
 
                 read_leb_uint32(frame_ip, frame_ip_end, flags);
-#if WASM_ENABLE_MEMORY64 != 0
-                is_memory64 = module->memories[0]->is_memory64;
-#endif
                 read_leb_mem_offset(frame_ip, frame_ip_end, offset);
                 addr = POP_MEM_OFFSET();
                 CHECK_MEMORY_OVERFLOW(2);
@@ -4319,9 +4308,6 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 mem_offset_t offset, addr;
 
                 read_leb_uint32(frame_ip, frame_ip_end, flags);
-#if WASM_ENABLE_MEMORY64 != 0
-                is_memory64 = module->memories[0]->is_memory64;
-#endif
                 read_leb_mem_offset(frame_ip, frame_ip_end, offset);
                 addr = POP_MEM_OFFSET();
                 CHECK_MEMORY_OVERFLOW(2);
@@ -4337,9 +4323,6 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 mem_offset_t offset, addr;
 
                 read_leb_uint32(frame_ip, frame_ip_end, flags);
-#if WASM_ENABLE_MEMORY64 != 0
-                is_memory64 = module->memories[0]->is_memory64;
-#endif
                 read_leb_mem_offset(frame_ip, frame_ip_end, offset);
                 addr = POP_MEM_OFFSET();
                 CHECK_MEMORY_OVERFLOW(1);
@@ -4355,9 +4338,6 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 mem_offset_t offset, addr;
 
                 read_leb_uint32(frame_ip, frame_ip_end, flags);
-#if WASM_ENABLE_MEMORY64 != 0
-                is_memory64 = module->memories[0]->is_memory64;
-#endif
                 read_leb_mem_offset(frame_ip, frame_ip_end, offset);
                 addr = POP_MEM_OFFSET();
                 CHECK_MEMORY_OVERFLOW(1);
@@ -4373,9 +4353,6 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 mem_offset_t offset, addr;
 
                 read_leb_uint32(frame_ip, frame_ip_end, flags);
-#if WASM_ENABLE_MEMORY64 != 0
-                is_memory64 = module->memories[0]->is_memory64;
-#endif
                 read_leb_mem_offset(frame_ip, frame_ip_end, offset);
                 addr = POP_MEM_OFFSET();
                 CHECK_MEMORY_OVERFLOW(2);
@@ -4391,9 +4368,6 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 mem_offset_t offset, addr;
 
                 read_leb_uint32(frame_ip, frame_ip_end, flags);
-#if WASM_ENABLE_MEMORY64 != 0
-                is_memory64 = module->memories[0]->is_memory64;
-#endif
                 read_leb_mem_offset(frame_ip, frame_ip_end, offset);
                 addr = POP_MEM_OFFSET();
                 CHECK_MEMORY_OVERFLOW(2);
@@ -4410,9 +4384,6 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
                 opcode = *(frame_ip - 1);
                 read_leb_uint32(frame_ip, frame_ip_end, flags);
-#if WASM_ENABLE_MEMORY64 != 0
-                is_memory64 = module->memories[0]->is_memory64;
-#endif
                 read_leb_mem_offset(frame_ip, frame_ip_end, offset);
                 addr = POP_MEM_OFFSET();
                 CHECK_MEMORY_OVERFLOW(4);
@@ -4428,9 +4399,6 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 mem_offset_t offset, addr;
 
                 read_leb_uint32(frame_ip, frame_ip_end, flags);
-#if WASM_ENABLE_MEMORY64 != 0
-                is_memory64 = module->memories[0]->is_memory64;
-#endif
                 read_leb_mem_offset(frame_ip, frame_ip_end, offset);
                 addr = POP_MEM_OFFSET();
                 CHECK_MEMORY_OVERFLOW(4);
@@ -4448,9 +4416,6 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 mem_offset_t offset, addr;
 
                 read_leb_uint32(frame_ip, frame_ip_end, flags);
-#if WASM_ENABLE_MEMORY64 != 0
-                is_memory64 = module->memories[0]->is_memory64;
-#endif
                 read_leb_mem_offset(frame_ip, frame_ip_end, offset);
                 frame_sp--;
                 addr = POP_MEM_OFFSET();
@@ -4476,9 +4441,6 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 mem_offset_t offset, addr;
 
                 read_leb_uint32(frame_ip, frame_ip_end, flags);
-#if WASM_ENABLE_MEMORY64 != 0
-                is_memory64 = module->memories[0]->is_memory64;
-#endif
                 read_leb_mem_offset(frame_ip, frame_ip_end, offset);
                 frame_sp -= 2;
                 addr = POP_MEM_OFFSET();
@@ -4509,9 +4471,6 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
                 opcode = *(frame_ip - 1);
                 read_leb_uint32(frame_ip, frame_ip_end, flags);
-#if WASM_ENABLE_MEMORY64 != 0
-                is_memory64 = module->memories[0]->is_memory64;
-#endif
                 read_leb_mem_offset(frame_ip, frame_ip_end, offset);
                 sval = (uint32)POP_I32();
                 addr = POP_MEM_OFFSET();
@@ -4539,9 +4498,6 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
                 opcode = *(frame_ip - 1);
                 read_leb_uint32(frame_ip, frame_ip_end, flags);
-#if WASM_ENABLE_MEMORY64 != 0
-                is_memory64 = module->memories[0]->is_memory64;
-#endif
                 read_leb_mem_offset(frame_ip, frame_ip_end, offset);
                 sval = (uint64)POP_I64();
                 addr = POP_MEM_OFFSET();
@@ -4568,9 +4524,6 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
             {
                 uint32 reserved;
                 read_leb_uint32(frame_ip, frame_ip_end, reserved);
-#if WASM_ENABLE_MEMORY64 != 0
-                is_memory64 = module->memories[0]->is_memory64;
-#endif
                 PUSH_PAGE_COUNT(memory->cur_page_count);
                 (void)reserved;
                 HANDLE_OP_END();
@@ -4581,9 +4534,6 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 uint32 reserved, delta,
                     prev_page_count = memory->cur_page_count;
 
-#if WASM_ENABLE_MEMORY64 != 0
-                is_memory64 = module->memories[0]->is_memory64;
-#endif
                 read_leb_uint32(frame_ip, frame_ip_end, reserved);
                 delta = (uint32)POP_PAGE_COUNT();
 
@@ -5601,9 +5551,6 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         read_leb_uint32(frame_ip, frame_ip_end, segment);
                         /* skip memory index */
                         frame_ip++;
-#if WASM_ENABLE_MEMORY64 != 0
-                        is_memory64 = module->memories[0]->is_memory64;
-#endif
 
                         bytes = (uint64)(uint32)POP_I32();
                         offset = (uint64)(uint32)POP_I32();
@@ -5654,9 +5601,6 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         uint8 *mdst, *msrc;
 
                         frame_ip += 2;
-#if WASM_ENABLE_MEMORY64 != 0
-                        is_memory64 = module->memories[0]->is_memory64;
-#endif
                         len = POP_MEM_OFFSET();
                         src = POP_MEM_OFFSET();
                         dst = POP_MEM_OFFSET();
@@ -5689,9 +5633,6 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         uint8 fill_val, *mdst;
                         frame_ip++;
 
-#if WASM_ENABLE_MEMORY64 != 0
-                        is_memory64 = module->memories[0]->is_memory64;
-#endif
                         len = POP_MEM_OFFSET();
                         fill_val = POP_I32();
                         dst = POP_MEM_OFFSET();
@@ -5935,9 +5876,6 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
                 if (opcode != WASM_OP_ATOMIC_FENCE) {
                     read_leb_uint32(frame_ip, frame_ip_end, align);
-#if WASM_ENABLE_MEMORY64 != 0
-                    is_memory64 = module->memories[0]->is_memory64;
-#endif
                     read_leb_mem_offset(frame_ip, frame_ip_end, offset);
                 }
 

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -5924,7 +5924,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 #if WASM_ENABLE_SHARED_MEMORY != 0
             HANDLE_OP(WASM_OP_ATOMIC_PREFIX)
             {
-                linear_mem_ptr_t offset = 0, addr;
+                mem_offset_t offset = 0, addr;
                 uint32 align = 0;
                 uint32 opcode1;
 
@@ -5935,6 +5935,9 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
                 if (opcode != WASM_OP_ATOMIC_FENCE) {
                     read_leb_uint32(frame_ip, frame_ip_end, align);
+#if WASM_ENABLE_MEMORY64 != 0
+                    is_memory64 = module->memories[0]->is_memory64;
+#endif
                     read_leb_mem_offset(frame_ip, frame_ip_end, offset);
                 }
 
@@ -6157,7 +6160,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                             CHECK_MEMORY_OVERFLOW(8);
                             CHECK_ATOMIC_MEMORY_ACCESS();
                             shared_memory_lock(memory);
-                            PUT_I64_TO_ADDR((uint32 *)maddr, sval);
+                            STORE_I64(maddr, sval);
                             shared_memory_unlock(memory);
                         }
                         break;

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -951,7 +951,7 @@ trunc_f64_to_int(WASMModuleInstance *module, uint32 *frame_sp, float64 src_min,
         uint32 readv, sval;                                          \
                                                                      \
         sval = POP_I32();                                            \
-        addr = POP_I32();                                            \
+        addr = POP_MEM_OFFSET();                                     \
                                                                      \
         if (opcode == WASM_OP_ATOMIC_RMW_I32_##OP_NAME##8_U) {       \
             CHECK_MEMORY_OVERFLOW(1);                                \
@@ -991,7 +991,7 @@ trunc_f64_to_int(WASMModuleInstance *module, uint32 *frame_sp, float64 src_min,
         uint64 readv, sval;                                          \
                                                                      \
         sval = (uint64)POP_I64();                                    \
-        addr = POP_I32();                                            \
+        addr = POP_MEM_OFFSET();                                     \
                                                                      \
         if (opcode == WASM_OP_ATOMIC_RMW_I64_##OP_NAME##8_U) {       \
             CHECK_MEMORY_OVERFLOW(1);                                \
@@ -5924,7 +5924,8 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 #if WASM_ENABLE_SHARED_MEMORY != 0
             HANDLE_OP(WASM_OP_ATOMIC_PREFIX)
             {
-                uint32 offset = 0, align = 0, addr;
+                linear_mem_ptr_t offset = 0, addr;
+                uint32 align = 0;
                 uint32 opcode1;
 
                 read_leb_uint32(frame_ip, frame_ip_end, opcode1);
@@ -5934,7 +5935,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
                 if (opcode != WASM_OP_ATOMIC_FENCE) {
                     read_leb_uint32(frame_ip, frame_ip_end, align);
-                    read_leb_uint32(frame_ip, frame_ip_end, offset);
+                    read_leb_mem_offset(frame_ip, frame_ip_end, offset);
                 }
 
                 switch (opcode) {
@@ -5943,7 +5944,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         uint32 notify_count, ret;
 
                         notify_count = POP_I32();
-                        addr = POP_I32();
+                        addr = POP_MEM_OFFSET();
                         CHECK_MEMORY_OVERFLOW(4);
                         CHECK_ATOMIC_MEMORY_ACCESS();
 
@@ -5963,7 +5964,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
                         timeout = POP_I64();
                         expect = POP_I32();
-                        addr = POP_I32();
+                        addr = POP_MEM_OFFSET();
                         CHECK_MEMORY_OVERFLOW(4);
                         CHECK_ATOMIC_MEMORY_ACCESS();
 
@@ -5987,7 +5988,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
                         timeout = POP_I64();
                         expect = POP_I64();
-                        addr = POP_I32();
+                        addr = POP_MEM_OFFSET();
                         CHECK_MEMORY_OVERFLOW(8);
                         CHECK_ATOMIC_MEMORY_ACCESS();
 
@@ -6018,7 +6019,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     {
                         uint32 readv;
 
-                        addr = POP_I32();
+                        addr = POP_MEM_OFFSET();
 
                         if (opcode == WASM_OP_ATOMIC_I32_LOAD8_U) {
                             CHECK_MEMORY_OVERFLOW(1);
@@ -6053,7 +6054,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     {
                         uint64 readv;
 
-                        addr = POP_I32();
+                        addr = POP_MEM_OFFSET();
 
                         if (opcode == WASM_OP_ATOMIC_I64_LOAD8_U) {
                             CHECK_MEMORY_OVERFLOW(1);
@@ -6095,7 +6096,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         uint32 sval;
 
                         sval = (uint32)POP_I32();
-                        addr = POP_I32();
+                        addr = POP_MEM_OFFSET();
 
                         if (opcode == WASM_OP_ATOMIC_I32_STORE8) {
                             CHECK_MEMORY_OVERFLOW(1);
@@ -6129,7 +6130,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         uint64 sval;
 
                         sval = (uint64)POP_I64();
-                        addr = POP_I32();
+                        addr = POP_MEM_OFFSET();
 
                         if (opcode == WASM_OP_ATOMIC_I64_STORE8) {
                             CHECK_MEMORY_OVERFLOW(1);
@@ -6170,7 +6171,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
                         sval = POP_I32();
                         expect = POP_I32();
-                        addr = POP_I32();
+                        addr = POP_MEM_OFFSET();
 
                         if (opcode == WASM_OP_ATOMIC_RMW_I32_CMPXCHG8_U) {
                             CHECK_MEMORY_OVERFLOW(1);
@@ -6216,7 +6217,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
                         sval = (uint64)POP_I64();
                         expect = (uint64)POP_I64();
-                        addr = POP_I32();
+                        addr = POP_MEM_OFFSET();
 
                         if (opcode == WASM_OP_ATOMIC_RMW_I64_CMPXCHG8_U) {
                             CHECK_MEMORY_OVERFLOW(1);

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -7672,8 +7672,8 @@ wasm_loader_find_block_addr(WASMExecEnv *exec_env, BlockAddr *block_addr_cache,
                 opcode = (uint8)opcode1;
 
                 if (opcode != WASM_OP_ATOMIC_FENCE) {
-                    skip_leb_uint32(p, p_end); /* align */
-                    skip_leb_uint32(p, p_end); /* offset */
+                    skip_leb_uint32(p, p_end);     /* align */
+                    skip_leb_mem_offset(p, p_end); /* offset */
                 }
                 else {
                     /* atomic.fence doesn't have memarg */
@@ -15460,8 +15460,15 @@ re_scan:
 #endif
                 if (opcode1 != WASM_OP_ATOMIC_FENCE) {
                     CHECK_MEMORY();
-                    read_leb_uint32(p, p_end, align);      /* align */
-                    read_leb_uint32(p, p_end, mem_offset); /* offset */
+                    read_leb_uint32(p, p_end, align); /* align */
+#if WASM_ENABLE_MEMORY64 != 0
+                    is_memory64 = module->memories[0].flags & MEMORY64_FLAG;
+                    mem_offset_type =
+                        is_memory64 ? VALUE_TYPE_I64 : VALUE_TYPE_I32;
+#else
+                    mem_offset_type = VALUE_TYPE_I32;
+#endif
+                    read_leb_mem_offset(p, p_end, mem_offset); /* offset */
                     if (!check_memory_align_equal(opcode1, align, error_buf,
                                                   error_buf_size)) {
                         goto fail;
@@ -15475,18 +15482,20 @@ re_scan:
 #endif
                 switch (opcode1) {
                     case WASM_OP_ATOMIC_NOTIFY:
-                        POP2_AND_PUSH(VALUE_TYPE_I32, VALUE_TYPE_I32);
+                        POP_I32();
+                        POP_MEM_OFFSET();
+                        PUSH_I32();
                         break;
                     case WASM_OP_ATOMIC_WAIT32:
                         POP_I64();
                         POP_I32();
-                        POP_I32();
+                        POP_MEM_OFFSET();
                         PUSH_I32();
                         break;
                     case WASM_OP_ATOMIC_WAIT64:
                         POP_I64();
                         POP_I64();
-                        POP_I32();
+                        POP_MEM_OFFSET();
                         PUSH_I32();
                         break;
                     case WASM_OP_ATOMIC_FENCE:
@@ -15500,26 +15509,26 @@ re_scan:
                     case WASM_OP_ATOMIC_I32_LOAD:
                     case WASM_OP_ATOMIC_I32_LOAD8_U:
                     case WASM_OP_ATOMIC_I32_LOAD16_U:
-                        POP_AND_PUSH(VALUE_TYPE_I32, VALUE_TYPE_I32);
+                        POP_AND_PUSH(mem_offset_type, VALUE_TYPE_I32);
                         break;
                     case WASM_OP_ATOMIC_I32_STORE:
                     case WASM_OP_ATOMIC_I32_STORE8:
                     case WASM_OP_ATOMIC_I32_STORE16:
                         POP_I32();
-                        POP_I32();
+                        POP_MEM_OFFSET();
                         break;
                     case WASM_OP_ATOMIC_I64_LOAD:
                     case WASM_OP_ATOMIC_I64_LOAD8_U:
                     case WASM_OP_ATOMIC_I64_LOAD16_U:
                     case WASM_OP_ATOMIC_I64_LOAD32_U:
-                        POP_AND_PUSH(VALUE_TYPE_I32, VALUE_TYPE_I64);
+                        POP_AND_PUSH(mem_offset_type, VALUE_TYPE_I64);
                         break;
                     case WASM_OP_ATOMIC_I64_STORE:
                     case WASM_OP_ATOMIC_I64_STORE8:
                     case WASM_OP_ATOMIC_I64_STORE16:
                     case WASM_OP_ATOMIC_I64_STORE32:
                         POP_I64();
-                        POP_I32();
+                        POP_MEM_OFFSET();
                         break;
                     case WASM_OP_ATOMIC_RMW_I32_ADD:
                     case WASM_OP_ATOMIC_RMW_I32_ADD8_U:
@@ -15539,7 +15548,9 @@ re_scan:
                     case WASM_OP_ATOMIC_RMW_I32_XCHG:
                     case WASM_OP_ATOMIC_RMW_I32_XCHG8_U:
                     case WASM_OP_ATOMIC_RMW_I32_XCHG16_U:
-                        POP2_AND_PUSH(VALUE_TYPE_I32, VALUE_TYPE_I32);
+                        POP_I32();
+                        POP_MEM_OFFSET();
+                        PUSH_I32();
                         break;
                     case WASM_OP_ATOMIC_RMW_I64_ADD:
                     case WASM_OP_ATOMIC_RMW_I64_ADD8_U:
@@ -15566,7 +15577,7 @@ re_scan:
                     case WASM_OP_ATOMIC_RMW_I64_XCHG16_U:
                     case WASM_OP_ATOMIC_RMW_I64_XCHG32_U:
                         POP_I64();
-                        POP_I32();
+                        POP_MEM_OFFSET();
                         PUSH_I64();
                         break;
                     case WASM_OP_ATOMIC_RMW_I32_CMPXCHG:
@@ -15574,7 +15585,7 @@ re_scan:
                     case WASM_OP_ATOMIC_RMW_I32_CMPXCHG16_U:
                         POP_I32();
                         POP_I32();
-                        POP_I32();
+                        POP_MEM_OFFSET();
                         PUSH_I32();
                         break;
                     case WASM_OP_ATOMIC_RMW_I64_CMPXCHG:
@@ -15583,7 +15594,7 @@ re_scan:
                     case WASM_OP_ATOMIC_RMW_I64_CMPXCHG32_U:
                         POP_I64();
                         POP_I64();
-                        POP_I32();
+                        POP_MEM_OFFSET();
                         PUSH_I64();
                         break;
                     default:

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -10785,6 +10785,16 @@ wasm_loader_prepare_bytecode(WASMModule *module, WASMFunction *func,
 #endif
 #if WASM_ENABLE_MEMORY64 != 0
     bool is_memory64 = false;
+    /* TODO: multi-memories for now assuming the memory idx type is consistent
+     * across multi-memories */
+    if (module->import_memory_count > 0)
+        is_memory64 = module->import_memories[0].u.memory.flags & MEMORY64_FLAG;
+    else if (module->memory_count > 0)
+        is_memory64 = module->memories[0].flags & MEMORY64_FLAG;
+
+    mem_offset_type = is_memory64 ? VALUE_TYPE_I64 : VALUE_TYPE_I32;
+#else
+    mem_offset_type = VALUE_TYPE_I32;
 #endif
 
     global_count = module->import_global_count + module->global_count;
@@ -10836,19 +10846,6 @@ re_scan:
         func->code_compiled = loader_ctx->p_code_compiled;
         func->code_compiled_size = loader_ctx->code_compiled_size;
     }
-#endif
-
-#if WASM_ENABLE_MEMORY64 != 0
-    /* TODO: multi-memories for now assuming the memory idx type is consistent
-     * across multi-memories */
-    if (module->import_memory_count > 0)
-        is_memory64 = module->import_memories[0].u.memory.flags & MEMORY64_FLAG;
-    else if (module->memory_count > 0)
-        is_memory64 = module->memories[0].flags & MEMORY64_FLAG;
-
-    mem_offset_type = is_memory64 ? VALUE_TYPE_I64 : VALUE_TYPE_I32;
-#else
-    mem_offset_type = VALUE_TYPE_I32;
 #endif
 
     PUSH_CSP(LABEL_TYPE_FUNCTION, func_block_type, p);

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -5960,6 +5960,16 @@ wasm_loader_prepare_bytecode(WASMModule *module, WASMFunction *func,
 #endif
 #if WASM_ENABLE_MEMORY64 != 0
     bool is_memory64 = false;
+    /* TODO: multi-memories for now assuming the memory idx type is consistent
+     * across multi-memories */
+    if (module->import_memory_count > 0)
+        is_memory64 = module->import_memories[0].u.memory.flags & MEMORY64_FLAG;
+    else if (module->memory_count > 0)
+        is_memory64 = module->memories[0].flags & MEMORY64_FLAG;
+
+    mem_offset_type = is_memory64 ? VALUE_TYPE_I64 : VALUE_TYPE_I32;
+#else
+    mem_offset_type = VALUE_TYPE_I32;
 #endif
 
     global_count = module->import_global_count + module->global_count;
@@ -5999,19 +6009,6 @@ re_scan:
         func->code_compiled = loader_ctx->p_code_compiled;
         func->code_compiled_size = loader_ctx->code_compiled_size;
     }
-#endif
-
-#if WASM_ENABLE_MEMORY64 != 0
-    /* TODO: multi-memories for now assuming the memory idx type is consistent
-     * across multi-memories */
-    if (module->import_memory_count > 0)
-        is_memory64 = module->import_memories[0].u.memory.flags & MEMORY64_FLAG;
-    else if (module->memory_count > 0)
-        is_memory64 = module->memories[0].flags & MEMORY64_FLAG;
-
-    mem_offset_type = is_memory64 ? VALUE_TYPE_I64 : VALUE_TYPE_I32;
-#else
-    mem_offset_type = VALUE_TYPE_I32;
 #endif
 
     PUSH_CSP(LABEL_TYPE_FUNCTION, func_block_type, p);

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -310,8 +310,9 @@ memory_instantiate(WASMModuleInstance *module_inst, WASMModuleInstance *parent,
     bh_assert(memory != NULL);
 
     if (wasm_allocate_linear_memory(&memory->memory_data, is_shared_memory,
-                                    num_bytes_per_page, init_page_count,
-                                    max_page_count, &memory_data_size)
+                                    memory->is_memory64, num_bytes_per_page,
+                                    init_page_count, max_page_count,
+                                    &memory_data_size)
         != BHT_OK) {
         set_error_buf(error_buf, error_buf_size,
                       "allocate linear memory failed");

--- a/core/iwasm/libraries/libc-builtin/libc_builtin_wrapper.c
+++ b/core/iwasm/libraries/libc-builtin/libc_builtin_wrapper.c
@@ -17,7 +17,7 @@ void
 wasm_runtime_set_exception(wasm_module_inst_t module, const char *exception);
 
 uint32
-wasm_runtime_module_realloc(wasm_module_inst_t module, uint32 ptr, uint32 size,
+wasm_runtime_module_realloc(wasm_module_inst_t module, uint64 ptr, uint64 size,
                             void **p_native_addr);
 
 /* clang-format off */

--- a/core/shared/platform/common/posix/posix_memmap.c
+++ b/core/shared/platform/common/posix/posix_memmap.c
@@ -65,9 +65,11 @@ os_mmap(void *hint, size_t size, int prot, int flags, os_file_handle file)
         /* integer overflow */
         return NULL;
 
+#if WASM_ENABLE_MEMORY64 == 0
     if (request_size > 16 * (uint64)UINT32_MAX)
-        /* at most 16 G is allowed */
+        /* at most 64 G is allowed */
         return NULL;
+#endif
 
     if (prot & MMAP_PROT_READ)
         map_prot |= PROT_READ;


### PR DESCRIPTION
- supported threads opcodes in classic-interpreter
- supported memory64 memory in related runtime API
- modified main function type check when it's memory64 wasm file
- modified `wasm_runtime_invoke_native` and `wasm_runtime_invoke_native_raw` to handle registered native function pointer argument when memory64 is enabled