### PR TITLE
Fixes for building iwasm_shared and iwasm_static libs on win32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,10 +48,6 @@ if (NOT DEFINED WAMR_BUILD_TARGET)
   endif ()
 endif ()
 
-if (NOT COMPILING_WASM_RUNTIME_API)
-  set(COMPILING_WASM_RUNTIME_API 1)
-endif ()
-
 if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif ()
@@ -123,9 +119,11 @@ endif ()
 
 set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-include (${WAMR_ROOT_DIR}/build-scripts/runtime_lib.cmake)
+if (MSVC)
+  include (${WAMR_ROOT_DIR}/build-scripts/runtime_lib.cmake)
+endif ()
 
-if (NOT MSVC)
+if (NOT WIN32)
   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security \
                                        -ffunction-sections -fdata-sections \
                                        -Wno-unused-parameter -Wno-pedantic")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,10 +121,18 @@ set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 include (${WAMR_ROOT_DIR}/build-scripts/runtime_lib.cmake)
 
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security -Wshadow -Wno-unused-parameter -fvisibility=hidden")
-# set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wconversion -Wsign-conversion")
+# -Wextra is not supported in MSVC compiler
+if (CMAKE_C_COMPILER MATCHES ".*MSVC.*")
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wformat -Wformat-security -Wshadow -Wno-unused-parameter -fvisibility=hidden")
+  # set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wconversion -Wsign-conversion")
 
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wformat -Wformat-security -Wno-unused")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wformat -Wformat-security -Wno-unused")
+else ()
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security -Wshadow -Wno-unused-parameter -fvisibility=hidden")
+  # set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wconversion -Wsign-conversion")
+
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wformat -Wformat-security -Wno-unused")
+endif ()
 
 if (WAMR_BUILD_TARGET MATCHES "X86_.*" OR WAMR_BUILD_TARGET STREQUAL "AMD_64")
   if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,13 +121,14 @@ set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 include (${WAMR_ROOT_DIR}/build-scripts/runtime_lib.cmake)
 
