### PR TITLE
Fix CI error when install packages for macos-14

### DIFF
--- a/.github/workflows/build_llvm_libraries.yml
+++ b/.github/workflows/build_llvm_libraries.yml
@@ -33,8 +33,14 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - name: install dependencies
+      - name: install dependencies for non macos-14
+        if: inputs.os != 'macos-14'
         run: /usr/bin/env python3 -m pip install -r requirements.txt
+        working-directory: build-scripts
+
+      - name: install dependencies for macos-14
+        if: inputs.os == 'macos-14'
+        run: /usr/bin/env python3 -m pip install -r requirements.txt --break-system-packages
         working-directory: build-scripts
 
       - name: retrive the last commit ID


### PR DESCRIPTION
MacOS CI ran failed with "error: externally-managed-environment" reported
when installing dependencies. Add argument "--break-system-packages" to
fix it.

ps.
https://github.com/bytecodealliance/wasm-micro-runtime/actions/runs/8503917001/job/23291537189
https://github.com/bytecodealliance/wasm-micro-runtime/actions/runs/8502961539/job/23289867170