### PR TITLE
Add memory import support

### DIFF
--- a/core/iwasm/aot/aot_runtime.h
+++ b/core/iwasm/aot/aot_runtime.h
@@ -336,6 +336,7 @@ typedef struct AOTModule {
 #endif
 } AOTModule;
 
+#define AOTMemoryWrapper WASMMemoryWrapper
 #define AOTMemoryInstance WASMMemoryInstance
 #define AOTTableInstance WASMTableInstance
 #define AOTModuleInstance WASMModuleInstance
@@ -509,7 +510,8 @@ aot_unload(AOTModule *module);
 AOTModuleInstance *
 aot_instantiate(AOTModule *module, AOTModuleInstance *parent,
                 WASMExecEnv *exec_env_main, uint32 stack_size, uint32 heap_size,
-                uint32 max_memory_pages, char *error_buf,
+                uint32 max_memory_pages, uint32 import_count,
+                const WASMImportInst *imports, char *error_buf,
                 uint32 error_buf_size);
 
 /**

--- a/core/iwasm/common/wasm_application.c
+++ b/core/iwasm/common/wasm_application.c
@@ -105,7 +105,7 @@ execute_main(WASMModuleInstanceCommon *module_inst, int32 argc, char *argv[])
     bool ret, is_import_func = true, is_memory64 = false;
 #if WASM_ENABLE_MEMORY64 != 0
     WASMModuleInstance *wasm_module_inst = (WASMModuleInstance *)module_inst;
-    is_memory64 = wasm_module_inst->memories[0]->is_memory64;
+    is_memory64 = wasm_module_inst->memories[0].memory->is_memory64;
 #endif
 
     exec_env = wasm_runtime_get_exec_env_singleton(module_inst);

--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -4294,8 +4294,9 @@ wasm_memory_new_internal(wasm_store_t *store, uint16 memory_idx_rt,
 
 #if WASM_ENABLE_INTERP != 0
     if (inst_comm_rt->module_type == Wasm_Module_Bytecode) {
-        WASMMemoryInstance *memory_interp =
-            ((WASMModuleInstance *)inst_comm_rt)->memories[memory_idx_rt];
+        WASMMemoryInstance *memory_interp = ((WASMModuleInstance *)inst_comm_rt)
+                                                ->memories[memory_idx_rt]
+                                                .memory;
         min_pages = memory_interp->cur_page_count;
         max_pages = memory_interp->max_page_count;
         init_flag = true;
@@ -4379,7 +4380,7 @@ wasm_memory_data(wasm_memory_t *memory)
         WASMModuleInstance *module_inst =
             (WASMModuleInstance *)module_inst_comm;
         WASMMemoryInstance *memory_inst =
-            module_inst->memories[memory->memory_idx_rt];
+            module_inst->memories[memory->memory_idx_rt].memory;
         return (byte_t *)memory_inst->memory_data;
     }
 #endif
@@ -4416,7 +4417,7 @@ wasm_memory_data_size(const wasm_memory_t *memory)
         WASMModuleInstance *module_inst =
             (WASMModuleInstance *)module_inst_comm;
         WASMMemoryInstance *memory_inst =
-            module_inst->memories[memory->memory_idx_rt];
+            module_inst->memories[memory->memory_idx_rt].memory;
         return (size_t)memory_inst->cur_page_count
                * memory_inst->num_bytes_per_page;
     }
@@ -4455,7 +4456,7 @@ wasm_memory_size(const wasm_memory_t *memory)
         WASMModuleInstance *module_inst =
             (WASMModuleInstance *)module_inst_comm;
         WASMMemoryInstance *memory_inst =
-            module_inst->memories[memory->memory_idx_rt];
+            module_inst->memories[memory->memory_idx_rt].memory;
         return memory_inst->cur_page_count;
     }
 #endif

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -575,6 +575,8 @@ wasm_runtime_instantiate_internal(WASMModuleCommon *module,
                                   WASMModuleInstanceCommon *parent,
                                   WASMExecEnv *exec_env_main, uint32 stack_size,
                                   uint32 heap_size, uint32 max_memory_pages,
+                                  uint32 import_count,
+                                  const WASMImportInst *imports,
                                   char *error_buf, uint32 error_buf_size);
 
 /* Internal API */

