### PR TITLE
fix(wasi-nn): use numpy v1 in wasi-nn tests

### DIFF
--- a/core/iwasm/libraries/wasi-nn/test/requirements.txt
+++ b/core/iwasm/libraries/wasi-nn/test/requirements.txt
@@ -1,1 +1,2 @@
 tensorflow==2.11.1
+numpy==1.26.4


### PR DESCRIPTION
We need to fix numpy version since latest is incompatible,

> A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.0.0 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.