### PR TITLE
fix(ios): Remove `float-abi` flag

### DIFF
--- a/product-mini/platforms/ios/CMakeLists.txt
+++ b/product-mini/platforms/ios/CMakeLists.txt
@@ -3,8 +3,6 @@
 
 cmake_minimum_required (VERSION 3.21)
 
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfloat-abi=hard")
-
 project (iwasm)
 
 set (WAMR_BUILD_PLATFORM "darwin")


### PR DESCRIPTION
Compiling `wamr` targeting `iOS` results in
```
clang: error: unsupported option '-mfloat-abi=' for target 'aarch64-apple-ios'
```

This small patch removes this setting in the related `CMakeLists.txt` file. 