### PR TITLE
wasm-mutator-fuzz: make compilers overridable

### DIFF
--- a/tests/fuzz/wasm-mutator-fuzz/CMakeLists.txt
+++ b/tests/fuzz/wasm-mutator-fuzz/CMakeLists.txt
@@ -7,8 +7,12 @@ project(wasm_mutator)
 
 set (CMAKE_BUILD_TYPE Debug)
 
+if (NOT DEFINED CMAKE_C_COMPILER)
 set (CMAKE_C_COMPILER "clang")
+endif ()
+if (NOT DEFINED CMAKE_CXX_COMPILER)
 set (CMAKE_CXX_COMPILER "clang++")
+endif ()
 
 string (TOLOWER ${CMAKE_HOST_SYSTEM_NAME} WAMR_BUILD_PLATFORM)
 


### PR DESCRIPTION
eg.
```shell
cmake .. \
-DCMAKE_C_COMPILER=/usr/local/opt/llvm@15/bin/clang \
-DCMAKE_CXX_COMPILER=/usr/local/opt/llvm@15/bin/clang++
```