### PR TITLE
Fix test-wamr-ide CI failure

### DIFF
--- a/test-tools/wamr-ide/VSCode-Extension/tsconfig.json
+++ b/test-tools/wamr-ide/VSCode-Extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
+        "moduleResolution": "node16",
         "target": "es6",
         "outDir": "out",
         "lib": ["es6"],


### PR DESCRIPTION
Set `moduleResolution` as `node16` in tsconfig.json.

ps.
https://github.com/bytecodealliance/wasm-micro-runtime/actions/runs/9296272681/job/25586420457
```
node_modules/@vscode/test-electron/out/util.d.ts(1,23): error TS1452:
'resolution-mode' assertions are only supported when `moduleResolution` is `node16` or `nodenext`.
```
