### PR TITLE
Fix basic example, parameter mismatch between host and wasm

### DIFF
--- a/samples/basic/src/main.c
+++ b/samples/basic/src/main.c
@@ -175,7 +175,7 @@ main(int argc, char *argv_main[])
            ret_val);
 
     // Next we will pass a buffer to the WASM function
-    uint32 argv2[5];
+    uint32 argv2[4];
 
     // must allocate buffer from wasm instance memory space (never use pointer
     // from host runtime)
@@ -184,8 +184,8 @@ main(int argc, char *argv_main[])
 
     memcpy(argv2, &ret_val, sizeof(float)); // the first argument
     argv2[1] = wasm_buffer; // the second argument is the wasm buffer address
-    argv2[3] = 100;         //  the third argument is the wasm buffer size
-    argv2[4] = 3; //  the last argument is the digits after decimal point for
+    argv2[2] = 100;         //  the third argument is the wasm buffer size
+    argv2[3] = 3; //  the last argument is the digits after decimal point for
                   //  converting float to string
 
     if (!(func2 =


### PR DESCRIPTION
### Problem

When you build the host application located at `samples\basic\src\main.c`
build the wasm-app located at `samples\basic\wasm-apps\testapp.c`
and then run the host with wasm app
```
./basic -f wasm-app/testapp.wasm
```

you will get an error when calling `float_to_string` function:
```
call wasm function float_to_string failed. error: Exception: out of bounds memory access
```
In my case, I'm compiling the host on Windows, and compiling the wasm-app on Linux. 



### Solution
After taking a look at the argument array for calling the `float_to_string` function on the main.c file
I have noticed that the array assignment is not correct.
```
    argv2[1] = wasm_buffer; // the second argument is the wasm buffer address
    argv2[3] = 1000;         //  the third argument is the wasm buffer size
    argv2[4] = 3; //  the last argument is the digits after decimal point for
                  //  converting float to string
```

it is supposed to be
```
    argv2[1] = wasm_buffer; // the second argument is the wasm buffer address
    argv2[2] = 1000;         //  the third argument is the wasm buffer size
    argv2[3] = 3; //  the last argument is the digits after decimal point for
                  //  converting float to string
```
