### PR TITLE
Fix posix no libc wasi debug interp build

### DIFF
--- a/core/shared/platform/common/posix/platform_api_posix.cmake
+++ b/core/shared/platform/common/posix/platform_api_posix.cmake
@@ -9,6 +9,11 @@ if (NOT WAMR_BUILD_LIBC_WASI EQUAL 1)
     list(REMOVE_ITEM source_all
         ${PLATFORM_COMMON_POSIX_DIR}/posix_file.c
         ${PLATFORM_COMMON_POSIX_DIR}/posix_clock.c
+    )
+endif()
+
+if ((NOT WAMR_BUILD_LIBC_WASI EQUAL 1) AND (NOT WAMR_BUILD_DEBUG_INTERP EQUAL 1))
+    list(REMOVE_ITEM source_all
         ${PLATFORM_COMMON_POSIX_DIR}/posix_socket.c
     )
 else()


### PR DESCRIPTION
This change supports building with `WAMR_BUILD_LIBC_WASI=0` and `WAMR_BUILD_DEBUG_INTERP=1`, otherwise the `os_socket_*` functions will be undefined.