### PR TITLE
Add API for disabling native stack boundary checks

### DIFF
--- a/core/iwasm/common/wasm_exec_env.c
+++ b/core/iwasm/common/wasm_exec_env.c
@@ -282,7 +282,9 @@ wasm_exec_env_set_thread_info(WASMExecEnv *exec_env)
     os_mutex_lock(&exec_env->wait_lock);
 #endif
     exec_env->handle = os_self_thread();
-    if (exec_env->user_native_stack_boundary)
+    if (exec_env->user_native_stack_boundary == (void *)UINTPTR_MAX)
+        exec_env->native_stack_boundary = NULL;
+    else if (exec_env->user_native_stack_boundary)
         /* WASM_STACK_GUARD_SIZE isn't added for flexibility to developer,
            he must ensure that enough guard bytes are kept. */
         exec_env->native_stack_boundary = exec_env->user_native_stack_boundary;

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -2232,6 +2232,12 @@ wasm_runtime_set_native_stack_boundary(WASMExecEnv *exec_env,
     exec_env->user_native_stack_boundary = native_stack_boundary;
 }
 
+void
+wasm_runtime_disable_native_stack_boundary_check(WASMExecEnv *exec_env)
+{
+    wasm_runtime_set_native_stack_boundary(exec_env, (void *)UINTPTR_MAX);
+}
+
 #ifdef OS_ENABLE_HW_BOUND_CHECK
 void
 wasm_runtime_access_exce_check_guard_page()

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -678,6 +678,10 @@ WASM_RUNTIME_API_EXTERN void
 wasm_runtime_set_native_stack_boundary(WASMExecEnv *exec_env,
                                        uint8 *native_stack_boundary);
 
+/* See wasm_export.h for description */
+WASM_RUNTIME_API_EXTERN void
+wasm_runtime_disable_native_stack_boundary_check(WASMExecEnv *exec_env);
+
 #if WASM_CONFIGURABLE_BOUNDS_CHECKS != 0
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN void

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -1778,6 +1778,14 @@ wasm_runtime_set_native_stack_boundary(wasm_exec_env_t exec_env,
                                        uint8_t *native_stack_boundary);
 
 /**
+ * Disable native stack boundary check.
+ *
+ * @param exec_env the execution environment
+ */
+WASM_RUNTIME_API_EXTERN void
+wasm_runtime_disable_native_stack_boundary_check(wasm_exec_env_t exec_env);
+
+/**
  * Dump runtime memory consumption, including:
  *     Exec env memory consumption
  *     WASM module memory consumption


### PR DESCRIPTION
This API can be helpful if e.g. module is working in a reactor mode, and the module is being used from multiple threads (where the caller guarantees that no two threads execute code on the same execution environment). Currently this usecase fails because the native stack boundaries for each thread are different.

Alternative to this solution would be to update the boundary on every thread switch but that might not be desired due to performance.

I've added a new API but just having a logic for `UINTPTR_MAX` and using `wasm_runtime_set_native_stack_boundary` would be good enough. If the preference is to not have a new API, I'm ok to remove it and add a comment in the `wasm_runtime_set_native_stack_boundary` about the special `UINTPTR_MAX` value.