### PR TITLE
Correctly use unsigned functions 

### DIFF
--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -6112,7 +6112,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i8x16_lt_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i8x16_lt);
+                        SIMD_DOUBLE_OP(simde_wasm_u8x16_lt);
                         break;
                     }
                     case SIMD_i8x16_gt_s:
@@ -6122,7 +6122,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i8x16_gt_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i8x16_gt);
+                        SIMD_DOUBLE_OP(simde_wasm_u8x16_gt);
                         break;
                     }
                     case SIMD_i8x16_le_s:
@@ -6132,7 +6132,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i8x16_le_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i8x16_le);
+                        SIMD_DOUBLE_OP(simde_wasm_u8x16_le);
                         break;
                     }
                     case SIMD_i8x16_ge_s:
@@ -6142,7 +6142,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i8x16_ge_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i8x16_ge);
+                        SIMD_DOUBLE_OP(simde_wasm_u8x16_ge);
                         break;
                     }
 
@@ -6164,7 +6164,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i16x8_lt_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i16x8_lt);
+                        SIMD_DOUBLE_OP(simde_wasm_u16x8_lt);
                         break;
                     }
                     case SIMD_i16x8_gt_s:
@@ -6174,7 +6174,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i16x8_gt_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i16x8_gt);
+                        SIMD_DOUBLE_OP(simde_wasm_u16x8_gt);
                         break;
                     }
                     case SIMD_i16x8_le_s:
@@ -6184,7 +6184,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i16x8_le_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i16x8_le);
+                        SIMD_DOUBLE_OP(simde_wasm_u16x8_le);
                         break;
                     }
                     case SIMD_i16x8_ge_s:
@@ -6194,7 +6194,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i16x8_ge_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i16x8_ge);
+                        SIMD_DOUBLE_OP(simde_wasm_u16x8_ge);
                         break;
                     }
 
@@ -6216,7 +6216,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i32x4_lt_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i32x4_lt);
+                        SIMD_DOUBLE_OP(simde_wasm_u32x4_lt);
                         break;
                     }
                     case SIMD_i32x4_gt_s:
@@ -6226,7 +6226,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i32x4_gt_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i32x4_gt);
+                        SIMD_DOUBLE_OP(simde_wasm_u32x4_gt);
                         break;
                     }
                     case SIMD_i32x4_le_s:
@@ -6236,7 +6236,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i32x4_le_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i32x4_le);
+                        SIMD_DOUBLE_OP(simde_wasm_u32x4_le);
                         break;
                     }
                     case SIMD_i32x4_ge_s:
@@ -6246,7 +6246,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i32x4_ge_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i32x4_ge);
+                        SIMD_DOUBLE_OP(simde_wasm_u32x4_ge);
                         break;
                     }
 
@@ -6285,32 +6285,32 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     /* f64x2 comparison operations */
                     case SIMD_f64x2_eq:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_f32x4_eq);
+                        SIMD_DOUBLE_OP(simde_wasm_f64x2_eq);
                         break;
                     }
                     case SIMD_f64x2_ne:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_f32x4_ne);
+                        SIMD_DOUBLE_OP(simde_wasm_f64x2_ne);
                         break;
                     }
                     case SIMD_f64x2_lt:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_f32x4_lt);
+                        SIMD_DOUBLE_OP(simde_wasm_f64x2_lt);
                         break;
                     }
                     case SIMD_f64x2_gt:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_f32x4_gt);
+                        SIMD_DOUBLE_OP(simde_wasm_f64x2_gt);
                         break;
                     }
                     case SIMD_f64x2_le:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_f32x4_le);
+                        SIMD_DOUBLE_OP(simde_wasm_f64x2_le);
                         break;
                     }
                     case SIMD_f64x2_ge:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_f32x4_ge);
+                        SIMD_DOUBLE_OP(simde_wasm_f64x2_ge);
                         break;
                     }
 
@@ -6571,7 +6571,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i8x16_narrow_i16x8_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i8x16_narrow_i16x8);
+                        SIMD_DOUBLE_OP(simde_wasm_u8x16_narrow_i16x8);
                         break;
                     }
                     case SIMD_f32x4_ceil:
@@ -6621,7 +6621,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i8x16_shr_u:
                     {
-                        SIMD_LANE_SHIFT(simde_wasm_i8x16_shr);
+                        SIMD_LANE_SHIFT(simde_wasm_u8x16_shr);
                         break;
                     }
                     case SIMD_i8x16_add:
@@ -6636,7 +6636,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i8x16_add_sat_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i8x16_add_sat);
+                        SIMD_DOUBLE_OP(simde_wasm_u8x16_add_sat);
                         break;
                     }
                     case SIMD_i8x16_sub:
