### PR TITLE
Fix compiler warning

### DIFF
--- a/core/shared/platform/alios/platform_internal.h
+++ b/core/shared/platform/alios/platform_internal.h
@@ -77,7 +77,7 @@ typedef void *os_dir_stream;
 typedef int os_raw_file_handle;
 
 static inline os_file_handle
-os_get_invalid_handle()
+os_get_invalid_handle(void)
 {
     return -1;
 }

--- a/core/shared/platform/android/platform_internal.h
+++ b/core/shared/platform/android/platform_internal.h
@@ -151,7 +151,7 @@ typedef DIR *os_dir_stream;
 typedef int os_raw_file_handle;
 
 static inline os_file_handle
-os_get_invalid_handle()
+os_get_invalid_handle(void)
 {
     return -1;
 }

--- a/core/shared/platform/cosmopolitan/platform_internal.h
+++ b/core/shared/platform/cosmopolitan/platform_internal.h
@@ -69,7 +69,7 @@ typedef DIR *os_dir_stream;
 typedef int os_raw_file_handle;
 
 static inline os_file_handle
-os_get_invalid_handle()
+os_get_invalid_handle(void)
 {
     return -1;
 }

--- a/core/shared/platform/darwin/platform_internal.h
+++ b/core/shared/platform/darwin/platform_internal.h
@@ -114,7 +114,7 @@ typedef DIR *os_dir_stream;
 typedef int os_raw_file_handle;
 
 static inline os_file_handle
-os_get_invalid_handle()
+os_get_invalid_handle(void)
 {
     return -1;
 }

--- a/core/shared/platform/esp-idf/platform_internal.h
+++ b/core/shared/platform/esp-idf/platform_internal.h
@@ -145,7 +145,7 @@ typedef DIR *os_dir_stream;
 typedef int os_raw_file_handle;
 
 static inline os_file_handle
-os_get_invalid_handle()
+os_get_invalid_handle(void)
 {
     return -1;
 }

--- a/core/shared/platform/freebsd/platform_internal.h
+++ b/core/shared/platform/freebsd/platform_internal.h
@@ -115,7 +115,7 @@ os_set_signal_number_for_blocking_op(int signo);
 typedef int os_file_handle;
 
 static inline os_file_handle
-os_get_invalid_handle()
+os_get_invalid_handle(void)
 {
     return -1;
 }

--- a/core/shared/platform/linux-sgx/platform_internal.h
+++ b/core/shared/platform/linux-sgx/platform_internal.h
@@ -74,7 +74,7 @@ typedef DIR *os_dir_stream;
 typedef int os_raw_file_handle;
 
 static inline os_file_handle
-os_get_invalid_handle()
+os_get_invalid_handle(void)
 {
     return -1;
 }

--- a/core/shared/platform/linux/platform_internal.h
+++ b/core/shared/platform/linux/platform_internal.h
@@ -127,7 +127,7 @@ typedef DIR *os_dir_stream;
 typedef int os_raw_file_handle;
 
 static inline os_file_handle
-os_get_invalid_handle()
+os_get_invalid_handle(void)
 {
     return -1;
 }

--- a/core/shared/platform/riot/platform_internal.h
+++ b/core/shared/platform/riot/platform_internal.h
@@ -89,7 +89,7 @@ int isnan(double x);
 #endif
 
 static inline os_file_handle
-os_get_invalid_handle()
+os_get_invalid_handle(void)
 {
     return -1;
 }

--- a/core/shared/platform/rt-thread/platform_internal.h
+++ b/core/shared/platform/rt-thread/platform_internal.h
@@ -124,7 +124,7 @@ typedef void *os_dir_stream;
 typedef int os_raw_file_handle;
 
 static inline os_file_handle
-os_get_invalid_handle()
+os_get_invalid_handle(void)
 {
     return -1;
 }

--- a/core/shared/platform/vxworks/platform_internal.h
+++ b/core/shared/platform/vxworks/platform_internal.h
@@ -101,7 +101,7 @@ os_sigreturn();
 #define os_getpagesize getpagesize
 
 static inline os_file_handle
-os_get_invalid_handle()
+os_get_invalid_handle(void)
 {
     return -1;
 }

--- a/core/shared/platform/windows/platform_internal.h
+++ b/core/shared/platform/windows/platform_internal.h
@@ -188,7 +188,7 @@ typedef uint32_t os_raw_file_handle;
 #endif
 
 static inline os_file_handle
-os_get_invalid_handle()
+os_get_invalid_handle(void)
 {
     return NULL;
 }

--- a/core/shared/platform/zephyr/platform_internal.h
+++ b/core/shared/platform/zephyr/platform_internal.h
@@ -209,7 +209,7 @@ typedef void *os_dir_stream;
 typedef int os_raw_file_handle;
 
 static inline os_file_handle
-os_get_invalid_handle()
+os_get_invalid_handle(void)
 {
     return -1;
 }


### PR DESCRIPTION
The definition of os_get_invalid_handle in platform_internal.h did not match the declaration in platform_api_extension.h