### PR TITLE
Appease GCC -Wformat

### DIFF
--- a/core/shared/mem-alloc/ems/ems_alloc.c
+++ b/core/shared/mem-alloc/ems/ems_alloc.c
@@ -992,8 +992,8 @@ gci_dump(gc_heap_t *heap)
 
         os_printf("#%d %08" PRIx32 " %" PRIx32 " %d %d"
                   " %c %" PRId32 "\n",
-                  i, (int32)((char *)cur - (char *)heap->base_addr), (int32)ut,
-                  p, mark, inuse, (int32)hmu_obj_size(size));
+                  i, (uint32)((char *)cur - (char *)heap->base_addr),
+                  (uint32)ut, p, mark, inuse, (int32)hmu_obj_size(size));
 #if BH_ENABLE_GC_VERIFY != 0
         if (inuse == 'V') {
             gc_object_prefix_t *prefix = (gc_object_prefix_t *)(cur + 1);


### PR DESCRIPTION
I'm not sure we want to use C99 %tu here.
While C99 %zu is more widely used in WAMR, %tu is rare (if any) and I'm not sure if it's ubiquitously implemented in platforms we support.