### PR TITLE
CMakeLists.txt: Do not require C++ by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ if(ESP_PLATFORM)
   return()
 endif()
 
-project (iwasm)
+project (iwasm LANGUAGES C)
 
 set (CMAKE_VERBOSE_MAKEFILE OFF)
 

--- a/core/iwasm/compilation/iwasm_compl.cmake
+++ b/core/iwasm/compilation/iwasm_compl.cmake
@@ -1,6 +1,7 @@
 set (IWASM_COMPL_DIR ${CMAKE_CURRENT_LIST_DIR})
 
 include_directories(${IWASM_COMPL_DIR})
+enable_language(CXX)
 
 if (WAMR_BUILD_DEBUG_AOT EQUAL 1)
     file (GLOB_RECURSE source_all

--- a/core/iwasm/fast-jit/iwasm_fast_jit.cmake
+++ b/core/iwasm/fast-jit/iwasm_fast_jit.cmake
@@ -9,6 +9,7 @@ if (WAMR_BUILD_FAST_JIT_DUMP EQUAL 1)
 endif ()
 
 include_directories (${IWASM_FAST_JIT_DIR})
+enable_language(CXX)
 
 if (WAMR_BUILD_TARGET STREQUAL "X86_64" OR WAMR_BUILD_TARGET STREQUAL "AMD_64")
     include(FetchContent)

--- a/core/iwasm/libraries/wasi-nn/cmake/wasi_nn.cmake
+++ b/core/iwasm/libraries/wasi-nn/cmake/wasi_nn.cmake
@@ -22,6 +22,7 @@ add_compile_definitions(
 # - tflite
 if(WAMR_BUILD_WASI_NN_TFLITE EQUAL 1)
   find_package(tensorflow_lite REQUIRED)
+  enable_language(CXX)
 
   add_library(
     wasi_nn_tflite

--- a/core/shared/platform/windows/shared_platform.cmake
+++ b/core/shared/platform/windows/shared_platform.cmake
@@ -6,6 +6,7 @@ set (PLATFORM_SHARED_DIR ${CMAKE_CURRENT_LIST_DIR})
 add_definitions(-DBH_PLATFORM_WINDOWS)
 add_definitions(-DHAVE_STRUCT_TIMESPEC)
 add_definitions(-D_WINSOCK_DEPRECATED_NO_WARNINGS)
+enable_language(CXX)
 
 include_directories(${PLATFORM_SHARED_DIR})
 include_directories(${PLATFORM_SHARED_DIR}/../include)


### PR DESCRIPTION
By default, the project() CMake command defaults to C and C++. [1] Therefore, CMake might perform tests for both C and C++ compilers as part of the configuration phase.

However, this has the consequence of the configuration phase to fail if the system does not have a C++ toolchain installed, even if C++ is not really used by the top-level project under the default settings.

Some configurations might still require a C++ toolchain, so `enable_language` is selectively called under such circumstances.

[1]: https://cmake.org/cmake/help/latest/command/project.html