### PR TITLE
Fix small bugs

### DIFF
--- a/core/iwasm/common/wasm_application.c
+++ b/core/iwasm/common/wasm_application.c
@@ -105,7 +105,8 @@ execute_main(WASMModuleInstanceCommon *module_inst, int32 argc, char *argv[])
     bool ret, is_import_func = true, is_memory64 = false;
 #if WASM_ENABLE_MEMORY64 != 0
     WASMModuleInstance *wasm_module_inst = (WASMModuleInstance *)module_inst;
-    is_memory64 = wasm_module_inst->memories[0]->is_memory64;
+    if (wasm_module_inst->memory_count > 0)
+        is_memory64 = wasm_module_inst->memories[0]->is_memory64;
 #endif
 
     exec_env = wasm_runtime_get_exec_env_singleton(module_inst);

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -9892,6 +9892,15 @@ fail:
             goto fail;                                                      \
     } while (0)
 
+#define RESERVE_BLOCK_RET_V2()                                              \
+    do {                                                                    \
+        if (!reserve_block_ret(loader_ctx, opcode, disable_emit, error_buf, \
+                               error_buf_size)) {                           \
+            free_label_patch_list(loader_ctx->frame_csp);                   \
+            goto fail;                                                      \
+        }                                                                   \
+    } while (0)
+
 #define PUSH_TYPE(type)                                               \
     do {                                                              \
         if (!(wasm_loader_push_frame_ref(loader_ctx, type, error_buf, \
@@ -11672,7 +11681,7 @@ re_scan:
 #if WASM_ENABLE_FAST_INTERP != 0
                 skip_label();
                 /* copy the result to the block return address */
-                RESERVE_BLOCK_RET();
+                RESERVE_BLOCK_RET_V2();
 
                 apply_label_patch(loader_ctx, 0, PATCH_END);
                 free_label_patch_list(loader_ctx->frame_csp);

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -9885,22 +9885,6 @@ fail:
 }
 #endif /* WASM_ENABLE_FAST_INTERP */
 
-#define RESERVE_BLOCK_RET()                                                 \
-    do {                                                                    \
-        if (!reserve_block_ret(loader_ctx, opcode, disable_emit, error_buf, \
-                               error_buf_size))                             \
-            goto fail;                                                      \
-    } while (0)
-
-#define RESERVE_BLOCK_RET_V2()                                              \
-    do {                                                                    \
-        if (!reserve_block_ret(loader_ctx, opcode, disable_emit, error_buf, \
-                               error_buf_size)) {                           \
-            free_label_patch_list(loader_ctx->frame_csp);                   \
-            goto fail;                                                      \
-        }                                                                   \
-    } while (0)
-
 #define PUSH_TYPE(type)                                               \
     do {                                                              \
         if (!(wasm_loader_push_frame_ref(loader_ctx, type, error_buf, \
@@ -11621,7 +11605,10 @@ re_scan:
 #if WASM_ENABLE_FAST_INTERP != 0
                 /* if the result of if branch is in local or const area, add a
                  * copy op */
-                RESERVE_BLOCK_RET();
+                if (!reserve_block_ret(loader_ctx, opcode, disable_emit,
+                                       error_buf, error_buf_size)) {
+                    goto fail;
+                }
 
                 emit_empty_label_addr_and_frame_ip(PATCH_END);
                 apply_label_patch(loader_ctx, 1, PATCH_ELSE);
@@ -11681,7 +11668,15 @@ re_scan:
 #if WASM_ENABLE_FAST_INTERP != 0
                 skip_label();
                 /* copy the result to the block return address */
-                RESERVE_BLOCK_RET_V2();
+                if (!reserve_block_ret(loader_ctx, opcode, disable_emit,
+                                       error_buf, error_buf_size)) {
+                    /* it could be tmp frame_csp allocated from opcode like
+                     * OP_BR and not counted in loader_ctx->csp_num, it won't
+                     * be freed in wasm_loader_ctx_destroy(loader_ctx) so need
+                     * to free the loader_ctx->frame_csp if fails */
+                    free_label_patch_list(loader_ctx->frame_csp);
+                    goto fail;
+                }
 
                 apply_label_patch(loader_ctx, 0, PATCH_END);
                 free_label_patch_list(loader_ctx->frame_csp);

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -5595,8 +5595,10 @@ fail:
 #define RESERVE_BLOCK_RET()                                                 \
     do {                                                                    \
         if (!reserve_block_ret(loader_ctx, opcode, disable_emit, error_buf, \
-                               error_buf_size))                             \
+                               error_buf_size)) {                           \
+            free_label_patch_list(loader_ctx->frame_csp);                   \
             goto fail;                                                      \
+        }                                                                   \
     } while (0)
 
 #define PUSH_TYPE(type)                                               \

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -5592,15 +5592,6 @@ fail:
 
 #endif /* WASM_ENABLE_FAST_INTERP */
 
-#define RESERVE_BLOCK_RET()                                                 \
-    do {                                                                    \
-        if (!reserve_block_ret(loader_ctx, opcode, disable_emit, error_buf, \
-                               error_buf_size)) {                           \
-            free_label_patch_list(loader_ctx->frame_csp);                   \
-            goto fail;                                                      \
-        }                                                                   \
-    } while (0)
-
 #define PUSH_TYPE(type)                                               \
     do {                                                              \
         if (!(wasm_loader_push_frame_ref(loader_ctx, type, error_buf, \
@@ -6368,7 +6359,10 @@ re_scan:
 #if WASM_ENABLE_FAST_INTERP != 0
                 /* if the result of if branch is in local or const area, add a
                  * copy op */
-                RESERVE_BLOCK_RET();
+                if (!reserve_block_ret(loader_ctx, opcode, disable_emit,
+                                       error_buf, error_buf_size)) {
+                    goto fail;
+                }
 
                 emit_empty_label_addr_and_frame_ip(PATCH_END);
                 apply_label_patch(loader_ctx, 1, PATCH_ELSE);
@@ -6428,7 +6422,11 @@ re_scan:
 #if WASM_ENABLE_FAST_INTERP != 0
                 skip_label();
                 /* copy the result to the block return address */
-                RESERVE_BLOCK_RET();
+                if (!reserve_block_ret(loader_ctx, opcode, disable_emit,
+                                       error_buf, error_buf_size)) {
+                    free_label_patch_list(loader_ctx->frame_csp);
+                    goto fail;
+                }
 
                 apply_label_patch(loader_ctx, 0, PATCH_END);
                 free_label_patch_list(loader_ctx->frame_csp);


### PR DESCRIPTION
- Make sure `wasm_module_inst->memories[0]` is valid before access in `execute_main`
- Free the memory allocated previously on the failure of `RESERVE_BLOCK_RET`