### PR TITLE
Drop declarative elements on module instantiation

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -1905,7 +1905,9 @@ aot_instantiate(AOTModule *module, AOTModuleInstance *parent,
             goto fail;
         }
         for (i = 0; i < module->table_init_data_count; i++) {
-            if (wasm_elem_is_active(module->table_init_data_list[i]->mode))
+            if (wasm_elem_is_active(module->table_init_data_list[i]->mode)
+                || wasm_elem_is_declarative(
+                    module->table_init_data_list[i]->mode))
                 bh_bitmap_set_bit(common->elem_dropped, i);
         }
     }

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -2467,7 +2467,8 @@ wasm_instantiate(WASMModule *module, WASMModuleInstance *parent,
             goto fail;
         }
         for (i = 0; i < module->table_seg_count; i++) {
-            if (wasm_elem_is_active(module->table_segments[i].mode))
+            if (wasm_elem_is_active(module->table_segments[i].mode)
+                || wasm_elem_is_declarative(module->table_segments[i].mode))
                 bh_bitmap_set_bit(module_inst->e->common.elem_dropped, i);
         }
     }


### PR DESCRIPTION
This may be sufficient to address https://github.com/bytecodealliance/wasm-micro-runtime/issues/2764. It certainly makes a few more spec tests pass for me.