### PR TITLE
Fix code scanning alert no. 1322: Pointer overflow check

### DIFF
--- a/core/iwasm/common/wasm_memory.c
+++ b/core/iwasm/common/wasm_memory.c
@@ -423,7 +423,7 @@ is_native_addr_in_shared_heap(WASMModuleInstanceCommon *module_inst,
 
     if (heap && addr >= heap->base_addr
         && addr + bytes <= heap->base_addr + heap->size
-        && addr + bytes > addr) {
+        && (size_t)bytes <= heap->base_addr + heap->size - addr) {
         return true;
     }
     return false;


### PR DESCRIPTION
Fixes [https://github.com/bytecodealliance/wasm-micro-runtime/security/code-scanning/1322](https://github.com/bytecodealliance/wasm-micro-runtime/security/code-scanning/1322)

To fix the problem, we need to avoid performing pointer arithmetic that could result in overflow. Instead, we should compare the index directly with the length of the array. Specifically, we should check if `bytes` is within the bounds of the memory region defined by `heap->base_addr` and `heap->size`.

- Replace the pointer arithmetic check `addr + bytes > addr` with a check that ensures `bytes` is within the valid range.
- Use the difference between the end of the memory region and the base address to perform the range check safely.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
