### PR TITLE
wamr-compiler: avoid size-level tweak if target is specified

### DIFF
--- a/wamr-compiler/main.c
+++ b/wamr-compiler/main.c
@@ -576,7 +576,7 @@ main(int argc, char *argv[])
         }
 #if defined(_WIN32) || defined(_WIN32_) || defined(__APPLE__) \
     || defined(__MACH__)
-        if (!option.target_abi) {
+        if (!option.target_arch && !option.target_abi) {
             LOG_VERBOSE("Set size level to 1 for Windows or MacOS AOT file");
             option.size_level = 1;
         }


### PR DESCRIPTION
if target is specified, assume a cross-build.

partly fixes: https://github.com/bytecodealliance/wasm-micro-runtime/issues/3356