### PR TITLE
Add wamr to esp-idf components registry.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,11 @@
 
 cmake_minimum_required (VERSION 3.0)
 
+if(ESP_PLATFORM)
+  include (${COMPONENT_DIR}/build-scripts/esp-idf/wamr/CMakeLists.txt)
+  return()
+endif()
+
 project (iwasm)
 
 set (CMAKE_VERBOSE_MAKEFILE OFF)

--- a/core/shared/platform/esp-idf/espidf_memmap.c
+++ b/core/shared/platform/esp-idf/espidf_memmap.c
@@ -55,7 +55,23 @@ os_mmap(void *hint, size_t size, int prot, int flags, os_file_handle file)
 #else
         uint32_t mem_caps = MALLOC_CAP_8BIT;
 #endif
-        return heap_caps_malloc(size, mem_caps);
+        void *buf_origin = heap_caps_malloc(size, mem_caps);
+        if (!buf_origin) {
+            return NULL;
+        }
+
+        // Memory allocation with MALLOC_CAP_SPIRAM or MALLOC_CAP_8BIT will
+        // return 4-byte aligned Reserve extra 4 byte to fixup alignment and
+        // size for the pointer to the originally allocated address
+        void *buf_fixed = buf_origin + sizeof(void *);
+        if ((uintptr_t)buf_fixed & (uintptr_t)0x7) {
+            buf_fixed = (void *)((uintptr_t)(buf_fixed + 4) & (~(uintptr_t)7));
+        }
+
+        uintptr_t *addr_field = buf_fixed - sizeof(uintptr_t);
+        *addr_field = (uintptr_t)buf_origin;
+
+        return buf_fixed;
     }
 }
 

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,8 @@
+version: "1.3.2"
+description: WebAssembly Micro Runtime - A lightweight standalone WebAssembly (Wasm) runtime with small footprint, high performance and highly configurable features
+url: https://bytecodealliance.org/
+repository: https://github.com/bytecodealliance/wasm-micro-runtime.git
+documentation: https://wamr.gitbook.io/
+issues: https://github.com/bytecodealliance/wasm-micro-runtime/issues
+dependencies:
+  idf: ">=4.4"

--- a/product-mini/platforms/esp-idf/CMakeLists.txt
+++ b/product-mini/platforms/esp-idf/CMakeLists.txt
@@ -6,7 +6,4 @@ cmake_minimum_required(VERSION 3.5)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
-set (COMPONENTS ${IDF_TARGET} main freertos esptool_py wamr)
-list(APPEND EXTRA_COMPONENT_DIRS "$ENV{WAMR_PATH}/build-scripts/esp-idf")
-
 project(wamr-simple)

--- a/product-mini/platforms/esp-idf/main/CMakeLists.txt
+++ b/product-mini/platforms/esp-idf/main/CMakeLists.txt
@@ -2,5 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 idf_component_register(SRCS "main.c"
-                    INCLUDE_DIRS "."
-                    REQUIRES wamr)
+                    INCLUDE_DIRS ".")

--- a/product-mini/platforms/esp-idf/main/idf_component.yml
+++ b/product-mini/platforms/esp-idf/main/idf_component.yml
@@ -1,0 +1,7 @@
+## IDF Component Manager Manifest File
+dependencies:
+  wasm-micro-runtime:
+    version: ">=1.3"
+    override_path: "../../../.."
+  idf:
+    version: ">=4.4"

--- a/product-mini/platforms/esp-idf/main/main.c
+++ b/product-mini/platforms/esp-idf/main/main.c
@@ -12,11 +12,7 @@
 
 #include "esp_log.h"
 
-#ifdef CONFIG_IDF_TARGET_ESP32S3
 #define IWASM_MAIN_STACK_SIZE 5120
-#else
-#define IWASM_MAIN_STACK_SIZE 4096
-#endif
 
 #define LOG_TAG "wamr"
 


### PR DESCRIPTION
Espressif has [ESP-IDF component registry](https://components.espressif.com/) to manage external components, and developers can use this directly and easily.

I plan to add `wasm-micro-runtime` to this registry, but it seems that wasm-micro-runtime team will not plan to cost much resource to maintain ESP-IDF platform and its related things, so I discuss with some internal Espressif developers. We hope you approve to let us publish WAMR into this registry with specific version(not WAMR official version). If some patches need to add for ESP-IDF platform, I will raised PR here, and when this PR is merged, I publish new version to registry.

If you want to register account in this registry, please add me into your namespace with necessary access permissions, otherwise we plan to use our own account to publish WAMR.