### PR TITLE
wasm-mutator-fuzz: disable SIMD by default

### DIFF
--- a/tests/fuzz/wasm-mutator-fuzz/CMakeLists.txt
+++ b/tests/fuzz/wasm-mutator-fuzz/CMakeLists.txt
@@ -96,8 +96,8 @@ if (NOT DEFINED WAMR_BUILD_MINI_LOADER)
 endif ()
 
 if (NOT DEFINED WAMR_BUILD_SIMD)
-  # Enable SIMD by default
-  set (WAMR_BUILD_SIMD 1)
+  # Disable SIMD by default
+  set (WAMR_BUILD_SIMD 0)
 endif ()
 
 if (NOT DEFINED WAMR_BUILD_REF_TYPES)


### PR DESCRIPTION
because our interpreter's SIMD support is incomplete.

cf. https://github.com/bytecodealliance/wasm-micro-runtime/issues/3580