### PR TITLE
Improvements for platform thread APIs on Windows and Zephyr

### DIFF
--- a/core/shared/platform/windows/win_thread.c
+++ b/core/shared/platform/windows/win_thread.c
@@ -88,6 +88,7 @@ thread_data_list_remove(os_thread_data *thread_data)
         p = p->next;
 
     if (p && p->next) {
+        bh_assert(p->next == thread_data);
         p->next = p->next->next;
         /* Release the resources in thread_data */
         os_cond_destroy(&thread_data->wait_cond);

--- a/core/shared/platform/windows/win_thread.c
+++ b/core/shared/platform/windows/win_thread.c
@@ -60,6 +60,62 @@ static DWORD thread_data_key;
 static void(WINAPI *GetCurrentThreadStackLimits_Kernel32)(PULONG_PTR,
                                                           PULONG_PTR) = NULL;
 
+static void
+thread_data_list_add(os_thread_data *thread_data)
+{
+    os_mutex_lock(&thread_data_list_lock);
+    /* If already in list, just return */
+    os_thread_data *p = &supervisor_thread_data;
+    while (p) {
+        if (p == thread_data) {
+            os_mutex_unlock(&thread_data_list_lock);
+            return;
+        }
+        p = p->next;
+    }
+    thread_data->next = supervisor_thread_data.next;
+    supervisor_thread_data.next = thread_data;
+    os_mutex_unlock(&thread_data_list_lock);
+}
+
+static void
+thread_data_list_remove(os_thread_data *thread_data)
+{
+    os_mutex_lock(&thread_data_list_lock);
+    /* Search and remove it from list */
+    os_thread_data *p = &supervisor_thread_data;
+    while (p && p->next != thread_data)
+        p = p->next;
+
+    if (p && p->next) {
+        p->next = p->next->next;
+        /* Release the resources in thread_data */
+        os_cond_destroy(&thread_data->wait_cond);
+        os_mutex_destroy(&thread_data->wait_lock);
+        os_sem_destroy(&thread_data->wait_node.sem);
+        BH_FREE(thread_data);
+    }
+    os_mutex_unlock(&thread_data_list_lock);
+}
+
+static os_thread_data *
+thread_data_list_lookup(korp_tid tid)
+{
+    os_thread_data *thread_data = (os_thread_data *)tid;
+    os_mutex_lock(&thread_data_list_lock);
+    os_thread_data *p = supervisor_thread_data.next;
+    while (p) {
+        if (p == thread_data) {
+            /* Found */
+            os_mutex_unlock(&thread_data_list_lock);
+            return p;
+        }
+        p = p->next;
+    }
+    os_mutex_unlock(&thread_data_list_lock);
+    return NULL;
+}
+
 int
 os_sem_init(korp_sem *sem);
 int
@@ -254,10 +310,7 @@ os_thread_create_with_prio(korp_tid *p_tid, thread_start_routine_t start,
     }
 
     /* Add thread data into thread data list */
-    os_mutex_lock(&thread_data_list_lock);
-    thread_data->next = supervisor_thread_data.next;
-    supervisor_thread_data.next = thread_data;
-    os_mutex_unlock(&thread_data_list_lock);
+    thread_data_list_add(thread_data);
 
     /* Wait for the thread routine to set thread_data's tid
        and add thread_data to thread data list */
@@ -302,8 +355,12 @@ os_thread_join(korp_tid thread, void **p_retval)
     curr_thread_data->wait_node.next = NULL;
 
     /* Get thread data of thread to join */
-    thread_data = (os_thread_data *)thread;
-    bh_assert(thread_data);
+    thread_data = thread_data_list_lookup(thread);
+
+    if (thread_data == NULL) {
+        os_printf("Can't join thread %p, it does not exist", thread);
+        return BHT_ERROR;
+    }
 
     os_mutex_lock(&thread_data->wait_lock);
 
@@ -312,6 +369,7 @@ os_thread_join(korp_tid thread, void **p_retval)
         if (p_retval)
             *p_retval = thread_data->thread_retval;
         os_mutex_unlock(&thread_data->wait_lock);
+        thread_data_list_remove(thread_data);
         return BHT_OK;
     }
 
@@ -332,6 +390,7 @@ os_thread_join(korp_tid thread, void **p_retval)
     os_sem_wait(&curr_thread_data->wait_node.sem);
     if (p_retval)
         *p_retval = curr_thread_data->wait_node.retval;
