### PR TITLE
fixes for compiling on windows

### DIFF
--- a/core/shared/platform/windows/win_clock.c
+++ b/core/shared/platform/windows/win_clock.c
@@ -11,9 +11,19 @@
 #define NANOSECONDS_PER_TICK 100
 
 #if WINAPI_PARTITION_DESKTOP
-extern NTSTATUS
-NtQueryTimerResolution(PULONG MinimumResolution, PULONG MaximumResolution,
-                       PULONG CurrentResolution);
+#ifndef __kernel_entry
+#define __kernel_entry
+#endif
+#ifndef NTAPI
+#define NTAPI
+#endif
+#ifndef _Out_
+#define _Out_
+#endif
+extern __kernel_entry NTSTATUS NTAPI
+NtQueryTimerResolution(_Out_ PULONG MinimumResolution,
+                       _Out_ PULONG MaximumResolution,
+                       _Out_ PULONG CurrentResolution);
 #endif
 
 static __wasi_errno_t

--- a/core/shared/platform/windows/win_thread.c
+++ b/core/shared/platform/windows/win_thread.c
@@ -60,6 +60,17 @@ static DWORD thread_data_key;
 static void(WINAPI *GetCurrentThreadStackLimits_Kernel32)(PULONG_PTR,
                                                           PULONG_PTR) = NULL;
 
+int
+os_sem_init(korp_sem *sem);
+int
+os_sem_destroy(korp_sem *sem);
+int
+os_sem_wait(korp_sem *sem);
+int
+os_sem_reltimed_wait(korp_sem *sem, uint64 useconds);
+int
+os_sem_signal(korp_sem *sem);
+
 static void
 thread_data_list_add(os_thread_data *thread_data)
 {
@@ -116,17 +127,6 @@ thread_data_list_lookup(korp_tid tid)
     os_mutex_unlock(&thread_data_list_lock);
     return NULL;
 }
-
-int
-os_sem_init(korp_sem *sem);
-int
-os_sem_destroy(korp_sem *sem);
-int
-os_sem_wait(korp_sem *sem);
-int
-os_sem_reltimed_wait(korp_sem *sem, uint64 useconds);
-int
-os_sem_signal(korp_sem *sem);
 
 int
 os_thread_sys_init()


### PR DESCRIPTION
small fixes:

> D:\a\cage\cage\externals\wamr\wamr\core\shared\platform\windows\win_clock.c(15,1): error C2373: 'NtQueryTimerResolution': redefinition; different type modifiers [D:\a\cage\cage\build\externals\wamr\iwasm_static.vcxproj]
      C:\Program Files (x86)\Windows Kits\10\Include\10.0.20348.0\um\winternl.h(713,1):
      see declaration of 'NtQueryTimerResolution'
      
when compiling with visual studio for win32

> D:\a\cage\cage\externals\wamr\wamr\core\shared\platform\windows\win_thread.c(96,9): error : call to undeclared function 'os_sem_destroy'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration] [D:\a\cage\cage\build\externals\wamr\iwasm_static.vcxproj]

when compiling with clang on windows