### PR TITLE
don't ignore wasm_resolve_import_func return value

### DIFF
--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -2488,10 +2488,7 @@ load_function_import(const uint8 **p_buf, const uint8 *buf_end,
     function->call_conv_raw = false;
 
     /* lookup registered native symbols first */
-    if (!no_resolve) {
-        wasm_resolve_import_func(parent_module, function);
-    }
-    return true;
+    return no_resolve || wasm_resolve_import_func(parent_module, function);
 fail:
     return false;
 }


### PR DESCRIPTION
Previously the loader would ignore the return value of wasm_resolve_import_func, which would mean it would report loading success even if there were unresolved function imports.