### PR TITLE
top-level cmakefile: fix macOS build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ endif()
 
 project (iwasm)
 
+set(CMAKE_CXX_STANDARD 17)
+
 set (CMAKE_VERBOSE_MAKEFILE OFF)
 
 if (NOT DEFINED WAMR_BUILD_PLATFORM)


### PR DESCRIPTION
At least fast-jit seems to require a bit new C++ standard. C++17 was chosen to match product-mini/platforms/darwin.

macOS 15.2
x86-64
Xcode 16.2

```
[ 62%] Building CXX object CMakeFiles/iwasm_shared.dir/_deps/asmjit-src/src/asmjit/core/constpool.cpp.o
In file included from /Users/yamamoto/git/wasm-micro-runtime/b/_deps/asmjit-src/src/asmjit/core/codeholder.cpp:7:
In file included from /Users/yamamoto/git/wasm-micro-runtime/b/_deps/asmjit-src/src/asmjit/core/../core/assembler.h:9:
In file included from /Users/yamamoto/git/wasm-micro-runtime/b/_deps/asmjit-src/src/asmjit/core/../core/../core/codeholder.h:9:
In file included from /Users/yamamoto/git/wasm-micro-runtime/b/_deps/asmjit-src/src/asmjit/core/../core/../core/../core/archtraits.h:9:
In file included from /Users/yamamoto/git/wasm-micro-runtime/b/_deps/asmjit-src/src/asmjit/core/../core/../core/../core/../core/operand.h:9:
In file included from /Users/yamamoto/git/wasm-micro-runtime/b/_deps/asmjit-src/src/asmjit/core/../core/../core/../core/../core/../core/archcommons.h:13:
/Users/yamamoto/git/wasm-micro-runtime/b/_deps/asmjit-src/src/asmjit/core/../core/../core/../core/../core/../core/../core/globals.h:11:1: warning: inline namespaces are a C++11 feature [-Wc++11-inline-namespace]
   11 | ASMJIT_BEGIN_NAMESPACE
      | ^
/Users/yamamoto/git/wasm-micro-runtime/b/_deps/asmjit-src/src/asmjit/core/../core/./api-config.h:486:24: note: expanded from macro 'ASMJIT_BEGIN_NAMESPACE'
  486 |     namespace asmjit { inline namespace ASMJIT_ABI_NAMESPACE {                \
      |                        ^
```

Note: Xcode-provided clang traditionally has a bit conservative default:

```shell
    spacetanuki% clang -dM -x c++ -E - < /dev/null | grep cplusplus
    #define __cplusplus 199711L
    spacetanuki%
```