### PR TITLE
Correct Exception Handling tag type when GC is enabled

### DIFF
--- a/core/iwasm/interpreter/wasm.h
+++ b/core/iwasm/interpreter/wasm.h
@@ -572,7 +572,7 @@ typedef struct WASMTagImport {
     char *field_name;
     uint8 attribute; /* the type of the tag (numerical) */
     uint32 type;     /* the type of the catch function (numerical)*/
-    WASMType *tag_type;
+    WASMFuncType *tag_type;
     void *tag_ptr_linked;
 
 #if WASM_ENABLE_MULTI_MODULE != 0
@@ -704,7 +704,7 @@ struct WASMFunction {
 struct WASMTag {
     uint8 attribute; /* the attribute property of the tag (expected to be 0) */
     uint32 type; /* the type of the tag (expected valid inden in type table) */
-    WASMType *tag_type;
+    WASMFuncType *tag_type;
 };
 #endif
 

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -1612,7 +1612,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
             /* landing pad for the rethrow ? */
             find_a_catch_handler:
             {
-                WASMType *tag_type = NULL;
+                WASMFuncType *tag_type = NULL;
                 uint32 cell_num_to_copy = 0;
                 if (IS_INVALID_TAGINDEX(exception_tag_index)) {
                     /*

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -11196,13 +11196,9 @@ re_scan:
 #if WASM_ENABLE_GC != 0
                     local_type = tag_type->types[tti];
                     local_idx = tti;
-                    bool is_type_multi_byte =
-                        wasm_is_type_multi_byte_type(local_type);
-                    WASMRefType *ref_type = NULL;
-                    if (is_type_multi_byte) {
-                        bh_assert(param_reftype_maps);
-                        GET_LOCAL_REFTYPE();
-                    }
+                    /* Get the wasm_ref_type if the local_type is multibyte
+                     * type */
+                    GET_LOCAL_REFTYPE();
 #endif
 
                     if (!check_stack_top_values(
@@ -11212,7 +11208,7 @@ re_scan:
 #endif
                             tag_type->types[tti],
 #if WASM_ENABLE_GC != 0
-                            ref_type,
+                            &wasm_ref_type,
 #endif
                             error_buf, error_buf_size)) {
                         snprintf(error_buf, error_buf_size,


### PR DESCRIPTION
Use `WASMFuncType` to represent tag_type in `WASMTagImport` and `WASMTag` so that the type definition is consistent no matter to GC is enabled or disabled. This patch will fix https://github.com/bytecodealliance/wasm-micro-runtime/issues/3409