### PR TITLE
Prefer to get & set exception from exec_env_tls

### DIFF
--- a/core/iwasm/common/wasm_exec_env.h
+++ b/core/iwasm/common/wasm_exec_env.h
@@ -33,6 +33,8 @@ typedef struct WASMJmpBuf {
 } WASMJmpBuf;
 #endif
 
+#define EXCEPTION_BUF_LEN 128
+
 /* Execution environment */
 typedef struct WASMExecEnv {
     /* Next thread's exec env of a WASM module instance. */
@@ -166,6 +168,9 @@ typedef struct WASMExecEnv {
         /* The WASM stack. */
         uint8 bottom[1];
     } wasm_stack_u;
+
+    /* The exception buffer for current execution environment. */
+    char cur_exception[EXCEPTION_BUF_LEN];
 } WASMExecEnv;
 
 #if WASM_ENABLE_MEMORY_PROFILING != 0


### PR DESCRIPTION
Exceptions are currently stored in module instance, but if most of them can be stored at the exec_env that would allow using a single module instance in parallel without locking and handle the exception separately.

Using a single module instance in parallel might not be usual, but it's possible from what I understand and tested WAMR, at least for specific use cases (e.g. no writing to globals or wasm memory, only reading from that and writing to wasm stack). Please correct me if I'm missing anything.

This PR proposes a change in how we store and retrieve exception from a given module instance:
- If the exec_env_tls is present, get/set exception from that and not touching the module instance.
- If not, keep getting/setting from the module instance. This is for exceptions that happens before an exec_env is created.