### PR TITLE
Fix ESP32-S3 compiling error

### DIFF
--- a/core/shared/platform/esp-idf/espidf_memmap.c
+++ b/core/shared/platform/esp-idf/espidf_memmap.c
@@ -9,11 +9,10 @@
 #include "soc/mmu.h"
 #include "rom/cache.h"
 
-#define MEM_DUAL_BUS_OFFSET (IRAM0_CACHE_ADDRESS_LOW - DRAM0_CACHE_ADDRESS_LOW)
+#define MEM_DUAL_BUS_OFFSET (SOC_IROM_LOW - SOC_IROM_HIGH)
 
-#define in_ibus_ext(addr)                      \
-    (((uint32)addr >= IRAM0_CACHE_ADDRESS_LOW) \
-     && ((uint32)addr < IRAM0_CACHE_ADDRESS_HIGH))
+#define in_ibus_ext(addr) \
+    (((uint32)addr >= SOC_IROM_LOW) && ((uint32)addr < SOC_IROM_HIGH))
 
 static portMUX_TYPE s_spinlock = portMUX_INITIALIZER_UNLOCKED;
 #endif

--- a/core/shared/platform/esp-idf/platform_internal.h
+++ b/core/shared/platform/esp-idf/platform_internal.h
@@ -56,38 +56,28 @@ typedef unsigned int korp_sem;
 #define UTIME_OMIT ((1l << 30) - 2l)
 #endif
 
-#ifdef DT_UNKNOWN
-#undef DT_UNKNOWN
-#endif
-
-#ifdef DT_REG
-#undef DT_REG
-#endif
-
-#ifdef DT_DIR
-#undef DT_DIR
-#endif
-
 /* Below parts of d_type define are ported from Nuttx, under Apache License v2.0
  */
 
-/* File type code for the d_type field in dirent structure.
- * Note that because of the simplified filesystem organization of the NuttX,
- * top-level, pseudo-file system, an inode can be BOTH a file and a directory
+/* Following macros are defined in espressif GCC of esp-idf v5.3
  */
 
 #define DTYPE_UNKNOWN 0
-#define DTYPE_FIFO 1
-#define DTYPE_CHR 2
-#define DTYPE_SEM 3
-#define DTYPE_DIRECTORY 4
-#define DTYPE_MQ 5
-#define DTYPE_BLK 6
-#define DTYPE_SHM 7
-#define DTYPE_FILE 8
-#define DTYPE_MTD 9
+#define DTYPE_FILE 1
+#define DTYPE_DIRECTORY 2
+#define DTYPE_CHR 4
+#define DTYPE_BLK 5
+#define DTYPE_FIFO 8
 #define DTYPE_LINK 10
 #define DTYPE_SOCK 12
+
+/* Following macros are not defined in espressif GCC of esp-idf v5.3
+ */
+
+#define DTYPE_SEM 100
+#define DTYPE_MQ 101
+#define DTYPE_SHM 102
+#define DTYPE_MTD 103
 
 /* The d_type field of the dirent structure is not specified by POSIX.  It
  * is a non-standard, 4.5BSD extension that is implemented by most OSs.  A
@@ -96,18 +86,53 @@ typedef unsigned int korp_sem;
  * type names:
  */
 
+#ifndef DT_UNKNOWN
 #define DT_UNKNOWN DTYPE_UNKNOWN
+#endif
+
+#ifndef DT_FIFO
 #define DT_FIFO DTYPE_FIFO
+#endif
+
+#ifndef DT_CHR
 #define DT_CHR DTYPE_CHR
+#endif
+
+#ifndef DT_SEM
 #define DT_SEM DTYPE_SEM
+#endif
+
+#ifndef DT_DIR
 #define DT_DIR DTYPE_DIRECTORY
+#endif
+
+#ifndef DT_MQ
 #define DT_MQ DTYPE_MQ
+#endif
+
+#ifndef DT_BLK
 #define DT_BLK DTYPE_BLK
+#endif
+
+#ifndef DT_SHM
 #define DT_SHM DTYPE_SHM
+#endif
+
+#ifndef DT_REG
 #define DT_REG DTYPE_FILE
+#endif
+
+#ifndef DT_MTD
 #define DT_MTD DTYPE_MTD
+#endif
+
+#ifndef DT_LNK
 #define DT_LNK DTYPE_LINK
+#endif
+
+#ifndef DT_SOCK
 #define DT_SOCK DTYPE_SOCK
+#endif
 
 static inline int
 os_getpagesize()


### PR DESCRIPTION

Fix ESP32-S3 compiling error:
1.  when enable SPIRAM
2. when using esp-idf v5.3