### PR TITLE
Prevent an integer overflow when checking start_func_index

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -2486,7 +2486,7 @@ load_init_data_section(const uint8 *buf, const uint8 *buf_end,
     /* check start function index */
     if (module->start_func_index != (uint32)-1
         && (module->start_func_index
-            >= module->import_func_count + module->func_count)) {
+            >= (uint64)module->import_func_count + module->func_count)) {
         set_error_buf(error_buf, error_buf_size,
                       "invalid start function index");
         return false;


### PR DESCRIPTION
[69920](https://oss-fuzz.com/testcase-detail/5082950006276096)