### PR TITLE
Release CI update

### DIFF
--- a/.github/scripts/fetch_and_compare_version.py
+++ b/.github/scripts/fetch_and_compare_version.py
@@ -42,9 +42,12 @@ def fetch_version_from_code():
 
 
 def fetch_latest_git_tag():
-    list_tag_cmd = (
-        'git tag --list WAMR-*.*.* --sort=committerdate --format="%(refname:short)"'
-    )
+    """
+    Get the most recent tag from the HEAD,
+    if it's main branch, it should be the latest release tag.
+    if it's release/x.x.x branch, it should be the latest release tag of the branch.
+    """
+    list_tag_cmd = "git describe --tags --abbrev=0 HEAD"
     p = subprocess.run(shlex.split(list_tag_cmd), capture_output=True, check=True)
 
     all_tags = p.stdout.decode().strip()

--- a/.github/workflows/build_wamr_lldb.yml
+++ b/.github/workflows/build_wamr_lldb.yml
@@ -82,9 +82,7 @@ jobs:
       - name: install utils macos
         if: steps.lldb_build_cache.outputs.cache-hit != 'true' && contains(inputs.runner, 'macos')
         run: |
-          brew remove swig
-          brew install swig@4.1 cmake ninja libedit
-          brew link --overwrite swig@4.1
+          brew install swig cmake ninja libedit
           sudo rm -rf /Library/Developer/CommandLineTools
 
       - name: install utils ubuntu

--- a/.github/workflows/build_wamr_sdk.yml
+++ b/.github/workflows/build_wamr_sdk.yml
@@ -58,6 +58,12 @@ jobs:
           sudo rm ${basename}
           sudo mv wasi-sdk-* wasi-sdk
 
+      - name: download dependencies
+        run: |
+          cd ./wamr-app-framework/deps
+          ./download.sh
+        working-directory: wamr-sdk
+
       - name: generate wamr-sdk release
         run: |
           cd ./wamr-app-framework/wamr-sdk

--- a/.github/workflows/create_tag.yml
+++ b/.github/workflows/create_tag.yml
@@ -32,8 +32,22 @@ jobs:
       - name: prepare
         id: preparation
         run: |
-          # show latest 3 versions
-          git tag --list WAMR-*.*.* --sort=committerdate --format="%(refname:short)" | tail -n 3
+          # show latest 3 versions on the branch that create release
+          # Set the initial commit to the head of the branch
+          commit="HEAD"
+          # 
+          # Loop to get the three most recent tags
+          for i in {1..3}
+          do
+              # Get the most recent tag reachable from the current commit
+              tag=$(git describe --tags --abbrev=0 $commit)
+
+              # Print the tag
+              echo "$tag"
+
+              # Move to the commit before the found tag to find the next tag in the next iteration
+              commit=$(git rev-list -n 1 $tag^)
+          done
           # compare latest git tag and semantic version definition
           result=$(python3 ./.github/scripts/fetch_and_compare_version.py)
           echo "script result is ${result}"


### PR DESCRIPTION
- In the release CI and related scripts, when comparing and printing to the CI, use the most recent **ancestor** tag(s) for the release branch rather than the most recent one(s)
- Fix build_wamr_sdk CI