### PR TITLE
core/shared/platform: Zero memory returned by os_mmap in some platforms

### DIFF
--- a/core/shared/platform/alios/alios_platform.c
+++ b/core/shared/platform/alios/alios_platform.c
@@ -49,9 +49,15 @@ os_dumps_proc_mem_info(char *out, unsigned int size)
 void *
 os_mmap(void *hint, size_t size, int prot, int flags, os_file_handle file)
 {
-    if ((uint64)size >= UINT32_MAX)
+    void *addr;
+
+    if (size >= UINT32_MAX)
         return NULL;
-    return BH_MALLOC((uint32)size);
+
+    if ((addr = BH_MALLOC((uint32)size)))
+        memset(addr, 0, (uint32)size);
+
+    return addr;
 }
 
 void

--- a/core/shared/platform/esp-idf/espidf_memmap.c
+++ b/core/shared/platform/esp-idf/espidf_memmap.c
@@ -43,8 +43,10 @@ os_mmap(void *hint, size_t size, int prot, int flags, os_file_handle file)
         uintptr_t *addr_field = buf_fixed - sizeof(uintptr_t);
         *addr_field = (uintptr_t)buf_origin;
 #if (WASM_MEM_DUAL_BUS_MIRROR != 0)
+        memset(buf_fixed + MEM_DUAL_BUS_OFFSET, 0, size);
         return buf_fixed + MEM_DUAL_BUS_OFFSET;
 #else
+        memset(buf_fixed, 0, size);
         return buf_fixed;
 #endif
     }
@@ -71,6 +73,7 @@ os_mmap(void *hint, size_t size, int prot, int flags, os_file_handle file)
         uintptr_t *addr_field = buf_fixed - sizeof(uintptr_t);
         *addr_field = (uintptr_t)buf_origin;
 
+        memset(buf_fixed, 0, size);
         return buf_fixed;
     }
 }

--- a/core/shared/platform/riot/riot_platform.c
+++ b/core/shared/platform/riot/riot_platform.c
@@ -52,9 +52,15 @@ os_dumps_proc_mem_info(char *out, unsigned int size)
 void *
 os_mmap(void *hint, size_t size, int prot, int flags, os_file_handle file)
 {
-    if (size > ((unsigned)~0))
+    void *addr;
+
+    if (size >= UINT32_MAX)
         return NULL;
-    return BH_MALLOC((unsigned)size);
+
+    if ((addr = BH_MALLOC((uint32)size)))
+        memset(addr, 0, (uint32)size);
+
+    return addr;
 }
 
 void *

--- a/core/shared/platform/rt-thread/rtt_platform.c
+++ b/core/shared/platform/rt-thread/rtt_platform.c
@@ -200,7 +200,12 @@ os_cond_wait(korp_cond *cond, korp_mutex *mutex)
 void *
 os_mmap(void *hint, size_t size, int prot, int flags, os_file_handle file)
 {
-    return rt_malloc(size);
+    void *addr;
+
+    if ((addr = rt_malloc(size)))
+        memset(addr, 0, size);
+
+    return addr;
 }
 
 void

--- a/core/shared/platform/zephyr/zephyr_platform.c
+++ b/core/shared/platform/zephyr/zephyr_platform.c
@@ -179,12 +179,19 @@ strcspn(const char *s, const char *reject)
 void *
 os_mmap(void *hint, size_t size, int prot, int flags, os_file_handle file)
 {
+    void *addr;
+
     if ((uint64)size >= UINT32_MAX)
         return NULL;
+
     if (exec_mem_alloc_func)
-        return exec_mem_alloc_func((uint32)size);
+        addr = exec_mem_alloc_func((uint32)size);
     else
-        return BH_MALLOC(size);
+        addr = BH_MALLOC(size);
+
+    if (addr)
+        memset(addr, 0, size);
+    return addr;
 }
 
 void *


### PR DESCRIPTION
The os_mmap should zero the mapped memory like what posix mmap does.