### PR TITLE
wasm-mutator-fuzz: disable fast interpreter by default

### DIFF
--- a/tests/fuzz/wasm-mutator-fuzz/CMakeLists.txt
+++ b/tests/fuzz/wasm-mutator-fuzz/CMakeLists.txt
@@ -76,8 +76,8 @@ if (NOT DEFINED WAMR_BUILD_LIBC_WASI)
 endif ()
 
 if (NOT DEFINED WAMR_BUILD_FAST_INTERP)
-  # Enable fast interpreter
-  set (WAMR_BUILD_FAST_INTERP 1)
+  # Disable fast interpreter
+  set (WAMR_BUILD_FAST_INTERP 0)
 endif ()
 
 if (NOT DEFINED WAMR_BUILD_MULTI_MODULE)


### PR DESCRIPTION
* our interpreters' SIMD support is not complete.

* we want to keep SIMD enabled for this fuzz target because, llvm-jit and aot, which support SIMD, use wasm_loader.c to load and validate the input module.

  well, we probably should test wasm_loader.c with the configuration actually used by llvm-jit and aot. (WASM_ENABLE_JIT/WASM_ENABLE_WAMR_COMPILER) but we ignore the difference for now.

* fast interpreter is not compatible with llvm-jit/aot.

cf. https://github.com/bytecodealliance/wasm-micro-runtime/issues/3580

an alternative:
https://github.com/bytecodealliance/wasm-micro-runtime/pull/3592