### PR TITLE
Fix typo of WAMR_CONFIGUABLE_BOUNDS_CHECKS

### DIFF
--- a/.github/scripts/codeql_buildscript.sh
+++ b/.github/scripts/codeql_buildscript.sh
@@ -264,7 +264,7 @@ fi
 # build iwasm with configurable bounds checks enabled
 cd ${WAMR_DIR}/product-mini/platforms/linux
 rm -rf build && mkdir build && cd build
-cmake .. -DCMAKE_BUILD_TYPE=Debug -DWAMR_CONFIGUABLE_BOUNDS_CHECKS=1
+cmake .. -DCMAKE_BUILD_TYPE=Debug -DWAMR_CONFIGURABLE_BOUNDS_CHECKS=1
 make -j
 if [[ $? != 0 ]]; then
     echo "Failed to build iwasm with configurable bounds checks enabled!"

--- a/build-scripts/config_common.cmake
+++ b/build-scripts/config_common.cmake
@@ -516,7 +516,7 @@ if (WAMR_BUILD_TARGET STREQUAL "X86_64"
     message ("     Write linear memory base addr to x86 GS register enabled")
   endif ()
 endif ()
-if (WAMR_CONFIGUABLE_BOUNDS_CHECKS EQUAL 1)
+if (WAMR_CONFIGURABLE_BOUNDS_CHECKS EQUAL 1)
   add_definitions (-DWASM_CONFIGURABLE_BOUNDS_CHECKS=1)
   message ("     Configurable bounds checks enabled")
 endif ()

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -2410,8 +2410,8 @@ wasm_loader_resolve_global(const char *module_name, const char *global_name,
     if (global->type.val_type != type
         || global->type.is_mutable != is_mutable) {
         LOG_DEBUG("%s,%s failed type check(%d, %d), expected(%d, %d)",
-                  module_name, global_name, global->type, global->is_mutable,
-                  type, is_mutable);
+                  module_name, global_name, global->type.val_type,
+                  global->type.is_mutable, type, is_mutable);
         set_error_buf(error_buf, error_buf_size, "incompatible import type");
         return NULL;
     }

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -475,8 +475,8 @@ load_init_expr(WASMModule *module, const uint8 **p_buf, const uint8 *buf_end,
                 global_idx = cur_value.global_index;
 
                 bh_assert(global_idx < module->import_global_count);
-                bh_assert(
-                    !module->import_globals[global_idx].u.global.is_mutable);
+                bh_assert(!module->import_globals[global_idx]
+                               .u.global.type.is_mutable);
 
                 if (global_idx < module->import_global_count) {
                     global_type = module->import_globals[global_idx]

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -796,8 +796,8 @@ load_global_import(const uint8 **p_buf, const uint8 *buf_end,
     ret = wasm_native_lookup_libc_builtin_global(sub_module_name, global_name,
                                                  global);
     if (ret) {
-        bh_assert(global->type == declare_type
-                  && global->is_mutable != declare_mutable);
+        bh_assert(global->type.val_type == declare_type
+                  && global->type.is_mutable != declare_mutable);
     }
 #endif /* WASM_ENABLE_LIBC_BUILTIN */
 

--- a/doc/build_wamr.md
+++ b/doc/build_wamr.md
@@ -286,7 +286,7 @@ Currently we only profile the memory consumption of module, module_instance and 
 > Note: See [Tuning the XIP intrinsic functions](./xip.md#tuning-the-xip-intrinsic-functions) for more details.
 
 #### **Configurable memory access boundary check**
-- **WAMR_CONFIGUABLE_BOUNDS_CHECKS**=1/0, default to disable if not set
+- **WAMR_CONFIGURABLE_BOUNDS_CHECKS**=1/0, default to disable if not set
 > Note: If it is enabled, allow to run `iwasm --disable-bounds-checks` to disable the memory access boundary checks for interpreter mode.
 
 #### **Module instance context APIs**

--- a/doc/perf_tune.md
+++ b/doc/perf_tune.md
@@ -84,7 +84,7 @@ Developer can refer to the `test_pgo.sh` files under each benchmark folder for m
 
 Please notice that this method is not a general solution since it may lead to security issues. And only boost the performance for some platforms in AOT mode and don't support hardware trap for memory boundary check.
 
-1. Build WAMR with `-DWAMR_CONFIGUABLE_BOUNDS_CHECKS=1` option.
+1. Build WAMR with `-DWAMR_CONFIGURABLE_BOUNDS_CHECKS=1` option.
 
 2. Compile AOT module by wamrc with `--bounds-check=0` option.
 


### PR DESCRIPTION
Change to WAMR_CONFIGURABLE_BOUNDS_CHECKS, and fix codeql compilation errors
which were introduced by PR #3406.

ps.
https://github.com/bytecodealliance/wasm-micro-runtime/pull/3393#discussion_r1591810998
https://github.com/bytecodealliance/wasm-micro-runtime/actions/runs/9055318553/job/24876266629