### PR TITLE
Enable AOT multi-module spec test

### DIFF
--- a/tests/wamr-test-suites/spec-test-script/multi_module_aot_ignore_cases.patch
+++ b/tests/wamr-test-suites/spec-test-script/multi_module_aot_ignore_cases.patch
@@ -1,124 +1,57 @@
-diff --git a/test/core/imports.wast b/test/core/imports.wast
-index 0cc07cb..4e8367a 100644
---- a/test/core/imports.wast
-+++ b/test/core/imports.wast
-@@ -86,7 +86,7 @@
- (assert_return (invoke "print64" (i64.const 24)))
- 
- (assert_invalid
--  (module 
-+  (module
-     (type (func (result i32)))
-     (import "test" "func" (func (type 1)))
-   )
-@@ -578,6 +578,7 @@
- (assert_return (invoke "grow" (i32.const 1)) (i32.const -1))
- (assert_return (invoke "grow" (i32.const 0)) (i32.const 2))
- 
-+(;
- (module $Mgm
-   (memory (export "memory") 1) ;; initial size is 1
-   (func (export "grow") (result i32) (memory.grow (i32.const 1)))
-@@ -586,7 +587,7 @@
- (assert_return (invoke $Mgm "grow") (i32.const 1)) ;; now size is 2
- (module $Mgim1
-   ;; imported memory limits should match, because external memory size is 2 now
--  (memory (export "memory") (import "grown-memory" "memory") 2) 
-+  (memory (export "memory") (import "grown-memory" "memory") 2)
-   (func (export "grow") (result i32) (memory.grow (i32.const 1)))
- )
- (register "grown-imported-memory" $Mgim1)
-@@ -597,7 +598,7 @@
-   (func (export "size") (result i32) (memory.size))
- )
- (assert_return (invoke $Mgim2 "size") (i32.const 3))
--
-+;)
- 
- ;; Syntax errors
- 
-@@ -669,6 +670,7 @@
-   "import after memory"
- )
- 
-+(;
- ;; This module is required to validate, regardless of whether it can be
- ;; linked. Overloading is not possible in wasm itself, but it is possible
- ;; in modules from which wasm can import.
-@@ -695,3 +697,4 @@
-   )
-   "unknown import"
- )
-+;)
-\ No newline at end of file
 diff --git a/test/core/linking.wast b/test/core/linking.wast
-index 994e0f4..8fbcc02 100644
+index 8fbcc02..a2254b3 100644
 --- a/test/core/linking.wast
 +++ b/test/core/linking.wast
