### PR TITLE
Add global export apis

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -393,7 +393,8 @@ global_instantiate(AOTModuleInstance *module_inst, AOTModule *module,
 
     /* Initialize import global data */
     global = globals;
-    for (i = 0; i < module->import_global_count; i++, import_global++) {
+    for (i = 0; i < module->import_global_count;
+         i++, import_global++, global++) {
         bh_assert(import_global->data_offset
                   == (uint32)(p - module_inst->global_data));
         init_global_data(p, import_global->type.val_type,
@@ -412,7 +413,7 @@ global_instantiate(AOTModuleInstance *module_inst, AOTModule *module,
     }
 
     /* Initialize defined global data */
-    for (i = 0; i < module->global_count; i++) {
+    for (i = 0; i < module->global_count; i++, global++) {
         uint8 flag;
         bh_assert(module->globals[i].data_offset
                   == (uint32)(p - module_inst->global_data));
@@ -623,7 +624,6 @@ global_instantiate(AOTModuleInstance *module_inst, AOTModule *module,
             }
         }
 
-        global++;
         p += module->globals[i].size;
     }
 

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -492,7 +492,7 @@ global_instantiate(AOTModuleInstance *module_inst, AOTModule *module,
             case INIT_EXPR_TYPE_I31_NEW:
             {
                 WASMI31ObjectRef i31_obj = wasm_i31_obj_new(init_expr->u.i32);
-                global->initial_value.gc_obj = i31_obj;
+                global->initial_value.gc_obj = (wasm_obj_t)i31_obj;
                 PUT_REF_TO_ADDR(p, i31_obj);
                 break;
             }

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -1891,8 +1891,9 @@ wasm_runtime_set_module_inst(WASMExecEnv *exec_env,
     wasm_exec_env_set_module_inst(exec_env, module_inst);
 }
 
-wasm_export_global_t
-wasm_runtime_get_export_global(wasm_exec_env_t exec_env, const char *name)
+wasm_global_instance_t
+wasm_runtime_get_export_global_instance(wasm_exec_env_t exec_env,
+                                        const char *name)
 {
 #if WASM_ENABLE_INTERP != 0
     if (exec_env->module_inst->module_type == Wasm_Module_Bytecode) {
@@ -1929,9 +1930,9 @@ wasm_runtime_get_export_global(wasm_exec_env_t exec_env, const char *name)
 }
 
 wasm_valkind_t
-wasm_runtime_export_global_get_kind(wasm_export_global_t export_global)
+wasm_runtime_global_instance_get_kind(wasm_global_instance_t global_instance)
 {
-    switch (export_global->type) {
+    switch (global_instance->type) {
         case VALUE_TYPE_I32:
             return WASM_I32;
         case VALUE_TYPE_I64:
@@ -1954,14 +1955,14 @@ wasm_runtime_export_global_get_kind(wasm_export_global_t export_global)
 }
 
 bool
-wasm_runtime_export_global_get_mutable(wasm_export_global_t export_global)
+wasm_runtime_global_instance_get_mutable(wasm_global_instance_t global_instance)
 {
-    return export_global->is_mutable;
+    return global_instance->is_mutable;
 }
 
 bool
-wasm_runtime_export_global_get_value(wasm_export_global_t export_global,
-                                     wasm_val_t *value)
+wasm_runtime_global_instance_get_value(wasm_global_instance_t global_instance,
+                                       wasm_val_t *value)
 {
     if (!value) {
         bh_assert(0);
@@ -1970,27 +1971,27 @@ wasm_runtime_export_global_get_value(wasm_export_global_t export_global,
 
     memset(value, 0, sizeof(wasm_val_t));
 
-    if (!export_global) {
+    if (!global_instance) {
         bh_assert(0);
         return false;
     }
 
-    switch (export_global->type) {
+    switch (global_instance->type) {
         case VALUE_TYPE_I32:
             value->kind = WASM_I32;
-            value->of.i32 = export_global->initial_value.i32;
+            value->of.i32 = global_instance->initial_value.i32;
             break;
         case VALUE_TYPE_I64:
             value->kind = WASM_I64;
-            value->of.i64 = export_global->initial_value.i64;
+            value->of.i64 = global_instance->initial_value.i64;
             break;
         case VALUE_TYPE_F32:
             value->kind = WASM_F32;
-            value->of.f32 = export_global->initial_value.f32;
+            value->of.f32 = global_instance->initial_value.f32;
             break;
         case VALUE_TYPE_F64:
             value->kind = WASM_F64;
-            value->of.f64 = export_global->initial_value.f64;
+            value->of.f64 = global_instance->initial_value.f64;
             break;
         case VALUE_TYPE_V128:
         case VALUE_TYPE_FUNCREF:
@@ -2005,30 +2006,30 @@ wasm_runtime_export_global_get_value(wasm_export_global_t export_global,
 }
 
 bool
-wasm_runtime_export_global_set_value(wasm_export_global_t export_global,
-                                     const wasm_val_t *value)
+wasm_runtime_global_instance_set_value(wasm_global_instance_t global_instance,
+                                       const wasm_val_t *value)
 {
-    if (!export_global || !value) {
+    if (!global_instance || !value) {
         bh_assert(0);
         return false;
     }
 
     switch (value->kind) {
         case WASM_I32:
-            export_global->type = VALUE_TYPE_I32;
-            export_global->initial_value.i32 = value->of.i32;
+            global_instance->type = VALUE_TYPE_I32;
+            global_instance->initial_value.i32 = value->of.i32;
             break;
         case WASM_I64:
-            export_global->type = VALUE_TYPE_I64;
-            export_global->initial_value.i64 = value->of.i64;
+            global_instance->type = VALUE_TYPE_I64;
+            global_instance->initial_value.i64 = value->of.i64;
             break;
         case WASM_F32:
-            export_global->type = VALUE_TYPE_F32;
-            export_global->initial_value.f32 = value->of.f32;
+            global_instance->type = VALUE_TYPE_F32;
+            global_instance->initial_value.f32 = value->of.f32;
             break;
         case WASM_F64:
-            export_global->type = VALUE_TYPE_F64;
-            export_global->initial_value.f64 = value->of.f64;
+            global_instance->type = VALUE_TYPE_F64;
+            global_instance->initial_value.f64 = value->of.f64;
             break;
         case WASM_V128:
         case WASM_FUNCREF:

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -1408,7 +1408,7 @@ wasm_runtime_unregister_natives(const char *module_name,
                                 NativeSymbol *native_symbols);
 
 struct WASMGlobalInstance;
-typedef struct WASMGlobalInstance *wasm_export_global_t;
+typedef struct WASMGlobalInstance *wasm_global_instance_t;
 /**
  * Get an export global
  *
@@ -1419,56 +1419,57 @@ typedef struct WASMGlobalInstance *wasm_export_global_t;
  * @return the export global
  *
  */
-wasm_export_global_t
-wasm_runtime_get_export_global(wasm_exec_env_t exec_env, const char *name);
+wasm_global_instance_t
+wasm_runtime_get_export_global_instance(wasm_exec_env_t exec_env,
+                                        const char *name);
 
 /**
- * Get the kind of an export global
+ * Get the kind of a global instance
  *
- * @param export_global the export global
+ * @param export_global the global instance
  *
- * @return the kind of the export global
+ * @return the kind of the global instance
  *
  */
 wasm_valkind_t
-wasm_runtime_export_global_get_kind(wasm_export_global_t export_global);
+wasm_runtime_global_instance_get_kind(wasm_global_instance_t export_global);
 
 /**
- * Get the mutability of an export global
+ * Get the mutability of a global instance
  *
- * @param export_global the export global
+ * @param export_global the global instance
  *
  * @return true if mutable, false otherwise
  *
  */
 bool
-wasm_runtime_export_global_get_mutable(wasm_export_global_t export_global);
+wasm_runtime_global_instance_get_mutable(wasm_global_instance_t export_global);
 
 /**
- * Get the value of an export global
+ * Get the value of a global instance
  *
- * @param export_global the export global
+ * @param export_global the global instance
  * @param value the pre-allocated pointer to store the value
  *
  * @return true if successful, false otherwise
  *
  */
 bool
-wasm_runtime_export_global_get_value(wasm_export_global_t export_global,
-                                     wasm_val_t *value);
+wasm_runtime_global_instance_get_value(wasm_global_instance_t export_global,
+                                       wasm_val_t *value);
 
 /**
- * Set the value of an export global
+ * Set the value of a global instance
  *
- * @param export_global the export global
+ * @param export_global the global instance
  * @param value pointer to the value to store
  *
  * @return true if successful, false otherwise
  *
  */
 bool
-wasm_runtime_export_global_set_value(wasm_export_global_t export_global,
-                                     const wasm_val_t *value);
+wasm_runtime_global_instance_set_value(wasm_global_instance_t export_global,
+                                       const wasm_val_t *value);
 
 /**
  * Get attachment of native function from execution environment

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -1407,6 +1407,69 @@ WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_unregister_natives(const char *module_name,
                                 NativeSymbol *native_symbols);
 
+struct WASMGlobalInstance;
+typedef struct WASMGlobalInstance *wasm_export_global_t;
+/**
+ * Get an export global
+ *
+ * @param exec_env the execution environment to retrieve
+ * @param module_name the export module name
+ * @param name the export global name
+ *
+ * @return the export global
+ *
+ */
+wasm_export_global_t
+wasm_runtime_get_export_global(wasm_exec_env_t exec_env, const char *name);
+
+/**
+ * Get the kind of an export global
+ *
+ * @param export_global the export global
+ *
+ * @return the kind of the export global
+ *
+ */
+wasm_valkind_t
+wasm_runtime_export_global_get_kind(wasm_export_global_t export_global);
+
+/**
+ * Get the mutability of an export global
+ *
+ * @param export_global the export global
+ *
+ * @return true if mutable, false otherwise
+ *
+ */
+bool
+wasm_runtime_export_global_get_mutable(wasm_export_global_t export_global);
+
+/**
+ * Get the value of an export global
+ *
+ * @param export_global the export global
+ * @param value the pre-allocated pointer to store the value
+ *
+ * @return true if successful, false otherwise
+ *
+ */
+bool
+wasm_runtime_export_global_get_value(wasm_export_global_t export_global,
+                                     wasm_val_t *value);
+
+/**
+ * Set the value of an export global
+ *
+ * @param export_global the export global
+ * @param value pointer to the value to store
+ *
+ * @return true if successful, false otherwise
+ *
+ */
+bool
+wasm_runtime_export_global_set_value(wasm_export_global_t export_global,
+                                     const wasm_val_t *value);
+
 /**
  * Get attachment of native function from execution environment
  *


### PR DESCRIPTION
I'm very new to this code, so I'm not confident at all that this is the best way (or even a good way) to expose export globals, so please let me know if there is a better strategy or if I've just done it wrong. As a minor detail, I didn't see a good way in the AOT global_instantiate() to fill in the ref_type.