### PR TITLE
Add APIs into wasm_c_api.h to summary wasm function execution duration

### DIFF
--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -5379,3 +5379,24 @@ wasm_extern_new_empty(wasm_store_t *store, wasm_externkind_t extern_kind)
     LOG_ERROR("Don't support linking table and memory for now");
     return NULL;
 }
+
+double
+wasm_instance_sum_wasm_exec_time(const wasm_instance_t *instance)
+{
+#if WASM_ENABLE_PERF_PROFILING != 0
+    return wasm_runtime_sum_wasm_exec_time(instance->inst_comm_rt);
+#else
+    return -1.0;
+#endif
+}
+
+double
+wasm_instance_get_wasm_func_exec_time(const wasm_instance_t *instance,
+                                      const char *name)
+{
+#if WASM_ENABLE_PERF_PROFILING != 0
+    return wasm_runtime_get_wasm_func_exec_time(instance->inst_comm_rt, name);
+#else
+    return -1.0;
+#endif
+}

--- a/core/iwasm/include/wasm_c_api.h
+++ b/core/iwasm/include/wasm_c_api.h
@@ -691,6 +691,11 @@ WASM_API_EXTERN own wasm_instance_t* wasm_instance_new_with_args_ex(
 
 WASM_API_EXTERN void wasm_instance_exports(const wasm_instance_t*, own wasm_extern_vec_t* out);
 
+// Return total wasm functions' execution time in ms
+WASM_API_EXTERN double wasm_instance_sum_wasm_exec_time(const wasm_instance_t*);
+// Return execution time in ms of a given wasm function with
+// func_name. If the function is not found, return 0.
+WASM_API_EXTERN double wasm_instance_get_wasm_func_exec_time(const wasm_instance_t*, const char *);
 
 ///////////////////////////////////////////////////////////////////////////////
 // Convenience


### PR DESCRIPTION
- `wasm_instance_sum_wasm_exec_time()` -> `wasm_runtime_sum_wasm_exec_time()`
- `wasm_instance_get_wasm_func_exec_time()` -> `wasm_runtime_get_wasm_func_exec_time()`