### PR TITLE
Fix warning.

### DIFF
--- a/core/shared/mem-alloc/ems/ems_gc.h
+++ b/core/shared/mem-alloc/ems/ems_gc.h
@@ -309,10 +309,10 @@ void
 wasm_runtime_set_wasm_object_extra_info_flag(gc_object_t obj, bool set);
 
 void
-wasm_runtime_gc_prepare();
+wasm_runtime_gc_prepare(void *exec_env);
 
 void
-wasm_runtime_gc_finalize();
+wasm_runtime_gc_finalize(void *exec_env);
 #endif /* end of WASM_ENABLE_GC != 0 */
 
 #define GC_HEAP_STAT_SIZE (128 / 4)


### PR DESCRIPTION
I get this warning on mac otherwise.

```
/Users/abakken/dev/wasm-micro-runtime/core/shared/mem-alloc/ems/ems_gc.c:454:22: warning: passing arguments to 'wasm_runtime_gc_prepare' without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
    gct_vm_gc_prepare(NULL);
                     ^
/Users/abakken/dev/wasm-micro-runtime/core/shared/mem-alloc/ems/ems_gc.c:466:23: warning: passing arguments to 'wasm_runtime_gc_finalize' without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
    gct_vm_gc_finished(NULL);
                      ^
2 warnings generated.
```