### PR TITLE
[gc] Subtyping fix

### DIFF
--- a/core/iwasm/common/gc/gc_type.c
+++ b/core/iwasm/common/gc/gc_type.c
@@ -1145,6 +1145,15 @@ wasm_reftype_is_subtype_of(uint8 type1, const WASMRefType *ref_type1,
                 return true;
             else {
                 int32 heap_type = ref_type1->ref_ht_common.heap_type;
+                // We dont care whether type2 is nullable or not. So
+                // we normalize it into its related one-byte type.
+                if (type2 == REF_TYPE_HT_NULLABLE
+                    || type2 == REF_TYPE_HT_NON_NULLABLE) {
+                    bh_assert(ref_type2);
+                    type2 =
+                        (uint8)(ref_type2->ref_ht_common.heap_type
+                                + REF_TYPE_FUNCREF - HEAP_TYPE_FUNC);
+                }
                 if (heap_type == HEAP_TYPE_ANY) {
                     /* (ref any) <: anyref */
                     return type2 == REF_TYPE_ANYREF ? true : false;
@@ -1188,19 +1197,15 @@ wasm_reftype_is_subtype_of(uint8 type1, const WASMRefType *ref_type1,
                 }
 #endif
                 else if (heap_type == HEAP_TYPE_NONE) {
-                    /* (ref none) */
-                    /* TODO */
-                    bh_assert(0);
+                    return wasm_is_reftype_supers_of_none(type2, NULL, types,
+                                              type_count);
                 }
                 else if (heap_type == HEAP_TYPE_NOEXTERN) {
-                    /* (ref noextern) */
-                    /* TODO */
-                    bh_assert(0);
+                    return wasm_is_reftype_supers_of_noextern(type2);
                 }
                 else if (heap_type == HEAP_TYPE_NOFUNC) {
-                    /* (ref nofunc) */
-                    /* TODO */
-                    bh_assert(0);
+                    return wasm_is_reftype_supers_of_nofunc(type2, NULL, types,
+                                              type_count);
                 }
                 else {
                     bh_assert(0);

--- a/core/iwasm/common/gc/gc_type.c
+++ b/core/iwasm/common/gc/gc_type.c
@@ -1150,9 +1150,8 @@ wasm_reftype_is_subtype_of(uint8 type1, const WASMRefType *ref_type1,
                 if (type2 == REF_TYPE_HT_NULLABLE
                     || type2 == REF_TYPE_HT_NON_NULLABLE) {
                     bh_assert(ref_type2);
-                    type2 =
-                        (uint8)(ref_type2->ref_ht_common.heap_type
-                                + REF_TYPE_FUNCREF - HEAP_TYPE_FUNC);
+                    type2 = (uint8)(ref_type2->ref_ht_common.heap_type
+                                    + REF_TYPE_FUNCREF - HEAP_TYPE_FUNC);
                 }
                 if (heap_type == HEAP_TYPE_ANY) {
                     /* (ref any) <: anyref */
@@ -1198,14 +1197,14 @@ wasm_reftype_is_subtype_of(uint8 type1, const WASMRefType *ref_type1,
 #endif
                 else if (heap_type == HEAP_TYPE_NONE) {
                     return wasm_is_reftype_supers_of_none(type2, NULL, types,
-                                              type_count);
+                                                          type_count);
                 }
                 else if (heap_type == HEAP_TYPE_NOEXTERN) {
                     return wasm_is_reftype_supers_of_noextern(type2);
                 }
                 else if (heap_type == HEAP_TYPE_NOFUNC) {
                     return wasm_is_reftype_supers_of_nofunc(type2, NULL, types,
-                                              type_count);
+                                                            type_count);
                 }
                 else {
                     bh_assert(0);

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -246,7 +246,7 @@ type2str(uint8 type)
                              "", /* reserved */
                              "arrayref",
                              "structref",
-                             "i32ref",
+                             "i31ref",
                              "eqref",
                              "anyref",
                              "externref",


### PR DESCRIPTION
The code was not handling the case where the right-hand side is a non-nullable ref type with a common heap type. For instance:
```
(ref eq) <: (ref any)
```