### PR TITLE
Enable libc-wasi for windows msvc build

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -2512,6 +2512,15 @@ try_merge_data_and_text(const uint8 **buf, const uint8 **buf_end,
         /* merge failed but may be not critical for some targets */
         return false;
     }
+
+#ifdef BH_PLATFORM_WINDOWS
+    if (!os_mem_commit(sections, code_size,
+                       MMAP_PROT_READ | MMAP_PROT_WRITE | MMAP_PROT_EXEC)) {
+        os_munmap(sections, (uint32)total_size);
+        return false;
+    }
+#endif
+
     /* change the code part to be executable */
     if (os_mprotect(sections, code_size,
                     MMAP_PROT_READ | MMAP_PROT_WRITE | MMAP_PROT_EXEC)

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/refcount.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/refcount.h
@@ -132,6 +132,35 @@ refcount_release(struct refcount *r)
 #error "Reference counter isn't implemented"
 #endif /* end of __GNUC_PREREQ (4.7) */
 
+#elif defined(_MSC_VER)
+
+/* Simple reference counter. */
+struct LOCKABLE refcount {
+    LONG count;
+};
+
+/* Initialize the reference counter. */
+static inline void
+refcount_init(struct refcount *r, unsigned int count)
+{
+    InterlockedExchange(&r->count, (LONG)count);
+}
+
+/* Increment the reference counter. */
+static inline void
+refcount_acquire(struct refcount *r)
+{
+    InterlockedIncrement(&r->count);
+}
+
+/* Decrement the reference counter, returning whether the reference
+   dropped to zero. */
+static inline bool
+refcount_release(struct refcount *r)
+{
+    return InterlockedDecrement(&r->count) == 0 ? true : false;
+}
+
 #else /* else of CONFIG_HAS_STD_ATOMIC */
 #error "Reference counter isn't implemented"
 #endif /* end of CONFIG_HAS_STD_ATOMIC */

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
@@ -75,36 +75,36 @@
 so we have to handle this case specially */
 #if defined(__clang__)
 
-  /* Clang provides stdatomic.h since 3.6.0
-  See https://releases.llvm.org/3.6.0/tools/clang/docs/ReleaseNotes.html */
-  #if __clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 6)
-  #define CONFIG_HAS_STD_ATOMIC 1
-  #else
-  #define CONFIG_HAS_STD_ATOMIC 0
-  #endif
+/* Clang provides stdatomic.h since 3.6.0
+See https://releases.llvm.org/3.6.0/tools/clang/docs/ReleaseNotes.html */
+#if __clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 6)
+#define CONFIG_HAS_STD_ATOMIC 1
+#else
+#define CONFIG_HAS_STD_ATOMIC 0
+#endif
 
 #elif defined(__GNUC_PREREQ)
 
-  /* Even though older versions of GCC support C11, atomics were
-  not implemented until 4.9. See
-  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58016 */
-  #if __GNUC_PREREQ(4, 9)
-  #define CONFIG_HAS_STD_ATOMIC 1
-  #else /* else of __GNUC_PREREQ(4, 9) */
-  #define CONFIG_HAS_STD_ATOMIC 0
-  #endif /* end of __GNUC_PREREQ(4, 9) */
+/* Even though older versions of GCC support C11, atomics were
+not implemented until 4.9. See
+https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58016 */
+#if __GNUC_PREREQ(4, 9)
+#define CONFIG_HAS_STD_ATOMIC 1
+#else /* else of __GNUC_PREREQ(4, 9) */
+#define CONFIG_HAS_STD_ATOMIC 0
+#endif /* end of __GNUC_PREREQ(4, 9) */
 
 #elif defined(_MSC_VER)
 
-  #define CONFIG_HAS_STD_ATOMIC 0
+#define CONFIG_HAS_STD_ATOMIC 0
 
 #else
 
-  #define CONFIG_HAS_STD_ATOMIC 1
+#define CONFIG_HAS_STD_ATOMIC 1
 
 #endif /* end of defined(__clang__) */
 
-#else  /* else of !defined(BH_PLATFORM_LINUX_SGX) */
+#else /* else of !defined(BH_PLATFORM_LINUX_SGX) */
 
 #define CONFIG_HAS_STD_ATOMIC 0
 

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
@@ -70,30 +70,44 @@
 #endif
 
 #if !defined(BH_PLATFORM_LINUX_SGX)
+
 /* Clang's __GNUC_PREREQ macro has a different meaning than GCC one,
 so we have to handle this case specially */
 #if defined(__clang__)
-/* Clang provides stdatomic.h since 3.6.0
-See https://releases.llvm.org/3.6.0/tools/clang/docs/ReleaseNotes.html */
-#if __clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 6)
-#define CONFIG_HAS_STD_ATOMIC 1
-#else
-#define CONFIG_HAS_STD_ATOMIC 0
-#endif
+
+  /* Clang provides stdatomic.h since 3.6.0
+  See https://releases.llvm.org/3.6.0/tools/clang/docs/ReleaseNotes.html */
+  #if __clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 6)
+  #define CONFIG_HAS_STD_ATOMIC 1
+  #else
+  #define CONFIG_HAS_STD_ATOMIC 0
+  #endif
+
 #elif defined(__GNUC_PREREQ)
-/* Even though older versions of GCC support C11, atomics were
-not implemented until 4.9. See
-https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58016 */
-#if __GNUC_PREREQ(4, 9)
-#define CONFIG_HAS_STD_ATOMIC 1
-#else /* else of __GNUC_PREREQ(4, 9) */
-#define CONFIG_HAS_STD_ATOMIC 0
-#endif /* end of __GNUC_PREREQ(4, 9) */
-#else  /* else of defined(__GNUC_PREREQ) */
-#define CONFIG_HAS_STD_ATOMIC 1
-#endif /* end of defined(__GNUC_PREREQ) */
+
+  /* Even though older versions of GCC support C11, atomics were
+  not implemented until 4.9. See
+  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58016 */
+  #if __GNUC_PREREQ(4, 9)
+  #define CONFIG_HAS_STD_ATOMIC 1
+  #else /* else of __GNUC_PREREQ(4, 9) */
+  #define CONFIG_HAS_STD_ATOMIC 0
+  #endif /* end of __GNUC_PREREQ(4, 9) */
+
+#elif defined(_MSC_VER)
+
+  #define CONFIG_HAS_STD_ATOMIC 0
+
+#else
+
+  #define CONFIG_HAS_STD_ATOMIC 1
+
+#endif /* end of defined(__clang__) */
+
 #else  /* else of !defined(BH_PLATFORM_LINUX_SGX) */
+
 #define CONFIG_HAS_STD_ATOMIC 0
+
 #endif /* end of !defined(BH_PLATFORM_LINUX_SGX) */
 
-#endif
+#endif /* end of SSP_CONFIG_H */

--- a/core/shared/platform/windows/platform_internal.h
+++ b/core/shared/platform/windows/platform_internal.h
@@ -6,6 +6,12 @@
 #ifndef _PLATFORM_INTERNAL_H
 #define _PLATFORM_INTERNAL_H
 
+/*
+ * Suppress the noisy warnings:
+ * winbase.h: warning C5105: macro expansion producing 'defined' has
+ * undefined behavior
+ */
+#pragma warning(disable: 5105)
 #include <inttypes.h>
 #include <stdbool.h>
 #include <assert.h>

--- a/core/shared/platform/windows/platform_internal.h
+++ b/core/shared/platform/windows/platform_internal.h
@@ -11,7 +11,7 @@
  * winbase.h: warning C5105: macro expansion producing 'defined' has
  * undefined behavior
  */
-#pragma warning(disable: 5105)
+#pragma warning(disable : 5105)
 #include <inttypes.h>
 #include <stdbool.h>
 #include <assert.h>

--- a/core/shared/platform/windows/win_clock.c
+++ b/core/shared/platform/windows/win_clock.c
@@ -10,6 +10,10 @@
 #define NANOSECONDS_PER_SECOND 1000000000ULL
 #define NANOSECONDS_PER_TICK 100
 
+extern NTSTATUS
+NtQueryTimerResolution(PULONG MinimumResolution, PULONG MaximumResolution,
+                       PULONG CurrentResolution);
+
 static __wasi_errno_t
 calculate_monotonic_clock_frequency(uint64 *out_frequency)
 {

--- a/core/shared/platform/windows/win_util.h
+++ b/core/shared/platform/windows/win_util.h
@@ -7,7 +7,13 @@
 #define _WIN_UTIL_H
 
 #include "platform_wasi_types.h"
-#include "windows.h"
+/*
+ * Suppress the noisy warnings:
+ * winbase.h: warning C5105: macro expansion producing 'defined' has
+ * undefined behavior
+ */
+#pragma warning(disable: 5105)
+#include <windows.h>
 
 __wasi_timestamp_t
 convert_filetime_to_wasi_timestamp(LPFILETIME filetime);

--- a/core/shared/platform/windows/win_util.h
+++ b/core/shared/platform/windows/win_util.h
@@ -12,7 +12,7 @@
  * winbase.h: warning C5105: macro expansion producing 'defined' has
  * undefined behavior
  */
-#pragma warning(disable: 5105)
+#pragma warning(disable : 5105)
 #include <windows.h>
 
 __wasi_timestamp_t

--- a/product-mini/platforms/windows/CMakeLists.txt
+++ b/product-mini/platforms/windows/CMakeLists.txt
@@ -52,9 +52,9 @@ if (NOT DEFINED WAMR_BUILD_LIBC_BUILTIN)
   set (WAMR_BUILD_LIBC_BUILTIN 1)
 endif ()
 
-if (NOT DEFINED WAMR_BUILD_LIBC_UVWASI)
-  # Enable libc uvwasi support by default
-  set (WAMR_BUILD_LIBC_UVWASI 1)
+if (NOT DEFINED WAMR_BUILD_LIBC_WASI)
+  # Enable libc wasi support by default
+  set (WAMR_BUILD_LIBC_WASI 1)
 endif ()
 
 if (NOT DEFINED WAMR_BUILD_FAST_INTERP)

--- a/wamr-compiler/CMakeLists.txt
+++ b/wamr-compiler/CMakeLists.txt
@@ -223,24 +223,14 @@ include_directories (${SHARED_DIR}/include
 
 enable_language (ASM)
 
-if (NOT MINGW AND NOT MSVC)
-  if ((NOT DEFINED WAMR_BUILD_LIBC_WASI) AND (NOT DEFINED WAMR_BUILD_LIBC_UVWASI))
-    set (WAMR_BUILD_LIBC_WASI 1)
-  endif ()
+if ((NOT DEFINED WAMR_BUILD_LIBC_WASI) AND (NOT DEFINED WAMR_BUILD_LIBC_UVWASI))
+  # Enable WAMR_BUILD_LIBC_WASI if both are not set
+  set (WAMR_BUILD_LIBC_WASI 1)
+endif ()
 
-  if ((WAMR_BUILD_LIBC_WASI EQUAL 1) AND (WAMR_BUILD_LIBC_UVWASI EQUAL 1))
-    message (WARNING "-- pick WAMR_BULID_LIBC_UVWASI when both are enabled")
-    set (WAMR_BUILD_LIBC_WASI 0)
-  endif ()
-else ()
-  if (NOT DEFINED WAMR_BUILD_LIBC_UVWASI)
-    set (WAMR_BUILD_LIBC_UVWASI 1)
-  endif ()
-
-  if (WAMR_BUILD_LIBC_WASI EQUAL 1)
-    message (WARNING "-- don't accept WAMR_BUILD_LIBC_WASI=1 on MINGW or MSVC")
-    set (WAMR_BUILD_LIBC_WASI 0)
-  endif ()
+if ((WAMR_BUILD_LIBC_WASI EQUAL 1) AND (WAMR_BUILD_LIBC_UVWASI EQUAL 1))
+  message (WARNING "-- pick WAMR_BULID_LIBC_UVWASI when both are enabled")
+  set (WAMR_BUILD_LIBC_WASI 0)
 endif ()
 
 if (NOT DEFINED WAMR_BUILD_LIBC_BUILTIN)
@@ -307,6 +297,16 @@ endif ()
 if (WAMR_BUILD_LIBC_WASI EQUAL 1)
   include (${IWASM_DIR}/libraries/libc-wasi/libc_wasi.cmake)
 endif ()
+
+if (WAMR_BUILD_LIBC_WASI EQUAL 1)
+  # Enable _Static_assert
+  set (CMAKE_C_STANDARD 11)
+  if (MSVC)
+    add_compile_options(/experimental:c11atomics)
+  endif()
+else()
+  set (CMAKE_C_STANDARD 99)
+endif()
 
 if (WAMR_BUILD_LIB_PTHREAD EQUAL 1)
   include (${IWASM_DIR}/libraries/lib-pthread/lib_pthread.cmake)


### PR DESCRIPTION
The default iwasm building in Windows MSVC enables libc-uvwasi because
libc-wasi isn't supported at the beginning. Since libc-wasi had been refactored
and is supported in Windows msys2 building, and libc-wasi supports more
functionalities(e.g. sockets) than libc-uvwasi, this PR fixes some issues to
enable libc-wasi in windows MSVC buidlings.