### PR TITLE
Fix missing symbols when using aot mode on riscv platforms. (#3731)

### DIFF
--- a/core/config.h
+++ b/core/config.h
@@ -692,18 +692,4 @@
 #endif
 #endif /* WASM_ENABLE_FUZZ_TEST != 0 */
 
-#if WASM_ENABLE_AOT != 0
-#if defined(BUILD_TARGET_RISCV64_LP64D) || defined(BUILD_TARGET_RISCV64_LP64) \
-    || defined(BUILD_TARGET_RISCV32_ILP32D)                                   \
-    || defined(BUILD_TARGET_RISCV32_ILP32F)                                   \
-    || defined(BUILD_TARGET_RISCV32_ILP32)
-#ifndef ARCH_RISCV_COMPILE_AOT_WITHOUT_FEATURE_A
-#define ARCH_RISCV_COMPILE_AOT_WITHOUT_FEATURE_A 0
-#endif
-#ifndef ARCH_RISCV_COMPILE_AOT_WITHOUT_FEATURE_M
-#define ARCH_RISCV_COMPILE_AOT_WITHOUT_FEATURE_M 0
-#endif
-#endif
-#endif /* WASM_ENABLE_AOT != 0 */
-
 #endif /* end of _CONFIG_H_ */

--- a/core/config.h
+++ b/core/config.h
@@ -692,4 +692,18 @@
 #endif
 #endif /* WASM_ENABLE_FUZZ_TEST != 0 */
 
+#if WASM_ENABLE_AOT != 0
+#if defined(BUILD_TARGET_RISCV64_LP64D) || defined(BUILD_TARGET_RISCV64_LP64) \
+    || defined(BUILD_TARGET_RISCV32_ILP32D)                                   \
+    || defined(BUILD_TARGET_RISCV32_ILP32F)                                   \
+    || defined(BUILD_TARGET_RISCV32_ILP32)
+#ifndef ARCH_RISCV_COMPILE_AOT_WITHOUT_FEATURE_A
+#define ARCH_RISCV_COMPILE_AOT_WITHOUT_FEATURE_A 0
+#endif
+#ifndef ARCH_RISCV_COMPILE_AOT_WITHOUT_FEATURE_M
+#define ARCH_RISCV_COMPILE_AOT_WITHOUT_FEATURE_M 0
+#endif
+#endif
+#endif /* WASM_ENABLE_AOT != 0 */
+
 #endif /* end of _CONFIG_H_ */

--- a/core/iwasm/aot/arch/aot_reloc_riscv.c
+++ b/core/iwasm/aot/arch/aot_reloc_riscv.c
@@ -106,8 +106,9 @@ void __umoddi3(void);
 void __umodsi3(void);
 void __unorddf2(void);
 void __unordsf2(void);
-void __atomic_compare_exchange_4(void);
-void __atomic_store_4(void);
+bool __atomic_compare_exchange_4(volatile void *, void *, unsigned int,
+                                 bool, int, int);
+void __atomic_store_4(volatile void *, unsigned int, int);
 /* clang-format on */
 
 static SymbolMap target_sym_map[] = {

--- a/core/iwasm/aot/arch/aot_reloc_riscv.c
+++ b/core/iwasm/aot/arch/aot_reloc_riscv.c
@@ -49,21 +49,8 @@
 #define NEED_SOFT_I64_DIV
 #endif
 
-#if !defined(__riscv_atomic)                              \
-    || (defined(ARCH_RISCV_COMPILE_AOT_WITHOUT_FEATURE_A) \
-        && ARCH_RISCV_COMPILE_AOT_WITHOUT_FEATURE_A != 0)
-/* clang-format off */
-void __atomic_compare_exchange_4(void);
-void __atomic_store_4(void);
-/* clang-format on */
+#ifndef __riscv_atomic
 #define NEED_SOFT_ATOMIC
-#endif
-
-#if (!defined(NEED_SOFT_I32_DIV) || !defined(NEED_SOFT_I32_MUL)) \
-    && (defined(ARCH_RISCV_COMPILE_AOT_WITHOUT_FEATURE_M)        \
-        && ARCH_RISCV_COMPILE_AOT_WITHOUT_FEATURE_M != 0)
-#define NEED_SOFT_I32_DIV
-#define NEED_SOFT_I32_MUL
 #endif
 
 /* clang-format off */
@@ -119,6 +106,8 @@ void __umoddi3(void);
 void __umodsi3(void);
 void __unorddf2(void);
 void __unordsf2(void);
+void __atomic_compare_exchange_4(void);
+void __atomic_store_4(void);
 /* clang-format on */
 
 static SymbolMap target_sym_map[] = {
@@ -146,7 +135,6 @@ static SymbolMap target_sym_map[] = {
      */
     REG_SYM(__floatundisf),
     REG_SYM(__floatdisf),
-    REG_SYM(__floatdidf),
 #endif
 #ifdef NEED_SOFT_DP
     REG_SYM(__adddf3),

--- a/core/iwasm/aot/arch/aot_reloc_riscv.c
+++ b/core/iwasm/aot/arch/aot_reloc_riscv.c
@@ -24,6 +24,7 @@
 #undef NEED_SOFT_I32_DIV
 #undef NEED_SOFT_I64_MUL
 #undef NEED_SOFT_I64_DIV
+#undef NEED_SOFT_ATOMIC
 
 #ifdef __riscv_flen
 #if __riscv_flen == 32
@@ -46,6 +47,23 @@
 #define NEED_SOFT_I64_DIV
 #elif __riscv_xlen == 32
 #define NEED_SOFT_I64_DIV
+#endif
+
+#if !defined(__riscv_atomic)                              \
+    || (defined(ARCH_RISCV_COMPILE_AOT_WITHOUT_FEATURE_A) \
+        && ARCH_RISCV_COMPILE_AOT_WITHOUT_FEATURE_A != 0)
+/* clang-format off */
+void __atomic_compare_exchange_4(void);
+void __atomic_store_4(void);
+/* clang-format on */
+#define NEED_SOFT_ATOMIC
+#endif
+
+#if (!defined(NEED_SOFT_I32_DIV) || !defined(NEED_SOFT_I32_MUL)) \
+    && (defined(ARCH_RISCV_COMPILE_AOT_WITHOUT_FEATURE_M)        \
+        && ARCH_RISCV_COMPILE_AOT_WITHOUT_FEATURE_M != 0)
+#define NEED_SOFT_I32_DIV
+#define NEED_SOFT_I32_MUL
 #endif
 
 /* clang-format off */
@@ -127,6 +145,8 @@ static SymbolMap target_sym_map[] = {
      * to convert float and long long
      */
     REG_SYM(__floatundisf),
+    REG_SYM(__floatdisf),
+    REG_SYM(__floatdidf),
 #endif
 #ifdef NEED_SOFT_DP
     REG_SYM(__adddf3),
@@ -175,6 +195,10 @@ static SymbolMap target_sym_map[] = {
     REG_SYM(__moddi3),
     REG_SYM(__udivdi3),
     REG_SYM(__umoddi3),
+#endif
+#ifdef NEED_SOFT_ATOMIC
+    REG_SYM(__atomic_compare_exchange_4),
+    REG_SYM(__atomic_store_4),
 #endif
     /* clang-format on */
 };


### PR DESCRIPTION
Fix missing symbols when using AOT mode on RISCV platforms.

If the target platform does not support the “Atomic Instructions” or “Integer Multiplication and Division” features, or does not turn on support for these CPU features when using wamrc to compile the aot file.

Just add these two macros when compiling iwasm:

- ARCH_RISCV_COMPILE_AOT_WITHOUT_FEATURE_A=1
- ARCH_RISCV_COMPILE_AOT_WITHOUT_FEATURE_M=1