### PR TITLE
Refactor AOT loader to support compatible versions

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -4236,6 +4236,16 @@ fail:
 }
 
 static bool
+aot_compatible_version(uint32 version)
+{
+    /*
+     * refer to "AoT-compiled module compatibility among WAMR versions" in
+     * ./doc/biuld_wasm_app.md
+     */
+    return version == 4 || version == 3;
+}
+
+static bool
 load(const uint8 *buf, uint32 size, AOTModule *module,
      bool wasm_binary_freeable, bool no_resolve, char *error_buf,
      uint32 error_buf_size)
@@ -4253,7 +4263,7 @@ load(const uint8 *buf, uint32 size, AOTModule *module,
     }
 
     read_uint32(p, p_end, version);
-    if (version != AOT_CURRENT_VERSION) {
+    if (!aot_compatible_version(version)) {
         set_error_buf(error_buf, error_buf_size, "unknown binary version");
         return false;
     }

--- a/doc/build_wasm_app.md
+++ b/doc/build_wasm_app.md
@@ -377,14 +377,22 @@ Examples: wamrc -o test.aot test.wasm
 When making major ABI changes for AoT-compiled modules, we bump
 `AOT_CURRENT_VERSION` constant in `core/config.h` header.
 The runtime rejects to load a module AoT-compiled with wamrc with
-a different `AOT_CURRENT_VERSION`.
+a non-compatible`AOT_CURRENT_VERSION`.
 
 We try our best to maintain our runtime ABI for AoT-compiled modules
-compatible among WAMR versions with the same `AOT_CURRENT_VERSION`
+compatible among WAMR versions with compatible `AOT_CURRENT_VERSION`
 so that combinations of older wamrc and newer runtime usually work.
 However, there might be minor incompatibilities time to time.
-For productions, we recommend to use the exactly same version of
+For productions, we recommend to use compatible versions of
 wamrc and the runtime.
+
+| WAMR version | AOT_CURRENT_VERSION | Compatible AOT version |
+| ------------ | ------------------- | ---------------------- |
+| 1.x          | 3                   | 3                      |
+| 2.0.0        | 3                   | 3                      |
+| 2.1.x        | 3                   | 3                      |
+| 2.2.0        | 3                   | 3                      |
+| next         | 4                   | 3,4                    |
 
 ## AoT compilation with 3rd-party toolchains
 


### PR DESCRIPTION
This commit refactors the AOT loader in `aot_loader.c` to support compatible versions of the AOT_CURRENT_VERSION constant. Previously, the loader only accepted the exact AOT_CURRENT_VERSION value, but now it also accepts version 3. This change ensures that the runtime can load modules AoT-compiled with different versions of wamrc as long as they have compatible AOT_CURRENT_VERSION values.

Related to #3880