### PR TITLE
AOT: Fix NaN handling for f32/f64 const op

### DIFF
--- a/core/iwasm/compilation/aot_emit_const.c
+++ b/core/iwasm/compilation/aot_emit_const.c
@@ -68,23 +68,21 @@ aot_compile_op_f32_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 {
     LLVMValueRef alloca, value;
 
-    if (!isnan(f32_const)) {
-        if (comp_ctx->is_indirect_mode
-            && aot_intrinsic_check_capability(comp_ctx, "f32.const")) {
-            WASMValue wasm_value;
-            memcpy(&wasm_value.f32, &f32_const, sizeof(float32));
-            value = aot_load_const_from_table(comp_ctx, func_ctx->native_symbol,
-                                              &wasm_value, VALUE_TYPE_F32);
-            if (!value) {
-                return false;
-            }
-            PUSH_F32(value);
+    if (comp_ctx->is_indirect_mode
+        && aot_intrinsic_check_capability(comp_ctx, "f32.const")) {
+        WASMValue wasm_value;
+        memcpy(&wasm_value.f32, &f32_const, sizeof(float32));
+        value = aot_load_const_from_table(comp_ctx, func_ctx->native_symbol,
+                                          &wasm_value, VALUE_TYPE_F32);
+        if (!value) {
+            return false;
         }
-        else {
-            value = F32_CONST(f32_const);
-            CHECK_LLVM_CONST(value);
-            PUSH_F32(value);
-        }
+        PUSH_F32(value);
+    }
+    else if (!isnan(f32_const)) {
+        value = F32_CONST(f32_const);
+        CHECK_LLVM_CONST(value);
+        PUSH_F32(value);
     }
     else {
         int32 i32_const;
@@ -123,23 +121,21 @@ aot_compile_op_f64_const(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 {
     LLVMValueRef alloca, value;
 
-    if (!isnan(f64_const)) {
-        if (comp_ctx->is_indirect_mode
-            && aot_intrinsic_check_capability(comp_ctx, "f64.const")) {
-            WASMValue wasm_value;
-            memcpy(&wasm_value.f64, &f64_const, sizeof(float64));
-            value = aot_load_const_from_table(comp_ctx, func_ctx->native_symbol,
-                                              &wasm_value, VALUE_TYPE_F64);
-            if (!value) {
-                return false;
-            }
-            PUSH_F64(value);
+    if (comp_ctx->is_indirect_mode
+        && aot_intrinsic_check_capability(comp_ctx, "f64.const")) {
+        WASMValue wasm_value;
+        memcpy(&wasm_value.f64, &f64_const, sizeof(float64));
+        value = aot_load_const_from_table(comp_ctx, func_ctx->native_symbol,
+                                          &wasm_value, VALUE_TYPE_F64);
+        if (!value) {
+            return false;
         }
-        else {
-            value = F64_CONST(f64_const);
-            CHECK_LLVM_CONST(value);
-            PUSH_F64(value);
-        }
+        PUSH_F64(value);
+    }
+    else if (!isnan(f64_const)) {
+        value = F64_CONST(f64_const);
+        CHECK_LLVM_CONST(value);
+        PUSH_F64(value);
     }
     else {
         int64 i64_const;


### PR DESCRIPTION
If the value of a float constant is NaN, it will not be handed correctly by f32.const or f64.const, then it may cause a relocation in the AOT file.