### PR TITLE
Use wasm32-wasip1 instead of wasm32-wasi target for rust code

### DIFF
--- a/.github/workflows/compilation_on_android_ubuntu.yml
+++ b/.github/workflows/compilation_on_android_ubuntu.yml
@@ -675,7 +675,7 @@ jobs:
             test_option: $MEMORY64_TEST_OPTIONS
           - running_mode: "multi-tier-jit"
             test_option: $MEMORY64_TEST_OPTIONS
-          # aot, fast-interp, fast-jit, llvm-jit, multi-tier-jit don't support Multi Memory 
+          # aot, fast-interp, fast-jit, llvm-jit, multi-tier-jit don't support Multi Memory
           - running_mode: "aot"
             test_option: $MULTI_MEMORY_TEST_OPTIONS
           - running_mode: "fast-interp"
@@ -817,7 +817,7 @@ jobs:
 
       - name: install dependencies
         run: |
-          rustup target add wasm32-wasi
+          rustup target add wasm32-wasip1
           sudo apt update && sudo apt-get install -y lld ninja-build
           npm install
         working-directory: test-tools/wamr-ide/VSCode-Extension

--- a/core/iwasm/libraries/wasi-nn/test/Dockerfile.wasi-nn-smoke
+++ b/core/iwasm/libraries/wasi-nn/test/Dockerfile.wasi-nn-smoke
@@ -13,7 +13,7 @@ RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends cmake
 
-RUN rustup target add wasm32-wasi
+RUN rustup target add wasm32-wasip1
 
 #
 # Openvino
@@ -37,10 +37,10 @@ WORKDIR /workspaces/wasi-nn
 RUN git clone --depth 1 https://github.com/bytecodealliance/wasi-nn.git .
 
 WORKDIR /workspaces/wasi-nn/rust/examples/classification-example/
-RUN cargo build --target=wasm32-wasi
+RUN cargo build --target=wasm32-wasip1
 
 WORKDIR /workspaces/wasi-nn/rust/examples/classification-example/build
-RUN cp ../target/wasm32-wasi/debug/wasi-nn-example.wasm . \
+RUN cp ../target/wasm32-wasip1/debug/wasi-nn-example.wasm . \
   && wget -q --no-clobber https://github.com/intel/openvino-rs/raw/main/crates/openvino/tests/fixtures/mobilenet/mobilenet.xml \
   && wget -q --no-clobber https://github.com/intel/openvino-rs/raw/main/crates/openvino/tests/fixtures/mobilenet/mobilenet.bin
 # There are model files(mobilenet*) and wasm files(wasi-nn-example.wasm) in the directory,
@@ -67,30 +67,30 @@ RUN git apply ./bump_wasi_nn_to_0_6_0.patch
 # recompile with wasi-nn 0.6.0
 WORKDIR /workspaces/wasmedge-wasinn-examples/openvino-mobilenet-image/
 RUN pushd rust \
-  && cargo build --target=wasm32-wasi \
+  && cargo build --target=wasm32-wasip1 \
   && popd \
   && ./download_mobilenet.sh . \
   && ls -l mobilenet.xml mobilenet.bin
 
 WORKDIR /workspaces/wasmedge-wasinn-examples/openvino-mobilenet-raw/
 RUN pushd rust \
-  && cargo build --target=wasm32-wasi \
+  && cargo build --target=wasm32-wasip1 \
   && popd \
   && ./download_mobilenet.sh . \
   && ls -l mobilenet.xml mobilenet.bin tensor-1x224x224x3-f32.bgr
 
 WORKDIR /workspaces/wasmedge-wasinn-examples/openvino-road-segmentation-adas/
 RUN pushd openvino-road-seg-adas \
-  && cargo build --target=wasm32-wasi
+  && cargo build --target=wasm32-wasip1
 
 WORKDIR /workspaces/wasmedge-wasinn-examples/tflite-birds_v1-image/
 RUN pushd rust \
-  && cargo build --target=wasm32-wasi
+  && cargo build --target=wasm32-wasip1
 
 # mount models when running
 WORKDIR /workspaces/wasmedge-wasinn-examples/wasmedge-ggml/qwen
 RUN wget --progress=dot:giga https://www.modelscope.cn/models/qwen/Qwen1.5-0.5B-Chat-GGUF/resolve/master/qwen1_5-0_5b-chat-q2_k.gguf
-RUN cargo build --target=wasm32-wasi
+RUN cargo build --target=wasm32-wasip1
 
 #
 # iwasm. build from source
@@ -107,7 +107,7 @@ RUN OpenVINO_DIR=/usr/lib/openvino-2023.2.0 \
     -DWAMR_BUILD_WASI_NN_LLAMACPP=1 \
   && cmake --build build \
   && cmake --install build
- 
+
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
 # add smoke test script

