### PR TITLE
Fix Windows compile error when uvwasi is enabled

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -2520,7 +2520,7 @@ try_merge_data_and_text(const uint8 **buf, const uint8 **buf_end,
     /* order not essential just as compiler does: .text section first */
     *buf = sections;
     *buf_end = sections + code_size;
-    bh_memcpy_s(sections, code_size, old_buf, code_size);
+    bh_memcpy_s(sections, (uint32)code_size, old_buf, (uint32)code_size);
     os_munmap(old_buf, code_size);
     sections += align_uint((uint32)code_size, page_size);
 

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -340,7 +340,6 @@ runtime_exception_handler(EXCEPTION_POINTERS *exce_info)
     PEXCEPTION_RECORD ExceptionRecord = exce_info->ExceptionRecord;
     uint8 *sig_addr = (uint8 *)ExceptionRecord->ExceptionInformation[1];
     WASMModuleInstance *module_inst;
-    WASMMemoryInstance *memory_inst;
     WASMJmpBuf *jmpbuf_node;
     uint8 *mapped_mem_start_addr = NULL;
     uint8 *mapped_mem_end_addr = NULL;

--- a/core/shared/platform/windows/platform_internal.h
+++ b/core/shared/platform/windows/platform_internal.h
@@ -168,12 +168,13 @@ typedef struct windows_dir_stream {
     windows_handle *handle;
 } windows_dir_stream;
 
-typedef windows_handle *os_file_handle;
 typedef windows_dir_stream *os_dir_stream;
 
-#if WASM_ENABLE_UVWASI != 1
+#if WASM_ENABLE_UVWASI == 0
+typedef windows_handle *os_file_handle;
 typedef HANDLE os_raw_file_handle;
 #else
+typedef uint32_t os_file_handle;
 typedef uint32_t os_raw_file_handle;
 #endif
 
@@ -190,7 +191,11 @@ typedef uint32_t os_raw_file_handle;
 static inline os_file_handle
 os_get_invalid_handle(void)
 {
+#if WASM_ENABLE_UVWASI == 0
     return NULL;
+#else
+    return -1;
+#endif
 }
 
 #ifdef __cplusplus

--- a/core/shared/platform/windows/shared_platform.cmake
+++ b/core/shared/platform/windows/shared_platform.cmake
@@ -15,6 +15,9 @@ file (GLOB_RECURSE source_all ${PLATFORM_SHARED_DIR}/*.c
 
 if (NOT WAMR_BUILD_LIBC_WASI EQUAL 1)
     list(REMOVE_ITEM source_all ${PLATFORM_SHARED_DIR}/win_file.c)
+elseif (WAMR_BUILD_LIBC_UVWASI EQUAL 1)
+    # uvwasi doesn't need to compile win_file.c
+    list(REMOVE_ITEM source_all ${PLATFORM_SHARED_DIR}/win_file.c)
 else()
     include (${CMAKE_CURRENT_LIST_DIR}/../common/libc-util/platform_common_libc_util.cmake)
     set(source_all ${source_all} ${PLATFORM_COMMON_LIBC_UTIL_SOURCE})

--- a/core/shared/platform/windows/win_socket.c
+++ b/core/shared/platform/windows/win_socket.c
@@ -182,8 +182,8 @@ os_socket_accept(bh_socket_t server_sock, bh_socket_t *sock, void *addr,
     (*sock)->type = windows_handle_type_socket;
     (*sock)->access_mode = windows_access_mode_read | windows_access_mode_write;
     (*sock)->fdflags = 0;
-    (*sock)->raw.socket =
-        accept(server_sock->raw.socket, (struct sockaddr *)&addr_tmp, &len);
+    (*sock)->raw.socket = accept(server_sock->raw.socket,
+                                 (struct sockaddr *)&addr_tmp, (int *)&len);
 
     if ((*sock)->raw.socket == INVALID_SOCKET) {
         BH_FREE(*sock);


### PR DESCRIPTION
No need to compile win_file.c when uvwasi is enabled.