### PR TITLE
aot: make precheck functions use short-call for xtensa

### DIFF
--- a/build-scripts/build_llvm.py
+++ b/build-scripts/build_llvm.py
@@ -261,7 +261,7 @@ def main():
         "xtensa": {
             "repo": "https://github.com/espressif/llvm-project.git",
             "repo_ssh": "git@github.com:espressif/llvm-project.git",
-            "branch": "xtensa_release_15.x",
+            "branch": "xtensa_release_17.0.1",
         },
         "default": {
             "repo": "https://github.com/llvm/llvm-project.git",

--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -2515,26 +2515,15 @@ load_function_section(const uint8 *buf, const uint8 *buf_end, AOTModule *module,
     const uint8 *p = buf, *p_end = buf_end;
     uint32 i;
     uint64 size, text_offset;
-    uint32 func_count = module->func_count;
 
-#if defined(BUILD_TARGET_XTENSA)
-    /*
-     * For Xtensa XIP, real func_count is doubled, including aot_func and
-     * aot_func_internal, so need to multiply func_count by 2 here.
-     */
-    if (module->is_indirect_mode) {
-        func_count *= 2;
-    }
-#endif
-
-    size = sizeof(void *) * (uint64)func_count;
+    size = sizeof(void *) * (uint64)module->func_count;
     if (size > 0
         && !(module->func_ptrs =
                  loader_malloc(size, error_buf, error_buf_size))) {
         return false;
     }
 
-    for (i = 0; i < func_count; i++) {
+    for (i = 0; i < module->func_count; i++) {
         if (sizeof(void *) == 8) {
             read_uint64(p, p_end, text_offset);
         }
@@ -2569,14 +2558,14 @@ load_function_section(const uint8 *buf, const uint8 *buf_end, AOTModule *module,
         module->start_function = NULL;
     }
 
-    size = sizeof(uint32) * (uint64)func_count;
+    size = sizeof(uint32) * (uint64)module->func_count;
     if (size > 0
         && !(module->func_type_indexes =
                  loader_malloc(size, error_buf, error_buf_size))) {
         return false;
     }
 
-    for (i = 0; i < func_count; i++) {
+    for (i = 0; i < module->func_count; i++) {
         read_uint32(p, p_end, module->func_type_indexes[i]);
         if (module->func_type_indexes[i] >= module->type_count) {
             set_error_buf(error_buf, error_buf_size, "unknown type");

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -1115,21 +1115,10 @@ init_func_ptrs(AOTModuleInstance *module_inst, AOTModule *module,
 {
     uint32 i;
     void **func_ptrs;
-    uint32 func_count = module->func_count;
-#if defined(BUILD_TARGET_XTENSA)
-    /*
-     * For Xtensa XIP, real func_count is doubled, including aot_func and
-     * aot_func_internal, so need to multiply func_count by 2 here.
-     */
-    if (module->is_indirect_mode) {
-        func_count *= 2;
-    }
-#endif
+    uint64 total_size = ((uint64)module->import_func_count + module->func_count)
+                        * sizeof(void *);
 
-    uint64 total_size =
-        ((uint64)module->import_func_count + func_count) * sizeof(void *);
-
-    if (module->import_func_count + func_count == 0)
+    if (module->import_func_count + module->func_count == 0)
         return true;
 
     /* Allocate memory */
@@ -1151,8 +1140,8 @@ init_func_ptrs(AOTModuleInstance *module_inst, AOTModule *module,
     }
 
     /* Set defined function pointers */
-    bh_memcpy_s(func_ptrs, sizeof(void *) * func_count, module->func_ptrs,
-                sizeof(void *) * func_count);
+    bh_memcpy_s(func_ptrs, sizeof(void *) * module->func_count,
+                module->func_ptrs, sizeof(void *) * module->func_count);
     return true;
 }
 
@@ -1162,21 +1151,10 @@ init_func_type_indexes(AOTModuleInstance *module_inst, AOTModule *module,
 {
     uint32 i;
     uint32 *func_type_index;
-    uint32 func_count = module->func_count;
-#if defined(BUILD_TARGET_XTENSA)
-    /*
-     * For Xtensa XIP, real func_count is doubled, including aot_func and
-     * aot_func_internal, so need to multiply func_count by 2 here.
-     */
-    if (module->is_indirect_mode) {
-        func_count *= 2;
-    }
-#endif
+    uint64 total_size = ((uint64)module->import_func_count + module->func_count)
+                        * sizeof(uint32);
 
-    uint64 total_size =
-        ((uint64)module->import_func_count + func_count) * sizeof(uint32);
-
-    if (module->import_func_count + func_count == 0)
+    if (module->import_func_count + module->func_count == 0)
         return true;
 
     /* Allocate memory */
@@ -1190,8 +1168,8 @@ init_func_type_indexes(AOTModuleInstance *module_inst, AOTModule *module,
     for (i = 0; i < module->import_func_count; i++, func_type_index++)
         *func_type_index = module->import_funcs[i].func_type_index;
 
-    bh_memcpy_s(func_type_index, sizeof(uint32) * func_count,
-                module->func_type_indexes, sizeof(uint32) * func_count);
+    bh_memcpy_s(func_type_index, sizeof(uint32) * module->func_count,
+                module->func_type_indexes, sizeof(uint32) * module->func_count);
     return true;
 }
 

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -743,7 +743,16 @@ aot_add_llvm_func(AOTCompContext *comp_ctx, LLVMModuleRef module,
             LLVMCreateEnumAttribute(comp_ctx->context, kind, 0);
         LLVMAddAttributeAtIndex(func, LLVMAttributeFunctionIndex,
                                 attr_noinline);
-
+        if (!strcmp(comp_ctx->target_arch, "xtensa")) {
+            /* Because "func" is only called by "precheck_func", short-call
+             * should be ok. We prefer short-call because it's smaller
+             * and more importantly doesn't involve relocations.
+             */
+            LLVMAttributeRef attr_short_call = LLVMCreateStringAttribute(
+                comp_ctx->context, "short-call", strlen("short-call"), "", 0);
+            LLVMAddAttributeAtIndex(func, LLVMAttributeFunctionIndex,
+                                    attr_short_call);
+        }
         if (!aot_build_precheck_function(comp_ctx, module, precheck_func,
                                          func_index, func_type, func))
             goto fail;

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -24,8 +24,6 @@ create_native_stack_bound(const AOTCompContext *comp_ctx,
 static bool
 create_native_stack_top_min(const AOTCompContext *comp_ctx,
                             AOTFuncContext *func_ctx);
-static bool
-create_func_ptrs(const AOTCompContext *comp_ctx, AOTFuncContext *func_ctx);
 
 LLVMTypeRef
 wasm_type_to_llvm_type(const AOTCompContext *comp_ctx,
@@ -539,51 +537,8 @@ aot_build_precheck_function(AOTCompContext *comp_ctx, LLVMModuleRef module,
     if (ret_type == VOID_TYPE) {
         name = "";
     }
-
-    LLVMValueRef retval;
-    if (comp_ctx->is_indirect_mode
-        && !strncmp(comp_ctx->target_arch, "xtensa", 6)) {
-        /* call wrapped_func indirectly */
-        if (!create_func_ptrs(comp_ctx, func_ctx)) {
-            goto fail;
-        }
-
-        LLVMTypeRef func_ptr_type;
-        LLVMValueRef wrapped_func_indirect;
-        uint32 import_func_count = comp_ctx->comp_data->import_func_count;
-        uint32 func_count = comp_ctx->func_ctx_count;
-
-        /* Check function index */
-        if (func_index >= import_func_count + func_count) {
-            aot_set_last_error("Function index out of range.");
-            goto fail;
-        }
-
-        /* Get function type */
-        if (!(func_ptr_type = LLVMPointerType(func_type, 0))) {
-            aot_set_last_error("create LLVM function type failed.");
-            goto fail;
-        }
-
-        /*
-         * func_index layout :
-         * aot_func#xxx, range from 0 ~ func_conut - 1;
-         * aot_func#internal#xxx,  range from func_conut ~ 2 * func_conut - 1;
-         */
-        if (!(wrapped_func_indirect = aot_get_func_from_table(
-                  comp_ctx, func_ctx->func_ptrs, func_ptr_type,
-                  func_index + func_count + import_func_count))) {
-            goto fail;
-        }
-
-        /* Call the function indirectly */
-        retval = LLVMBuildCall2(b, func_type, wrapped_func_indirect, params,
-                                param_count, name);
-    }
-    else
-        retval = LLVMBuildCall2(b, func_type, wrapped_func, params, param_count,
-                                name);
-
+    LLVMValueRef retval =
+        LLVMBuildCall2(b, func_type, wrapped_func, params, param_count, name);
     if (!retval) {
         goto fail;
     }
@@ -780,9 +735,7 @@ aot_add_llvm_func(AOTCompContext *comp_ctx, LLVMModuleRef module,
     }
 
     if (need_precheck) {
-        if (!comp_ctx->is_jit_mode
-            && !(comp_ctx->is_indirect_mode
-                 && !strncmp(comp_ctx->target_arch, "xtensa", 6)))
+        if (!comp_ctx->is_jit_mode)
             LLVMSetLinkage(func, LLVMInternalLinkage);
         unsigned int kind =
             LLVMGetEnumAttributeKindForName("noinline", strlen("noinline"));


### PR DESCRIPTION
Note: this breaks AOT ABI for xtensa again because of a revert of an ABI-breaking change.