### PR TITLE
Update esp-idf platform support in main

### DIFF
--- a/core/shared/platform/esp-idf/espidf_platform.c
+++ b/core/shared/platform/esp-idf/espidf_platform.c
@@ -6,6 +6,12 @@
 #include "platform_api_vmcore.h"
 #include "platform_api_extension.h"
 
+#if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)) \
+    && (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 2, 0))
+#define UTIMENSAT_TIMESPEC_POINTER 1
+#define FUTIMENS_TIMESPEC_POINTER 1
+#endif
+
 int
 bh_platform_init()
 {
@@ -234,7 +240,13 @@ unlinkat(int fd, const char *path, int flag)
 }
 
 int
-utimensat(int fd, const char *path, const struct timespec ts[2], int flag)
+utimensat(int fd, const char *path,
+#if UTIMENSAT_TIMESPEC_POINTER
+          const struct timespec *ts,
+#else
+          const struct timespec ts[2],
+#endif
+          int flag)
 {
     errno = ENOSYS;
     return -1;
@@ -257,7 +269,13 @@ ftruncate(int fd, off_t length)
 #endif
 
 int
-futimens(int fd, const struct timespec times[2])
+futimens(int fd,
+#if FUTIMENS_TIMESPEC_POINTER
+         const struct timespec *times
+#else
+         const struct timespec times[2]
+#endif
+)
 {
     errno = ENOSYS;
     return -1;

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -6,3 +6,10 @@ documentation: https://wamr.gitbook.io/
 issues: https://github.com/bytecodealliance/wasm-micro-runtime/issues
 dependencies:
   idf: ">=4.4"
+targets:
+  - esp32
+  - esp32s3
+  - esp32c3
+  - esp32c6
+examples:
+  - path: product-mini/platforms/esp-idf

--- a/product-mini/platforms/esp-idf/main/idf_component.yml
+++ b/product-mini/platforms/esp-idf/main/idf_component.yml
@@ -1,7 +1,7 @@
 ## IDF Component Manager Manifest File
 dependencies:
   wasm-micro-runtime:
-    version: ">=2.0"
+    version: "^2"
     override_path: "../../../.."
   idf:
     version: ">=4.4"


### PR DESCRIPTION
Update esp-idf platform support in main:

1. Fix API "futimens" and "utimensat" compiling error in different esp-idf version
2. Update component registry description file