### PR TITLE
always include bh_mkstemp and bh_system

### DIFF
--- a/core/shared/utils/bh_common.c
+++ b/core/shared/utils/bh_common.c
@@ -166,7 +166,6 @@ wa_strdup(const char *s)
     return s1;
 }
 
-#if WASM_ENABLE_WAMR_COMPILER != 0 || WASM_ENABLE_JIT != 0
 int
 bh_system(const char *cmd)
 {
@@ -214,4 +213,3 @@ bh_mkstemp(char *file_name, size_t name_len)
 fail:
     return false;
 }
-#endif /* End of WASM_ENABLE_WAMR_COMPILER != 0 || WASM_ENABLE_JIT != 0 */

--- a/core/shared/utils/bh_common.h
+++ b/core/shared/utils/bh_common.h
@@ -66,7 +66,6 @@ bh_strdup(const char *s);
 char *
 wa_strdup(const char *s);
 
-#if WASM_ENABLE_WAMR_COMPILER != 0 || WASM_ENABLE_JIT != 0
 /* Executes a system command in bash/cmd.exe */
 int
 bh_system(const char *cmd);
@@ -74,7 +73,6 @@ bh_system(const char *cmd);
 /* Tests whether can create a temporary file with the given name */
 bool
 bh_mkstemp(char *filename, size_t name_len);
-#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Internally, Google builds WAMR with blaze rules, and these rules currently assume anything in shared/common libraries are shared by all configurations of WAMR. Fixing this substantially increases our build complexity.

If it doesn't introduce an unacceptable additional cost, it would be good if we could just include these symbols unconditionally, or perhaps move them closer to where they are used.