### PR TITLE
Optimize memory initialization handling in AOT loader

### DIFF
--- a/core/iwasm/compilation/aot.h
+++ b/core/iwasm/compilation/aot.h
@@ -103,7 +103,7 @@ typedef struct AOTMemInitData {
     /* Byte count */
     uint32 byte_count;
     /* Byte array */
-    uint8 bytes[1];
+    uint8 *bytes;
 } AOTMemInitData;
 
 /**


### PR DESCRIPTION
Save memory if the file buffer is always exist before exit.