### PR TITLE
Typo fix on_docker.md

### DIFF
--- a/gitbook/basics/getting-started/on_docker.md
+++ b/gitbook/basics/getting-started/on_docker.md
@@ -14,8 +14,8 @@ make
 Then you are ready to go to the directory that contains the hello world program and copy our iwasm vmcore
 
 ```sh
-cp iwasm ../../app-samples/hello-world
-cd ../../app-samples/hello-world
+cp iwasm ../../../app-samples/hello-world
+cd ../../../app-samples/hello-world
 ./build.sh
 ```
 


### PR DESCRIPTION
I Found some typo in wamr gitbook getting-started.
(https://wamr.gitbook.io/document/basics/getting-started/on_docker)

```
cp iwasm ../../app-samples/hello-world
cd ../../app-samples/hello-world
./build.sh

```

This path is incorrect

```
cp iwasm ../../../app-samples/hello-world
cd ../../../app-samples/hello-world
./build.sh

```

This path is correct.

Therefore, I am requesting a pull request.