### PR TITLE
spec-test-script: skip a few tests for xtensa

### DIFF
--- a/tests/wamr-test-suites/spec-test-script/all.py
+++ b/tests/wamr-test-suites/spec-test-script/all.py
@@ -95,7 +95,7 @@ def ignore_the_case(
         return True
 
     # esp32s3 qemu doesn't have PSRAM emulation
-    if target == 'xtensa' and case_name in ["memory_size"]:
+    if qemu_flag and target == 'xtensa' and case_name in ["memory_size"]:
         return True
 
     if gc_flag:

--- a/tests/wamr-test-suites/spec-test-script/all.py
+++ b/tests/wamr-test-suites/spec-test-script/all.py
@@ -94,6 +94,10 @@ def ignore_the_case(
     if "i386" == target and case_name in ["float_exprs", "conversions"]:
         return True
 
+    # esp32s3 qemu doesn't have PSRAM emulation
+    if target == 'xtensa' and case_name in ["memory_size"]:
+        return True
+
     if gc_flag:
         if case_name in ["array_init_elem", "array_init_data"]:
             return True

--- a/tests/wamr-test-suites/spec-test-script/runtest.py
+++ b/tests/wamr-test-suites/spec-test-script/runtest.py
@@ -833,6 +833,10 @@ def test_assert_return(r, opts, form):
         if ' ' in func:
             func = func.replace(' ', '\\')
 
+        if opts.target == 'xtensa' and func in {'as-memory.grow-value', 'as-memory.grow-size'}:
+            log("ignoring memory.grow test")
+            return
+
         if m.group(2) == '':
             args = []
         else:

--- a/tests/wamr-test-suites/spec-test-script/runtest.py
+++ b/tests/wamr-test-suites/spec-test-script/runtest.py
@@ -833,7 +833,9 @@ def test_assert_return(r, opts, form):
         if ' ' in func:
             func = func.replace(' ', '\\')
 
-        if opts.target == 'xtensa' and func in {'as-memory.grow-value', 'as-memory.grow-size'}:
+        # Note: 'as-memory.grow-first' doesn't actually grow memory.
+        # (thus not in this list)
+        if opts.target == 'xtensa' and func in {'as-memory.grow-value', 'as-memory.grow-size', 'as-memory.grow-last', 'as-memory.grow-everywhere'}:
             log("ignoring memory.grow test")
             return
 

--- a/tests/wamr-test-suites/spec-test-script/runtest.py
+++ b/tests/wamr-test-suites/spec-test-script/runtest.py
@@ -835,7 +835,7 @@ def test_assert_return(r, opts, form):
 
         # Note: 'as-memory.grow-first' doesn't actually grow memory.
         # (thus not in this list)
-        if opts.target == 'xtensa' and func in {'as-memory.grow-value', 'as-memory.grow-size', 'as-memory.grow-last', 'as-memory.grow-everywhere'}:
+        if opts.qemu and opts.target == 'xtensa' and func in {'as-memory.grow-value', 'as-memory.grow-size', 'as-memory.grow-last', 'as-memory.grow-everywhere'}:
             log("ignoring memory.grow test")
             return
 


### PR DESCRIPTION
because these test cases require more memory than what nuttx on esp32s3 qemu can afford.