### PR TITLE
samples/native-stack-overflow: examine native functions with signature

### DIFF
--- a/samples/native-stack-overflow/build.sh
+++ b/samples/native-stack-overflow/build.sh
@@ -41,6 +41,11 @@ if [ $? != 0 ];then
 fi
 cp -a native-stack-overflow ${OUT_DIR}/native-stack-overflow.WAMR_DISABLE_HW_BOUND_CHECK
 
+echo "##################### signature shared lib"
+cd ${CURR_DIR}
+cc -I ../../core/iwasm/include -shared -o ${OUT_DIR}/signature.so \
+src/signature.c
+
 echo
 
 echo "##################### build wasm apps"
@@ -69,7 +74,30 @@ echo "#################### build wasm apps done"
 
 echo "#################### aot-compile"
 WAMRC=${WAMR_DIR}/wamr-compiler/build/wamrc
-${WAMRC} -o ${OUT_DIR}/wasm-apps/${OUT_FILE}.aot --size-level=0 ${OUT_DIR}/wasm-apps/${OUT_FILE}
+${WAMRC} \
+-o ${OUT_DIR}/wasm-apps/${OUT_FILE}.aot \
+--size-level=0 \
+${OUT_DIR}/wasm-apps/${OUT_FILE}
+
+echo "#################### aot-compile w/ signature"
+WAMRC=${WAMR_DIR}/wamr-compiler/build/wamrc
+${WAMRC} \
+-o ${OUT_DIR}/wasm-apps/${OUT_FILE}.aot.signature \
+--size-level=0 \
+--native-lib=${OUT_DIR}/signature.so \
+${OUT_DIR}/wasm-apps/${OUT_FILE}
 
 echo "#################### aot-compile (--bounds-checks=1)"
-${WAMRC} -o ${OUT_DIR}/wasm-apps/${OUT_FILE}.aot.bounds-checks --size-level=0 --bounds-checks=1 ${OUT_DIR}/wasm-apps/${OUT_FILE}
+${WAMRC} \
+-o ${OUT_DIR}/wasm-apps/${OUT_FILE}.aot.bounds-checks \
+--size-level=0 \
+--bounds-checks=1 \
+${OUT_DIR}/wasm-apps/${OUT_FILE}
+
+echo "#################### aot-compile (--bounds-checks=1) w/ signature"
+${WAMRC} \
+-o ${OUT_DIR}/wasm-apps/${OUT_FILE}.aot.signature.bounds-checks \
+--size-level=0 \
+--native-lib=${OUT_DIR}/signature.so \
+--bounds-checks=1 \
+${OUT_DIR}/wasm-apps/${OUT_FILE}

--- a/samples/native-stack-overflow/run.sh
+++ b/samples/native-stack-overflow/run.sh
@@ -16,5 +16,13 @@ echo "====== AOT ${NAME}"
 out/native-stack-overflow out/wasm-apps/testapp.wasm.aot ${NAME}
 
 echo
+echo "====== AOT w/ signature ${NAME}"
+out/native-stack-overflow out/wasm-apps/testapp.wasm.aot.signature ${NAME}
+
+echo
 echo "====== AOT WAMR_DISABLE_HW_BOUND_CHECK=1 ${NAME}"
 out/native-stack-overflow.WAMR_DISABLE_HW_BOUND_CHECK out/wasm-apps/testapp.wasm.aot.bounds-checks ${NAME}
+
+echo
+echo "====== AOT w/ signature WAMR_DISABLE_HW_BOUND_CHECK=1 ${NAME}"
+out/native-stack-overflow.WAMR_DISABLE_HW_BOUND_CHECK out/wasm-apps/testapp.wasm.aot.signature.bounds-checks ${NAME}

--- a/samples/native-stack-overflow/src/signature.c
+++ b/samples/native-stack-overflow/src/signature.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 Midokura Japan KK.  All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "wasm_export.h"
+
+static int
+dummy(wasm_exec_env_t exec_env)
+{
+    return 0;
+}
+
+/* clang-format off */
+#define REG_NATIVE_FUNC(func_name, signature) \
+    { #func_name, dummy, signature, NULL }
+
+static NativeSymbol native_symbols[] = {
+    REG_NATIVE_FUNC(host_consume_stack_and_call_indirect, "(iii)i"),
+    REG_NATIVE_FUNC(host_consume_stack, "(i)i"),
+};
+/* clang-format on */
+
+uint32_t
+get_native_lib(char **p_module_name, NativeSymbol **p_native_symbols)
+{
+    *p_module_name = "env";
+    *p_native_symbols = native_symbols;
+    return sizeof(native_symbols) / sizeof(NativeSymbol);
+}


### PR DESCRIPTION
Note: wamrc chooses different methods to call native functions with and without signatures.