### PR TITLE
builtin-libc: Fix function prototype for wasm_runtime_module_realloc

### DIFF
--- a/core/iwasm/libraries/libc-builtin/libc_builtin_wrapper.c
+++ b/core/iwasm/libraries/libc-builtin/libc_builtin_wrapper.c
@@ -16,7 +16,7 @@
 void
 wasm_runtime_set_exception(wasm_module_inst_t module, const char *exception);
 
-uint32
+uint64
 wasm_runtime_module_realloc(wasm_module_inst_t module, uint64 ptr, uint64 size,
                             void **p_native_addr);
 
@@ -683,9 +683,12 @@ calloc_wrapper(wasm_exec_env_t exec_env, uint32 nmemb, uint32 size)
 static uint32
 realloc_wrapper(wasm_exec_env_t exec_env, uint32 ptr, uint32 new_size)
 {
+    uint64 ret_offset = 0;
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
 
-    return wasm_runtime_module_realloc(module_inst, ptr, new_size, NULL);
+    ret_offset = wasm_runtime_module_realloc(module_inst, ptr, new_size, NULL);
+    bh_assert(ret_offset < UINT32_MAX);
+    return (uint32)ret_offset;
 }
 
 static void


### PR DESCRIPTION
Fix:
wamr/core/iwasm/libraries/libc-builtin/libc_builtin_wrapper.c:20:1: warning: type of 'wasm_runtime_module_realloc' does not match original declaration [-Wlto-type-mismatch]
wamr/core/iwasm/common/wasm_runtime_common.c:3033:1: note: return value type mismatch
wamr/core/iwasm/common/wasm_runtime_common.c:3033:1: note: type 'uint64' should match type 'uint32'
wamr/core/iwasm/common/wasm_runtime_common.c:3033:1: note: 'wasm_runtime_module_realloc' was previously declared here
wamr/core/iwasm/common/wasm_runtime_common.c:3033:1: note: code may be misoptimized unless '-fno-strict-aliasing' is used