### PR TITLE
Fix unused param for disabled GC

### DIFF
--- a/core/iwasm/interpreter/wasm.h
+++ b/core/iwasm/interpreter/wasm.h
@@ -1230,6 +1230,9 @@ wasm_value_type_size_internal(uint8 value_type, uint8 pointer_size)
     else {
         bh_assert(0);
     }
+#if WASM_ENABLE_GC == 0
+    (void)pointer_size;
+#endif
     return 0;
 }
 


### PR DESCRIPTION
Fix compile error when -Wunused-parameter is used and WASM_ENABLE_GC == 0