### PR TITLE
Implement the first few SIMD opcodes for fast interpreter (v128.const, v128.any_true)

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -37,6 +37,10 @@ extern "C" {
     do {                                   \
         *(int64 *)(addr) = (int64)(value); \
     } while (0)
+#define PUT_V128_TO_ADDR(addr, value) \
+    do {                              \
+        *(V128 *)(addr) = (value);    \
+    } while (0)
 #define PUT_F64_TO_ADDR(addr, value)           \
     do {                                       \
         *(float64 *)(addr) = (float64)(value); \
@@ -49,6 +53,7 @@ extern "C" {
 #define GET_I64_FROM_ADDR(addr) (*(int64 *)(addr))
 #define GET_F64_FROM_ADDR(addr) (*(float64 *)(addr))
 #define GET_REF_FROM_ADDR(addr) (*(void **)(addr))
+#define GET_V128_FROM_ADDR(addr) (*(V128 *)(addr))
 
 /* For STORE opcodes */
 #define STORE_I64 PUT_I64_TO_ADDR
@@ -82,6 +87,15 @@ STORE_U8(void *addr, uint8_t value)
     } while (0)
 
 #else /* WASM_CPU_SUPPORTS_UNALIGNED_ADDR_ACCESS != 0 */
+
+#define PUT_V128_TO_ADDR(addr, value)        \
+    do {                                     \
+        uint32 *addr_u32 = (uint32 *)(addr); \
+        addr_u32[0] = (value).i32x4[0];      \
+        addr_u32[1] = (value).i32x4[1];      \
+        addr_u32[2] = (value).i32x4[2];      \
+        addr_u32[3] = (value).i32x4[3];      \
+    } while (0)
 
 #define PUT_I64_TO_ADDR(addr, value)         \
     do {                                     \
@@ -123,6 +137,17 @@ STORE_U8(void *addr, uint8_t value)
         *(void **)(addr) = (void *)(value); \
     } while (0)
 #endif
+
+static inline V128
+GET_V128_FROM_ADDR(uint32 *addr)
+{
+    V128 ret;
+    ret.i32x4[0] = addr[0];
+    ret.i32x4[1] = addr[1];
+    ret.i32x4[2] = addr[2];
+    ret.i32x4[3] = addr[3];
+    return ret;
+}
 
 static inline int64
 GET_I64_FROM_ADDR(uint32 *addr)

--- a/core/iwasm/interpreter/wasm_opcode.h
+++ b/core/iwasm/interpreter/wasm_opcode.h
@@ -782,7 +782,8 @@ typedef enum WASMAtomicEXTOpcode {
 
 #define SET_GOTO_TABLE_ELEM(opcode) [opcode] = HANDLE_OPCODE(opcode)
 
-#if WASM_ENABLE_JIT != 0 && WASM_ENABLE_SIMD != 0
+#if (WASM_ENABLE_JIT != 0 || WASM_ENABLE_FAST_INTERP != 0) \
+    && WASM_ENABLE_SIMD != 0
 #define SET_GOTO_TABLE_SIMD_PREFIX_ELEM() \
     SET_GOTO_TABLE_ELEM(WASM_OP_SIMD_PREFIX),
 #else


### PR DESCRIPTION
Tested on the following code:
```
(module
  (import "wasi_snapshot_preview1" "proc_exit" (func $proc_exit (param i32)))
  
  (memory (export "memory") 1)

  ;; WASI entry point
  (func $main (export "_start")
    v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
    v128.any_true
    if
      unreachable
    end
    
    v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15     
    v128.any_true
    i32.const 0
    i32.eq
    if
      unreachable
    end

    i32.const 0
    call $proc_exit
  )
)
```