### PR TITLE
Emit load_addr and load_size if WAMR_ENABLE_COMPILER is set

### DIFF
--- a/core/iwasm/interpreter/wasm.h
+++ b/core/iwasm/interpreter/wasm.h
@@ -976,8 +976,9 @@ struct WASMModule {
     uint64 buf_code_size;
 #endif
 
-#if WASM_ENABLE_DEBUG_INTERP != 0 || WASM_ENABLE_FAST_JIT != 0 \
-    || WASM_ENABLE_DUMP_CALL_STACK != 0 || WASM_ENABLE_JIT != 0
+#if WASM_ENABLE_DEBUG_INTERP != 0 || WASM_ENABLE_FAST_JIT != 0  \
+    || WASM_ENABLE_DUMP_CALL_STACK != 0 || WASM_ENABLE_JIT != 0 \
+    || WASM_ENABLE_WAMR_COMPILER != 0
     uint8 *load_addr;
     uint64 load_size;
 #endif


### PR DESCRIPTION
Currently, the open-source builds set WASM_ENABLE_DUMP_CALL_STACK, which causes these two fields to be emitted. They are required by aot_emit_exception.cc.

Internally at Google, we don't enable call stack dumps, so we've been using the attached patch to make sure the fields are emitted anyway.

Does it make sense to build the compiler without ENABLE_DUMP_CALL_STACK? This could just be an oversight on our part when we import WAMR.