### PR TITLE
Fix compile warnings/error reported in Windows

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -1139,7 +1139,7 @@ memories_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
 
         if (memory_inst->memory_data) {
             bh_memcpy_s((uint8 *)memory_inst->memory_data + base_offset,
-                        (uint32)memory_inst->memory_data_size - base_offset,
+                        (uint32)(memory_inst->memory_data_size - base_offset),
                         data_seg->bytes, length);
         }
     }
@@ -1212,7 +1212,7 @@ aot_get_function_instance(AOTModuleInstance *module_inst, uint32 func_idx)
             return NULL;
         }
 
-        extra->function_count = func_count;
+        extra->function_count = (uint32)func_count;
     }
 
     /* instantiate function if needed */
@@ -1765,7 +1765,7 @@ aot_instantiate(AOTModule *module, AOTModuleInstance *parent,
 
 #if WASM_ENABLE_PERF_PROFILING != 0
     total_size = (uint64)sizeof(AOTFuncPerfProfInfo)
-                 * (module->import_func_count + module->func_count);
+                 * ((uint64)module->import_func_count + module->func_count);
     if (!(module_inst->func_perf_profilings =
               runtime_malloc(total_size, error_buf, error_buf_size))) {
         goto fail;
@@ -2536,7 +2536,7 @@ execute_malloc_function(AOTModuleInstance *module_inst, WASMExecEnv *exec_env,
     if (ret) {
 #if WASM_ENABLE_MEMORY64 != 0
         if (is_memory64)
-            *p_result = GET_I64_FROM_ADDR(&argv.u64);
+            *p_result = argv.u64;
         else
 #endif
         {

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -1764,7 +1764,7 @@ aot_instantiate(AOTModule *module, AOTModuleInstance *parent,
         aot_get_data_section_addr(module, AOT_STACK_SIZES_SECTION_NAME, NULL);
 
 #if WASM_ENABLE_PERF_PROFILING != 0
-    total_size = (uint64)sizeof(AOTFuncPerfProfInfo)
+    total_size = sizeof(AOTFuncPerfProfInfo)
                  * ((uint64)module->import_func_count + module->func_count);
     if (!(module_inst->func_perf_profilings =
               runtime_malloc(total_size, error_buf, error_buf_size))) {

--- a/core/iwasm/common/wasm_loader_common.c
+++ b/core/iwasm/common/wasm_loader_common.c
@@ -104,7 +104,9 @@ bool
 is_valid_func_type(const WASMFuncType *func_type)
 {
     unsigned i;
-    for (i = 0; i < func_type->param_count + func_type->result_count; i++) {
+    for (i = 0;
+         i < (unsigned)(func_type->param_count + func_type->result_count);
+         i++) {
         if (!is_valid_value_type(func_type->types[i]))
             return false;
     }

--- a/core/iwasm/common/wasm_memory.c
+++ b/core/iwasm/common/wasm_memory.c
@@ -930,13 +930,13 @@ wasm_runtime_enlarge_memory(WASMModuleInstanceCommon *module_inst,
 #if WASM_ENABLE_AOT != 0
     if (module_inst->module_type == Wasm_Module_AoT) {
         return aot_enlarge_memory((AOTModuleInstance *)module_inst,
-                                  inc_page_count);
+                                  (uint32)inc_page_count);
     }
 #endif
 #if WASM_ENABLE_INTERP != 0
     if (module_inst->module_type == Wasm_Module_Bytecode) {
         return wasm_enlarge_memory((WASMModuleInstance *)module_inst,
-                                   inc_page_count);
+                                   (uint32)inc_page_count);
     }
 #endif
 

--- a/core/iwasm/compilation/aot_emit_memory.c
+++ b/core/iwasm/compilation/aot_emit_memory.c
@@ -91,6 +91,23 @@ get_memory_check_bound(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     return mem_check_bound;
 }
 
+#if defined(_WIN32) || defined(_WIN32_)
+static inline int
+ffs(int n)
+{
+    int pos = 0;
+
+    if (n == 0)
+        return 0;
+
+    while (!(n & 1)) {
+        pos++;
+        n >>= 1;
+    }
+    return pos + 1;
+}
+#endif
+
 static LLVMValueRef
 get_memory_curr_page_count(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx);
 
@@ -198,7 +215,7 @@ aot_check_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
              * has the natural alignment. for platforms using mmap, it can
              * be even larger. for now, use a conservative value.
              */
-            const int max_align = 8;
+            const unsigned int max_align = 8;
             int shift = ffs((int)(unsigned int)mem_offset);
             if (shift == 0) {
                 *alignp = max_align;

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -748,9 +748,9 @@ aot_add_llvm_func(AOTCompContext *comp_ctx, LLVMModuleRef module,
              * should be ok. We prefer short-call because it's smaller
              * and more importantly doesn't involve relocations.
              */
-            LLVMAttributeRef attr_short_call =
-                LLVMCreateStringAttribute(comp_ctx->context, "short-call",
-                                          (uint32)strlen("short-call"), "", 0);
+            LLVMAttributeRef attr_short_call = LLVMCreateStringAttribute(
+                comp_ctx->context, "short-call", (unsigned)strlen("short-call"),
+                "", 0);
             LLVMAddAttributeAtIndex(func, LLVMAttributeFunctionIndex,
                                     attr_short_call);
         }

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -748,8 +748,9 @@ aot_add_llvm_func(AOTCompContext *comp_ctx, LLVMModuleRef module,
              * should be ok. We prefer short-call because it's smaller
              * and more importantly doesn't involve relocations.
              */
-            LLVMAttributeRef attr_short_call = LLVMCreateStringAttribute(
-                comp_ctx->context, "short-call", strlen("short-call"), "", 0);
+            LLVMAttributeRef attr_short_call =
+                LLVMCreateStringAttribute(comp_ctx->context, "short-call",
+                                          (uint32)strlen("short-call"), "", 0);
             LLVMAddAttributeAtIndex(func, LLVMAttributeFunctionIndex,
                                     attr_short_call);
         }
@@ -3529,7 +3530,7 @@ aot_block_destroy(AOTCompContext *comp_ctx, AOTBlock *block)
 
 bool
 aot_checked_addr_list_add(AOTFuncContext *func_ctx, uint32 local_idx,
-                          uint32 offset, uint32 bytes)
+                          uint64 offset, uint32 bytes)
 {
     AOTCheckedAddr *node = func_ctx->checked_addr_list;
 
@@ -3573,7 +3574,7 @@ aot_checked_addr_list_del(AOTFuncContext *func_ctx, uint32 local_idx)
 
 bool
 aot_checked_addr_list_find(AOTFuncContext *func_ctx, uint32 local_idx,
-                           uint32 offset, uint32 bytes)
+                           uint64 offset, uint32 bytes)
 {
     AOTCheckedAddr *node = func_ctx->checked_addr_list;
 

--- a/core/iwasm/compilation/aot_llvm.h
+++ b/core/iwasm/compilation/aot_llvm.h
@@ -197,7 +197,7 @@ typedef struct AOTBlockStack {
 typedef struct AOTCheckedAddr {
     struct AOTCheckedAddr *next;
     uint32 local_idx;
-    uint32 offset;
+    uint64 offset;
     uint32 bytes;
 } AOTCheckedAddr, *AOTCheckedAddrList;
 
@@ -574,14 +574,14 @@ wasm_type_to_llvm_type(const AOTCompContext *comp_ctx,
 
 bool
 aot_checked_addr_list_add(AOTFuncContext *func_ctx, uint32 local_idx,
-                          uint32 offset, uint32 bytes);
+                          uint64 offset, uint32 bytes);
 
 void
 aot_checked_addr_list_del(AOTFuncContext *func_ctx, uint32 local_idx);
 
 bool
 aot_checked_addr_list_find(AOTFuncContext *func_ctx, uint32 local_idx,
-                           uint32 offset, uint32 bytes);
+                           uint64 offset, uint32 bytes);
 
 void
 aot_checked_addr_list_destroy(AOTFuncContext *func_ctx);

--- a/core/iwasm/compilation/aot_llvm_extra.cpp
+++ b/core/iwasm/compilation/aot_llvm_extra.cpp
@@ -411,7 +411,7 @@ aot_compress_aot_func_names(AOTCompContext *comp_ctx, uint32 *p_size)
         return NULL;
     }
 
-    compressed_str_len = Result.size();
+    compressed_str_len = (uint32)Result.size();
     if (!(compressed_str = (char *)wasm_runtime_malloc(compressed_str_len))) {
         aot_set_last_error("allocate memory failed");
         return NULL;

--- a/core/iwasm/compilation/aot_orc_extra.cpp
+++ b/core/iwasm/compilation/aot_orc_extra.cpp
@@ -189,7 +189,7 @@ PartitionFunction(GlobalValueSet Requested)
             auto GVName = GV->getName();         /* get the function name */
             const char *gvname = GVName.begin(); /* C function name */
             const char *wrapper;
-            uint32 prefix_len = strlen(AOT_FUNC_PREFIX);
+            uint32 prefix_len = (uint32)strlen(AOT_FUNC_PREFIX);
 
             LOG_DEBUG("requested func %s", gvname);
             /* Convert "aot_func#n_wrapper" to "aot_func#n" */

--- a/core/iwasm/compilation/simd/simd_load_store.c
+++ b/core/iwasm/compilation/simd/simd_load_store.c
@@ -281,7 +281,7 @@ aot_compile_simd_load_zero(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 /* data_length in bytes */
 static bool
 simd_store(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx, uint32 align,
-           uint32 offset, uint32 data_length, LLVMValueRef value,
+           mem_offset_t offset, uint32 data_length, LLVMValueRef value,
            LLVMTypeRef value_ptr_type, bool enable_segue)
 {
     LLVMValueRef maddr, result;

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -5639,7 +5639,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
                         /* allowing the destination and source to overlap */
                         bh_memmove_s(mdst, (uint32)(linear_mem_size - dst),
-                                     msrc, len);
+                                     msrc, (uint32)len);
                         break;
                     }
                     case WASM_OP_MEMORY_FILL:

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -5638,8 +5638,14 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 #endif
 
                         /* allowing the destination and source to overlap */
+#if WASM_ENABLE_MEMORY64 == 0
                         bh_memmove_s(mdst, (uint32)(linear_mem_size - dst),
                                      msrc, (uint32)len);
+#else
+                        /* use memmove when memory64 is enabled since len
+                           may be larger than UINT32_MAX */
+                        memmove(mdst, msrc, len);
+#endif
                         break;
                     }
                     case WASM_OP_MEMORY_FILL:

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1608,7 +1608,7 @@ execute_malloc_function(WASMModuleInstance *module_inst, WASMExecEnv *exec_env,
     if (ret) {
 #if WASM_ENABLE_MEMORY64 != 0
         if (is_memory64)
-            *p_result = GET_I64_FROM_ADDR(&argv.u64);
+            *p_result = argv.u64;
         else
 #endif
         {
@@ -2185,7 +2185,7 @@ wasm_instantiate(WASMModule *module, WASMModuleInstance *parent,
 
     module_inst_mem_inst_size =
         (uint64)sizeof(WASMMemoryInstance)
-        * (module->import_memory_count + module->memory_count);
+        * ((uint64)module->import_memory_count + module->memory_count);
 
 #if WASM_ENABLE_JIT != 0
     /* If the module doesn't have memory, reserve one mem_info space
@@ -2615,7 +2615,7 @@ wasm_instantiate(WASMModule *module, WASMModuleInstance *parent,
 
         if (memory_data) {
             bh_memcpy_s(memory_data + base_offset,
-                        (uint32)memory_size - base_offset, data_seg->data,
+                        (uint32)(memory_size - base_offset), data_seg->data,
                         length);
         }
     }

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -2184,7 +2184,7 @@ wasm_instantiate(WASMModule *module, WASMModuleInstance *parent,
         heap_size = APP_HEAP_SIZE_MAX;
 
     module_inst_mem_inst_size =
-        (uint64)sizeof(WASMMemoryInstance)
+        sizeof(WASMMemoryInstance)
         * ((uint64)module->import_memory_count + module->memory_count);
 
 #if WASM_ENABLE_JIT != 0


### PR DESCRIPTION
Clear some compile warnings and fix undefined reference error for symbol ffs
in Windows platform.