--- a/core/iwasm/libraries/wasi-nn/test/run_smoke_test.py
+++ b/core/iwasm/libraries/wasi-nn/test/run_smoke_test.py
@@ -53,7 +53,7 @@ def execute_openvino_road_segmentation_adas_once(
     """
 
     wasm_file = (
-        "./openvino-road-seg-adas/target/wasm32-wasi/debug/openvino-road-seg-adas.wasm"
+        "./openvino-road-seg-adas/target/wasm32-wasip1/debug/openvino-road-seg-adas.wasm"
     )
     wasm_args = [
         "./model/road-segmentation-adas-0001.xml",
@@ -70,7 +70,7 @@ def execute_openvino_mobilenet_raw_once(
     execute openvino-mobilenet-image with iwasm and wasmedge
     """
 
-    wasm_file = "./rust/target/wasm32-wasi/debug/wasmedge-wasinn-example-mobilenet.wasm"
+    wasm_file = "./rust/target/wasm32-wasip1/debug/wasmedge-wasinn-example-mobilenet.wasm"
     wasm_args = [
         "mobilenet.xml",
         "mobilenet.bin",
@@ -87,7 +87,7 @@ def execute_openvino_mobilenet_image_once(
     """
 
     wasm_file = (
-        "./rust/target/wasm32-wasi/debug/wasmedge-wasinn-example-mobilenet-image.wasm"
+        "./rust/target/wasm32-wasip1/debug/wasmedge-wasinn-example-mobilenet-image.wasm"
     )
     wasm_args = [
         "mobilenet.xml",
@@ -105,7 +105,7 @@ def execute_tflite_birds_v1_image_once(
     """
 
     wasm_file = (
-        "rust/target/wasm32-wasi/debug/wasmedge-wasinn-example-tflite-bird-image.wasm"
+        "rust/target/wasm32-wasip1/debug/wasmedge-wasinn-example-tflite-bird-image.wasm"
     )
     wasm_args = ["lite-model_aiy_vision_classifier_birds_V1_3.tflite", "bird.jpg"]
     return execute_once(runtime_bin, runtime_args, wasm_file, wasm_args, cwd)
@@ -262,7 +262,7 @@ def execute_openvino_road_segmentation_adas(
 
 def execute_wasmedge_ggml_qwen(iwasm_bin: str, wasmedge_bin: str, cwd: Path):
     iwasm_args = ["--dir=."]
-    wasm_file = ["./target/wasm32-wasi/debug/wasmedge-ggml-qwen.wasm"]
+    wasm_file = ["./target/wasm32-wasip1/debug/wasmedge-ggml-qwen.wasm"]
     wasm_args = ["./qwen1_5-0_5b-chat-q2_k.gguf"]
 
     cmd = [iwasm_bin]

--- a/doc/build_wasm_app.md
+++ b/doc/build_wasm_app.md
@@ -16,24 +16,24 @@ For [AssemblyScript](https://github.com/AssemblyScript/assemblyscript), please r
 
 For Rust, please refer to [Install Rust and Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html) to install *cargo*, *rustc* and *rustup*. By default they are under ~/.cargo/bin.
 
-And then run such a command to install `wasm32-wasi` target.
+And then run such a command to install `wasm32-wasip1` target.
 
 ``` bash
-$ rustup target add wasm32-wasi
+$ rustup target add wasm32-wasip1
 ```
 
 To build WASM applications, run
 
 ``` bash
-$ cargo build --target wasm32-wasi
+$ cargo build --target wasm32-wasip1
 ```
 
-The output files are under `target/wasm32-wasi`.
+The output files are under `target/wasm32-wasip1`.
 
 To build a release version
 
 ``` bash
-$ cargo build --release --target wasm32-wasi
+$ cargo build --release --target wasm32-wasip1
 ```
 
 

--- a/test-tools/wamr-ide/VSCode-Extension/resource/test/build.sh
+++ b/test-tools/wamr-ide/VSCode-Extension/resource/test/build.sh
@@ -1,2 +1,2 @@
 # compile with debug symbols and no optimization
-rustc --target wasm32-wasi ./test.rs -g -C opt-level=0
+rustc --target wasm32-wasip1 ./test.rs -g -C opt-level=0

--- a/test-tools/wamr-ide/VSCode-Extension/src/test/suite/utils.ts
+++ b/test-tools/wamr-ide/VSCode-Extension/src/test/suite/utils.ts
@@ -39,7 +39,7 @@ export function setBpAtMarker(file: string, bpMarker: string): void {
 export function compileRustToWasm(): void {
     const testResourceFolder = `${EXTENSION_PATH}/resource/test`;
     // compile with debug symbols and no optimization
-    const cmd = `rustc --target wasm32-wasi ${testResourceFolder}/test.rs -g -C opt-level=0 -o ${testResourceFolder}/test.wasm`;
+    const cmd = `rustc --target wasm32-wasip1 ${testResourceFolder}/test.rs -g -C opt-level=0 -o ${testResourceFolder}/test.wasm`;
 
     try {
         cp.execSync(cmd, { stdio: [null, null, process.stderr] });


### PR DESCRIPTION
Rust compiler previously deprecated, and now removed the wasm32-wasi target and replaced it with wasm32-wasip1. This change updates all the occurrences of wasm32-wasi in the context of Rust compilation