### PR TITLE
Suppress AOT undefined behavior sanitizer issues

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -593,6 +593,7 @@ global_instantiate(AOTModuleInstance *module_inst, AOTModule *module,
     return true;
 }
 
+NO_SANITIZE_UNDEFINED
 static bool
 tables_instantiate(AOTModuleInstance *module_inst, AOTModule *module,
                    AOTTableInstance *first_tbl_inst, char *error_buf,

--- a/core/iwasm/aot/aot_runtime.h
+++ b/core/iwasm/aot/aot_runtime.h
@@ -18,6 +18,12 @@
 #include "../libraries/wasi-nn/src/wasi_nn_private.h"
 #endif
 
+#if defined(__GNUC__)
+#define NO_SANITIZE_UNDEFINED __attribute__((no_sanitize("undefined")))
+#else
+#define NO_SANITIZE_UNDEFINED
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/core/iwasm/aot/arch/aot_reloc_x86_64.c
+++ b/core/iwasm/aot/arch/aot_reloc_x86_64.c
@@ -72,6 +72,7 @@ get_plt_table_size()
     return size;
 }
 
+NO_SANITIZE_UNDEFINED
 void
 init_plt_table(uint8 *plt)
 {
@@ -106,6 +107,7 @@ check_reloc_offset(uint32 target_section_size, uint64 reloc_offset,
     return true;
 }
 
+NO_SANITIZE_UNDEFINED
 bool
 apply_relocation(AOTModule *module, uint8 *target_section_addr,
                  uint32 target_section_size, uint64 reloc_offset,


### PR DESCRIPTION
Fixes #2349 - WAMR triggers UBSAN alignment issues on x86-64/x86 when built with Fast JIT.