### PR TITLE
EH: use the consistent type for EH handlers

### DIFF
--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -495,6 +495,12 @@ wasm_interp_get_frame_ref(WASMInterpFrame *frame)
     } while (0)
 #endif
 
+#if UINTPTR_MAX == UINT64_MAX
+#define PUSH_PTR(value) PUSH_I64(value)
+#else
+#define PUSH_PTR(value) PUSH_I32(value)
+#endif
+
 /* in exception handling, label_type needs to be stored to lookup exception
  * handlers */
 
@@ -1892,19 +1898,19 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     switch (handler_opcode) {
                         case WASM_OP_CATCH:
                             skip_leb(lookup_cursor); /* skip tag_index */
-                            PUSH_I64(end_addr);
+                            PUSH_PTR(end_addr);
                             break;
                         case WASM_OP_CATCH_ALL:
-                            PUSH_I64(end_addr);
+                            PUSH_PTR(end_addr);
                             break;
                         case WASM_OP_DELEGATE:
                             skip_leb(lookup_cursor); /* skip depth */
-                            PUSH_I64(end_addr);
+                            PUSH_PTR(end_addr);
                             /* patch target_addr */
                             (frame_csp - 1)->target_addr = lookup_cursor;
                             break;
                         case WASM_OP_END:
-                            PUSH_I64(0);
+                            PUSH_PTR(0);
                             /* patch target_addr */
                             (frame_csp - 1)->target_addr = end_addr;
                             break;


### PR DESCRIPTION
The "handlers" on the interpreter stack is sometimes treated as host pointers and sometimes treated as i64 values. It's quite broken for targets where pointers are not 64-bit.

This commit makes them host pointers consistently. (at least for 32-bit and 64-bit pointers. We don't support other pointer sizes anyway.)

Fixes https://github.com/bytecodealliance/wasm-micro-runtime/issues/3110