### PR TITLE
aot compiler: Fix the length type passed to aot_memmove/aot_memset

### DIFF
--- a/core/iwasm/compilation/aot_compiler.h
+++ b/core/iwasm/compilation/aot_compiler.h
@@ -603,6 +603,7 @@ set_local_gc_ref(AOTCompFrame *frame, int n, LLVMValueRef value, uint8 ref_type)
 #define INT8_TYPE comp_ctx->basic_types.int8_type
 #define INT16_TYPE comp_ctx->basic_types.int16_type
 #define INTPTR_T_TYPE comp_ctx->basic_types.intptr_t_type
+#define SIZE_T_TYPE comp_ctx->basic_types.size_t_type
 #define MD_TYPE comp_ctx->basic_types.meta_data_type
 #define INT8_PTR_TYPE comp_ctx->basic_types.int8_ptr_type
 #define INT16_PTR_TYPE comp_ctx->basic_types.int16_ptr_type

--- a/core/iwasm/compilation/aot_emit_memory.c
+++ b/core/iwasm/compilation/aot_emit_memory.c
@@ -1094,7 +1094,7 @@ aot_compile_op_memory_copy(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
         /* zero extend to uint64 if the target is 64-bit */
         len = LLVMBuildZExt(comp_ctx->builder, len, I64_TYPE, "len64");
         if (!len) {
-            aot_set_last_error("llvm build bitcast failed.");
+            aot_set_last_error("llvm build zero extend failed.");
             return false;
         }
     }
@@ -1185,7 +1185,7 @@ aot_compile_op_memory_fill(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
         /* zero extend to uint64 if the target is 64-bit */
         len = LLVMBuildZExt(comp_ctx->builder, len, I64_TYPE, "len64");
         if (!len) {
-            aot_set_last_error("llvm build bitcast failed.");
+            aot_set_last_error("llvm build zero extend failed.");
             return false;
         }
     }

--- a/core/iwasm/compilation/aot_emit_memory.c
+++ b/core/iwasm/compilation/aot_emit_memory.c
@@ -1090,6 +1090,15 @@ aot_compile_op_memory_copy(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
     if (!(dst_addr = check_bulk_memory_overflow(comp_ctx, func_ctx, dst, len)))
         return false;
 
+    if (comp_ctx->pointer_size == sizeof(uint64)) {
+        /* zero extend to uint64 if the target is 64-bit */
+        len = LLVMBuildZExt(comp_ctx->builder, len, I64_TYPE, "len64");
+        if (!len) {
+            aot_set_last_error("llvm build bitcast failed.");
+            return false;
+        }
+    }
+
     call_aot_memmove = comp_ctx->is_indirect_mode || comp_ctx->is_jit_mode;
     if (call_aot_memmove) {
         LLVMTypeRef param_types[3], ret_type, func_type, func_ptr_type;
@@ -1097,7 +1106,7 @@ aot_compile_op_memory_copy(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 
         param_types[0] = INT8_PTR_TYPE;
         param_types[1] = INT8_PTR_TYPE;
-        param_types[2] = I32_TYPE;
+        param_types[2] = INTPTR_T_TYPE; /* int32 for 32-bit, int64 for 64-bit */
         ret_type = INT8_PTR_TYPE;
 
         if (!(func_type = LLVMFunctionType(ret_type, param_types, 3, false))) {
@@ -1172,9 +1181,18 @@ aot_compile_op_memory_fill(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
     if (!(dst_addr = check_bulk_memory_overflow(comp_ctx, func_ctx, dst, len)))
         return false;
 
+    if (comp_ctx->pointer_size == sizeof(uint64)) {
+        /* zero extend to uint64 if the target is 64-bit */
+        len = LLVMBuildZExt(comp_ctx->builder, len, I64_TYPE, "len64");
+        if (!len) {
+            aot_set_last_error("llvm build bitcast failed.");
+            return false;
+        }
+    }
+
     param_types[0] = INT8_PTR_TYPE;
     param_types[1] = I32_TYPE;
-    param_types[2] = I32_TYPE;
+    param_types[2] = INTPTR_T_TYPE; /* int32 for 32-bit, int64 for 64-bit */
     ret_type = INT8_PTR_TYPE;
 
     if (!(func_type = LLVMFunctionType(ret_type, param_types, 3, false))) {

--- a/core/iwasm/compilation/aot_emit_memory.c
+++ b/core/iwasm/compilation/aot_emit_memory.c
@@ -1106,7 +1106,7 @@ aot_compile_op_memory_copy(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 
         param_types[0] = INT8_PTR_TYPE;
         param_types[1] = INT8_PTR_TYPE;
-        param_types[2] = INTPTR_T_TYPE; /* int32 for 32-bit, int64 for 64-bit */
+        param_types[2] = SIZE_T_TYPE;
         ret_type = INT8_PTR_TYPE;
 
         if (!(func_type = LLVMFunctionType(ret_type, param_types, 3, false))) {
@@ -1192,7 +1192,7 @@ aot_compile_op_memory_fill(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 
     param_types[0] = INT8_PTR_TYPE;
     param_types[1] = I32_TYPE;
-    param_types[2] = INTPTR_T_TYPE; /* int32 for 32-bit, int64 for 64-bit */
+    param_types[2] = SIZE_T_TYPE;
     ret_type = INT8_PTR_TYPE;
 
     if (!(func_type = LLVMFunctionType(ret_type, param_types, 3, false))) {

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -1973,10 +1973,12 @@ aot_set_llvm_basic_types(AOTLLVMTypes *basic_types, LLVMContextRef context,
     if (pointer_size == 4) {
         basic_types->intptr_t_type = basic_types->int32_type;
         basic_types->intptr_t_ptr_type = basic_types->int32_ptr_type;
+        basic_types->size_t_type = basic_types->int32_type;
     }
     else {
         basic_types->intptr_t_type = basic_types->int64_type;
         basic_types->intptr_t_ptr_type = basic_types->int64_ptr_type;
+        basic_types->size_t_type = basic_types->int64_type;
     }
 
     basic_types->gc_ref_type = basic_types->int8_ptr_type;

--- a/core/iwasm/compilation/aot_llvm.h
+++ b/core/iwasm/compilation/aot_llvm.h
@@ -262,6 +262,7 @@ typedef struct AOTLLVMTypes {
     LLVMTypeRef int32_type;
     LLVMTypeRef int64_type;
     LLVMTypeRef intptr_t_type;
+    LLVMTypeRef size_t_type;
     LLVMTypeRef float32_type;
     LLVMTypeRef float64_type;
     LLVMTypeRef void_type;


### PR DESCRIPTION
The current length type of aot_memmove/aot_memset is size_t, and on
a 64 bit host it is uint64, while what the aot code passes to it is uint32,
this might lead to unexpected behavior.

ps. https://github.com/bytecodealliance/wasm-micro-runtime/pull/3376.