### PR TITLE
thread suspension test: Fix several issues

### DIFF
--- a/core/iwasm/common/wasm_blocking_op.c
+++ b/core/iwasm/common/wasm_blocking_op.c
@@ -11,8 +11,10 @@
 
 #if WASM_ENABLE_THREAD_MGR != 0 && defined(OS_ENABLE_WAKEUP_BLOCKING_OP)
 
-#define LOCK(env) WASM_SUSPEND_FLAGS_LOCK((env)->wait_lock)
-#define UNLOCK(env) WASM_SUSPEND_FLAGS_UNLOCK((env)->wait_lock)
+#include "../libraries/thread-mgr/thread_manager.h"
+
+#define LOCK(env) WASM_SUSPEND_FLAGS_LOCK((env)->cluster->thread_state_lock)
+#define UNLOCK(env) WASM_SUSPEND_FLAGS_UNLOCK((env)->cluster->thread_state_lock)
 
 #define ISSET(env, bit)                                                       \
     ((WASM_SUSPEND_FLAGS_GET((env)->suspend_flags) & WASM_SUSPEND_FLAG_##bit) \

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -4561,7 +4561,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
                 if (opcode == WASM_OP_I32_STORE8) {
                     CHECK_MEMORY_OVERFLOW(1);
-                    *(uint8 *)maddr = (uint8)sval;
+                    STORE_U8(maddr, (uint8)sval);
                 }
                 else {
                     CHECK_MEMORY_OVERFLOW(2);
@@ -4587,7 +4587,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
                 if (opcode == WASM_OP_I64_STORE8) {
                     CHECK_MEMORY_OVERFLOW(1);
-                    *(uint8 *)maddr = (uint8)sval;
+                    STORE_U8(maddr, (uint8)sval);
                 }
                 else if (opcode == WASM_OP_I64_STORE16) {
                     CHECK_MEMORY_OVERFLOW(2);
@@ -6354,9 +6354,11 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 #if WASM_ENABLE_DEBUG_INTERP != 0
             HANDLE_OP(DEBUG_OP_BREAK)
             {
+                WASM_SUSPEND_FLAGS_LOCK(exec_env->cluster->thread_state_lock);
                 wasm_cluster_thread_send_signal(exec_env, WAMR_SIG_TRAP);
                 WASM_SUSPEND_FLAGS_FETCH_OR(exec_env->suspend_flags,
                                             WASM_SUSPEND_FLAG_SUSPEND);
+                WASM_SUSPEND_FLAGS_UNLOCK(exec_env->cluster->thread_state_lock);
                 frame_ip--;
                 SYNC_ALL_TO_FRAME();
                 CHECK_SUSPEND_FLAGS();

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -3763,7 +3763,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 addr = GET_OPERAND(uint32, I32, 2);
                 frame_ip += 4;
                 CHECK_MEMORY_OVERFLOW(1);
-                STORE_U8(maddr, (uint8_t)sval);
+                STORE_U8(maddr, (uint8)sval);
                 HANDLE_OP_END();
             }
 
@@ -3802,7 +3802,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 addr = GET_OPERAND(uint32, I32, 2);
                 frame_ip += 4;
                 CHECK_MEMORY_OVERFLOW(1);
-                *(uint8 *)maddr = (uint8)sval;
+                STORE_U8(maddr, (uint8)sval);
                 HANDLE_OP_END();
             }
 


### PR DESCRIPTION
- Use united macros to access exec_env->suspend_flags
- Acquire global_exec_env_list_lock when accessing exec_env in some places
- Several minor fixes in interpreter