-@@ -19,11 +19,11 @@
- (assert_return (invoke $Nf "call") (i32.const 3))
- (assert_return (invoke $Nf "call Mf.call") (i32.const 2))
- 
--(module
-+(module $M1
+@@ -23,6 +23,8 @@
    (import "spectest" "print_i32" (func $f (param i32)))
    (export "print" (func $f))
  )
--(register "reexport_f")
-+(register "reexport_f" $M1)
++
++(; doesn't support empty files
+ (register "reexport_f" $M1)
  (assert_unlinkable
    (module (import "reexport_f" "print" (func (param i64))))
+@@ -32,9 +34,11 @@
+   (module (import "reexport_f" "print" (func (param i32) (result i32))))
    "incompatible import type"
-@@ -35,7 +35,6 @@
+ )
++;)
  
  
  ;; Globals
--
++(; aot doesn't support to import globals
  (module $Mg
    (global $glob (export "glob") i32 (i32.const 42))
    (func (export "get") (result i32) (global.get $glob))
-@@ -47,6 +46,7 @@
+@@ -45,6 +49,7 @@
+   (func (export "set_mut") (param i32) (global.set $mut_glob (local.get 0)))
  )
  (register "Mg" $Mg)
- 
-+(; only sharing initial values
- (module $Ng
-   (global $x (import "Mg" "glob") i32)
-   (global $mut_glob (import "Mg" "mut_glob") (mut i32))
-@@ -81,7 +81,7 @@
- (assert_return (get $Ng "Mg.mut_glob") (i32.const 241))
- (assert_return (invoke $Mg "get_mut") (i32.const 241))
- (assert_return (invoke $Ng "Mg.get_mut") (i32.const 241))
--
 +;)
  
+ (; only sharing initial values
+ (module $Ng
+@@ -83,6 +88,7 @@
+ (assert_return (invoke $Ng "Mg.get_mut") (i32.const 241))
+ ;)
+ 
++(;
  (assert_unlinkable
    (module (import "Mg" "mut_glob" (global i32)))
-@@ -130,7 +130,7 @@
+   "incompatible import type"
+@@ -92,7 +98,6 @@
+   "incompatible import type"
+ )
  
- 
- ;; Tables
 -
-+(; no such support
- (module $Mt
-   (type (func (result i32)))
-   (type (func))
-@@ -307,10 +307,11 @@
-   (module (table (import "Mtable_ex" "t-extern") 1 funcref))
+ (module $Mref_ex
+   (global (export "g-const-func") funcref (ref.null func))
+   (global (export "g-var-func") (mut funcref) (ref.null func))
+@@ -127,6 +132,7 @@
+   (module (global (import "Mref_ex" "g-var-extern") (mut funcref)))
    "incompatible import type"
  )
 +;)
  
  
- ;; Memories
--
-+(; no such support
- (module $Mm
-   (memory (export "mem") 1 5)
-   (data (i32.const 10) "\00\01\02\03\04\05\06\07\08\09")
-@@ -451,3 +452,4 @@
- 
- (assert_return (invoke $Ms "get memory[0]") (i32.const 104))  ;; 'h'
- (assert_return (invoke $Ms "get table[0]") (i32.const 0xdead))
-+;)
-\ No newline at end of file
+ ;; Tables

--- a/tests/wamr-test-suites/spec-test-script/multi_module_ignore_cases.patch
+++ b/tests/wamr-test-suites/spec-test-script/multi_module_ignore_cases.patch
@@ -1,0 +1,124 @@
+diff --git a/test/core/imports.wast b/test/core/imports.wast
+index 0cc07cb..4e8367a 100644
+--- a/test/core/imports.wast
++++ b/test/core/imports.wast
+@@ -86,7 +86,7 @@
+ (assert_return (invoke "print64" (i64.const 24)))
+ 
+ (assert_invalid
+-  (module 
++  (module
+     (type (func (result i32)))
+     (import "test" "func" (func (type 1)))
+   )
+@@ -578,6 +578,7 @@
+ (assert_return (invoke "grow" (i32.const 1)) (i32.const -1))
+ (assert_return (invoke "grow" (i32.const 0)) (i32.const 2))
+ 
++(;
+ (module $Mgm
+   (memory (export "memory") 1) ;; initial size is 1
+   (func (export "grow") (result i32) (memory.grow (i32.const 1)))
+@@ -586,7 +587,7 @@
+ (assert_return (invoke $Mgm "grow") (i32.const 1)) ;; now size is 2
+ (module $Mgim1
+   ;; imported memory limits should match, because external memory size is 2 now
+-  (memory (export "memory") (import "grown-memory" "memory") 2) 
++  (memory (export "memory") (import "grown-memory" "memory") 2)
+   (func (export "grow") (result i32) (memory.grow (i32.const 1)))
+ )
+ (register "grown-imported-memory" $Mgim1)
+@@ -597,7 +598,7 @@
+   (func (export "size") (result i32) (memory.size))
+ )
+ (assert_return (invoke $Mgim2 "size") (i32.const 3))
+-
++;)
+ 
+ ;; Syntax errors
+ 
+@@ -669,6 +670,7 @@
+   "import after memory"
+ )
+ 
++(;
+ ;; This module is required to validate, regardless of whether it can be
+ ;; linked. Overloading is not possible in wasm itself, but it is possible
+ ;; in modules from which wasm can import.
+@@ -695,3 +697,4 @@
+   )
+   "unknown import"
+ )
++;)
+\ No newline at end of file
+diff --git a/test/core/linking.wast b/test/core/linking.wast
+index 994e0f4..8fbcc02 100644
+--- a/test/core/linking.wast
++++ b/test/core/linking.wast
+@@ -19,11 +19,11 @@
+ (assert_return (invoke $Nf "call") (i32.const 3))
+ (assert_return (invoke $Nf "call Mf.call") (i32.const 2))
+ 
+-(module
++(module $M1
+   (import "spectest" "print_i32" (func $f (param i32)))
+   (export "print" (func $f))
+ )
+-(register "reexport_f")
++(register "reexport_f" $M1)
+ (assert_unlinkable
+   (module (import "reexport_f" "print" (func (param i64))))
+   "incompatible import type"
+@@ -35,7 +35,6 @@
+ 
+ 
+ ;; Globals
+-
+ (module $Mg
+   (global $glob (export "glob") i32 (i32.const 42))
+   (func (export "get") (result i32) (global.get $glob))
+@@ -47,6 +46,7 @@
+ )
+ (register "Mg" $Mg)
+ 
++(; only sharing initial values
+ (module $Ng
+   (global $x (import "Mg" "glob") i32)
+   (global $mut_glob (import "Mg" "mut_glob") (mut i32))
+@@ -81,7 +81,7 @@
+ (assert_return (get $Ng "Mg.mut_glob") (i32.const 241))
+ (assert_return (invoke $Mg "get_mut") (i32.const 241))
+ (assert_return (invoke $Ng "Mg.get_mut") (i32.const 241))
+-
++;)
+ 
+ (assert_unlinkable
+   (module (import "Mg" "mut_glob" (global i32)))
+@@ -130,7 +130,7 @@
+ 
+ 
+ ;; Tables
+-
++(; no such support
+ (module $Mt
+   (type (func (result i32)))
+   (type (func))
+@@ -307,10 +307,11 @@
+   (module (table (import "Mtable_ex" "t-extern") 1 funcref))
+   "incompatible import type"
+ )
++;)
+ 
+ 
+ ;; Memories
+-
++(; no such support
+ (module $Mm
+   (memory (export "mem") 1 5)
+   (data (i32.const 10) "\00\01\02\03\04\05\06\07\08\09")
+@@ -451,3 +452,4 @@
+ 
+ (assert_return (invoke $Ms "get memory[0]") (i32.const 104))  ;; 'h'
+ (assert_return (invoke $Ms "get table[0]") (i32.const 0xdead))
++;)
+\ No newline at end of file

--- a/tests/wamr-test-suites/test_wamr.sh
+++ b/tests/wamr-test-suites/test_wamr.sh
@@ -427,6 +427,8 @@ function compile_reference_interpreter()
 # TODO: with iwasm only
 function spec_test()
 {
+    local RUNNING_MODE="$1"
+
     echo "Now start spec tests"
     touch ${REPORT_DIR}/spec_test_report.txt
 
@@ -499,7 +501,11 @@ function spec_test()
             git apply ../../spec-test-script/simd_ignore_cases.patch || exit 1
         fi
         if [[ ${ENABLE_MULTI_MODULE} == 1 ]]; then
-            git apply ../../spec-test-script/multi_module_aot_ignore_cases.patch || exit 1
+            git apply ../../spec-test-script/multi_module_ignore_cases.patch || exit 1
+
+            if [[ ${RUNNING_MODE} == "aot" ]]; then
+                git apply ../../spec-test-script/multi_module_aot_ignore_cases.patch || exit 1
+            fi
         fi
     fi
 
@@ -856,10 +862,10 @@ function do_execute_in_running_mode()
         fi
     fi
 
-    # FIXME: add "aot" after fix the linking failure
     if [[ ${ENABLE_MULTI_MODULE} -eq 1 ]]; then
         if [[ "${RUNNING_MODE}" != "classic-interp" \
-                && "${RUNNING_MODE}" != "fast-interp" ]]; then
+                && "${RUNNING_MODE}" != "fast-interp" \
+                && "${RUNNING_MODE}" != "aot" ]]; then
             echo "support multi-module in both interp modes"
             return 0
         fi


### PR DESCRIPTION
- doesn't support empty modules
- aot doesn't support import globals