### PR TITLE
Allow no-op empty fd_pread

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -830,9 +830,6 @@ wasmtime_ssp_fd_pread(wasm_exec_env_t exec_env, struct fd_table *curfds,
                       __wasi_fd_t fd, const __wasi_iovec_t *iov, size_t iovcnt,
                       __wasi_filesize_t offset, size_t *nread)
 {
-    if (iovcnt == 0)
-        return __WASI_EINVAL;
-
     struct fd_object *fo;
     __wasi_errno_t error =
         fd_object_get(curfds, &fo, fd, __WASI_RIGHT_FD_READ, 0);

--- a/core/shared/platform/common/posix/posix_file.c
+++ b/core/shared/platform/common/posix/posix_file.c
@@ -469,6 +469,11 @@ os_preadv(os_file_handle handle, const struct __wasi_iovec_t *iov, int iovcnt,
     *nread = (size_t)len;
     return __WASI_ESUCCESS;
 #else
+    if (iovcnt == 0) {
+        *nread = 0;
+        return __WASI_ESUCCESS;
+    }
+
     if (iovcnt == 1) {
         ssize_t len = pread(handle, iov->buf, iov->buf_len, offset);
 


### PR DESCRIPTION
This commit removes an unnecessary check on `iovcnt` in the implementation of `fd_pread`.  This new behavior aligns with those of Wasmtime, Node, and Wasmer as well as native host Linux.

fixes #3394