### PR TITLE
Fix ifdef for android random api

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
@@ -18,7 +18,7 @@
 #include "gnuc.h"
 
 #if defined(__FreeBSD__) || defined(__APPLE__) \
-    || ((defined(ANDROID) || defined(__ANDROID__)) && __ANDROID_API__ < 28)
+    || ((defined(ANDROID) || defined(__ANDROID__)) && (__ANDROID_API__ < 28))
 #define CONFIG_HAS_ARC4RANDOM_BUF 1
 #else
 #define CONFIG_HAS_ARC4RANDOM_BUF 0

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
@@ -18,7 +18,7 @@
 #include "gnuc.h"
 
 #if defined(__FreeBSD__) || defined(__APPLE__) \
-    || (defined(ANDROID) && __ANDROID_API__ < 28)
+    || ((defined(ANDROID) || defined(__ANDROID__)) && __ANDROID_API__ < 28)
 #define CONFIG_HAS_ARC4RANDOM_BUF 1
 #else
 #define CONFIG_HAS_ARC4RANDOM_BUF 0


### PR DESCRIPTION
This fixes an Android build failure because `getrandom()` is not declared. I was specifically using Android NDK 24, and `getrandom()` was not available in the NDK until version 28.

I am not an export on the Android platform, but based on the thread below it looks like the preferred preprocessor check for Android is `__ANDROID__` instead of `ANDROID`:

https://groups.google.com/g/android-ndk/c/cf9_f1SLXls

However it looks like maybe there are cases where the one without underscores is necessary, so this change just checks for either one. This causes `CONFIG_HAS_ARC4RANDOM_BUF` to be set to 1 for either Android preprocessor define, and in turn to use `arc4random_buf()` instead of `getrandom()`.