### PR TITLE
Fix out of bounds issue in is_native_addr_in_shared_heap function

### DIFF
--- a/core/iwasm/common/wasm_memory.c
+++ b/core/iwasm/common/wasm_memory.c
@@ -420,13 +420,31 @@ is_native_addr_in_shared_heap(WASMModuleInstanceCommon *module_inst,
                               uint8 *addr, uint32 bytes)
 {
     WASMSharedHeap *heap = get_shared_heap(module_inst);
+    uintptr_t base_addr;
+    uintptr_t addr_int;
+    uintptr_t end_addr;
 
-    if (heap && addr >= heap->base_addr
-        && addr + bytes <= heap->base_addr + heap->size
-        && addr + bytes > addr) {
-        return true;
+    if (!heap) {
+        return false;
     }
-    return false;
+
+    base_addr = (uintptr_t)heap->base_addr;
+    addr_int = (uintptr_t)addr;
+    if (addr_int < base_addr) {
+        return false;
+    }
+
+    end_addr = addr_int + bytes;
+    /* Check for overflow */
+    if (end_addr <= addr_int) {
+        return false;
+    }
+
+    if (end_addr > base_addr + heap->size) {
+        return false;
+    }
+
+    return true;
 }
 
 uint64


### PR DESCRIPTION
When checking for integer overflow, you may often write tests like p + i < p. This works fine if p and i are unsigned integers, since any overflow in the addition will cause the value to simply "wrap around." However, using this pattern when p is a pointer is problematic because pointer overflow has undefined behavior according to the C and C++ standards. If the addition overflows and has an undefined result, the comparison will likewise be undefined; it may produce an unintended result, or may be deleted entirely by an optimizing compiler.