### PR TITLE
Fix wasm loader check data segment count

### DIFF
--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -5926,6 +5926,15 @@ load_from_sections(WASMModule *module, WASMSection *sections,
         section = section->next;
     }
 
+#if WASM_ENABLE_BULK_MEMORY != 0
+    if (has_datacount_section
+        && module->data_seg_count != module->data_seg_count1) {
+        set_error_buf(error_buf, error_buf_size,
+                      "data count and data section have inconsistent lengths");
+        return false;
+    }
+#endif
+
     module->aux_data_end_global_index = (uint32)-1;
     module->aux_heap_base_global_index = (uint32)-1;
     module->aux_stack_top_global_index = (uint32)-1;

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -4719,7 +4719,7 @@ check_data_count_consistency(bool has_datacount_section, int datacount_len,
                              int data_seg_len, char *error_buf,
                              uint32 error_buf_size)
 {
-    if (has_datacount_section && data_seg_len != data_seg_len) {
+    if (has_datacount_section && datacount_len != data_seg_len) {
         set_error_buf(error_buf, error_buf_size,
                       "data count and data section have inconsistent lengths");
         return false;

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -2734,6 +2734,11 @@ load_from_sections(WASMModule *module, WASMSection *sections,
         section = section->next;
     }
 
+#if WASM_ENABLE_BULK_MEMORY != 0
+    bh_assert(!has_datacount_section
+              || module->data_seg_count == module->data_seg_count1);
+#endif
+
     module->aux_data_end_global_index = (uint32)-1;
     module->aux_heap_base_global_index = (uint32)-1;
     module->aux_stack_top_global_index = (uint32)-1;


### PR DESCRIPTION
Correctly report the error in the loader when the datacount section has a non-zero data segment count, while the data section is not present.
