### PR TITLE
add missing stdint.h header

### DIFF
--- a/core/iwasm/include/aot_comp_option.h
+++ b/core/iwasm/include/aot_comp_option.h
@@ -6,6 +6,8 @@
 #ifndef __AOT_COMP_OPTION_H__
 #define __AOT_COMP_OPTION_H__
 
+#include <stdint.h>
+
 typedef struct {
     /* Enables or disables bounds checks for stack frames. When enabled, the AOT
      * compiler generates code to check if the stack pointer is within the


### PR DESCRIPTION
We use bazel to build wamrc internally at Google, it complains if we don't have this header included (missing types such as `uint32_t`)