### PR TITLE
Fix a pip instatllion failure in CI in macos-latest

### DIFF
--- a/.github/workflows/build_llvm_libraries.yml
+++ b/.github/workflows/build_llvm_libraries.yml
@@ -33,17 +33,11 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - name: install dependencies for non macos-14
-        if: inputs.os != 'macos-14'
-        run: /usr/bin/env python3 -m pip install -r requirements.txt
-        working-directory: build-scripts
-
-      - name: install dependencies for macos-14
-        if: inputs.os == 'macos-14'
+      - name: install dependencies
         run: /usr/bin/env python3 -m pip install -r requirements.txt --break-system-packages
         working-directory: build-scripts
 
-      - name: retrive the last commit ID
+      - name: retrieve the last commit ID
         id: get_last_commit
         run: echo "last_commit=$(GH_TOKEN=${{ secrets.GITHUB_TOKEN }} /usr/bin/env python3 ./build_llvm.py --llvm-ver)" >> $GITHUB_OUTPUT
         working-directory: build-scripts


### PR DESCRIPTION
Run /usr/bin/env python3 -m pip install -r requirements.txt error: externally-managed-environment

× This environment is externally managed
...