### PR TITLE
NuttX: Fix a dbus-related crash on esp32s3

### DIFF
--- a/core/shared/platform/nuttx/nuttx_platform.c
+++ b/core/shared/platform/nuttx/nuttx_platform.c
@@ -53,7 +53,13 @@ os_mmap(void *hint, size_t size, int prot, int flags, os_file_handle file)
     if ((prot & MMAP_PROT_EXEC) != 0) {
         p = up_textheap_memalign(sizeof(void *), size);
         if (p) {
+#if (WASM_MEM_DUAL_BUS_MIRROR != 0)
+            void *dp = os_get_dbus_mirror(p);
+            memset(dp, 0, size);
+            os_dcache_flush();
+#else
             memset(p, 0, size);
+#endif
         }
         return p;
     }


### PR DESCRIPTION
Although I don't know what exactly the esp32s3 rom version of memset does, it seems that the current code crashes only with a small "len". I guess it changes the logic depending on the size.
Anyway, it's safer to use dbus here.