### PR TITLE
add ability for wasm_application_execute_func to return return values

### DIFF
--- a/core/iwasm/common/wasm_application.c
+++ b/core/iwasm/common/wasm_application.c
@@ -685,6 +685,10 @@ execute_func(WASMModuleInstanceCommon *module_inst, const char *name,
         goto fail;
     }
 
+    if (argv && type->result_count == 1 && type->types[type->param_count] == VALUE_TYPE_I32)
+        /* copy the return value */
+        *(int *)argv = (int)argv1[0];
+
 #if WASM_ENABLE_GC != 0
     ref_type_map = type->result_ref_type_maps;
 #endif


### PR DESCRIPTION
This only works for i32 values.

If you think this should be extended to other kind of values please let me know

It should address https://github.com/bytecodealliance/wasm-micro-runtime/issues/3840 at least for me 