### PR TITLE
Fix llvm build error

### DIFF
--- a/product-mini/platforms/android/build_llvm.sh
+++ b/product-mini/platforms/android/build_llvm.sh
@@ -3,5 +3,5 @@
 # Copyright (C) 2020 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-/usr/bin/env python3 -m pip install --user -r ../../../build-scripts/requirements.txt
+/usr/bin/env python3 -m pip install --user -r ../../../build-scripts/requirements.txt --break-system-packages
 /usr/bin/env python3 ../../../build-scripts/build_llvm.py --platform android "$@"

--- a/product-mini/platforms/darwin/build_llvm.sh
+++ b/product-mini/platforms/darwin/build_llvm.sh
@@ -3,5 +3,5 @@
 # Copyright (C) 2020 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-/usr/bin/env python3 -m pip install --user -r ../../../build-scripts/requirements.txt
+/usr/bin/env python3 -m pip install --user -r ../../../build-scripts/requirements.txt --break-system-packages
 /usr/bin/env python3 ../../../build-scripts/build_llvm.py --platform darwin "$@"

--- a/product-mini/platforms/freebsd/build_llvm.sh
+++ b/product-mini/platforms/freebsd/build_llvm.sh
@@ -3,5 +3,5 @@
 # Copyright (C) 2020 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-/usr/bin/env python3 -m pip install --user -r ../../../build-scripts/requirements.txt
+/usr/bin/env python3 -m pip install --user -r ../../../build-scripts/requirements.txt --break-system-packages
 /usr/bin/env python3 ../../../build-scripts/build_llvm.py "$@"

--- a/product-mini/platforms/linux/build_llvm.sh
+++ b/product-mini/platforms/linux/build_llvm.sh
@@ -3,5 +3,5 @@
 # Copyright (C) 2020 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-/usr/bin/env python3 -m pip install --user -r ../../../build-scripts/requirements.txt
+/usr/bin/env python3 -m pip install --user -r ../../../build-scripts/requirements.txt --break-system-packages
 /usr/bin/env python3 ../../../build-scripts/build_llvm.py "$@"

--- a/wamr-compiler/build_llvm.sh
+++ b/wamr-compiler/build_llvm.sh
@@ -3,5 +3,5 @@
 # Copyright (C) 2020 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-/usr/bin/env python3 -m pip install --user -r ../build-scripts/requirements.txt
+/usr/bin/env python3 -m pip install --user -r ../build-scripts/requirements.txt --break-system-packages
 /usr/bin/env python3 ../build-scripts/build_llvm.py "$@"

--- a/wamr-compiler/build_llvm_arc.sh
+++ b/wamr-compiler/build_llvm_arc.sh
@@ -3,5 +3,5 @@
 # Copyright (C) 2020 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-/usr/bin/env python3 -m pip install --user -r ../build-scripts/requirements.txt
+/usr/bin/env python3 -m pip install --user -r ../build-scripts/requirements.txt --break-system-packages
 /usr/bin/env python3 ../build-scripts/build_llvm.py --platform arc "$@"

--- a/wamr-compiler/build_llvm_xtensa.sh
+++ b/wamr-compiler/build_llvm_xtensa.sh
@@ -3,5 +3,5 @@
 # Copyright (C) 2020 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-/usr/bin/env python3 -m pip install --user -r ../build-scripts/requirements.txt
+/usr/bin/env python3 -m pip install --user -r ../build-scripts/requirements.txt --break-system-packages
 /usr/bin/env python3 ../build-scripts/build_llvm.py --platform xtensa "$@"


### PR DESCRIPTION
Otherwise we get error: externally-managed-environment.

I'm not sure if this would be the best way to handle the issue, but we are already doing this anyway (in Dockerfile, for example).