### PR TITLE
Restore linux iwasm default visibility

### DIFF
--- a/product-mini/platforms/linux/CMakeLists.txt
+++ b/product-mini/platforms/linux/CMakeLists.txt
@@ -145,7 +145,7 @@ set_target_properties (vmlib PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
 
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security -Wshadow -fvisibility=hidden")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security -Wshadow")
 # set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wconversion -Wsign-conversion")
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wformat -Wformat-security -Wno-unused")


### PR DESCRIPTION
Reverts commit 6d8d60d0f0c53d5fb2477506a33bb7308b08596b: "Set linux iwasm default visibility to hidden also"

Addresses comments for pull request #3655.