### PR TITLE
runtest.py: Wait more time when compiling wasm to aot in QEMU testing

### DIFF
--- a/tests/wamr-test-suites/spec-test-script/runtest.py
+++ b/tests/wamr-test-suites/spec-test-script/runtest.py
@@ -1323,6 +1323,9 @@ if __name__ == "__main__":
         # it will be simple ignore during final deletion if not exist
         prefix = wasm_tempfile.split(".wasm")[0]
         temp_file_repo.append(prefix + ".aot")
+        if opts.qemu:
+            # increase fail timeout in QEMU testing
+            opts.start_fail_timeout = 3
 
     ret_code = 0
     try:

--- a/tests/wamr-test-suites/spec-test-script/runtest.py
+++ b/tests/wamr-test-suites/spec-test-script/runtest.py
@@ -1325,7 +1325,7 @@ if __name__ == "__main__":
         temp_file_repo.append(prefix + ".aot")
         if opts.qemu:
             # increase fail timeout in QEMU testing
-            opts.start_fail_timeout = 4
+            opts.start_fail_timeout = 10
 
     ret_code = 0
     try:

--- a/tests/wamr-test-suites/spec-test-script/runtest.py
+++ b/tests/wamr-test-suites/spec-test-script/runtest.py
@@ -1325,7 +1325,7 @@ if __name__ == "__main__":
         temp_file_repo.append(prefix + ".aot")
         if opts.qemu:
             # increase fail timeout in QEMU testing
-            opts.start_fail_timeout = 3
+            opts.start_fail_timeout = 4
 
     ret_code = 0
     try:

--- a/tests/wamr-test-suites/spec-test-script/runtest.py
+++ b/tests/wamr-test-suites/spec-test-script/runtest.py
@@ -1325,7 +1325,7 @@ if __name__ == "__main__":
         temp_file_repo.append(prefix + ".aot")
         if opts.qemu:
             # increase fail timeout in QEMU testing
-            opts.start_fail_timeout = 10
+            opts.start_fail_timeout = 20
 
     ret_code = 0
     try:


### PR DESCRIPTION
Test whether it can fix issue of the CI spec test on nuttx often running into failure.