### PR TITLE
spec_test_on_nuttx.yml: disable riscv32_ilp32f for now

### DIFF
--- a/.github/workflows/spec_test_on_nuttx.yml
+++ b/.github/workflows/spec_test_on_nuttx.yml
@@ -74,11 +74,11 @@ jobs:
             target: "riscv32",
             fpu_type: "none"
           },
-          {
-            config: "boards/risc-v/qemu-rv/rv-virt/configs/nsh",
-            target: "riscv32_ilp32f",
-            fpu_type: "fp"
-          },
+          #{
+          #  config: "boards/risc-v/qemu-rv/rv-virt/configs/nsh",
+          #  target: "riscv32_ilp32f",
+          #  fpu_type: "fp"
+          #},
           # {
           #   config: "boards/risc-v/qemu-rv/rv-virt/configs/nsh",
           #   target: "riscv32_ilp32d",


### PR DESCRIPTION
It seems failing too frequently.

cf. https://github.com/bytecodealliance/wasm-micro-runtime/issues/3776