### PR TITLE
aot compiler: enlarge AOTNativeSymbol->symbol

### DIFF
--- a/core/iwasm/compilation/aot.h
+++ b/core/iwasm/compilation/aot.h
@@ -300,7 +300,7 @@ typedef struct AOTCompData {
 
 typedef struct AOTNativeSymbol {
     bh_list_link link;
-    char symbol[32];
+    char symbol[48];
     int32 index;
 } AOTNativeSymbol;
 


### PR DESCRIPTION
The old value was not enough for wasm_externref_obj_to_internal_obj, which is 34 characters long.