### PR TITLE
Fix readdir for posix

### DIFF
--- a/core/shared/platform/common/posix/posix_file.c
+++ b/core/shared/platform/common/posix/posix_file.c
@@ -922,7 +922,8 @@ os_readdir(os_dir_stream dir_stream, __wasi_dirent_t *entry,
         *d_name = NULL;
         if (errno != 0) {
             return convert_errno(errno);
-        } else {
+        }
+        else {
             return 0;
         }
     }

--- a/core/shared/platform/common/posix/posix_file.c
+++ b/core/shared/platform/common/posix/posix_file.c
@@ -920,7 +920,11 @@ os_readdir(os_dir_stream dir_stream, __wasi_dirent_t *entry,
 
     if (dent == NULL) {
         *d_name = NULL;
-        return convert_errno(errno);
+        if (errno != 0) {
+            return convert_errno(errno);
+        } else {
+            return 0;
+        }
     }
 
     long offset = (__wasi_dircookie_t)telldir(dir_stream);


### PR DESCRIPTION
This PR fixes a readir for posix. readdir is not working correctly in rust.

The current WAMR's readdir implementation for posix is,
If readdir returns 0, it will exit with an error.

https://github.com/bytecodealliance/wasm-micro-runtime/blob/e7a8b3e743f8821eddbfc526eec19782c51c8408/core/shared/platform/common/posix/posix_file.c#L921

Posix readdir returns 0 at the end of the directory. To handle this correctly, if readdir returns 0, it should only raise an error if errno has changed.

You can reproduce it with the following rust code.

```rust
use std::fs;

fn main() {
    let entries  = fs::read_dir(".").unwrap();
    for entry in entries {
        println!("read_dir:{:?}", entry);
    }
}
```

```shell
# Ubuntu 22
% iwasm --dir=. rust_wasm_readdir.wasm
read_dir:Err(Os { code: 52, kind: Unsupported, message: "Function not implemented" }
```

It seems that readdir is implemented differently in C and Rust, and a similar implementation in C did not cause this problem.

This problem didn't occur on Mac + iwasm. But this occured on Linux + iwasm.  