### PR TITLE
Correct default value for wasm local variable(externref and funcref)

### DIFF
--- a/core/iwasm/fast-jit/jit_frontend.c
+++ b/core/iwasm/fast-jit/jit_frontend.c
@@ -1242,6 +1242,16 @@ init_func_translation(JitCompContext *cc)
         GEN_INSN(STI32, NEW_CONST(I32, 0), cc->fp_reg,
                  NEW_CONST(I32, local_off));
     }
+    /* externref/funcref should be NULL_REF rather than 0 */
+    local_off = (uint32)offsetof(WASMInterpFrame, lp)
+                + cur_wasm_func->param_cell_num * 4;
+    for (i = 0; i < cur_wasm_func->local_cell_num; i++) {
+        if (cur_wasm_func->local_types[i] == VALUE_TYPE_EXTERNREF
+            || cur_wasm_func->local_types[i] == VALUE_TYPE_FUNCREF) {
+            GEN_INSN(STI32, NEW_CONST(I32, NULL_REF), cc->fp_reg,
+                     NEW_CONST(I32, local_off));
+        }
+    }
 
     return jit_frame;
 }

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -6545,6 +6545,13 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
             /* Initialize the local variables */
             memset(frame_lp + cur_func->param_cell_num, 0,
                    (uint32)(cur_func->local_cell_num * 4));
+            /* externref/funcref should be NULL_REF rather than 0 */
+            for (i = 0; i < cur_func->local_cell_num; i++) {
+                if (cur_wasm_func->local_types[i] == VALUE_TYPE_EXTERNREF
+                    || cur_wasm_func->local_types[i] == VALUE_TYPE_FUNCREF) {
+                    *(frame_lp + cur_func->param_cell_num + i) = NULL_REF;
+                }
+            }
 
             /* Push function block as first block */
             cell_num = func_type->ret_cell_num;

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -1484,7 +1484,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
     uint32 cond, count, fidx, tidx, frame_size = 0;
     uint32 all_cell_num = 0;
     int16 addr1, addr2, addr_ret = 0;
-    int32 didx, val;
+    int32 i, didx, val;
     uint8 *maddr = NULL;
     uint32 local_idx, local_offset, global_idx;
     uint8 opcode = 0, local_type, *global_addr;
@@ -5946,6 +5946,13 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
             /* Initialize the local variables */
             memset(frame_lp + cur_func->param_cell_num, 0,
                    (uint32)(cur_func->local_cell_num * 4));
+            /* externref/funcref should be NULL_REF rather than 0 */
+            for (i = 0; i < cur_func->local_cell_num; i++) {
+                if (cur_wasm_func->local_types[i] == VALUE_TYPE_EXTERNREF
+                    || cur_wasm_func->local_types[i] == VALUE_TYPE_FUNCREF) {
+                    *(frame_lp + cur_func->param_cell_num + i) = NULL_REF;
+                }
+            }
 
 #if WASM_ENABLE_GC != 0
             /* frame->ip is used during GC root set enumeration, so we must


### PR DESCRIPTION
In classic-interpreter, fast-interpreter, and fast-jit running modes, set the local variables' default value to NULL_REF rather than 0 if they are externref and funcref
This PR will fix #3390 #3391