### PR TITLE
aot: fix a type mismatch in compile_op_float_min_max

### DIFF
--- a/core/iwasm/compilation/aot_emit_numberic.c
+++ b/core/iwasm/compilation/aot_emit_numberic.c
@@ -228,6 +228,7 @@ compile_op_float_min_max(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                          bool is_f32, LLVMValueRef left, LLVMValueRef right,
                          bool is_min)
 {
+    LLVMTypeRef float_param_types[2];
     LLVMTypeRef param_types[2], ret_type = is_f32 ? F32_TYPE : F64_TYPE,
                                 int_type = is_f32 ? I32_TYPE : I64_TYPE;
     LLVMValueRef cmp, is_eq, is_nan, ret, left_int, right_int, tmp,
@@ -236,7 +237,9 @@ compile_op_float_min_max(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                              : (is_f32 ? "llvm.maxnum.f32" : "llvm.maxnum.f64");
     CHECK_LLVM_CONST(nan);
 
-    param_types[0] = param_types[1] = ret_type;
+    /* Note: param_types is used by LLVM_BUILD_OP_OR_INTRINSIC */
+    param_types[0] = param_types[1] = int_type;
+    float_param_types[0] = float_param_types[1] = ret_type;
 
     if (comp_ctx->disable_llvm_intrinsics
         && aot_intrinsic_check_capability(comp_ctx,
@@ -304,7 +307,7 @@ compile_op_float_min_max(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     }
 
     if (!(cmp = aot_call_llvm_intrinsic(comp_ctx, func_ctx, intrinsic, ret_type,
-                                        param_types, 2, left, right)))
+                                        float_param_types, 2, left, right)))
         return NULL;
 
     /* The result of XIP intrinsic is 0 or 1, should return it directly */


### PR DESCRIPTION
Fixes https://github.com/bytecodealliance/wasm-micro-runtime/issues/3422