### PR TITLE
Add aot_emit_aot_file.h to expose functions related to emitting AOT files

### DIFF
--- a/core/iwasm/compilation/aot_compiler.h
+++ b/core/iwasm/compilation/aot_compiler.h
@@ -783,14 +783,6 @@ bool
 aot_emit_llvm_file(AOTCompContext *comp_ctx, const char *file_name);
 
 bool
-aot_emit_aot_file(AOTCompContext *comp_ctx, AOTCompData *comp_data,
-                  const char *file_name);
-
-uint8 *
-aot_emit_aot_file_buf(AOTCompContext *comp_ctx, AOTCompData *comp_data,
-                      uint32 *p_aot_file_size);
-
-bool
 aot_emit_object_file(AOTCompContext *comp_ctx, char *file_name);
 
 char *

--- a/core/iwasm/compilation/aot_emit_aot_file.c
+++ b/core/iwasm/compilation/aot_emit_aot_file.c
@@ -1190,8 +1190,8 @@ static uint32
 get_custom_sections_size(AOTCompContext *comp_ctx, AOTCompData *comp_data);
 
 uint32
-get_aot_file_size(AOTCompContext *comp_ctx, AOTCompData *comp_data,
-                  AOTObjectData *obj_data)
+aot_get_aot_file_size(AOTCompContext *comp_ctx, AOTCompData *comp_data,
+                      AOTObjectData *obj_data)
 {
     uint32 size = 0;
     uint32 size_custom_section = 0;
@@ -4449,7 +4449,7 @@ aot_emit_aot_file_buf(AOTCompContext *comp_ctx, AOTCompData *comp_data,
     if (!obj_data)
         return NULL;
 
-    aot_file_size = get_aot_file_size(comp_ctx, comp_data, obj_data);
+    aot_file_size = aot_get_aot_file_size(comp_ctx, comp_data, obj_data);
     if (aot_file_size == 0) {
         aot_set_last_error("get aot file size failed");
         goto fail1;
@@ -4485,6 +4485,7 @@ aot_emit_aot_file_buf_ex(AOTCompContext *comp_ctx, AOTCompData *comp_data,
 {
     uint8 *buf_end = buf + aot_file_size;
     uint32 offset = 0;
+
     if (!aot_emit_file_header(buf, buf_end, &offset, comp_data, obj_data)
         || !aot_emit_target_info_section(buf, buf_end, &offset, comp_data,
                                          obj_data)

--- a/core/iwasm/compilation/aot_emit_aot_file.c
+++ b/core/iwasm/compilation/aot_emit_aot_file.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
-#include "aot_compiler.h"
+#include "aot_emit_aot_file.h"
 #include "../aot/aot_runtime.h"
 
 #define PUT_U64_TO_ADDR(addr, value)        \
@@ -24,65 +24,6 @@
             return (uint32)-1;                             \
         }                                                  \
     } while (0)
-
-/* Internal function in object file */
-typedef struct AOTObjectFunc {
-    char *func_name;
-    /* text offset of aot_func#n */
-    uint64 text_offset;
-    /* text offset of aot_func_internal#n */
-    uint64 text_offset_of_aot_func_internal;
-} AOTObjectFunc;
-
-/* Symbol table list node */
-typedef struct AOTSymbolNode {
-    struct AOTSymbolNode *next;
-    uint32 str_len;
-    char *symbol;
-} AOTSymbolNode;
-
-typedef struct AOTSymbolList {
-    AOTSymbolNode *head;
-    AOTSymbolNode *end;
-    uint32 len;
-} AOTSymbolList;
-
-/* AOT object data */
-typedef struct AOTObjectData {
-    AOTCompContext *comp_ctx;
-
-    LLVMMemoryBufferRef mem_buf;
-    LLVMBinaryRef binary;
-
-    AOTTargetInfo target_info;
-
-    void *text;
-    uint32 text_size;
-
-    void *text_unlikely;
-    uint32 text_unlikely_size;
-
-    void *text_hot;
-    uint32 text_hot_size;
-
-    /* literal data and size */
-    void *literal;
-    uint32 literal_size;
-
-    AOTObjectDataSection *data_sections;
-    uint32 data_sections_count;
-
-    AOTObjectFunc *funcs;
-    uint32 func_count;
-
-    AOTSymbolList symbol_list;
-    AOTRelocationGroup *relocation_groups;
-    uint32 relocation_group_count;
-
-    const char *stack_sizes_section_name;
-    uint32 stack_sizes_offset;
-    uint32 *stack_sizes;
-} AOTObjectData;
 
 #if 0
 static void dump_buf(uint8 *buf, uint32 size, char *title)

--- a/core/iwasm/compilation/aot_emit_aot_file.c
+++ b/core/iwasm/compilation/aot_emit_aot_file.c
@@ -1130,7 +1130,7 @@ get_string_literal_section_size(AOTCompContext *comp_ctx,
 static uint32
 get_custom_sections_size(AOTCompContext *comp_ctx, AOTCompData *comp_data);
 
-static uint32
+uint32
 get_aot_file_size(AOTCompContext *comp_ctx, AOTCompData *comp_data,
                   AOTObjectData *obj_data)
 {
@@ -4169,7 +4169,7 @@ destroy_relocation_symbol_list(AOTSymbolList *symbol_list)
     }
 }
 
-static void
+void
 aot_obj_data_destroy(AOTObjectData *obj_data)
 {
     if (obj_data->binary)
@@ -4202,7 +4202,7 @@ aot_obj_data_destroy(AOTObjectData *obj_data)
     wasm_runtime_free(obj_data);
 }
 
-static AOTObjectData *
+AOTObjectData *
 aot_obj_data_create(AOTCompContext *comp_ctx)
 {
     char *err = NULL;
@@ -4384,8 +4384,8 @@ aot_emit_aot_file_buf(AOTCompContext *comp_ctx, AOTCompData *comp_data,
                       uint32 *p_aot_file_size)
 {
     AOTObjectData *obj_data = aot_obj_data_create(comp_ctx);
-    uint8 *aot_file_buf, *buf, *buf_end;
-    uint32 aot_file_size, offset = 0;
+    uint8 *aot_file_buf;
+    uint32 aot_file_size;
 
     if (!obj_data)
         return NULL;
@@ -4396,14 +4396,36 @@ aot_emit_aot_file_buf(AOTCompContext *comp_ctx, AOTCompData *comp_data,
         goto fail1;
     }
 
-    if (!(buf = aot_file_buf = wasm_runtime_malloc(aot_file_size))) {
+    if (!(aot_file_buf = wasm_runtime_malloc(aot_file_size))) {
         aot_set_last_error("allocate memory failed.");
         goto fail1;
     }
 
     memset(aot_file_buf, 0, aot_file_size);
-    buf_end = buf + aot_file_size;
+    if (!aot_emit_aot_file_buf_ex(comp_ctx, comp_data, obj_data,
+                                  aot_file_buf, aot_file_size))
+        goto fail2;
 
+    *p_aot_file_size = aot_file_size;
+
+    aot_obj_data_destroy(obj_data);
+    return aot_file_buf;
+
+fail2:
+    wasm_runtime_free(aot_file_buf);
+
+fail1:
+    aot_obj_data_destroy(obj_data);
+    return NULL;
+}
+
+bool
+aot_emit_aot_file_buf_ex(AOTCompContext *comp_ctx, AOTCompData *comp_data,
+                         AOTObjectData *obj_data,
+                         uint8 *buf, uint32 aot_file_size)
+{
+    uint8 *buf_end = buf + aot_file_size;
+    uint32 offset = 0;
     if (!aot_emit_file_header(buf, buf_end, &offset, comp_data, obj_data)
         || !aot_emit_target_info_section(buf, buf_end, &offset, comp_data,
                                          obj_data)
@@ -4423,7 +4445,7 @@ aot_emit_aot_file_buf(AOTCompContext *comp_ctx, AOTCompData *comp_data,
                                             comp_ctx)
 #endif
     )
-        goto fail2;
+        return false;
 
 #if 0
     dump_buf(buf, offset, "sections");
@@ -4431,20 +4453,10 @@ aot_emit_aot_file_buf(AOTCompContext *comp_ctx, AOTCompData *comp_data,
 
     if (offset != aot_file_size) {
         aot_set_last_error("emit aot file failed.");
-        goto fail2;
+        return false;
     }
 
-    *p_aot_file_size = aot_file_size;
-
-    aot_obj_data_destroy(obj_data);
-    return aot_file_buf;
-
-fail2:
-    wasm_runtime_free(aot_file_buf);
-
-fail1:
-    aot_obj_data_destroy(obj_data);
-    return NULL;
+    return true;
 }
 
 bool

--- a/core/iwasm/compilation/aot_emit_aot_file.c
+++ b/core/iwasm/compilation/aot_emit_aot_file.c
@@ -25,6 +25,65 @@
         }                                                  \
     } while (0)
 
+/* Internal function in object file */
+typedef struct AOTObjectFunc {
+    char *func_name;
+    /* text offset of aot_func#n */
+    uint64 text_offset;
+    /* text offset of aot_func_internal#n */
+    uint64 text_offset_of_aot_func_internal;
+} AOTObjectFunc;
+
+/* Symbol table list node */
+typedef struct AOTSymbolNode {
+    struct AOTSymbolNode *next;
+    uint32 str_len;
+    char *symbol;
+} AOTSymbolNode;
+
+typedef struct AOTSymbolList {
+    AOTSymbolNode *head;
+    AOTSymbolNode *end;
+    uint32 len;
+} AOTSymbolList;
+
+/* AOT object data */
+typedef struct AOTObjectData {
+    AOTCompContext *comp_ctx;
+
+    LLVMMemoryBufferRef mem_buf;
+    LLVMBinaryRef binary;
+
+    AOTTargetInfo target_info;
+
+    void *text;
+    uint32 text_size;
+
+    void *text_unlikely;
+    uint32 text_unlikely_size;
+
+    void *text_hot;
+    uint32 text_hot_size;
+
+    /* literal data and size */
+    void *literal;
+    uint32 literal_size;
+
+    AOTObjectDataSection *data_sections;
+    uint32 data_sections_count;
+
+    AOTObjectFunc *funcs;
+    uint32 func_count;
+
+    AOTSymbolList symbol_list;
+    AOTRelocationGroup *relocation_groups;
+    uint32 relocation_group_count;
+
+    const char *stack_sizes_section_name;
+    uint32 stack_sizes_offset;
+    uint32 *stack_sizes;
+} AOTObjectData;
+
 #if 0
 static void dump_buf(uint8 *buf, uint32 size, char *title)
 {

--- a/core/iwasm/compilation/aot_emit_aot_file.c
+++ b/core/iwasm/compilation/aot_emit_aot_file.c
@@ -4402,8 +4402,8 @@ aot_emit_aot_file_buf(AOTCompContext *comp_ctx, AOTCompData *comp_data,
     }
 
     memset(aot_file_buf, 0, aot_file_size);
-    if (!aot_emit_aot_file_buf_ex(comp_ctx, comp_data, obj_data,
-                                  aot_file_buf, aot_file_size))
+    if (!aot_emit_aot_file_buf_ex(comp_ctx, comp_data, obj_data, aot_file_buf,
+                                  aot_file_size))
         goto fail2;
 
     *p_aot_file_size = aot_file_size;
@@ -4421,8 +4421,8 @@ fail1:
 
 bool
 aot_emit_aot_file_buf_ex(AOTCompContext *comp_ctx, AOTCompData *comp_data,
-                         AOTObjectData *obj_data,
-                         uint8 *buf, uint32 aot_file_size)
+                         AOTObjectData *obj_data, uint8 *buf,
+                         uint32 aot_file_size)
 {
     uint8 *buf_end = buf + aot_file_size;
     uint32 offset = 0;

--- a/core/iwasm/compilation/aot_emit_aot_file.h
+++ b/core/iwasm/compilation/aot_emit_aot_file.h
@@ -72,6 +72,13 @@ typedef struct AOTObjectData {
 } AOTObjectData;
 
 
+AOTObjectData *
+aot_obj_data_create(AOTCompContext *comp_ctx);
+
+uint32
+get_aot_file_size(AOTCompContext *comp_ctx, AOTCompData *comp_data,
+                  AOTObjectData *obj_data);
+
 bool
 aot_emit_aot_file(AOTCompContext *comp_ctx, AOTCompData *comp_data,
                   const char *file_name);
@@ -79,6 +86,15 @@ aot_emit_aot_file(AOTCompContext *comp_ctx, AOTCompData *comp_data,
 uint8 *
 aot_emit_aot_file_buf(AOTCompContext *comp_ctx, AOTCompData *comp_data,
                       uint32 *p_aot_file_size);
+
+bool
+aot_emit_aot_file_buf_ex(AOTCompContext *comp_ctx, AOTCompData *comp_data,
+                         AOTObjectData *obj_data,
+                         uint8 *aot_file_buf, uint32 aot_file_size);
+
+void
+aot_obj_data_destroy(AOTObjectData *obj_data);
+
 
 #ifdef __cplusplus
 } /* end of extern "C" */

--- a/core/iwasm/compilation/aot_emit_aot_file.h
+++ b/core/iwasm/compilation/aot_emit_aot_file.h
@@ -71,7 +71,6 @@ typedef struct AOTObjectData {
     uint32 *stack_sizes;
 } AOTObjectData;
 
-
 AOTObjectData *
 aot_obj_data_create(AOTCompContext *comp_ctx);
 
@@ -89,12 +88,11 @@ aot_emit_aot_file_buf(AOTCompContext *comp_ctx, AOTCompData *comp_data,
 
 bool
 aot_emit_aot_file_buf_ex(AOTCompContext *comp_ctx, AOTCompData *comp_data,
-                         AOTObjectData *obj_data,
-                         uint8 *aot_file_buf, uint32 aot_file_size);
+                         AOTObjectData *obj_data, uint8 *aot_file_buf,
+                         uint32 aot_file_size);
 
 void
 aot_obj_data_destroy(AOTObjectData *obj_data);
-
 
 #ifdef __cplusplus
 } /* end of extern "C" */

--- a/core/iwasm/compilation/aot_emit_aot_file.h
+++ b/core/iwasm/compilation/aot_emit_aot_file.h
@@ -17,9 +17,12 @@ typedef struct AOTObjectData AOTObjectData;
 AOTObjectData *
 aot_obj_data_create(AOTCompContext *comp_ctx);
 
+void
+aot_obj_data_destroy(AOTObjectData *obj_data);
+
 uint32
-get_aot_file_size(AOTCompContext *comp_ctx, AOTCompData *comp_data,
-                  AOTObjectData *obj_data);
+aot_get_aot_file_size(AOTCompContext *comp_ctx, AOTCompData *comp_data,
+                      AOTObjectData *obj_data);
 
 bool
 aot_emit_aot_file(AOTCompContext *comp_ctx, AOTCompData *comp_data,
@@ -33,9 +36,6 @@ bool
 aot_emit_aot_file_buf_ex(AOTCompContext *comp_ctx, AOTCompData *comp_data,
                          AOTObjectData *obj_data, uint8 *aot_file_buf,
                          uint32 aot_file_size);
-
-void
-aot_obj_data_destroy(AOTObjectData *obj_data);
 
 #ifdef __cplusplus
 } /* end of extern "C" */

--- a/core/iwasm/compilation/aot_emit_aot_file.h
+++ b/core/iwasm/compilation/aot_emit_aot_file.h
@@ -12,64 +12,7 @@
 extern "C" {
 #endif
 
-/* Internal function in object file */
-typedef struct AOTObjectFunc {
-    char *func_name;
-    /* text offset of aot_func#n */
-    uint64 text_offset;
-    /* text offset of aot_func_internal#n */
-    uint64 text_offset_of_aot_func_internal;
-} AOTObjectFunc;
-
-/* Symbol table list node */
-typedef struct AOTSymbolNode {
-    struct AOTSymbolNode *next;
-    uint32 str_len;
-    char *symbol;
-} AOTSymbolNode;
-
-typedef struct AOTSymbolList {
-    AOTSymbolNode *head;
-    AOTSymbolNode *end;
-    uint32 len;
-} AOTSymbolList;
-
-/* AOT object data */
-typedef struct AOTObjectData {
-    AOTCompContext *comp_ctx;
-
-    LLVMMemoryBufferRef mem_buf;
-    LLVMBinaryRef binary;
-
-    AOTTargetInfo target_info;
-
-    void *text;
-    uint32 text_size;
-
-    void *text_unlikely;
-    uint32 text_unlikely_size;
-
-    void *text_hot;
-    uint32 text_hot_size;
-
-    /* literal data and size */
-    void *literal;
-    uint32 literal_size;
-
-    AOTObjectDataSection *data_sections;
-    uint32 data_sections_count;
-
-    AOTObjectFunc *funcs;
-    uint32 func_count;
-
-    AOTSymbolList symbol_list;
-    AOTRelocationGroup *relocation_groups;
-    uint32 relocation_group_count;
-
-    const char *stack_sizes_section_name;
-    uint32 stack_sizes_offset;
-    uint32 *stack_sizes;
-} AOTObjectData;
+typedef struct AOTObjectData AOTObjectData;
 
 AOTObjectData *
 aot_obj_data_create(AOTCompContext *comp_ctx);

--- a/core/iwasm/compilation/aot_emit_aot_file.h
+++ b/core/iwasm/compilation/aot_emit_aot_file.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#ifndef _AOT_EMIT_AOT_FILE_H_
+#define _AOT_EMIT_AOT_FILE_H_
+
+#include "aot_compiler.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Internal function in object file */
+typedef struct AOTObjectFunc {
+    char *func_name;
+    /* text offset of aot_func#n */
+    uint64 text_offset;
+    /* text offset of aot_func_internal#n */
+    uint64 text_offset_of_aot_func_internal;
+} AOTObjectFunc;
+
+/* Symbol table list node */
+typedef struct AOTSymbolNode {
+    struct AOTSymbolNode *next;
+    uint32 str_len;
+    char *symbol;
+} AOTSymbolNode;
+
+typedef struct AOTSymbolList {
+    AOTSymbolNode *head;
+    AOTSymbolNode *end;
+    uint32 len;
+} AOTSymbolList;
+
+/* AOT object data */
+typedef struct AOTObjectData {
+    AOTCompContext *comp_ctx;
+
+    LLVMMemoryBufferRef mem_buf;
+    LLVMBinaryRef binary;
+
+    AOTTargetInfo target_info;
+
+    void *text;
+    uint32 text_size;
+
+    void *text_unlikely;
+    uint32 text_unlikely_size;
+
+    void *text_hot;
+    uint32 text_hot_size;
+
+    /* literal data and size */
+    void *literal;
+    uint32 literal_size;
+
+    AOTObjectDataSection *data_sections;
+    uint32 data_sections_count;
+
+    AOTObjectFunc *funcs;
+    uint32 func_count;
+
+    AOTSymbolList symbol_list;
+    AOTRelocationGroup *relocation_groups;
+    uint32 relocation_group_count;
+
+    const char *stack_sizes_section_name;
+    uint32 stack_sizes_offset;
+    uint32 *stack_sizes;
+} AOTObjectData;
+
+
+bool
+aot_emit_aot_file(AOTCompContext *comp_ctx, AOTCompData *comp_data,
+                  const char *file_name);
+
+uint8 *
+aot_emit_aot_file_buf(AOTCompContext *comp_ctx, AOTCompData *comp_data,
+                      uint32 *p_aot_file_size);
+
+#ifdef __cplusplus
+} /* end of extern "C" */
+#endif
+
+#endif /* end of _AOT_EMIT_AOT_FILE_H_ */

--- a/core/iwasm/include/aot_export.h
+++ b/core/iwasm/include/aot_export.h
@@ -72,8 +72,8 @@ void
 aot_obj_data_destroy(aot_obj_data_t obj_data);
 
 uint32_t
-get_aot_file_size(aot_comp_context_t comp_ctx, aot_comp_data_t comp_data,
-                  aot_obj_data_t obj_data);
+aot_get_aot_file_size(aot_comp_context_t comp_ctx, aot_comp_data_t comp_data,
+                      aot_obj_data_t obj_data);
 
 uint8_t *
 aot_emit_aot_file_buf(aot_comp_context_t comp_ctx, aot_comp_data_t comp_data,

--- a/core/iwasm/include/aot_export.h
+++ b/core/iwasm/include/aot_export.h
@@ -27,6 +27,9 @@ typedef struct AOTCompData *aot_comp_data_t;
 struct AOTCompContext;
 typedef struct AOTCompContext *aot_comp_context_t;
 
+struct AOTObjectData;
+typedef struct AOTObjectData *aot_obj_data_t;
+
 aot_comp_data_t
 aot_create_comp_data(void *wasm_module, const char *target_arch,
                      bool gc_enabled);
@@ -61,6 +64,25 @@ aot_destroy_comp_context(aot_comp_context_t comp_ctx);
 
 bool
 aot_compile_wasm(aot_comp_context_t comp_ctx);
+
+aot_obj_data_t
+aot_obj_data_create(aot_comp_context_t comp_ctx);
+
+void
+aot_obj_data_destroy(aot_obj_data_t obj_data);
+
+uint32_t
+get_aot_file_size(aot_comp_context_t comp_ctx, aot_comp_data_t comp_data,
+                  aot_obj_data_t obj_data);
+
+uint8_t *
+aot_emit_aot_file_buf(aot_comp_context_t comp_ctx, aot_comp_data_t comp_data,
+                      uint32_t *p_aot_file_size);
+
+bool
+aot_emit_aot_file_buf_ex(aot_comp_context_t comp_ctx, aot_comp_data_t comp_data,
+                         aot_obj_data_t obj_data, uint8_t *aot_file_buf,
+                         uint32_t aot_file_size);
 
 bool
 aot_emit_llvm_file(aot_comp_context_t comp_ctx, const char *file_name);


### PR DESCRIPTION
* add declarations related to emitting AOT files into a separate header file named `aot_emit_aot_file.h`
* extracting `aot_emit_aot_file_buf_ex` and expose through the `aot_emit_aot_file.h`