### PR TITLE
Use uint32_t for value passed to memmove and memset

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -2957,13 +2957,13 @@ aot_check_app_addr_and_convert(AOTModuleInstance *module_inst, bool is_str,
 }
 
 void *
-aot_memmove(void *dest, const void *src, size_t n)
+aot_memmove(void *dest, const void *src, uint32_t n)
 {
     return memmove(dest, src, n);
 }
 
 void *
-aot_memset(void *s, int c, size_t n)
+aot_memset(void *s, int c, uint32_t n)
 {
     return memset(s, c, n);
 }

--- a/core/iwasm/aot/aot_runtime.h
+++ b/core/iwasm/aot/aot_runtime.h
@@ -613,10 +613,10 @@ uint32
 aot_get_plt_table_size();
 
 void *
-aot_memmove(void *dest, const void *src, size_t n);
+aot_memmove(void *dest, const void *src, uint32_t n);
 
 void *
-aot_memset(void *s, int c, size_t n);
+aot_memset(void *s, int c, uint32_t n);
 
 double
 aot_sqrt(double x);


### PR DESCRIPTION
On a 64 bit host the top bits of `n` here can be garbage (as the value is 32bit in the wasm memory).

I have promised @loganek I'll write some tests for this in `tests/wamr-compiler` but so far I haven't made a minimal reproduction, will update the PR when I've done that.