### PR TITLE
Fix compile errors on workload bwa and benchmark jetstream

### DIFF
--- a/samples/workload/bwa/CMakeLists.txt
+++ b/samples/workload/bwa/CMakeLists.txt
@@ -35,9 +35,8 @@ ExternalProject_Add(libz_src
 ################ bwa ################
 ExternalProject_Add(bwa
   GIT_REPOSITORY https://github.com/lh3/bwa.git
-  GIT_TAG        139f68fc4c3747813783a488aef2adc86626b01b
+  GIT_TAG        v0.7.18
   GIT_PROGRESS   ON
-  GIT_SHALLOW    ON
   SOURCE_DIR     ${CMAKE_CURRENT_SOURCE_DIR}/bwa
   DEPENDS        libz_src
   UPDATE_COMMAND git clean -ffdx && git checkout -- *

--- a/samples/workload/bwa/README.md
+++ b/samples/workload/bwa/README.md
@@ -42,5 +42,5 @@ Then compile wasm file to aot file and run:
 ``` shell
 $ cd <wamr dir>/samples/workload/bwa/build
 $ <wamr dir>/wamr-compiler/build/wamrc -o bwa.aot bwa.wasm
-$ <wamr dir>/product-mini/platforms/linux/iwasm --dir=. bwa.aot index hs38DH.fa
+$ <wamr dir>/product-mini/platforms/linux/iwasm --dir=. bwa.aot index hs38DH-extra.fa
 ```

--- a/tests/benchmarks/jetstream/build.sh
+++ b/tests/benchmarks/jetstream/build.sh
@@ -16,7 +16,7 @@ mkdir -p ${OUT_DIR}
 
 if [[ $1 != "--no-simd" ]];then
     NATIVE_SIMD_FLAGS="-msse2 -msse3 -msse4"
-    WASM_SIMD_FLAGS="-msimd128 -msse2 -msse3 -msse4"
+    WASM_SIMD_FLAGS="-msimd128"
 else
     NATIVE_SIMD_FLAGS=""
     WASM_SIMD_FLAGS=""


### PR DESCRIPTION
Error was reported when building jetstream benchmark with emsdk:
```
clang: error: unsupported option '-msse2' for target 'wasm32-wasi'
```

Error was reported when building bwa workload:
```
fatal: reference is not a tree: 139f68fc4c3747813783a488aef2adc86626b01b
```