### PR TITLE
spec-test-script/runtest.py: don't assume the tmp dir path

### DIFF
--- a/tests/wamr-test-suites/spec-test-script/runtest.py
+++ b/tests/wamr-test-suites/spec-test-script/runtest.py
@@ -1158,6 +1158,9 @@ def run_wasm_with_repl(wasm_tempfile, aot_tempfile, opts, r):
     tmpfile = aot_tempfile if test_aot else wasm_tempfile
     log("Starting interpreter for module '%s'" % tmpfile)
 
+    if opts.qemu:
+        tmpfile = f"/tmp/{os.path.basename(tmpfile)}"
+
     cmd_iwasm = [opts.interpreter, "--heap-size=0", "-v=5" if opts.verbose else "-v=0", "--repl", tmpfile]
 
     if opts.multi_module:


### PR DESCRIPTION
The current coding assumes the tmp file is created in /tmp. However,

* It's somewhere under /var/folders/... by default on macOS.

* A user can set TMPDIR.