### PR TITLE
Optimize for multi-module support in AOT mode

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -2269,11 +2269,13 @@ load_import_funcs(const uint8 **p_buf, const uint8 *buf_end, AOTModule *module,
             &import_funcs[i].signature, &import_funcs[i].attachment,
             &import_funcs[i].call_conv_raw);
         if (!linked_func) {
+            sub_module = NULL;
             if (!wasm_runtime_is_built_in_module(module_name)) {
                 sub_module = (AOTModule *)wasm_runtime_load_depended_module(
                     (WASMModuleCommon *)module, module_name, error_buf,
                     error_buf_size);
                 if (!sub_module) {
+                    LOG_ERROR("failed to load sub module: %s", error_buf);
                     return false;
                 }
             }

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -1647,7 +1647,6 @@ aot_instantiate(AOTModule *module, AOTModuleInstance *parent,
                  runtime_malloc((uint64)module->import_func_count
                                     * sizeof(WASMModuleInstanceCommon *),
                                 error_buf, error_buf_size))) {
-        wasm_runtime_free(extra->import_func_module_insts);
         goto fail;
     }
 

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -2012,6 +2012,8 @@ aot_deinstantiate(AOTModuleInstance *module_inst, bool is_sub_inst)
 #if WASM_ENABLE_MULTI_MODULE != 0
     wasm_runtime_sub_module_deinstantiate(
         (WASMModuleInstanceCommon *)module_inst);
+    if (extra->import_func_module_insts)
+        wasm_runtime_free(extra->import_func_module_insts);
 #endif
 
     if (module_inst->tables)
@@ -2035,9 +2037,6 @@ aot_deinstantiate(AOTModuleInstance *module_inst, bool is_sub_inst)
 
     if (module_inst->func_ptrs)
         wasm_runtime_free(module_inst->func_ptrs);
-
-    if (extra->import_func_module_insts)
-        wasm_runtime_free(extra->import_func_module_insts);
 
     if (module_inst->func_type_indexes)
         wasm_runtime_free(module_inst->func_type_indexes);

