### PR TITLE
Fix global initialization

### DIFF
--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1209,7 +1209,7 @@ globals_instantiate(WASMModule *module, WASMModuleInstance *module_inst,
             /* The linked global instance has been initialized, we
                just need to copy the value. */
             bh_memcpy_s(&(global->initial_value), sizeof(WASMValue),
-                        &(global_import->import_global_linked->init_expr),
+                        &(global_import->import_global_linked->init_expr.u),
                         sizeof(WASMValue));
         }
         else


### PR DESCRIPTION
While resolving linked globals, WAMR tries to copy the linked global's initial value into the destination global in the current module. However, a bug in the implementation causes the copy to be done from the InitializerExpression struct, not from its WASMValue field.

This did not come up in WAMR's spec test runner because those are built with WASM_ENABLE_SPEC_TEST, which means these globals are resolved as builtins, not linked globals, which goes through a different (presumably not faulty) path.