### PR TITLE
Prevent mmap size overflow on 32 bit platform for memory.grow

### DIFF
--- a/core/iwasm/common/wasm_memory.c
+++ b/core/iwasm/common/wasm_memory.c
@@ -1253,6 +1253,12 @@ wasm_mremap_linear_memory(void *mapped_mem, uint64 old_size, uint64 new_size,
     bh_assert(new_size > 0);
     bh_assert(new_size > old_size);
 
+#if UINTPTR_MAX == UINT32_MAX
+    if (new_size == 4 * (uint64)BH_GB) {
+        return NULL;
+    }
+#endif
+
     if (mapped_mem) {
         new_mem = os_mremap(mapped_mem, old_size, new_size);
     }


### PR DESCRIPTION
As discussed in https://github.com/bytecodealliance/wasm-micro-runtime/pull/4064, on 32-bit platform, memory.grow 65536 can cause incorrect conversion when `wasm_mremap_linear_memory`  pass the u64 size to mmap as size_t