### PR TITLE
Fix WASI Path Mapping Processing

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -3631,8 +3631,18 @@ wasm_runtime_init_wasi(WASMModuleInstanceCommon *module_inst,
 
         bh_memcpy_s(mapping_copy, max_len, map_dir_list[i],
                     (uint32)(strlen(map_dir_list[i]) + 1));
-        map_mapped = strtok(mapping_copy, "::");
-        map_host = strtok(NULL, "::");
+
+        const char *delim = "::";
+        char *delim_pos = strstr(mapping_copy, delim);
+        if (delim_pos) {
+            *delim_pos = '\0';
+            map_mapped = mapping_copy;
+            map_host = delim_pos + strlen(delim);
+        }
+        else {
+            map_mapped = NULL;
+            map_host = NULL;
+        }
 
         if (!map_mapped || !map_host) {
             if (error_buf)

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -3639,10 +3639,6 @@ wasm_runtime_init_wasi(WASMModuleInstanceCommon *module_inst,
             map_mapped = mapping_copy;
             map_host = delim_pos + strlen(delim);
         }
-        else {
-            map_mapped = NULL;
-            map_host = NULL;
-        }
 
         if (!map_mapped || !map_host) {
             if (error_buf)


### PR DESCRIPTION
Filesystem paths can be mapped from the host path to a guest path using the format `<guest-path>::<host-path>`.

Previously `strtok` was used to find the `::` delimiter. Unfortunately `strtok` processes each delimiter character individually. This meant that the code was ~equivalent to `strtok(mapping_copy, ":")` which breaks with Windows-style paths (E.g. `C:\my_path\`).

To fix this `strstr` is used to search for the exact delimiter.