### PR TITLE
Fix replacement value not being correct

### DIFF
--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -15217,17 +15217,27 @@ re_scan:
                                                     error_buf_size)) {
                             goto fail;
                         }
+#if WASM_ENABLE_FAST_INTERP != 0
+                        emit_byte(loader_ctx, lane);
+#endif
                         if (replace[opcode1 - SIMD_i8x16_extract_lane_s]) {
+#if WASM_ENABLE_FAST_INTERP != 0
+                            if (!(wasm_loader_pop_frame_ref_offset(
+                                    loader_ctx,
+                                    replace[opcode1
+                                            - SIMD_i8x16_extract_lane_s],
+                                    error_buf, error_buf_size)))
+                                goto fail;
+#else
                             if (!(wasm_loader_pop_frame_ref(
                                     loader_ctx,
                                     replace[opcode1
                                             - SIMD_i8x16_extract_lane_s],
                                     error_buf, error_buf_size)))
                                 goto fail;
+#endif /* end of WASM_ENABLE_FAST_INTERP != 0 */
                         }
-#if WASM_ENABLE_FAST_INTERP != 0
-                        emit_byte(loader_ctx, lane);
-#endif
+
                         POP_AND_PUSH(
                             VALUE_TYPE_V128,
                             push_type[opcode1 - SIMD_i8x16_extract_lane_s]);


### PR DESCRIPTION
Changing this call allows to correctly implement replace opcode 

with existing call the following wat was failing 

```
    v128.const i32x4 10 11 12 13
    i32.const 15
    i32x4.replace_lane 3
    i32x4.extract_lane 3
    call $assert_true_i32
```


with replace on my branch looking like that

```
                    case SIMD_i32x4_replace_lane:
                    {
                        uint8_t lane = *frame_ip++;
                        int rep = POP_I32();
                        V128 v = POP_V128();

                        v.i32x4[lane] = rep;
                        addr_ret = GET_OFFSET();
                        PUT_V128_TO_ADDR(frame_lp + addr_ret, v);
                        break;
                    }
 ```