--- a/core/iwasm/aot/aot_runtime.h
+++ b/core/iwasm/aot/aot_runtime.h
@@ -320,11 +320,6 @@ typedef struct AOTModule {
 
 #if WASM_ENABLE_MULTI_MODULE != 0
 #define AOTSubModInstNode WASMSubModInstNode
-
-bool
-init_import_func_module_insts(AOTModuleInstance *module_inst, AOTModule *module,
-                              AOTSubModInstNode *sub_module_inst_node,
-                              char *error_buf, uint32 error_buf_size);
 #endif
 
 /* Target info, read from ELF header of object file */

--- a/core/iwasm/aot/aot_runtime.h
+++ b/core/iwasm/aot/aot_runtime.h
@@ -109,6 +109,7 @@ typedef struct AOTModuleInstanceExtra {
 #if WASM_ENABLE_MULTI_MODULE != 0
     bh_list sub_module_inst_list_head;
     bh_list *sub_module_inst_list;
+    WASMModuleInstanceCommon **func_module_insts;
 #endif
 } AOTModuleInstanceExtra;
 

--- a/core/iwasm/aot/aot_runtime.h
+++ b/core/iwasm/aot/aot_runtime.h
@@ -109,7 +109,7 @@ typedef struct AOTModuleInstanceExtra {
 #if WASM_ENABLE_MULTI_MODULE != 0
     bh_list sub_module_inst_list_head;
     bh_list *sub_module_inst_list;
-    WASMModuleInstanceCommon **func_module_insts;
+    WASMModuleInstanceCommon **import_func_module_insts;
 #endif
 } AOTModuleInstanceExtra;
 
@@ -320,6 +320,11 @@ typedef struct AOTModule {
 
 #if WASM_ENABLE_MULTI_MODULE != 0
 #define AOTSubModInstNode WASMSubModInstNode
+
+bool
+init_import_func_module_insts(AOTModuleInstance *module_inst, AOTModule *module,
+                              AOTSubModInstNode *sub_module_inst_node,
+                              char *error_buf, uint32 error_buf_size);
 #endif
 
 /* Target info, read from ELF header of object file */

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -7322,6 +7322,15 @@ wasm_runtime_sub_module_instantiate(WASMModuleCommon *module,
             (WASMModuleInstance *)sub_module_inst;
         sub_module_inst_list_node->module_name =
             sub_module_list_node->module_name;
+
+#if WASM_ENABLE_AOT != 0
+        if (!init_import_func_module_insts(
+                (AOTModuleInstance *)module_inst, (AOTModule *)module,
+                sub_module_inst_list_node, error_buf, error_buf_size)) {
+            return false;
+        }
+#endif
+
         bh_list_status ret =
             bh_list_insert(sub_module_inst_list, sub_module_inst_list_node);
         bh_assert(BH_LIST_SUCCESS == ret);

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -7324,10 +7324,24 @@ wasm_runtime_sub_module_instantiate(WASMModuleCommon *module,
             sub_module_list_node->module_name;
 
 #if WASM_ENABLE_AOT != 0
-        if (!init_import_func_module_insts(
-                (AOTModuleInstance *)module_inst, (AOTModule *)module,
-                sub_module_inst_list_node, error_buf, error_buf_size)) {
-            return false;
+        AOTModuleInstance *aot_module_inst = (AOTModuleInstance *)module_inst;
+        AOTModule *aot_module = (AOTModule *)module;
+        AOTModuleInstanceExtra *aot_extra =
+            (AOTModuleInstanceExtra *)aot_module_inst->e;
+        uint32 i;
+        AOTImportFunc *import_func;
+        for (i = 0; i < aot_module->import_func_count; i++) {
+            if (aot_extra->import_func_module_insts[i])
+                continue;
+
+            import_func = &aot_module->import_funcs[i];
+            if (strcmp(sub_module_inst_list_node->module_name,
+                       import_func->module_name)
+                == 0) {
+                aot_extra->import_func_module_insts[i] =
+                    (WASMModuleInstanceCommon *)
+                        sub_module_inst_list_node->module_inst;
+            }
         }
 #endif
 

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -7324,23 +7324,26 @@ wasm_runtime_sub_module_instantiate(WASMModuleCommon *module,
             sub_module_list_node->module_name;
 
 #if WASM_ENABLE_AOT != 0
-        AOTModuleInstance *aot_module_inst = (AOTModuleInstance *)module_inst;
-        AOTModule *aot_module = (AOTModule *)module;
-        AOTModuleInstanceExtra *aot_extra =
-            (AOTModuleInstanceExtra *)aot_module_inst->e;
-        uint32 i;
-        AOTImportFunc *import_func;
-        for (i = 0; i < aot_module->import_func_count; i++) {
-            if (aot_extra->import_func_module_insts[i])
-                continue;
+        if (module_inst->module_type == Wasm_Module_AoT) {
+            AOTModuleInstance *aot_module_inst =
+                (AOTModuleInstance *)module_inst;
+            AOTModule *aot_module = (AOTModule *)module;
+            AOTModuleInstanceExtra *aot_extra =
+                (AOTModuleInstanceExtra *)aot_module_inst->e;
+            uint32 i;
+            AOTImportFunc *import_func;
+            for (i = 0; i < aot_module->import_func_count; i++) {
+                if (aot_extra->import_func_module_insts[i])
+                    continue;
 
-            import_func = &aot_module->import_funcs[i];
-            if (strcmp(sub_module_inst_list_node->module_name,
-                       import_func->module_name)
-                == 0) {
-                aot_extra->import_func_module_insts[i] =
-                    (WASMModuleInstanceCommon *)
-                        sub_module_inst_list_node->module_inst;
+                import_func = &aot_module->import_funcs[i];
+                if (strcmp(sub_module_inst_list_node->module_name,
+                           import_func->module_name)
+                    == 0) {
+                    aot_extra->import_func_module_insts[i] =
+                        (WASMModuleInstanceCommon *)
+                            sub_module_inst_list_node->module_inst;
+                }
             }
         }
 #endif


### PR DESCRIPTION
* split the `aot_loader_resolve_function` into two functions to prevent redundant module lookups and loads
* access pre-associated module instances from `func_module_insts`, avoiding unnecessary instances lookups and improving performance