### PR TITLE
Enable ref types by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,8 +113,8 @@ if (NOT DEFINED WAMR_BUILD_SIMD)
 endif ()
 
 if (NOT DEFINED WAMR_BUILD_REF_TYPES)
-  # Disable reference types by default
-  set (WAMR_BUILD_REF_TYPES 0)
+  # Enable reference types by default
+  set (WAMR_BUILD_REF_TYPES 1)
 endif ()
 
 set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})

--- a/doc/build_wamr.md
+++ b/doc/build_wamr.md
@@ -223,7 +223,7 @@ Currently we only profile the memory consumption of module, module_instance and 
 > See [basic sample](../samples/basic/src/main.c) for a usage example.
 
 #### **Enable reference types feature**
-- **WAMR_BUILD_REF_TYPES**=1/0, default to disable if not set
+- **WAMR_BUILD_REF_TYPES**=1/0, default to enable if not set
 
 #### **Exclude WAMR application entry functions**
 - **WAMR_DISABLE_APP_ENTRY**=1/0, default to disable if not set

--- a/product-mini/platforms/linux/CMakeLists.txt
+++ b/product-mini/platforms/linux/CMakeLists.txt
@@ -108,8 +108,8 @@ if (NOT DEFINED WAMR_BUILD_SIMD)
 endif ()
 
 if (NOT DEFINED WAMR_BUILD_REF_TYPES)
-  # Disable reference types by default
-  set (WAMR_BUILD_REF_TYPES 0)
+  # Enable reference types by default
+  set (WAMR_BUILD_REF_TYPES 1)
 endif ()
 
 if (NOT DEFINED WAMR_BUILD_DEBUG_INTERP)


### PR DESCRIPTION
After Rust 1.82.0 was released enabling reftypes by default for rust wasm target https://blog.rust-lang.org/2024/09/24/webassembly-targets-change-in-default-target-features.html#enabling-reference-types-by-default I think this would be helpful for users to have this enabled by default in runtime as well, so that rust file compiled to wasm with the default flags can be run on wamr compiled with the default flags 