### PR TITLE
Add V128 SIMD value type

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -59,7 +59,7 @@ bh_static_assert(offsetof(AOTModuleInstanceExtra, stack_sizes) == 0);
 
 bh_static_assert(sizeof(CApiFuncImport) == sizeof(uintptr_t) * 3);
 
-bh_static_assert(sizeof(wasm_val_t) == 24);
+bh_static_assert(sizeof(wasm_val_t) == 16);
 bh_static_assert(offsetof(wasm_val_t, of) == 8);
 
 bh_static_assert(offsetof(AOTFrame, prev_frame) == sizeof(uintptr_t) * 0);

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -59,7 +59,7 @@ bh_static_assert(offsetof(AOTModuleInstanceExtra, stack_sizes) == 0);
 
 bh_static_assert(sizeof(CApiFuncImport) == sizeof(uintptr_t) * 3);
 
-bh_static_assert(sizeof(wasm_val_t) == 16);
+bh_static_assert(sizeof(wasm_val_t) == 24);
 bh_static_assert(offsetof(wasm_val_t, of) == 8);
 
 bh_static_assert(offsetof(AOTFrame, prev_frame) == sizeof(uintptr_t) * 0);

--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -1649,11 +1649,7 @@ rt_val_to_wasm_val(const uint8 *data, uint8 val_type_rt, wasm_val_t *out)
             out->of.f64 = *((float64 *)data);
             break;
         case VALUE_TYPE_V128:
-            out->kind = WASM_V128;
-            out->of.v128.i32x4[0] = ((int32 *)data)[0];
-            out->of.v128.i32x4[1] = ((int32 *)data)[1];
-            out->of.v128.i32x4[2] = ((int32 *)data)[2];
-            out->of.v128.i32x4[3] = ((int32 *)data)[3];
+            bh_assert(0);
             break;
 #if WASM_ENABLE_GC == 0 && WASM_ENABLE_REF_TYPES != 0
         case VALUE_TYPE_EXTERNREF:
