### PR TITLE
Track non-0x00 tableindex as ref types use

### DIFF
--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -12083,6 +12083,14 @@ re_scan:
 
                 read_leb_uint32(p, p_end, type_idx);
 #if WASM_ENABLE_REF_TYPES != 0 || WASM_ENABLE_GC != 0
+#if WASM_ENABLE_WAMR_COMPILER != 0
+                if (*p != 0x00) {
+                    // Any non-0x00 byte requires the ref types proposal.
+                    // This is different from checking the table_idx value
+                    // since `0x80 0x00` etc. are all valid encodings of zero.
+                    module->is_ref_types_used = true;
+                }
+#endif
                 read_leb_uint32(p, p_end, table_idx);
 #else
                 CHECK_BUF(p, p_end, 1);


### PR DESCRIPTION
Any use of a table index that isn't exactly a null byte (`0x00`) means
that the module makes use of the reference types proposal. This is
important to track because `aot_compiler.c` will blindly assume that all
table indices are a single byte long otherwise.

This fixes a crash in WAMR for modules that contain multi-byte encodings
of table indices in `call_indirect` but make no other use of reference
types features.