### PR TITLE
Exclude fuzz test python and npm packages in scoreboard scan

### DIFF
--- a/ci/coding_guidelines_check.py
+++ b/ci/coding_guidelines_check.py
@@ -180,7 +180,7 @@ def check_file_name(path: Path) -> bool:
         "docker-compose",
         "package-lock",
         "vite-env.d",
-        "osv-scanner.toml",
+        "osv-scanner",
     ]:
         return True
 

--- a/ci/coding_guidelines_check.py
+++ b/ci/coding_guidelines_check.py
@@ -180,6 +180,7 @@ def check_file_name(path: Path) -> bool:
         "docker-compose",
         "package-lock",
         "vite-env.d",
+        "osv-scanner.toml",
     ]:
         return True
 

--- a/tests/fuzz/wasm-mutator-fuzz/portal/osv-scanner.toml
+++ b/tests/fuzz/wasm-mutator-fuzz/portal/osv-scanner.toml
@@ -1,0 +1,52 @@
+# GHSA-67hx-6x53-jw92
+[[PackageOverrides]]
+name = "@babel/traverse"
+ecosystem = "npm"
+ignore = true
+reason = "Accepted known vulnerabilities for testing purposes"
+
+# GHSA-67hx-6x53-jw92
+[[PackageOverrides]]
+name = "babel-traverse"
+ecosystem = "npm"
+ignore = true
+reason = "Accepted known vulnerabilities for testing purposes"
+
+# GHSA-9c47-m6qq-7p4h	
+[[PackageOverrides]]
+name = "json5"
+ecosystem = "npm"
+ignore = true
+reason = "Dependency not critical for security"
+
+# GHSA-7fh5-64p2-3v2j
+[[PackageOverrides]]
+name = "postcss"
+ecosystem = "npm"
+ignore = true
+reason = "Vulnerabilities do not affect current use case"
+
+# GHSA-gcx4-mw62-g8wm
+[[PackageOverrides]]
+name = "rollup"
+ecosystem = "npm"
+ignore = true
+reason = "Legacy build tool under controlled environment"
+
+# GHSA-c2qf-rxjj-qqgw
+[[PackageOverrides]]
+name = "semver"
+ecosystem = "npm"
+ignore = true
+reason = "Version parsing is managed securely"
+
+# GHSA-353f-5xf4-qw67
+# GHSA-c24v-8rfc-w8vw
+# GHSA-8jhw-289h-jh2g
+# GHSA-64vr-g452-qvp3
+# GHSA-9cwx-2883-4wfx
+[[PackageOverrides]]
+name = "vite"
+ecosystem = "npm"
+ignore = true
+reason = "Development server not exposed to untrusted networks"

--- a/tests/fuzz/wasm-mutator-fuzz/server/osv-scanner.toml
+++ b/tests/fuzz/wasm-mutator-fuzz/server/osv-scanner.toml
@@ -1,0 +1,32 @@
+# GHSA-m2qf-hxjv-5gpq / PYSEC-2023-62
+[[PackageOverrides]]
+name = "Flask"
+ecosystem = "PyPI"
+ignore = true
+reason = "Accepted known vulnerabilities for testing purposes"
+
+# GHSA-m2qf-hxjv-5gpq / PYSEC-2023-62
+[[PackageOverrides]]
+name = "flask"
+ecosystem = "PyPI"
+ignore = true
+reason = "Accepted known vulnerabilities for testing purposes"
+
+# GHSA-84pr-m4jr-85g5
+# GHSA-hxwh-jpp2-84pm / PYSEC-2024-71
+[[PackageOverrides]]
+name = "flask-cors"
+ecosystem = "PyPI"
+ignore = true
+reason = "Accepted known vulnerabilities for testing purposes"
+
+# GHSA-2g68-c3qc-8985
+# GHSA-hrfv-mqp8-q5rw / PYSEC-2023-221
+# GHSA-px8h-6qxv-m22q / PYSEC-2023-57
+# GHSA-xg9f-g7g7-2323 / PYSEC-2023-58
+# PYSEC-2022-203
+[[PackageOverrides]]
+name = "werkzeug"
+ecosystem = "PyPI"
+ignore = true
+reason = "Accepted known vulnerabilities for testing purposes"


### PR DESCRIPTION
Ignore some vulnerabilities reported in the scoreboard CI since they are only used in fuzz test. They won't be included in the actual product.