--- a/core/iwasm/fast-jit/fe/jit_emit_memory.c
+++ b/core/iwasm/fast-jit/fe/jit_emit_memory.c
@@ -636,7 +636,7 @@ wasm_init_memory(WASMModuleInstance *inst, uint32 mem_idx, uint32 seg_idx,
     uint32 seg_len;
 
     /* if d + n > the length of mem.data */
-    mem_inst = inst->memories[mem_idx];
+    mem_inst = inst->memories[mem_idx].memory;
     mem_size = mem_inst->cur_page_count * (uint64)mem_inst->num_bytes_per_page;
     if (mem_size < mem_offset || mem_size - mem_offset < len)
         goto out_of_bounds;
@@ -723,8 +723,8 @@ wasm_copy_memory(WASMModuleInstance *inst, uint32 src_mem_idx,
     uint64 src_mem_size, dst_mem_size;
     uint8 *src_addr, *dst_addr;
 
-    src_mem = inst->memories[src_mem_idx];
-    dst_mem = inst->memories[dst_mem_idx];
+    src_mem = inst->memories[src_mem_idx].memory;
+    dst_mem = inst->memories[dst_mem_idx].memory;
     src_mem_size =
         src_mem->cur_page_count * (uint64)src_mem->num_bytes_per_page;
     dst_mem_size =
@@ -790,7 +790,7 @@ wasm_fill_memory(WASMModuleInstance *inst, uint32 mem_idx, uint32 len,
     uint64 mem_size;
     uint8 *dst_addr;
 
-    mem_inst = inst->memories[mem_idx];
+    mem_inst = inst->memories[mem_idx].memory;
     mem_size = mem_inst->cur_page_count * (uint64)mem_inst->num_bytes_per_page;
 
     if (mem_size < dst || mem_size - dst < len)

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -256,6 +256,15 @@ typedef struct LoadArgs {
 } LoadArgs;
 #endif /* LOAD_ARGS_OPTION_DEFINED */
 
+typedef struct WASMImportInst {
+    const char *module_name;
+    const char *name;
+    wasm_import_export_kind_t kind;
+    union {
+        wasm_memory_inst_t memory_inst;
+    } u;
+} WASMImportInst;
+
 #ifndef INSTANTIATION_ARGS_OPTION_DEFINED
 #define INSTANTIATION_ARGS_OPTION_DEFINED
 /* WASM module instantiation arguments */
@@ -263,6 +272,8 @@ typedef struct InstantiationArgs {
     uint32_t default_stack_size;
     uint32_t host_managed_heap_size;
     uint32_t max_memory_pages;
+    uint32_t import_count;
+    const WASMImportInst *imports;
 } InstantiationArgs;
 #endif /* INSTANTIATION_ARGS_OPTION_DEFINED */
 
@@ -942,6 +953,27 @@ wasm_runtime_get_module_inst(wasm_exec_env_t exec_env);
 WASM_RUNTIME_API_EXTERN void
 wasm_runtime_set_module_inst(wasm_exec_env_t exec_env,
                              const wasm_module_inst_t module_inst);
+
+/**
+ * Create a memory instance
+ *
+ * @param initial_pages The initial number of pages
+ * @param max_pages The maximum number of pages, or zero for no maximum
+ * @param shared Whether the memory is shared
+ *
+ * @return The created memory instance if successful, NULL otherwise
+ */
+WASM_RUNTIME_API_EXTERN wasm_memory_inst_t
+wasm_runtime_memory_create(uint64_t initial_pages, uint64_t max_pages,
+                           bool shared);
+
+/**
+ * @brief Destroy a memory instance
+ *
+ * @param memory_inst The memory instance to destroy
+ */
+WASM_RUNTIME_API_EXTERN void
+wasm_memory_destroy(wasm_memory_inst_t memory_inst);
 
 /**
  * @brief Lookup a memory instance by name

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -3455,7 +3455,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         str_obj = (WASMString)wasm_stringref_obj_get_value(
                             stringref_obj);
 
-                        memory_inst = module->memories[mem_idx];
+                        memory_inst = module->memories[mem_idx].memory;
                         maddr = memory_inst->memory_data + addr;
 
                         if (opcode == WASM_OP_STRING_ENCODE_WTF16) {
@@ -3623,7 +3623,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         addr = POP_I32();
                         stringview_wtf8_obj = POP_REF();
 
-                        memory_inst = module->memories[mem_idx];
+                        memory_inst = module->memories[mem_idx].memory;
                         maddr = memory_inst->memory_data + addr;
 
                         bytes_written = wasm_string_encode(

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -362,6 +362,11 @@ typedef struct WASMModuleInstanceExtra {
 
 struct AOTFuncPerfProfInfo;
 
+typedef struct WASMMemoryWrapper {
+    WASMMemoryInstance *memory;
+    WASMMemoryImport *memory_import;
+} WASMMemoryWrapper;
+
 struct WASMModuleInstance {
     /* Module instance type, for module instance loaded from
        WASM bytecode binary, this field is Wasm_Module_Bytecode;
@@ -371,7 +376,7 @@ struct WASMModuleInstance {
     uint32 module_type;
 
     uint32 memory_count;
-    DefPointer(WASMMemoryInstance **, memories);
+    DefPointer(WASMMemoryWrapper *, memories);
 
     /* global and table info */
     uint32 global_data_size;
@@ -516,7 +521,8 @@ wasm_unload(WASMModule *module);
 WASMModuleInstance *
 wasm_instantiate(WASMModule *module, WASMModuleInstance *parent,
                  WASMExecEnv *exec_env_main, uint32 stack_size,
-                 uint32 heap_size, uint32 max_memory_pages, char *error_buf,
+                 uint32 heap_size, uint32 max_memory_pages, uint32 import_count,
+                 const WASMImportInst *imports, char *error_buf,
                  uint32 error_buf_size);
 
 void

--- a/core/iwasm/libraries/lib-pthread/lib_pthread_wrapper.c
+++ b/core/iwasm/libraries/lib-pthread/lib_pthread_wrapper.c
@@ -580,7 +580,8 @@ pthread_create_wrapper(wasm_exec_env_t exec_env,
 #endif
 
     if (!(new_module_inst = wasm_runtime_instantiate_internal(
-              module, module_inst, exec_env, stack_size, 0, 0, NULL, 0)))
+              module, module_inst, exec_env, stack_size, 0, 0, 0, NULL, NULL,
+              0)))
         return -1;
 
     /* Set custom_data to new module instance */

--- a/core/iwasm/libraries/lib-wasi-threads/lib_wasi_threads_wrapper.c
+++ b/core/iwasm/libraries/lib-wasi-threads/lib_wasi_threads_wrapper.c
@@ -87,7 +87,8 @@ thread_spawn_wrapper(wasm_exec_env_t exec_env, uint32 start_arg)
     stack_size = ((WASMModuleInstance *)module_inst)->default_wasm_stack_size;
 
     if (!(new_module_inst = wasm_runtime_instantiate_internal(
-              module, module_inst, exec_env, stack_size, 0, 0, NULL, 0)))
+              module, module_inst, exec_env, stack_size, 0, 0, 0, NULL, NULL,
+              0)))
         return -1;
 
     wasm_runtime_set_custom_data_internal(

--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -506,7 +506,8 @@ wasm_cluster_spawn_exec_env(WASMExecEnv *exec_env)
     }
 
     if (!(new_module_inst = wasm_runtime_instantiate_internal(
-              module, module_inst, exec_env, stack_size, 0, 0, NULL, 0))) {
+              module, module_inst, exec_env, stack_size, 0, 0, 0, NULL, NULL,
+              0))) {
         return NULL;
     }
 


### PR DESCRIPTION
This adds support to the public export API and internal implementation for import memory objects. The exception to this is that the AOT compiler and loader are currently hardcoded not to support import memories, so that will need to be fixed in a future change.

Please let me know if there's anything about the approach used here that should be improved or re-done.