### PR TITLE
aot compiler: bail out on too long native symbol names

### DIFF
--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -3277,6 +3277,7 @@ static bool
 insert_native_symbol(AOTCompContext *comp_ctx, const char *symbol, int32 idx)
 {
     AOTNativeSymbol *sym = wasm_runtime_malloc(sizeof(AOTNativeSymbol));
+    int ret;
 
     if (!sym) {
         aot_set_last_error("alloc native symbol failed.");
@@ -3285,7 +3286,11 @@ insert_native_symbol(AOTCompContext *comp_ctx, const char *symbol, int32 idx)
 
     memset(sym, 0, sizeof(AOTNativeSymbol));
     bh_assert(strlen(symbol) <= sizeof(sym->symbol));
-    snprintf(sym->symbol, sizeof(sym->symbol), "%s", symbol);
+    ret = snprintf(sym->symbol, sizeof(sym->symbol), "%s", symbol);
+    if (ret < 0 || ret + 1 > sizeof(sym->symbol)) {
+        aot_set_last_error_v("symbol name too long: %s", symbol);
+        return false;
+    }
     sym->index = idx;
 
     if (BH_LIST_ERROR == bh_list_insert(&comp_ctx->native_symbols, sym)) {


### PR DESCRIPTION
the old code was silently truncating long names.