### PR TITLE
Implement load lanes opcodes for wasm

### DIFF
--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -6391,12 +6391,46 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         break;
                     }
 
-                    // TODO:
-                    /* load lane operations */
+#define SIMD_LOAD_LANE_OP(register, width)                 \
+    do {                                                   \
+        uint32 offset, addr;                               \
+        offset = read_uint32(frame_ip);                    \
+        V128 vec = POP_V128();                             \
+        int32 base = POP_I32();                            \
+        offset += base;                                    \
+        int lane = *frame_ip++;                            \
+        addr = GET_OPERAND(uint32, I32, 0);                \
+        addr_ret = GET_OFFSET();                           \
+        CHECK_MEMORY_OVERFLOW(width / 8);                  \
+        if (width == 64) {                                 \
+            vec.register[lane] = GET_I64_FROM_ADDR(maddr); \
+        }                                                  \
+        else {                                             \
+            vec.register[lane] = *(uint##width *)(maddr);  \
+        }                                                  \
+        PUT_V128_TO_ADDR(frame_lp + addr_ret, vec);        \
+    } while (0)
+
                     case SIMD_v128_load8_lane:
+                    {
+                        SIMD_LOAD_LANE_OP(i8x16, 8);
+                        break;
+                    }
                     case SIMD_v128_load16_lane:
+                    {
+                        SIMD_LOAD_LANE_OP(i16x8, 16);
+                        break;
+                    }
                     case SIMD_v128_load32_lane:
+                    {
+                        SIMD_LOAD_LANE_OP(i32x4, 32);
+                        break;
+                    }
                     case SIMD_v128_load64_lane:
+                    {
+                        SIMD_LOAD_LANE_OP(i64x2, 64);
+                        break;
+                    }
                     case SIMD_v128_store8_lane:
                     case SIMD_v128_store16_lane:
                     case SIMD_v128_store32_lane:

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -15368,9 +15368,14 @@ re_scan:
                                                     error_buf_size)) {
                             goto fail;
                         }
-
+#if WASM_ENABLE_FAST_INTERP != 0
+                        emit_uint32(loader_ctx, mem_offset);
+#endif
                         POP_V128();
                         POP_MEM_OFFSET();
+#if WASM_ENABLE_FAST_INTERP != 0
+                        emit_byte(loader_ctx, lane);
+#endif
                         if (opcode1 < SIMD_v128_store8_lane) {
                             PUSH_V128();
                         }


### PR DESCRIPTION
Tested using a simple wat file while we're still setting up the testsuite 