### PR TITLE
Mac doesn't support MMAP_MAP_32BIT so this condition ends up asserting.

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -302,7 +302,10 @@ loader_mmap(uint32 size, bool prot_exec, char *error_buf, uint32 error_buf_size)
     int map_flags;
     void *mem;
 
-#if UINTPTR_MAX == UINT64_MAX
+#if defined(BUILD_TARGET_X86_64) || defined(BUILD_TARGET_AMD_64) \
+    || defined(BUILD_TARGET_RISCV64_LP64D)                       \
+    || defined(BUILD_TARGET_RISCV64_LP64)
+#ifndef __APPLE__
     /* The mmapped AOT data and code in 64-bit targets had better be in
        range 0 to 2G, or aot loader may fail to apply some relocations,
        e.g., R_X86_64_32/R_X86_64_32S/R_X86_64_PC32/R_RISCV_32.
@@ -316,6 +319,7 @@ loader_mmap(uint32 size, bool prot_exec, char *error_buf, uint32 error_buf_size)
         bh_assert((uintptr_t)mem < INT32_MAX);
         return mem;
     }
+#endif
 #endif
 
     map_flags = MMAP_MAP_NONE;


### PR DESCRIPTION
Mac on aarch64 uses posix_memmap.c which doesn't do anything with the flag MMAP_MAP_32BIT for that build so this condition ends up asserting unless the mapping ends up in the first 4 gigs worth of addressable space. Not entirely what problems not guaranteeing the mapping to be in that range will cause but as of now it asserts for me every time. It appears the usage of MAP_32BIT isn't functional after MacOS 13 (if I understand this thread correctly https://github.com/bytecodealliance/wasm-micro-runtime/issues/3009)