### PR TITLE
GlobalValueSet was moved to IRPartitionLayer recently, but we have a …

### DIFF
--- a/core/iwasm/compilation/aot_orc_extra.cpp
+++ b/core/iwasm/compilation/aot_orc_extra.cpp
@@ -177,7 +177,7 @@ LLVMOrcLLLazyJITBuilderSetJITTargetMachineBuilder(
     LLVMOrcDisposeJITTargetMachineBuilder(JTMP);
 }
 
-static Optional<CompileOnDemandLayer::GlobalValueSet>
+static Optional<GlobalValueSet>
 PartitionFunction(GlobalValueSet Requested)
 {
     std::vector<const GlobalValue *> GVsToAdd;


### PR DESCRIPTION
…local definition anyway