### PR TITLE
Fix codeql compilation error

### DIFF
--- a/.github/scripts/codeql_buildscript.sh
+++ b/.github/scripts/codeql_buildscript.sh
@@ -7,7 +7,7 @@
 
 sudo apt update
 
-sudo apt install -y build-essential cmake g++-multilib libgcc-11-dev lib32gcc-11-dev ccache ninja-build ccache
+sudo apt install -y build-essential cmake g++-multilib libgcc-12-dev lib32gcc-12-dev ccache ninja-build
 
 WAMR_DIR=${PWD}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners
     # Consider using larger runners for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-13') || 'ubuntu-20.04' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-13') || 'ubuntu-22.04' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:
       actions: read

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -926,8 +926,8 @@ instantiate_struct_global_recursive(WASMModule *module,
                 wasm_type = module->types[heap_type];
 
                 bh_assert(wasm_type->type_flag == WASM_TYPE_STRUCT
-                          && wasm_type->type_flag == WASM_TYPE_ARRAY
-                          && wasm_type->type_flag == WASM_TYPE_FUNC);
+                          || wasm_type->type_flag == WASM_TYPE_ARRAY
+                          || wasm_type->type_flag == WASM_TYPE_FUNC);
 
                 if (wasm_type->type_flag == WASM_TYPE_STRUCT) {
                     WASMStructNewInitValues *init_values1 =


### PR DESCRIPTION
Update OS to ubuntu-22.04 and install `libgcc-12-dev lib32gcc-12-dev` instead
of `libgcc-11-dev lib32gcc-11-dev`.

ps.
https://github.com/bytecodealliance/wasm-micro-runtime/actions/runs/9183310069/job/25253782329