### PR TITLE
Remove install_wasi_sdk from workload preparation script

### DIFF
--- a/samples/workload/preparation.sh
+++ b/samples/workload/preparation.sh
@@ -100,8 +100,7 @@ else
     && install_binaryen \
     && install_cmake \
     && install_emsdk \
-    && install_wabt \
-    && install_wasi-sdk
+    && install_wabt
 fi
 cd - > /dev/null || exit
 DEBUG && set +xevu


### PR DESCRIPTION
This function was removed in 7be0d38 while building a customized wasi-sdk.