### PR TITLE
Correct nuttx repo names

### DIFF
--- a/.github/workflows/compilation_on_nuttx.yml
+++ b/.github/workflows/compilation_on_nuttx.yml
@@ -85,14 +85,14 @@ jobs:
       - name: Checkout NuttX
         uses: actions/checkout@v4
         with:
-          repository: apache/incubator-nuttx
+          repository: apache/nuttx
           ref: releases/12.4
           path: nuttx
 
       - name: Checkout NuttX Apps
         uses: actions/checkout@v4
         with:
-          repository: apache/incubator-nuttx-apps
+          repository: apache/nuttx-apps
           ref: releases/12.4
           path: apps
 

--- a/.github/workflows/spec_test_on_nuttx.yml
+++ b/.github/workflows/spec_test_on_nuttx.yml
@@ -112,14 +112,14 @@ jobs:
       - name: Checkout NuttX
         uses: actions/checkout@v4
         with:
-          repository: apache/incubator-nuttx
+          repository: apache/nuttx
           ref: releases/12.4
           path: nuttx
 
       - name: Checkout NuttX Apps
         uses: actions/checkout@v4
         with:
-          repository: apache/incubator-nuttx-apps
+          repository: apache/nuttx-apps
           ref: releases/12.4
           path: apps
 

--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -35,7 +35,7 @@ The WAMR fast interpreter is a clean room development. We would acknowledge the 
 | uvwasi | unspecified | v0.0.12 | https://github.com/nodejs/uvwasi | |
 | asmjit | unspecified | unspecified | https://github.com/asmjit/asmjit | |
 | zydis | unspecified | e14a07895136182a5b53e181eec3b1c6e0b434de | https://github.com/zyantific/zydis | |
-| NuttX ELF headers | 72313301e23f9c2de969fb64b9a0f67bb4c284df | 10.3.0 | https://github.com/apache/incubator-nuttx | |
+| NuttX ELF headers | 72313301e23f9c2de969fb64b9a0f67bb4c284df | 10.3.0 | https://github.com/apache/nuttx | |
 | Dhrystone | 2.1 | 2.1 | https://fossies.org/linux/privat/old/ | |
 
 ## Licenses


### PR DESCRIPTION
Seems that the nuttx repo had been changed from
https://github.com/apache/incubator-nuttx
to https://github.com/apache/nuttx.

Not sure whether it will cause CI failure, but had better
use the correct repo name.

ps.
https://github.com/bytecodealliance/wasm-micro-runtime/actions/runs/9295718669
```
unable to access 'https://github.com/apache/incubator-nuttx/':
Failed to connect to github.com port 443 after 134634 ms: Connection timed out
```