@@ -6651,7 +6651,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i8x16_sub_sat_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i8x16_sub_sat);
+                        SIMD_DOUBLE_OP(simde_wasm_u8x16_sub_sat);
                         break;
                     }
                     case SIMD_f64x2_ceil:
@@ -6671,7 +6671,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i8x16_min_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i8x16_min);
+                        SIMD_DOUBLE_OP(simde_wasm_u8x16_min);
                         break;
                     }
                     case SIMD_i8x16_max_s:
@@ -6681,7 +6681,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i8x16_max_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i8x16_max);
+                        SIMD_DOUBLE_OP(simde_wasm_u8x16_max);
                         break;
                     }
                     case SIMD_f64x2_trunc:
@@ -6701,7 +6701,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i16x8_extadd_pairwise_i8x16_u:
                     {
-                        SIMD_SINGLE_OP(simde_wasm_i16x8_extadd_pairwise_i8x16);
+                        SIMD_SINGLE_OP(simde_wasm_u16x8_extadd_pairwise_u8x16);
                         break;
                     }
                     case SIMD_i32x4_extadd_pairwise_i16x8_s:
@@ -6711,7 +6711,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i32x4_extadd_pairwise_i16x8_u:
                     {
-                        SIMD_SINGLE_OP(simde_wasm_i32x4_extadd_pairwise_i16x8);
+                        SIMD_SINGLE_OP(simde_wasm_u32x4_extadd_pairwise_u16x8);
                         break;
                     }
 
@@ -6760,7 +6760,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i16x8_narrow_i32x4_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i16x8_narrow_i32x4);
+                        SIMD_DOUBLE_OP(simde_wasm_u16x8_narrow_i32x4);
                         break;
                     }
                     case SIMD_i16x8_extend_low_i8x16_s:
@@ -6775,12 +6775,12 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i16x8_extend_low_i8x16_u:
                     {
-                        SIMD_SINGLE_OP(simde_wasm_i16x8_extend_low_i8x16);
+                        SIMD_SINGLE_OP(simde_wasm_u16x8_extend_low_u8x16);
                         break;
                     }
                     case SIMD_i16x8_extend_high_i8x16_u:
                     {
-                        SIMD_SINGLE_OP(simde_wasm_i16x8_extend_high_i8x16);
+                        SIMD_SINGLE_OP(simde_wasm_u16x8_extend_high_u8x16);
                         break;
                     }
                     case SIMD_i16x8_shl:
@@ -6795,7 +6795,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i16x8_shr_u:
                     {
-                        SIMD_LANE_SHIFT(simde_wasm_i16x8_shr);
+                        SIMD_LANE_SHIFT(simde_wasm_u16x8_shr);
                         break;
                     }
                     case SIMD_i16x8_add:
@@ -6810,7 +6810,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i16x8_add_sat_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i16x8_add_sat);
+                        SIMD_DOUBLE_OP(simde_wasm_u16x8_add_sat);
                         break;
                     }
                     case SIMD_i16x8_sub:
@@ -6825,7 +6825,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i16x8_sub_sat_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i16x8_sub_sat);
+                        SIMD_DOUBLE_OP(simde_wasm_u16x8_sub_sat);
                         break;
                     }
                     case SIMD_f64x2_nearest:
@@ -6845,7 +6845,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i16x8_min_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i16x8_min);
+                        SIMD_DOUBLE_OP(simde_wasm_u16x8_min);
                         break;
                     }
                     case SIMD_i16x8_max_s:
@@ -6855,7 +6855,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i16x8_max_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i16x8_max);
+                        SIMD_DOUBLE_OP(simde_wasm_u16x8_max);
                         break;
                     }
                     case SIMD_i16x8_avgr_u:
@@ -6875,12 +6875,12 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i16x8_extmul_low_i8x16_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i16x8_extmul_low_i8x16);
+                        SIMD_DOUBLE_OP(simde_wasm_u16x8_extmul_low_u8x16);
                         break;
                     }
                     case SIMD_i16x8_extmul_high_i8x16_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i16x8_extmul_high_i8x16);
+                        SIMD_DOUBLE_OP(simde_wasm_u16x8_extmul_high_u8x16);
                         break;
                     }
 
@@ -6929,12 +6929,12 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i32x4_extend_low_i16x8_u:
                     {
-                        SIMD_SINGLE_OP(simde_wasm_i32x4_extend_low_i16x8);
+                        SIMD_SINGLE_OP(simde_wasm_u32x4_extend_low_u16x8);
                         break;
                     }
                     case SIMD_i32x4_extend_high_i16x8_u:
                     {
-                        SIMD_SINGLE_OP(simde_wasm_i32x4_extend_high_i16x8);
+                        SIMD_SINGLE_OP(simde_wasm_u32x4_extend_high_u16x8);
                         break;
                     }
                     case SIMD_i32x4_shl:
