### PR TITLE
Add shared lib build to ubuntu and nightly

### DIFF
--- a/.github/workflows/compilation_on_android_ubuntu.yml
+++ b/.github/workflows/compilation_on_android_ubuntu.yml
@@ -156,6 +156,7 @@ jobs:
             "-DWAMR_DISABLE_HW_BOUND_CHECK=1",
             "-DWAMR_BUILD_MEMORY64=1",
             "-DWAMR_BUILD_MULTI_MEMORY=1",
+            "-DWAMR_BUILD_SHARED=1",
           ]
         os: [ubuntu-22.04]
         platform: [android, linux]
@@ -252,6 +253,9 @@ jobs:
           - make_options_run_mode: $LLVM_LAZY_JIT_BUILD_OPTIONS
             platform: android
           - make_options_run_mode: $LLVM_EAGER_JIT_BUILD_OPTIONS
+            platform: android
+          # android does not support WAMR_BUILD_SHARED in its CMakeLists.txt.
+          - make_options_feature: "-DWAMR_BUILD_SHARED=1"
             platform: android
         include:
           - os: ubuntu-22.04

--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -142,6 +142,7 @@ jobs:
             "-DWAMR_DISABLE_HW_BOUND_CHECK=1",
             "-DWAMR_BUILD_MEMORY64=1",
             "-DWAMR_BUILD_MULTI_MEMORY=1",
+            "-DWAMR_BUILD_SHARED=1",
           ]
         os: [ubuntu-20.04]
         platform: [android, linux]


### PR DESCRIPTION
So far, no workflows would attempt to build the shared version of the iwasm library (namely, vmlib).

Note that, as opposed to GC_EH_BUILD_OPTIONS and DEFAULT_BUILD_OPTIONS, the actual default options defined by the build system are assumed, for the sake of simplicity and avoiding repeated code.