### PR TITLE
add testcases for shared heap and fix POP_MEM_OFFSET of memory64

### DIFF
--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -593,8 +593,8 @@ wasm_interp_get_frame_ref(WASMInterpFrame *frame)
 #endif
 
 #if WASM_ENABLE_MEMORY64 != 0
-#define POP_MEM_OFFSET() (is_memory64 ? POP_I64() : POP_I32())
-#define POP_TBL_ELEM_IDX() (is_table64 ? POP_I64() : POP_I32())
+#define POP_MEM_OFFSET() (is_memory64 ? POP_I64() : (uint32)POP_I32())
+#define POP_TBL_ELEM_IDX() (is_table64 ? POP_I64() : (uint32)POP_I32())
 #else
 #define POP_MEM_OFFSET() POP_I32()
 #define POP_TBL_ELEM_IDX() POP_I32()

--- a/tests/unit/shared-heap/CMakeLists.txt
+++ b/tests/unit/shared-heap/CMakeLists.txt
@@ -8,7 +8,7 @@ project(test-shared-heap)
 add_definitions(-DRUN_ON_LINUX)
 
 set(WAMR_BUILD_APP_FRAMEWORK 0)
-set(WAMR_BUILD_AOT 0)
+set(WAMR_BUILD_AOT 1)
 set(WAMR_BUILD_INTERP 1)
 set(WAMR_BUILD_FAST_INTERP 1)
 set(WAMR_BUILD_JIT 0)

--- a/tests/unit/shared-heap/wasm-apps/CMakeLists.txt
+++ b/tests/unit/shared-heap/wasm-apps/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_minimum_required(VERSION 3.14)
 project(wasm-apps)
 
 set(WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../..)
+set(WAMRC_ROOT_DIR ${WAMR_ROOT_DIR}/wamr-compiler/build)
 
 set(CMAKE_SYSTEM_PROCESSOR wasm32)
 set(CMAKE_SYSROOT ${WAMR_ROOT_DIR}/wamr-sdk/app/libc-builtin-sysroot)
@@ -36,4 +37,36 @@ add_custom_command(TARGET test.wasm POST_BUILD
         ${CMAKE_CURRENT_BINARY_DIR}/test.wasm
         ${CMAKE_CURRENT_BINARY_DIR}/../
         COMMENT "Copy test.wasm to the same directory of google test"
+        )
+
+add_custom_command(TARGET test.wasm POST_BUILD
+        COMMAND ${WAMRC_ROOT_DIR}/wamrc --opt-level=0 --enable-shared-heap --bounds-checks=1
+        -o
+        test.aot
+        test.wasm
+        COMMAND ${CMAKE_COMMAND} -E copy
+        ${CMAKE_CURRENT_BINARY_DIR}/test.aot
+        ${CMAKE_CURRENT_BINARY_DIR}/../
+        COMMENT "Copy test.aot to the same directory of google test"
+        )
+
+add_executable(test_addr_conv.wasm test_addr_conv.c)
+target_link_libraries(test.wasm)
+
+add_custom_command(TARGET test_addr_conv.wasm POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+        ${CMAKE_CURRENT_BINARY_DIR}/test_addr_conv.wasm
+        ${CMAKE_CURRENT_BINARY_DIR}/../
+        COMMENT "Copy test_addr_conv.wasm to the same directory of google test"
+        )
+
+add_custom_command(TARGET test_addr_conv.wasm POST_BUILD
+        COMMAND ${WAMRC_ROOT_DIR}/wamrc --opt-level=0 --enable-shared-heap --bounds-checks=1
+        -o
+        test_addr_conv.aot
+        test_addr_conv.wasm
+        COMMAND ${CMAKE_COMMAND} -E copy
+        ${CMAKE_CURRENT_BINARY_DIR}/test_addr_conv.aot
+        ${CMAKE_CURRENT_BINARY_DIR}/../
+        COMMENT "Copy test_addr_conv.aot to the same directory of google test"
         )

--- a/tests/unit/shared-heap/wasm-apps/test_addr_conv.c
+++ b/tests/unit/shared-heap/wasm-apps/test_addr_conv.c
@@ -9,26 +9,24 @@ extern void *
 shared_heap_malloc(int size);
 extern void
 shared_heap_free(void *offset);
+extern void *
+test_addr_conv(void *ptr);
 
 int
 test()
 {
-    int *ptr = (int *)shared_heap_malloc(4);
+    int *ptr = NULL;
+    int *ptr2 = NULL;
 
-    *ptr = 10;
-    int a = *ptr;
-    shared_heap_free(ptr);
-    return a;
-}
-
-int
-test_malloc_fail()
-{
-    int *ptr = (int *)shared_heap_malloc(8192);
+    ptr = (int *)shared_heap_malloc(4);
 
     if (ptr == NULL) {
-        return 1;
+        return 0;
+    }
+    ptr2 = test_addr_conv(ptr);
+    if (ptr2 != ptr) {
+        return 0;
     }
     shared_heap_free(ptr);
-    return 0;
+    return 1;
 }


### PR DESCRIPTION
fix POP_MEM_OFFSET of memory64:
When WAMR_BUILD_MEMORY64 is enabled but is_memory64 is false, if the addr is larger than 0x80000000 and the addr is directly converted to uint64 from int32, the result is wrong, as follows
![20241120-162228](https://github.com/user-attachments/assets/a3c51fd6-c3e8-4c37-9514-982a2fd2e1e0)
