### PR TITLE
In wasm32, fix potential conversion overflow when enlarging 65536 pages

### DIFF
--- a/core/iwasm/common/wasm_memory.c
+++ b/core/iwasm/common/wasm_memory.c
@@ -1389,7 +1389,7 @@ wasm_enlarge_memory_internal(WASMModuleInstanceCommon *module,
     if (full_size_mmaped) {
 #ifdef BH_PLATFORM_WINDOWS
         if (!os_mem_commit(memory->memory_data_end,
-                           (uint64)(total_size_new - total_size_old),
+                           total_size_new - total_size_old,
                            MMAP_PROT_READ | MMAP_PROT_WRITE)) {
             ret = false;
             goto return_func;
@@ -1397,12 +1397,12 @@ wasm_enlarge_memory_internal(WASMModuleInstanceCommon *module,
 #endif
 
         if (os_mprotect(memory->memory_data_end,
-                        (uint64)(total_size_new - total_size_old),
+                        total_size_new - total_size_old,
                         MMAP_PROT_READ | MMAP_PROT_WRITE)
             != 0) {
 #ifdef BH_PLATFORM_WINDOWS
             os_mem_decommit(memory->memory_data_end,
-                            (uint64)(total_size_new - total_size_old));
+                            total_size_new - total_size_old);
 #endif
             ret = false;
             goto return_func;

--- a/core/iwasm/common/wasm_memory.c
+++ b/core/iwasm/common/wasm_memory.c
@@ -1389,7 +1389,7 @@ wasm_enlarge_memory_internal(WASMModuleInstanceCommon *module,
     if (full_size_mmaped) {
 #ifdef BH_PLATFORM_WINDOWS
         if (!os_mem_commit(memory->memory_data_end,
-                           (mem_offset_t)(total_size_new - total_size_old),
+                           (uint64)(total_size_new - total_size_old),
                            MMAP_PROT_READ | MMAP_PROT_WRITE)) {
             ret = false;
             goto return_func;
@@ -1397,12 +1397,12 @@ wasm_enlarge_memory_internal(WASMModuleInstanceCommon *module,
 #endif
 
         if (os_mprotect(memory->memory_data_end,
-                        (mem_offset_t)(total_size_new - total_size_old),
+                        (uint64)(total_size_new - total_size_old),
                         MMAP_PROT_READ | MMAP_PROT_WRITE)
             != 0) {
 #ifdef BH_PLATFORM_WINDOWS
             os_mem_decommit(memory->memory_data_end,
-                            (mem_offset_t)(total_size_new - total_size_old));
+                            (uint64)(total_size_new - total_size_old));
 #endif
             ret = false;
             goto return_func;


### PR DESCRIPTION
Fix conversion error when the total_size_new is 4G(0x100000000) and the old is 0