### PR TITLE
Added missing functions to make RIOT work with the 2.x.x version

### DIFF
--- a/core/shared/platform/riot/platform_internal.h
+++ b/core/shared/platform/riot/platform_internal.h
@@ -94,4 +94,12 @@ os_get_invalid_handle()
     return -1;
 }
 
+/* There is no MMU in RIOT so the function return 1024 to make the compiler
+   happy */
+static inline int
+os_getpagesize()
+{
+    return 1024;
+}
+
 #endif /* end of _BH_PLATFORM_H */

--- a/core/shared/platform/riot/riot_platform.c
+++ b/core/shared/platform/riot/riot_platform.c
@@ -57,6 +57,12 @@ os_mmap(void *hint, size_t size, int prot, int flags, os_file_handle file)
     return BH_MALLOC((unsigned)size);
 }
 
+void *
+os_mremap(void *old_addr, size_t old_size, size_t new_size)
+{
+    return os_mremap_slow(old_addr, old_size, new_size);
+}
+
 void
 os_munmap(void *addr, size_t size)
 {


### PR DESCRIPTION
I saw that the `os_mremap` and `os_getpagesize` were missing in the `core/shared/platform/riot` and were preventing RIOT from compiling if using WAMR v2.x.x+. This PR is adding both functions and should allow RIOT to update WAMR version to v2.x.x