### PR TITLE
CI: --break-system-packages

### DIFF
--- a/.github/workflows/build_llvm_libraries.yml
+++ b/.github/workflows/build_llvm_libraries.yml
@@ -35,12 +35,12 @@ jobs:
 
       - name: install dependencies for non macos-14
         if: inputs.os != 'macos-14'
-        run: /usr/bin/env python3 -m pip install -r requirements.txt
+        run: /usr/bin/env python3 -m pip install --break-system-packages -r requirements.txt
         working-directory: build-scripts
 
       - name: install dependencies for macos-14
         if: inputs.os == 'macos-14'
-        run: /usr/bin/env python3 -m pip install -r requirements.txt --break-system-packages
+        run: /usr/bin/env python3 -m pip install --break-system-packages -r requirements.txt --break-system-packages
         working-directory: build-scripts
 
       - name: retrive the last commit ID


### PR DESCRIPTION
The following error was observed with the latest github macOS runner. This commit add the --break-system-packages option as suggested by the error messsage.

```
  Image: macos-14-arm64
  Version: 20240422.3
  Included Software: https://github.com/actions/runner-images/blob/macos-14-arm64/20240422.3/images/macos/macos-14-arm64-Readme.md
  Image Release: https://github.com/actions/runner-images/releases/tag/macos-14-arm64%2F20240422.3
```

```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try brew install
    xyz, where xyz is the package you are trying to
    install.

    If you wish to install a Python library that isn't in Homebrew,
    use a virtual environment:

    python3 -m venv path/to/venv
    source path/to/venv/bin/activate
    python3 -m pip install xyz

    If you wish to install a Python application that isn't in Homebrew,
    it may be easiest to use 'pipx install xyz', which will manage a
    virtual environment for you. You can install pipx with

    brew install pipx

    You may restore the old behavior of pip by passing
    the '--break-system-packages' flag to pip, or by adding
    'break-system-packages = true' to your pip.conf file. The latter
    will permanently disable this error.

    If you disable this error, we STRONGLY recommend that you additionally
    pass the '--user' flag to pip, or set 'user = true' in your pip.conf
    file. Failure to do this can result in a broken Homebrew installation.

    Read more about this behavior here: <https://peps.python.org/pep-0668/>

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```