@@ -6949,7 +6949,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i32x4_shr_u:
                     {
-                        SIMD_LANE_SHIFT(simde_wasm_i32x4_shr);
+                        SIMD_LANE_SHIFT(simde_wasm_u32x4_shr);
                         break;
                     }
                     case SIMD_i32x4_add:
@@ -6974,7 +6974,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i32x4_min_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i32x4_min);
+                        SIMD_DOUBLE_OP(simde_wasm_u32x4_min);
                         break;
                     }
                     case SIMD_i32x4_max_s:
@@ -6984,7 +6984,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i32x4_max_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i32x4_max);
+                        SIMD_DOUBLE_OP(simde_wasm_u32x4_max);
                         break;
                     }
                     case SIMD_i32x4_dot_i16x8_s:
@@ -7004,12 +7004,12 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i32x4_extmul_low_i16x8_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i32x4_extmul_low_i16x8);
+                        SIMD_DOUBLE_OP(simde_wasm_u32x4_extmul_low_u16x8);
                         break;
                     }
                     case SIMD_i32x4_extmul_high_i16x8_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i32x4_extmul_high_i16x8);
+                        SIMD_DOUBLE_OP(simde_wasm_u32x4_extmul_high_u16x8);
                         break;
                     }
 
@@ -7058,12 +7058,12 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i64x2_extend_low_i32x4_u:
                     {
-                        SIMD_SINGLE_OP(simde_wasm_i64x2_extend_low_i32x4);
+                        SIMD_SINGLE_OP(simde_wasm_u64x2_extend_low_u32x4);
                         break;
                     }
                     case SIMD_i64x2_extend_high_i32x4_u:
                     {
-                        SIMD_SINGLE_OP(simde_wasm_i64x2_extend_high_i32x4);
+                        SIMD_SINGLE_OP(simde_wasm_u64x2_extend_high_u32x4);
                         break;
                     }
 
@@ -7080,7 +7080,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i64x2_shr_u:
                     {
-                        SIMD_LANE_SHIFT(simde_wasm_i64x2_shr);
+                        SIMD_LANE_SHIFT(simde_wasm_u64x2_shr);
                         break;
                     }
                     case SIMD_i64x2_add:
@@ -7140,12 +7140,12 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i64x2_extmul_low_i32x4_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i64x2_extmul_low_i32x4);
+                        SIMD_DOUBLE_OP(simde_wasm_u64x2_extmul_low_u32x4);
                         break;
                     }
                     case SIMD_i64x2_extmul_high_i32x4_u:
                     {
-                        SIMD_DOUBLE_OP(simde_wasm_i64x2_extmul_high_i32x4);
+                        SIMD_DOUBLE_OP(simde_wasm_u64x2_extmul_high_u32x4);
                         break;
                     }
 
@@ -7271,7 +7271,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i32x4_trunc_sat_f32x4_u:
                     {
-                        SIMD_SINGLE_OP(simde_wasm_i32x4_trunc_sat_f32x4);
+                        SIMD_SINGLE_OP(simde_wasm_u32x4_trunc_sat_f32x4);
                         break;
                     }
                     case SIMD_f32x4_convert_i32x4_s:
@@ -7281,7 +7281,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_f32x4_convert_i32x4_u:
                     {
-                        SIMD_SINGLE_OP(simde_wasm_f32x4_convert_i32x4);
+                        SIMD_SINGLE_OP(simde_wasm_f32x4_convert_u32x4);
                         break;
                     }
                     case SIMD_i32x4_trunc_sat_f64x2_s_zero:
@@ -7291,7 +7291,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_i32x4_trunc_sat_f64x2_u_zero:
                     {
-                        SIMD_SINGLE_OP(simde_wasm_i32x4_trunc_sat_f64x2_zero);
+                        SIMD_SINGLE_OP(simde_wasm_u32x4_trunc_sat_f64x2_zero);
                         break;
                     }
                     case SIMD_f64x2_convert_low_i32x4_s:
@@ -7301,7 +7301,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
                     case SIMD_f64x2_convert_low_i32x4_u:
                     {
-                        SIMD_SINGLE_OP(simde_wasm_f64x2_convert_low_i32x4);
+                        SIMD_SINGLE_OP(simde_wasm_f64x2_convert_low_u32x4);
                         break;
                     }
 


### PR DESCRIPTION
This PR changes the function name used in simde to the correct one 