-# -Wextra is not supported in MSVC compiler
-if (NOT CMAKE_C_COMPILER MATCHES ".*MSVC.*")
-  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security -Wshadow -Wno-unused-parameter -fvisibility=hidden")
-  # set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wconversion -Wsign-conversion")
-
+if (NOT MSVC)
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security \
+                                       -ffunction-sections -fdata-sections \
+                                       -Wno-unused-parameter -Wno-pedantic")
+  # Remove the extra spaces for better make log
+  string (REGEX REPLACE "  *" " " CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wformat -Wformat-security -Wno-unused")
-endif ()
+endif()
 
 if (WAMR_BUILD_TARGET MATCHES "X86_.*" OR WAMR_BUILD_TARGET STREQUAL "AMD_64")
   if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,8 @@ include (${SHARED_DIR}/utils/uncommon/shared_uncommon.cmake)
 set (THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
+add_definitions(-DCOMPILING_WASM_RUNTIME_API=1)
+
 # STATIC LIBRARY
 if (WAMR_BUILD_STATIC)
     add_library(iwasm_static STATIC ${WAMR_RUNTIME_LIB_SOURCE})
@@ -164,11 +166,11 @@ if (WAMR_BUILD_STATIC)
     endif ()
 
     if (MINGW)
-      target_link_libraries (iwasm_static INTERFACE ws2_32)
+      target_link_libraries (iwasm_static PRIVATE ws2_32)
     endif ()
 
     if (WIN32)
-      target_link_libraries(iwasm_static INTERFACE ntdll)  
+      target_link_libraries(iwasm_static PRIVATE ntdll)  
     endif()
 
     install (TARGETS iwasm_static ARCHIVE DESTINATION lib)
@@ -185,11 +187,12 @@ if (WAMR_BUILD_SHARED)
     endif ()
 
     if (MINGW)
-      target_link_libraries (iwasm_shared INTERFACE -lWs2_32 -lwsock32 ws2_32)
+      target_link_libraries(iwasm_shared INTERFACE -lWs2_32 -lwsock32)
+      target_link_libraries(iwasm_shared PRIVATE ws2_32)
     endif ()
 
     if (WIN32)
-      target_link_libraries(iwasm_shared INTERFACE ntdll)  
+      target_link_libraries(iwasm_shared PRIVATE ntdll)  
     endif()
 
     install (TARGETS iwasm_shared LIBRARY DESTINATION lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,12 +122,7 @@ set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 include (${WAMR_ROOT_DIR}/build-scripts/runtime_lib.cmake)
 
 # -Wextra is not supported in MSVC compiler
-if (CMAKE_C_COMPILER MATCHES ".*MSVC.*")
-  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wformat -Wformat-security -Wshadow -Wno-unused-parameter -fvisibility=hidden")
-  # set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wconversion -Wsign-conversion")
-
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wformat -Wformat-security -Wno-unused")
-else ()
+if (NOT CMAKE_C_COMPILER MATCHES ".*MSVC.*")
   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security -Wshadow -Wno-unused-parameter -fvisibility=hidden")
   # set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wconversion -Wsign-conversion")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,10 @@ if (NOT DEFINED WAMR_BUILD_TARGET)
   endif ()
 endif ()
 
+if (NOT COMPILING_WASM_RUNTIME_API)
+  set(COMPILING_WASM_RUNTIME_API 1)
+endif ()
+
 if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif ()
@@ -159,6 +163,16 @@ if (WAMR_BUILD_STATIC)
       target_link_libraries(iwasm_static INTERFACE boringssl_crypto)
     endif ()
 
+    if (MINGW)
+      target_link_libraries (libiwasm ws2_32)
+    endif ()
+
+    if (WIN32)
+      target_link_libraries(libiwasm ntdll)
+
+      target_link_libraries(iwasm_static ntdll)  
+    endif()
+
     install (TARGETS iwasm_static ARCHIVE DESTINATION lib)
 endif ()
 
@@ -174,7 +188,15 @@ if (WAMR_BUILD_SHARED)
 
     if (MINGW)
       target_link_libraries (iwasm_shared INTERFACE -lWs2_32 -lwsock32)
+
+      target_link_libraries (libiwasm ws2_32)
     endif ()
+
+    if (WIN32)
+      target_link_libraries(libiwasm ntdll)
+
+      target_link_libraries(iwasm_shared ntdll)  
+    endif()
 
     install (TARGETS iwasm_shared LIBRARY DESTINATION lib)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,9 @@ include (${SHARED_DIR}/utils/uncommon/shared_uncommon.cmake)
 set (THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
-add_definitions(-DCOMPILING_WASM_RUNTIME_API=1)
+if (MSVC)
+  add_definitions(-DCOMPILING_WASM_RUNTIME_API=1)
+endif ()
 
 # STATIC LIBRARY
 if (WAMR_BUILD_STATIC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,13 +164,11 @@ if (WAMR_BUILD_STATIC)
     endif ()
 
     if (MINGW)
-      target_link_libraries (libiwasm ws2_32)
+      target_link_libraries (iwasm_static INTERFACE ws2_32)
     endif ()
 
     if (WIN32)
-      target_link_libraries(libiwasm ntdll)
-
-      target_link_libraries(iwasm_static ntdll)  
+      target_link_libraries(iwasm_static INTERFACE ntdll)  
     endif()
 
     install (TARGETS iwasm_static ARCHIVE DESTINATION lib)
@@ -187,15 +185,11 @@ if (WAMR_BUILD_SHARED)
     endif ()
 
     if (MINGW)
-      target_link_libraries (iwasm_shared INTERFACE -lWs2_32 -lwsock32)
-
-      target_link_libraries (libiwasm ws2_32)
+      target_link_libraries (iwasm_shared INTERFACE -lWs2_32 -lwsock32 ws2_32)
     endif ()
 
     if (WIN32)
-      target_link_libraries(libiwasm ntdll)
-
-      target_link_libraries(iwasm_shared ntdll)  
+      target_link_libraries(iwasm_shared INTERFACE ntdll)  
     endif()
 
     install (TARGETS iwasm_shared LIBRARY DESTINATION lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,9 +119,7 @@ endif ()
 
 set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-if (MSVC)
-  include (${WAMR_ROOT_DIR}/build-scripts/runtime_lib.cmake)
-endif ()
+include (${WAMR_ROOT_DIR}/build-scripts/runtime_lib.cmake)
 
 if (NOT WIN32)
   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security \


### PR DESCRIPTION
Fixes to enable building iwasm_shared and iwasm_static libraries on win32. Still doesn't work the default build flags, but works for mine:

```
cmake .. -DWAMR_BUILD_AOT=0 -DWAMR_BUILD_BULK_MEMORY=1 -DWAMR_BUILD_REF_TYPES=1 -DWAMR_BUILD_SIMD=1 -DWAMR_BUILD_LIB_PTHREAD=1 -DWAMR_BUILD_LIB_WASI_THREADS=0 -DWAMR_BUILD_LIBC_WASI=0 -DWAMR_BUILD_LIBC_BUILTIN=0 -DWAMR_BUILD_SHARED_MEMORY=1 -DWAMR_BUILD_MULTI_MODULE=0 -DWAMR_DISABLE_HW_BOUND_CHECK=1```