### PR TITLE
don't return an uninitialized trap if argv_to_results fails

### DIFF
--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -3441,6 +3441,8 @@ wasm_func_call(const wasm_func_t *func, const wasm_val_vec_t *params,
     if (result_count) {
         if (!argv_to_results(argv, wasm_functype_results(func->type),
                              results)) {
+            wasm_runtime_set_exception(func->inst_comm_rt,
+                                       "argv_to_results failed");
             goto failed;
         }
         results->num_elems = result_count;


### PR DESCRIPTION
Currently, if argv_to_results fails (e.g. because an unsupported type is encountered), an non-null trap with an uninitialized message is returned.