### PR TITLE
fix(uwp): Gate NTSTATUS definition behind WINAPI_PARTITION_DESKTOP for UWP build 

### DIFF
--- a/core/shared/platform/windows/win_clock.c
+++ b/core/shared/platform/windows/win_clock.c
@@ -10,9 +10,11 @@
 #define NANOSECONDS_PER_SECOND 1000000000ULL
 #define NANOSECONDS_PER_TICK 100
 
+#if WINAPI_PARTITION_DESKTOP
 extern NTSTATUS
 NtQueryTimerResolution(PULONG MinimumResolution, PULONG MaximumResolution,
                        PULONG CurrentResolution);
+#endif
 
 static __wasi_errno_t
 calculate_monotonic_clock_frequency(uint64 *out_frequency)


### PR DESCRIPTION
UWP build showed that this API wasn’t gated and is not supported by UWP. This error was discovered when porting WAMR2.2.0

Error : `unknown type name 'NTSTATUS'; did you mean 'LSTATUS'? `