### PR TITLE
Error message improvement

### DIFF
--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -4237,7 +4237,10 @@ check_table_index(const WASMModule *module, uint32 table_index, char *error_buf,
 {
 #if WASM_ENABLE_REF_TYPES == 0 && WASM_ENABLE_GC == 0
     if (table_index != 0) {
-        set_error_buf(error_buf, error_buf_size, "zero byte expected");
+        set_error_buf(
+            error_buf, error_buf_size,
+            "zero byte expected. The module uses reference types feature "
+            "which is disabled in the runtime.");
         return false;
     }
 #endif


### PR DESCRIPTION
Improve error message in the scenario where the runtime was built with ref types disabled but the module uses reference types feature.

See #3980