### PR TITLE
Add global export apis

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -91,6 +91,9 @@ wasm_runtime_destroy_registered_module_list();
 
 #define E_TYPE_XIP 4
 
+static uint8
+val_type_to_val_kind(uint8 value_type);
+
 #if WASM_ENABLE_GC == 0 && WASM_ENABLE_REF_TYPES != 0
 /* Initialize externref hashmap */
 static bool
@@ -1889,6 +1892,67 @@ wasm_runtime_set_module_inst(WASMExecEnv *exec_env,
                              WASMModuleInstanceCommon *const module_inst)
 {
     wasm_exec_env_set_module_inst(exec_env, module_inst);
+}
+
+bool
+wasm_runtime_get_export_global_inst(const wasm_module_inst_t module_inst,
+                                    char const *name,
+                                    wasm_global_inst_t *global_inst)
+{
+#if WASM_ENABLE_INTERP != 0
+    if (module_inst->module_type == Wasm_Module_Bytecode) {
+        const WASMModuleInstance *wasm_module_inst =
+            (const WASMModuleInstance *)module_inst;
+        const WASMModule *wasm_module = wasm_module_inst->module;
+        uint32 i;
+        for (i = 0; i < wasm_module->export_count; i++) {
+            const WASMExport *wasm_export = &wasm_module->exports[i];
+            if ((wasm_export->kind == WASM_IMPORT_EXPORT_KIND_GLOBAL)
+                && !strcmp(wasm_export->name, name)) {
+                const WASMModuleInstanceExtra *e =
+                    (WASMModuleInstanceExtra *)wasm_module_inst->e;
+                const WASMGlobalInstance *global =
+                    &e->globals[wasm_export->index];
+                global_inst->kind = val_type_to_val_kind(global->type);
+                global_inst->is_mutable = global->is_mutable;
+#if WASM_ENABLE_MULTI_MODULE == 0
+                global_inst->global_data =
+                    wasm_module_inst->global_data + global->data_offset;
+#else
+                global_inst->global_data =
+                    global->import_global_inst
+                        ? global->import_module_inst->global_data
+                              + global->import_global_inst->data_offset
+                        : wasm_module_inst->global_data + global->data_offset;
+#endif
+                return true;
+            }
+        }
+    }
+#endif
+#if WASM_ENABLE_AOT != 0
+    if (module_inst->module_type == Wasm_Module_AoT) {
+        const AOTModuleInstance *aot_module_inst =
+            (AOTModuleInstance *)module_inst;
+        const AOTModule *aot_module = (AOTModule *)aot_module_inst->module;
+        uint32 i;
+        for (i = 0; i < aot_module->export_count; i++) {
+            const AOTExport *aot_export = &aot_module->exports[i];
+            if ((aot_export->kind == WASM_IMPORT_EXPORT_KIND_GLOBAL)
+                && !strcmp(aot_export->name, name)) {
+                const AOTGlobal *global =
+                    &aot_module->globals[aot_export->index];
+                global_inst->kind = val_type_to_val_kind(global->type.val_type);
+                global_inst->is_mutable = global->type.is_mutable;
+                global_inst->global_data =
+                    aot_module_inst->global_data + global->data_offset;
+                return true;
+            }
+        }
+    }
+#endif
+
+    return false;
 }
 
 void *

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -1895,7 +1895,7 @@ wasm_runtime_set_module_inst(WASMExecEnv *exec_env,
 }
 
 bool
-wasm_runtime_get_export_global_inst(const wasm_module_inst_t module_inst,
+wasm_runtime_get_export_global_inst(WASMModuleInstanceCommon *const module_inst,
                                     char const *name,
                                     wasm_global_inst_t *global_inst)
 {

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -275,6 +275,13 @@ typedef struct wasm_val_t {
 } wasm_val_t;
 #endif
 
+/* Global instance*/
+typedef struct wasm_global_inst_t {
+    wasm_valkind_t kind;
+    bool is_mutable;
+    void *global_data;
+} wasm_global_inst_t;
+
 typedef enum {
     WASM_LOG_LEVEL_FATAL = 0,
     WASM_LOG_LEVEL_ERROR = 1,
@@ -1406,6 +1413,21 @@ wasm_runtime_register_natives_raw(const char *module_name,
 WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_unregister_natives(const char *module_name,
                                 NativeSymbol *native_symbols);
+
+/**
+ * Get an export global instance
+ *
+ * @param module_inst the module instance
+ * @param name the export global name
+ * @param global_inst location to store the global instance
+ *
+ * @return true if success, false otherwise
+ *
+ */
+WASM_RUNTIME_API_EXTERN bool
+wasm_runtime_get_export_global_inst(const wasm_module_inst_t module_inst,
+                                    const char *name,
+                                    wasm_global_inst_t *global_inst);
 
 /**
  * Get attachment of native function from execution environment


### PR DESCRIPTION
I'm very new to this code, so I'm not confident at all that this is the best way (or even a good way) to expose export globals, so please let me know if there is a better strategy or if I've just done it wrong. As a minor detail, I didn't see a good way in the AOT global_instantiate() to fill in the ref_type.