### PR TITLE
Add reference type support by default for darwin to support WASI-SDK-25

### DIFF
--- a/product-mini/platforms/darwin/CMakeLists.txt
+++ b/product-mini/platforms/darwin/CMakeLists.txt
@@ -91,6 +91,11 @@ if (NOT DEFINED WAMR_BUILD_SIMD)
   set (WAMR_BUILD_SIMD 1)
 endif ()
 
+if (NOT DEFINED WAMR_BUILD_REF_TYPES)
+  # Enable reference types by default
+  set (WAMR_BUILD_REF_TYPES 1)
+endif ()
+
 if (NOT DEFINED WAMR_BUILD_DEBUG_INTERP)
   # Disable Debug feature by default
   set (WAMR_BUILD_DEBUG_INTERP 0)


### PR DESCRIPTION
This resolved the issue [WASI-SDK 25 `call_indrect` doesn't work on Darwin](https://github.com/bytecodealliance/wasm-micro-runtime/issues/3977), by turning on reference types by default for iwasm on Darwin.

The error message is triggered by the way call indirect is rendered by WASI-SDK25, which has changed from WASI-SDK24. Turning on the reference checks allows iwasm on Darwin use the WASI-SDK generated code directly.

*Updated with additional information*
