### PR TITLE
Fix interpreter unit test case failure

### DIFF
--- a/tests/unit/interpreter/CMakeLists.txt
+++ b/tests/unit/interpreter/CMakeLists.txt
@@ -14,6 +14,7 @@ add_definitions (-Dattr_container_free=free)
 set (WAMR_BUILD_LIBC_WASI 0)
 set (WAMR_BUILD_APP_FRAMEWORK 1)
 set (WAMR_BUILD_AOT 0)
+set (WAMR_BUILD_INTERP 1)
 
 include (../unit_common.cmake)
 


### PR DESCRIPTION
Please be awared of: Still need to go through all unit cases' CMakeLists.txt. Make sure they don't depend on previous configuration or default configuration.