### PR TITLE
spec-test-script/runtest.py: avoid specifying -v=0 unnecessarily

### DIFF
--- a/tests/wamr-test-suites/spec-test-script/runtest.py
+++ b/tests/wamr-test-suites/spec-test-script/runtest.py
@@ -1161,7 +1161,10 @@ def run_wasm_with_repl(wasm_tempfile, aot_tempfile, opts, r):
     if opts.qemu:
         tmpfile = f"/tmp/{os.path.basename(tmpfile)}"
 
-    cmd_iwasm = [opts.interpreter, "--heap-size=0", "-v=5" if opts.verbose else "-v=0", "--repl", tmpfile]
+    if opts.verbose:
+        cmd_iwasm = [opts.interpreter, "--heap-size=0", "-v=5", "--repl", tmpfile]
+    else:
+        cmd_iwasm = [opts.interpreter, "--heap-size=0", "--repl", tmpfile]
 
     if opts.multi_module:
         cmd_iwasm.insert(1, "--module-path=" + (tempfile.gettempdir() if not opts.qemu else "/tmp" ))


### PR DESCRIPTION
The -v=n option is not always available.
Note: WASM_ENABLE_LOG is off by default on NuttX.