+    thread_data_list_remove(thread_data);
     return BHT_OK;
 }
 

--- a/core/shared/platform/zephyr/zephyr_thread.c
+++ b/core/shared/platform/zephyr/zephyr_thread.c
@@ -393,13 +393,6 @@ os_thread_join(korp_tid thread, void **value_ptr)
     os_thread_data *thread_data;
     os_thread_wait_node *node;
 
-    /* Create wait node and append it to wait list */
-    if (!(node = BH_MALLOC(sizeof(os_thread_wait_node))))
-        return BHT_ERROR;
-
-    sem_init(&node->sem, 0, 1);
-    node->next = NULL;
-
     /* Get thread data */
     thread_data = thread_data_list_lookup(thread);
 
@@ -407,9 +400,15 @@ os_thread_join(korp_tid thread, void **value_ptr)
         os_printf(
             "Can't join thread %p, probably already exited or does not exist",
             thread);
-        BH_FREE(node);
         return BHT_OK;
     }
+
+    /* Create wait node and append it to wait list */
+    if (!(node = BH_MALLOC(sizeof(os_thread_wait_node))))
+        return BHT_ERROR;
+
+    sem_init(&node->sem, 0, 1);
+    node->next = NULL;
 
     mutex_lock(&thread_data->wait_list_lock, K_FOREVER);
     if (!thread_data->thread_wait_list)

--- a/core/shared/platform/zephyr/zephyr_thread.c
+++ b/core/shared/platform/zephyr/zephyr_thread.c
@@ -402,7 +402,14 @@ os_thread_join(korp_tid thread, void **value_ptr)
 
     /* Get thread data */
     thread_data = thread_data_list_lookup(thread);
-    bh_assert(thread_data != NULL);
+
+    if (thread_data == NULL) {
+        os_printf(
+            "Can't join thread %p, probably already exited or does not exist",
+            thread);
+        BH_FREE(node);
+        return BHT_OK;
+    }
 
     mutex_lock(&thread_data->wait_list_lock, K_FOREVER);
     if (!thread_data->thread_wait_list)
@@ -580,7 +587,8 @@ os_thread_get_stack_boundary()
 
 void
 os_thread_jit_write_protect_np(bool enabled)
-{}
+{
+}
 
 int
 os_thread_detach(korp_tid thread)

--- a/core/shared/platform/zephyr/zephyr_thread.c
+++ b/core/shared/platform/zephyr/zephyr_thread.c
@@ -587,8 +587,7 @@ os_thread_get_stack_boundary()
 
 void
 os_thread_jit_write_protect_np(bool enabled)
-{
-}
+{}
 
 int
 os_thread_detach(korp_tid thread)

--- a/core/shared/utils/bh_atomic.h
+++ b/core/shared/utils/bh_atomic.h
@@ -114,7 +114,8 @@ typedef uint16 bh_atomic_16_t;
 #endif
 
 /* On some 32-bit platform, disable 64-bit atomic operations, otherwise
- * undefined reference to `__atomic_load_8' */
+ * undefined reference to `__atomic_load_8', if on Zephyr, can add board related
+ * macro in autoconf.h to control */
 #ifndef WASM_UINT64_IS_ATOMIC
 #if !defined(__linux__) && !defined(__FreeBSD__) && !defined(__NetBSD__) \
     && !defined(__OpenBSD__) && (defined(__riscv) || defined(__arm__))   \


### PR DESCRIPTION
This PR includes the following modifications:

- On the Zephyr platform:
  - The `os_thread_wrapper` will call `os_thread_cleanup` to free `thread_data`, so when another thread tries to wait on its termination using `os_thread_join`, it's possible that thread is already terminated and won't be in `thread_data_list`. So simply print the warning and return `OK` if in `os_thread_join` find out the joining thread is not in the list.
- On Windows:
  - Unlike Zephyr, the `os_thread_cleanup` won't free the `thread_data` but set a flag, and the `thread_data` will still be in the list. So in `os_thread_join` if can't find the `thread_data` in the list, it must be a non-existent thread, returning an error in this case.
  - Release the resources of `thread_data` when the corresponding thread is joined, rather than delaying to release of them at the end altogether using `os_thread_sys_destroy

