### PR TITLE
Fix posix_fadvise error handling

### DIFF
--- a/core/shared/platform/common/posix/posix_file.c
+++ b/core/shared/platform/common/posix/posix_file.c
@@ -823,7 +823,7 @@ os_fadvise(os_file_handle handle, __wasi_filesize_t offset,
 
     int ret = posix_fadvise(handle, (off_t)offset, (off_t)length, nadvice);
 
-    if (ret < 0)
+    if (ret != 0)
         return convert_errno(ret);
 
     return __WASI_ESUCCESS;


### PR DESCRIPTION
`posix_fadvise()` returns 0 on success and the errno on error.  This commit fixes the handling of the return value such that it does not always succeeds.

fixes #3322