@@ -1697,11 +1693,7 @@ wasm_val_to_rt_val(WASMModuleInstanceCommon *inst_comm_rt, uint8 val_type_rt,
             *((float64 *)data) = v->of.f64;
             break;
         case VALUE_TYPE_V128:
-            bh_assert(WASM_V128 == v->kind);
-            ((int32 *)data)[0] = v->of.v128.i32x4[0];
-            ((int32 *)data)[1] = v->of.v128.i32x4[1];
-            ((int32 *)data)[2] = v->of.v128.i32x4[2];
-            ((int32 *)data)[3] = v->of.v128.i32x4[3];
+            bh_assert(0);
             break;
 #if WASM_ENABLE_GC == 0 && WASM_ENABLE_REF_TYPES != 0
         case VALUE_TYPE_EXTERNREF:
@@ -3268,11 +3260,7 @@ params_to_argv(const wasm_val_vec_t *params,
                 argv += 2;
                 break;
             case WASM_V128:
-                ((int32 *)argv)[0] = param->of.v128.i32x4[0];
-                ((int32 *)argv)[1] = param->of.v128.i32x4[1];
-                ((int32 *)argv)[2] = param->of.v128.i32x4[3];
-                ((int32 *)argv)[3] = param->of.v128.i32x4[3];
-                argv += 4;
+                bh_assert(0);
                 break;
 #if WASM_ENABLE_GC == 0 && WASM_ENABLE_REF_TYPES != 0
             case WASM_ANYREF:
@@ -3317,11 +3305,7 @@ argv_to_results(const uint32 *argv, const wasm_valtype_vec_t *result_defs,
                 argv += 2;
                 break;
             case WASM_V128:
-                result->of.v128.i32x4[0] = ((int32 *)argv)[0];
-                result->of.v128.i32x4[1] = ((int32 *)argv)[1];
-                result->of.v128.i32x4[2] = ((int32 *)argv)[2];
-                result->of.v128.i32x4[3] = ((int32 *)argv)[3];
-                argv += 4;
+                bh_assert(0);
                 break;
 #if WASM_ENABLE_GC == 0 && WASM_ENABLE_REF_TYPES != 0
             case WASM_ANYREF:

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -2305,12 +2305,7 @@ parse_args_to_uint32_array(WASMFuncType *type, wasm_val_t *args,
             }
             case WASM_V128:
             {
-                wasm_v128_t val;
-                val = args[i].of.v128;
-                out_argv[p++] = val.i32x4[0];
-                out_argv[p++] = val.i32x4[1];
-                out_argv[p++] = val.i32x4[2];
-                out_argv[p++] = val.i32x4[3];
+                bh_assert(0);
                 break;
             }
 #if WASM_ENABLE_REF_TYPES != 0
@@ -2396,13 +2391,7 @@ parse_uint32_array_to_results(WASMFuncType *type, uint32 *argv,
             }
             case VALUE_TYPE_V128:
             {
-                wasm_v128_t val;
-                val.i32x4[0] = argv[p++];
-                val.i32x4[1] = argv[p++];
-                val.i32x4[2] = argv[p++];
-                val.i32x4[3] = argv[p++];
-                out_results[i].kind = WASM_V128;
-                out_results[i].of.v128 = val;
+                bh_assert(0);
                 break;
             }
 #if WASM_ENABLE_REF_TYPES != 0
@@ -2582,8 +2571,7 @@ wasm_runtime_call_wasm_v(WASMExecEnv *exec_env,
                 args[i].of.f64 = va_arg(vargs, float64);
                 break;
             case VALUE_TYPE_V128:
-                args[i].kind = WASM_V128;
-                args[i].of.v128 = va_arg(vargs, wasm_v128_t);
+                bh_assert(0);
                 break;
 #if WASM_ENABLE_GC == 0 && WASM_ENABLE_REF_TYPES != 0
             case VALUE_TYPE_FUNCREF:

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -1995,6 +1995,8 @@ val_type_to_val_kind(uint8 value_type)
             return WASM_F32;
         case VALUE_TYPE_F64:
             return WASM_F64;
+        case VALUE_TYPE_V128:
+            return WASM_V128;
         case VALUE_TYPE_FUNCREF:
             return WASM_FUNCREF;
         case VALUE_TYPE_EXTERNREF:
@@ -2301,6 +2303,16 @@ parse_args_to_uint32_array(WASMFuncType *type, wasm_val_t *args,
                 out_argv[p++] = u.parts[1];
                 break;
             }
+            case WASM_V128:
+            {
+                wasm_v128_t val;
+                val = args[i].of.v128;
+                out_argv[p++] = val.i32x4[0];
+                out_argv[p++] = val.i32x4[1];
+                out_argv[p++] = val.i32x4[2];
+                out_argv[p++] = val.i32x4[3];
+                break;
+            }
 #if WASM_ENABLE_REF_TYPES != 0
 #if WASM_ENABLE_GC == 0
             case WASM_FUNCREF:
@@ -2380,6 +2392,17 @@ parse_uint32_array_to_results(WASMFuncType *type, uint32 *argv,
                 u.parts[1] = argv[p++];
                 out_results[i].kind = WASM_F64;
                 out_results[i].of.f64 = u.val;
+                break;
+            }
+            case VALUE_TYPE_V128:
+            {
+                wasm_v128_t val;
+                val.i32x4[0] = argv[p++];
+                val.i32x4[1] = argv[p++];
+                val.i32x4[2] = argv[p++];
+                val.i32x4[3] = argv[p++];
+                out_results[i].kind = WASM_V128;
+                out_results[i].of.v128 = val;
                 break;
             }
 #if WASM_ENABLE_REF_TYPES != 0
@@ -2557,6 +2580,10 @@ wasm_runtime_call_wasm_v(WASMExecEnv *exec_env,
             case VALUE_TYPE_F64:
                 args[i].kind = WASM_F64;
                 args[i].of.f64 = va_arg(vargs, float64);
+                break;
+            case VALUE_TYPE_V128:
+                args[i].kind = WASM_V128;
+                args[i].of.v128 = va_arg(vargs, wasm_v128_t);
                 break;
 #if WASM_ENABLE_GC == 0 && WASM_ENABLE_REF_TYPES != 0
             case VALUE_TYPE_FUNCREF:
@@ -3975,10 +4002,11 @@ wasm_func_type_get_param_valkind(WASMFuncType *const func_type,
             return WASM_F32;
         case VALUE_TYPE_F64:
             return WASM_F64;
+        case VALUE_TYPE_V128:
+            return WASM_V128;
         case VALUE_TYPE_FUNCREF:
             return WASM_FUNCREF;
 
-        case VALUE_TYPE_V128:
         case VALUE_TYPE_EXTERNREF:
         case VALUE_TYPE_VOID:
         default:
@@ -4020,6 +4048,7 @@ wasm_func_type_get_result_valkind(WASMFuncType *const func_type,
 
 #if WASM_ENABLE_SIMD != 0
         case VALUE_TYPE_V128:
+            return WASM_V128;
 #endif
 #if WASM_ENABLE_REF_TYPES != 0
         case VALUE_TYPE_EXTERNREF:

--- a/core/iwasm/include/gc_export.h
+++ b/core/iwasm/include/gc_export.h
@@ -71,7 +71,7 @@ typedef struct WASMObject *wasm_obj_t;
 typedef union V128 {
     int8_t i8x16[16];
     int16_t i16x8[8];
-    int32_t i32x8[4];
+    int32_t i32x4[4];
     int64_t i64x2[2];
     float f32x4[4];
     double f64x2[2];

--- a/core/iwasm/include/wasm_c_api.h
+++ b/core/iwasm/include/wasm_c_api.h
@@ -297,6 +297,7 @@ enum wasm_valkind_enum {
   WASM_I64,
   WASM_F32,
   WASM_F64,
+  WASM_V128,
   WASM_ANYREF = 128,
   WASM_FUNCREF,
 };
@@ -431,6 +432,15 @@ WASM_API_EXTERN const wasm_externtype_t* wasm_exporttype_type(const wasm_exportt
 #define WASM_VAL_T_DEFINED
 struct wasm_ref_t;
 
+typedef union wasm_v128_t {
+    int8_t i8x16[16];
+    int16_t i16x8[8];
+    int32_t i32x4[4];
+    int64_t i64x2[2];
+    float32_t f32x4[4];
+    float64_t f64x2[2];
+} wasm_v128_t;
+
 typedef struct wasm_val_t {
   wasm_valkind_t kind;
   uint8_t __paddings[7];
@@ -439,6 +449,7 @@ typedef struct wasm_val_t {
     int64_t i64;
     float32_t f32;
     float64_t f64;
+    wasm_v128_t v128;
     struct wasm_ref_t* ref;
   } of;
 } wasm_val_t;
@@ -705,6 +716,9 @@ static inline own wasm_valtype_t* wasm_valtype_new_f32(void) {
 }
 static inline own wasm_valtype_t* wasm_valtype_new_f64(void) {
   return wasm_valtype_new(WASM_F64);
+}
+static inline own wasm_valtype_t* wasm_valtype_new_v128(void) {
+  return wasm_valtype_new(WASM_V128);
 }
 
 static inline own wasm_valtype_t* wasm_valtype_new_anyref(void) {

--- a/core/iwasm/include/wasm_c_api.h
+++ b/core/iwasm/include/wasm_c_api.h
@@ -432,15 +432,6 @@ WASM_API_EXTERN const wasm_externtype_t* wasm_exporttype_type(const wasm_exportt
 #define WASM_VAL_T_DEFINED
 struct wasm_ref_t;
 
-typedef union wasm_v128_t {
-    int8_t i8x16[16];
-    int16_t i16x8[8];
-    int32_t i32x4[4];
-    int64_t i64x2[2];
-    float32_t f32x4[4];
-    float64_t f64x2[2];
-} wasm_v128_t;
-
 typedef struct wasm_val_t {
   wasm_valkind_t kind;
   uint8_t __paddings[7];
@@ -449,7 +440,6 @@ typedef struct wasm_val_t {
     int64_t i64;
     float32_t f32;
     float64_t f64;
-    wasm_v128_t v128;
     struct wasm_ref_t* ref;
   } of;
 } wasm_val_t;

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -254,15 +254,6 @@ enum wasm_valkind_enum {
 #define WASM_VAL_T_DEFINED
 struct wasm_ref_t;
 
-typedef union wasm_v128_t {
-    int8_t i8x16[16];
-    int16_t i16x8[8];
-    int32_t i32x4[4];
-    int64_t i64x2[2];
-    float f32x4[4];
-    double f64x2[2];
-} wasm_v128_t;
-
 typedef struct wasm_val_t {
     wasm_valkind_t kind;
     uint8_t __paddings[7];
@@ -272,7 +263,6 @@ typedef struct wasm_val_t {
         int64_t i64;
         float f32;
         double f64;
-        wasm_v128_t v128;
         /* represent a foreign object, aka externref in .wat */
         uintptr_t foreign;
         struct wasm_ref_t *ref;

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -244,6 +244,7 @@ enum wasm_valkind_enum {
     WASM_I64,
     WASM_F32,
     WASM_F64,
+    WASM_V128,
     WASM_ANYREF = 128,
     WASM_FUNCREF,
 };
@@ -252,6 +253,15 @@ enum wasm_valkind_enum {
 #ifndef WASM_VAL_T_DEFINED
 #define WASM_VAL_T_DEFINED
 struct wasm_ref_t;
+
+typedef union wasm_v128_t {
+    int8_t i8x16[16];
+    int16_t i16x8[8];
+    int32_t i32x4[4];
+    int64_t i64x2[2];
+    float f32x4[4];
+    double f64x2[2];
+} wasm_v128_t;
 
 typedef struct wasm_val_t {
     wasm_valkind_t kind;
@@ -262,6 +272,7 @@ typedef struct wasm_val_t {
         int64_t i64;
         float f32;
         double f64;
+        wasm_v128_t v128;
         /* represent a foreign object, aka externref in .wat */
         uintptr_t foreign;
         struct wasm_ref_t *ref;

--- a/core/iwasm/interpreter/wasm.h
+++ b/core/iwasm/interpreter/wasm.h
@@ -213,10 +213,11 @@ typedef struct WASMTag WASMTag;
 
 #ifndef WASM_VALUE_DEFINED
 #define WASM_VALUE_DEFINED
+
 typedef union V128 {
     int8 i8x16[16];
     int16 i16x8[8];
-    int32 i32x8[4];
+    int32 i32x4[4];
     int64 i64x2[2];
     float32 f32x4[4];
     float64 f64x2[2];

--- a/samples/wasm-c-api/src/reflect.c
+++ b/samples/wasm-c-api/src/reflect.c
@@ -29,6 +29,7 @@ void print_valtype(const wasm_valtype_t* type) {
     case WASM_I64: printf("i64"); break;
     case WASM_F32: printf("f32"); break;
     case WASM_F64: printf("f64"); break;
+    case WASM_V128: printf("v128"); break;
     case WASM_ANYREF: printf("anyref"); break;
     case WASM_FUNCREF: printf("funcref"); break;
   }


### PR DESCRIPTION
Referencing a comment here:

https://github.com/bytecodealliance/wasm-micro-runtime/pull/3363#discussion_r1586952358

@wenyongh suggested that a 128 bit vector type should be added to the value type enum for SIMD support. This change adds an item to the relevant enums, and also adds code in various places to support that enum item. Please let me know if I missed anything.

Note that this requires changing the union inside the `wasm_val_t` structure to add a v128 member, which increases the overall size of the structure. As far as I can tell that doesn't cause any compatibility issues, even with AOT, but I'm not confident about that.