### PR TITLE
Reduce number of aot_copy_exception inside aot_call_function

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -2630,7 +2630,7 @@ aot_call_function(WASMExecEnv *exec_env, AOTFunctionInstance *function,
         ret = invoke_native_internal(exec_env, func_ptr, func_type, NULL,
                                      attachment, argv, argc, argv);
 
-        if (aot_copy_exception(module_inst, NULL)) {
+        if (!ret) {
 #ifdef AOT_STACK_FRAME_DEBUG
             if (aot_stack_frame_callback) {
                 aot_stack_frame_callback(exec_env);
@@ -2651,7 +2651,7 @@ aot_call_function(WASMExecEnv *exec_env, AOTFunctionInstance *function,
             aot_free_frame(exec_env);
 #endif
 
-        return ret && !aot_copy_exception(module_inst, NULL) ? true : false;
+        return ret;
     }
 }
 


### PR DESCRIPTION
Remove redundant calls to `aot_copy_exception`. Exception has checked inside `invoke_native_internal` and the result has returned back. There is no need to recheck two more times. Each `aot_copy_exception` locks global `_exception_lock`, this can be bottleneck and hit performance in concurrent environments.
Relates to https://github.com/bytecodealliance/wasm-micro-runtime/issues/4058