### PR TITLE
Consume the placeholders that were put when emitting table info

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -1333,7 +1333,12 @@ load_import_table_list(const uint8 **p_buf, const uint8 *buf_end,
         if (wasm_is_type_multi_byte_type(import_table->table_type.elem_type)) {
             read_uint8(buf, buf_end, ref_type.ref_ht_common.nullable);
         }
+        else
 #endif
+        {
+            /* Skip 1 byte */
+            buf += 1;
+        }
         read_uint32(buf, buf_end, import_table->table_type.init_size);
         read_uint32(buf, buf_end, import_table->table_type.max_size);
 #if WASM_ENABLE_GC != 0
@@ -1393,7 +1398,12 @@ load_table_list(const uint8 **p_buf, const uint8 *buf_end, AOTModule *module,
         if (wasm_is_type_multi_byte_type(table->table_type.elem_type)) {
             read_uint8(buf, buf_end, ref_type.ref_ht_common.nullable);
         }
+        else
 #endif
+        {
+            /* Skip 1 byte */
+            buf += 1;
+        }
         read_uint32(buf, buf_end, table->table_type.init_size);
         read_uint32(buf, buf_end, table->table_type.max_size);
 #if WASM_ENABLE_GC != 0
@@ -1481,7 +1491,7 @@ load_table_init_data_list(const uint8 **p_buf, const uint8 *buf_end,
         else
 #endif
         {
-            /* Skip 8 byte for ref type info */
+            /* Skip 8 byte(2+2+4) for ref type info */
             buf += 8;
         }
 


### PR DESCRIPTION
https://github.com/bytecodealliance/wasm-micro-runtime/pull/3898#discussion_r1864760131

Fix a potential issue and make it more readable.