### PR TITLE
Cmake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,11 @@ endif ()
 
 add_library (vmlib ${WAMR_RUNTIME_LIB_SOURCE})
 set_target_properties (vmlib PROPERTIES OUTPUT_NAME iwasm)
-target_include_directories(vmlib INTERFACE ${WAMR_ROOT_DIR}/core/iwasm/include)
+target_include_directories(vmlib INTERFACE
+  $<BUILD_INTERFACE:${WAMR_ROOT_DIR}/core/iwasm/include>
+  $<INSTALL_INTERFACE:include/iwasm>
+)
+
 target_link_libraries (vmlib PUBLIC ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl ${CMAKE_THREAD_LIBS_INIT})
 if (WAMR_BUILD_WASM_CACHE EQUAL 1)
   target_link_libraries(vmlib INTERFACE boringssl_crypto)
@@ -168,12 +172,16 @@ if (WIN32)
   target_link_libraries(vmlib PRIVATE ntdll)
 endif()
 
-set_version_info (vmlib)
-install (TARGETS vmlib LIBRARY DESTINATION lib)
+set (WAMR_PUBLIC_HEADERS
+  ${WAMR_ROOT_DIR}/core/iwasm/include/wasm_c_api.h
+  ${WAMR_ROOT_DIR}/core/iwasm/include/wasm_export.h
+  ${WAMR_ROOT_DIR}/core/iwasm/include/lib_export.h
+)
+set_target_properties (vmlib PROPERTIES PUBLIC_HEADER "${WAMR_PUBLIC_HEADERS}")
 
-# HEADERS
-install (FILES
-    ${WAMR_ROOT_DIR}/core/iwasm/include/wasm_c_api.h
-    ${WAMR_ROOT_DIR}/core/iwasm/include/wasm_export.h
-    ${WAMR_ROOT_DIR}/core/iwasm/include/lib_export.h
-    DESTINATION include)
+set_version_info (vmlib)
+
+install (TARGETS vmlib
+  LIBRARY DESTINATION lib
+  PUBLIC_HEADER DESTINATION include/iwasm
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,5 +176,4 @@ install (FILES
     ${WAMR_ROOT_DIR}/core/iwasm/include/wasm_c_api.h
     ${WAMR_ROOT_DIR}/core/iwasm/include/wasm_export.h
     ${WAMR_ROOT_DIR}/core/iwasm/include/lib_export.h
-    ${WAMR_ROOT_DIR}/core/version.h
     DESTINATION include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,9 @@ set_target_properties (vmlib PROPERTIES PUBLIC_HEADER "${WAMR_PUBLIC_HEADERS}")
 set_version_info (vmlib)
 
 install (TARGETS vmlib
+  EXPORT iwasmTargets
   LIBRARY DESTINATION lib
   PUBLIC_HEADER DESTINATION include/iwasm
 )
+
+install_iwasm_package ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 cmake_minimum_required (VERSION 3.0)
 
+option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
+
 if(ESP_PLATFORM)
   include (${COMPONENT_DIR}/build-scripts/esp-idf/wamr/CMakeLists.txt)
   return()
@@ -16,13 +18,6 @@ set (CMAKE_VERBOSE_MAKEFILE OFF)
 
 if (NOT DEFINED WAMR_BUILD_PLATFORM)
   string (TOLOWER ${CMAKE_HOST_SYSTEM_NAME} WAMR_BUILD_PLATFORM)
-endif ()
-
-if (NOT DEFINED WAMR_BUILD_STATIC)
-  set (WAMR_BUILD_STATIC 1)
-endif ()
-if (NOT DEFINED WAMR_BUILD_SHARED)
-  set (WAMR_BUILD_SHARED 1)
 endif ()
 
 # Reset default linker flags
@@ -156,50 +151,25 @@ if (MSVC)
   add_definitions(-DCOMPILING_WASM_RUNTIME_API=1)
 endif ()
 
-# STATIC LIBRARY
-if (WAMR_BUILD_STATIC)
-    add_library(iwasm_static STATIC ${WAMR_RUNTIME_LIB_SOURCE})
-    set_target_properties (iwasm_static PROPERTIES OUTPUT_NAME vmlib)
-    target_include_directories(iwasm_static INTERFACE ${WAMR_ROOT_DIR}/core/iwasm/include)
-    target_link_libraries (iwasm_static INTERFACE ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl ${CMAKE_THREAD_LIBS_INIT})
-    if (WAMR_BUILD_WASM_CACHE EQUAL 1)
-      target_link_libraries(iwasm_static INTERFACE boringssl_crypto)
-    endif ()
-
-    if (MINGW)
-      target_link_libraries (iwasm_static PRIVATE ws2_32)
-    endif ()
-
-    if (WIN32)
-      target_link_libraries(iwasm_static PRIVATE ntdll)
-    endif()
-
-    set_version_info (iwasm_static)
-    install (TARGETS iwasm_static ARCHIVE DESTINATION lib)
+add_library (vmlib ${WAMR_RUNTIME_LIB_SOURCE})
+set_target_properties (vmlib PROPERTIES OUTPUT_NAME iwasm)
+target_include_directories(vmlib INTERFACE ${WAMR_ROOT_DIR}/core/iwasm/include)
+target_link_libraries (vmlib PUBLIC ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl ${CMAKE_THREAD_LIBS_INIT})
+if (WAMR_BUILD_WASM_CACHE EQUAL 1)
+  target_link_libraries(vmlib INTERFACE boringssl_crypto)
 endif ()
 
-# SHARED LIBRARY
-if (WAMR_BUILD_SHARED)
-    add_library (iwasm_shared SHARED ${WAMR_RUNTIME_LIB_SOURCE})
-    set_target_properties (iwasm_shared PROPERTIES OUTPUT_NAME iwasm)
-    target_include_directories(iwasm_shared INTERFACE ${WAMR_ROOT_DIR}/core/iwasm/include)
-    target_link_libraries (iwasm_shared PUBLIC ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl ${CMAKE_THREAD_LIBS_INIT})
-    if (WAMR_BUILD_WASM_CACHE EQUAL 1)
-      target_link_libraries(iwasm_shared INTERFACE boringssl_crypto)
-    endif ()
-
-    if (MINGW)
-      target_link_libraries(iwasm_shared INTERFACE -lWs2_32 -lwsock32)
-      target_link_libraries(iwasm_shared PRIVATE ws2_32)
-    endif ()
-
-    if (WIN32)
-      target_link_libraries(iwasm_shared PRIVATE ntdll)
-    endif()
-
-    set_version_info (iwasm_shared)
-    install (TARGETS iwasm_shared LIBRARY DESTINATION lib)
+if (MINGW)
+  target_link_libraries(vmlib INTERFACE -lWs2_32 -lwsock32)
+  target_link_libraries(vmlib PRIVATE ws2_32)
 endif ()
+
+if (WIN32)
+  target_link_libraries(vmlib PRIVATE ntdll)
+endif()
+
+set_version_info (vmlib)
+install (TARGETS vmlib LIBRARY DESTINATION lib)
 
 # HEADERS
 install (FILES

--- a/build-scripts/config_common.cmake
+++ b/build-scripts/config_common.cmake
@@ -214,6 +214,7 @@ endif ()
 
 message ("-- Build Configurations:")
 message ("     Build as target ${WAMR_BUILD_TARGET}")
+message ("     Build for platform ${WAMR_BUILD_PLATFORM}")
 message ("     CMAKE_BUILD_TYPE " ${CMAKE_BUILD_TYPE})
 message ("     BUILD_SHARED_LIBS " ${BUILD_SHARED_LIBS})
 ################## running mode ##################

--- a/build-scripts/config_common.cmake
+++ b/build-scripts/config_common.cmake
@@ -134,6 +134,9 @@ endif ()
 # Version
 include (${WAMR_ROOT_DIR}/build-scripts/version.cmake)
 
+# Package
+include (${WAMR_ROOT_DIR}/build-scripts/package.cmake)
+
 # Sanitizers
 
 if (NOT DEFINED WAMR_BUILD_SANITIZER)

--- a/build-scripts/config_common.cmake
+++ b/build-scripts/config_common.cmake
@@ -212,6 +212,7 @@ endif ()
 message ("-- Build Configurations:")
 message ("     Build as target ${WAMR_BUILD_TARGET}")
 message ("     CMAKE_BUILD_TYPE " ${CMAKE_BUILD_TYPE})
+message ("     BUILD_SHARED_LIBS " ${BUILD_SHARED_LIBS})
 ################## running mode ##################
 if (WAMR_BUILD_INTERP EQUAL 1)
   message ("     WAMR Interpreter enabled")

--- a/build-scripts/iwasmConfig.cmake.in
+++ b/build-scripts/iwasmConfig.cmake.in
@@ -1,0 +1,6 @@
+# Copyright (C) 2019 Intel Corporation.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/iwasmTargets.cmake")

--- a/build-scripts/package.cmake
+++ b/build-scripts/package.cmake
@@ -1,0 +1,28 @@
+# Copyright (C) 2019 Intel Corporation.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+function(install_iwasm_package)
+    install (EXPORT iwasmTargets
+        FILE iwasmTargets.cmake
+        NAMESPACE iwasm::
+        DESTINATION lib/cmake/iwasm
+    )
+
+    include (CMakePackageConfigHelpers)
+    configure_package_config_file (${CMAKE_CURRENT_FUNCTION_LIST_DIR}/iwasmConfig.cmake.in
+        "${CMAKE_CURRENT_BINARY_DIR}/iwasmConfig.cmake"
+        INSTALL_DESTINATION lib/cmake/iwasm
+    )
+
+    write_basic_package_version_file(
+        "${CMAKE_CURRENT_BINARY_DIR}/iwasmConfigVersion.cmake"
+        VERSION ${WAMR_VERSION_MAJOR}.${WAMR_VERSION_MINOR}.${WAMR_VERSION_PATCH}
+        COMPATIBILITY SameMajorVersion
+    )
+
+    install (FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/iwasmConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/iwasmConfigVersion.cmake"
+        DESTINATION lib/cmake/iwasm
+    )
+endfunction()

--- a/product-mini/platforms/darwin/CMakeLists.txt
+++ b/product-mini/platforms/darwin/CMakeLists.txt
@@ -1,9 +1,11 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required (VERSION 2.9)
+cmake_minimum_required (VERSION 3.14)
 
 project (iwasm)
+
+option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
 
 set (WAMR_BUILD_PLATFORM "darwin")
 
@@ -115,9 +117,6 @@ set (CMAKE_MACOSX_RPATH True)
 set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 
 include (${WAMR_ROOT_DIR}/build-scripts/runtime_lib.cmake)
-add_library(vmlib ${WAMR_RUNTIME_LIB_SOURCE})
-set_version_info (vmlib)
-
 include (${SHARED_DIR}/utils/uncommon/shared_uncommon.cmake)
 
 add_executable (iwasm main.c ${UNCOMMON_SHARED_SOURCE})
@@ -126,15 +125,33 @@ set_version_info (iwasm)
 
 install (TARGETS iwasm DESTINATION bin)
 
-target_link_libraries (iwasm vmlib ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl -lpthread)
+target_link_libraries (iwasm vmlib)
 
-add_library (libiwasm SHARED ${WAMR_RUNTIME_LIB_SOURCE})
+add_library (vmlib ${WAMR_RUNTIME_LIB_SOURCE})
 
-install (TARGETS libiwasm DESTINATION lib)
+set_version_info (vmlib)
 
-set_target_properties (libiwasm PROPERTIES OUTPUT_NAME iwasm)
+target_include_directories(vmlib INTERFACE
+  $<INSTALL_INTERFACE:include/iwasm>
+)
 
-set_version_info (libiwasm)
+set (WAMR_PUBLIC_HEADERS
+  ${WAMR_ROOT_DIR}/core/iwasm/include/wasm_c_api.h
+  ${WAMR_ROOT_DIR}/core/iwasm/include/wasm_export.h
+  ${WAMR_ROOT_DIR}/core/iwasm/include/lib_export.h
+)
 
-target_link_libraries (libiwasm ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl -lpthread)
+set_target_properties (vmlib PROPERTIES
+  OUTPUT_NAME iwasm
+  PUBLIC_HEADER "${WAMR_PUBLIC_HEADERS}"
+)
 
+target_link_libraries (vmlib ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl -lpthread)
+
+install (TARGETS vmlib
+  EXPORT iwasmTargets
+  DESTINATION lib
+  PUBLIC_HEADER DESTINATION include/iwasm
+)
+
+install_iwasm_package ()

--- a/product-mini/platforms/linux/CMakeLists.txt
+++ b/product-mini/platforms/linux/CMakeLists.txt
@@ -192,9 +192,12 @@ set_target_properties (vmlib PROPERTIES
   POSITION_INDEPENDENT_CODE ON
 )
 
+target_link_libraries (vmlib ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl -lpthread)
+
 install (TARGETS vmlib
+  EXPORT iwasmTargets
   DESTINATION lib
   PUBLIC_HEADER DESTINATION include/iwasm
 )
 
-target_link_libraries (vmlib ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl -lpthread)
+install_iwasm_package ()

--- a/product-mini/platforms/linux/CMakeLists.txt
+++ b/product-mini/platforms/linux/CMakeLists.txt
@@ -7,6 +7,8 @@ include(CheckPIESupported)
 
 project (iwasm)
 
+option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
+
 set (CMAKE_VERBOSE_MAKEFILE OFF)
 
 set (WAMR_BUILD_PLATFORM "linux")
@@ -126,13 +128,7 @@ endif ()
 # if enable wasi-nn, both wasi-nn-backends and iwasm
 # need to use same WAMR (dynamic) libraries
 if (WAMR_BUILD_WASI_NN EQUAL 1)
-  set (WAMR_BUILD_SHARED 1)
-endif ()
-
-if (NOT DEFINED WAMR_BUILD_SHARED)
-  set (WAMR_BUILD_SHARED 0)
-elseif (WAMR_BUILD_SHARED EQUAL 1)
-  message ("build WAMR as shared libraries")
+  set (BUILD_SHARED_LIBS ON)
 endif ()
 
 set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
@@ -140,9 +136,6 @@ set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 include (${WAMR_ROOT_DIR}/build-scripts/runtime_lib.cmake)
 
 check_pie_supported()
-add_library(vmlib ${WAMR_RUNTIME_LIB_SOURCE})
-set_target_properties (vmlib PROPERTIES POSITION_INDEPENDENT_CODE ON)
-set_version_info (vmlib)
 
 set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
 
@@ -175,23 +168,19 @@ set_version_info (iwasm)
 
 set_target_properties (iwasm PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-target_link_libraries(iwasm
-  $<$<BOOL:${WAMR_BUILD_SHARED}>:libiwasm> $<$<NOT:$<BOOL:${WAMR_BUILD_SHARED}>>:vmlib>
-  ${LLVM_AVAILABLE_LIBS}
-  ${UV_A_LIBS}
-  -lm
-  -ldl
-  -lpthread
-)
+target_link_libraries(iwasm vmlib)
 
 install (TARGETS iwasm DESTINATION bin)
 
-add_library (libiwasm SHARED ${WAMR_RUNTIME_LIB_SOURCE})
+add_library (vmlib ${WAMR_RUNTIME_LIB_SOURCE})
 
-set_version_info (libiwasm)
+set_version_info (vmlib)
 
-install (TARGETS libiwasm DESTINATION lib)
+set_target_properties (vmlib PROPERTIES
+  OUTPUT_NAME iwasm
+  POSITION_INDEPENDENT_CODE ON
+)
 
-set_target_properties (libiwasm PROPERTIES OUTPUT_NAME iwasm)
+install (TARGETS vmlib DESTINATION lib)
 
-target_link_libraries (libiwasm ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl -lpthread)
+target_link_libraries (vmlib ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl -lpthread)

--- a/product-mini/platforms/linux/CMakeLists.txt
+++ b/product-mini/platforms/linux/CMakeLists.txt
@@ -176,11 +176,25 @@ add_library (vmlib ${WAMR_RUNTIME_LIB_SOURCE})
 
 set_version_info (vmlib)
 
+target_include_directories(vmlib INTERFACE
+  $<INSTALL_INTERFACE:include/iwasm>
+)
+
+set (WAMR_PUBLIC_HEADERS
+  ${WAMR_ROOT_DIR}/core/iwasm/include/wasm_c_api.h
+  ${WAMR_ROOT_DIR}/core/iwasm/include/wasm_export.h
+  ${WAMR_ROOT_DIR}/core/iwasm/include/lib_export.h
+)
+
 set_target_properties (vmlib PROPERTIES
   OUTPUT_NAME iwasm
+  PUBLIC_HEADER "${WAMR_PUBLIC_HEADERS}"
   POSITION_INDEPENDENT_CODE ON
 )
 
-install (TARGETS vmlib DESTINATION lib)
+install (TARGETS vmlib
+  DESTINATION lib
+  PUBLIC_HEADER DESTINATION include/iwasm
+)
 
 target_link_libraries (vmlib ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl -lpthread)

--- a/product-mini/platforms/windows/CMakeLists.txt
+++ b/product-mini/platforms/windows/CMakeLists.txt
@@ -6,6 +6,8 @@ cmake_minimum_required (VERSION 2.9)
 project (iwasm C ASM CXX)
 # set (CMAKE_VERBOSE_MAKEFILE 1)
 
+option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
+
 set (WAMR_BUILD_PLATFORM "windows")
 
 # Reset default linker flags
@@ -105,8 +107,6 @@ endif()
 set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 
 include (${WAMR_ROOT_DIR}/build-scripts/runtime_lib.cmake)
-add_library(vmlib ${WAMR_RUNTIME_LIB_SOURCE})
-set_version_info(vmlib)
 
 #set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWIN32_LEAN_AND_MEAN")
 if (NOT MINGW)
@@ -139,28 +139,40 @@ set_version_info (iwasm)
 
 install (TARGETS iwasm DESTINATION bin)
 
-target_link_libraries (iwasm vmlib ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS})
+target_link_libraries (iwasm vmlib)
 
+add_library (vmlib ${WAMR_RUNTIME_LIB_SOURCE})
+set_version_info (vmlib)
+
+target_include_directories(vmlib INTERFACE
+  $<INSTALL_INTERFACE:include/iwasm>
+)
+
+set (WAMR_PUBLIC_HEADERS
+  ${WAMR_ROOT_DIR}/core/iwasm/include/wasm_c_api.h
+  ${WAMR_ROOT_DIR}/core/iwasm/include/wasm_export.h
+  ${WAMR_ROOT_DIR}/core/iwasm/include/lib_export.h
+)
+
+set_target_properties (vmlib PROPERTIES
+  OUTPUT_NAME libiwasm
+  PUBLIC_HEADER "${WAMR_PUBLIC_HEADERS}"
+  POSITION_INDEPENDENT_CODE ON
+)
+
+target_link_libraries (vmlib ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS})
 if (MINGW)
-  target_link_libraries (iwasm ws2_32)
-endif ()
-
-add_library (libiwasm SHARED ${WAMR_RUNTIME_LIB_SOURCE})
-
-set_version_info (libiwasm)
-
-install (TARGETS libiwasm DESTINATION lib)
-
-set_target_properties (libiwasm PROPERTIES OUTPUT_NAME libiwasm)
-
-target_link_libraries (libiwasm ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS})
-
-if (MINGW)
-  target_link_libraries (libiwasm ws2_32)
+  target_link_libraries (vmlib ws2_32)
 endif ()
 
 if (WIN32)
-  target_link_libraries(libiwasm ntdll)
-
-  target_link_libraries(iwasm ntdll)  
+  target_link_libraries(vmlib ntdll)
 endif()
+
+install (TARGETS vmlib
+  EXPORT iwasmTargets
+  DESTINATION lib
+  PUBLIC_HEADER DESTINATION include/iwasm
+)
+
+install_iwasm_package ()

--- a/product-mini/platforms/windows/CMakeLists.txt
+++ b/product-mini/platforms/windows/CMakeLists.txt
@@ -133,7 +133,7 @@ endif ()
 
 include (${SHARED_DIR}/utils/uncommon/shared_uncommon.cmake)
 
-add_executable (iwasm main.c ${UNCOMMON_SHARED_SOURCE})
+add_executable (iwasm main.c ${PLATFORM_SHARED_SOURCE} ${UNCOMMON_SHARED_SOURCE} ${UTILS_SHARED_SOURCE})
 
 set_version_info (iwasm)
 


### PR DESCRIPTION
#### Summary
This pull request introduces several improvements to the CMake configuration for the product-mini project on Linux. These changes simplify and standardize the packaging of the iwasm binary and library.

#### Changes

1. Use of the standard BUILD_SHARED_LIBS variable
   - Simplifies the CMake configuration by using the standard BUILD_SHARED_LIBS variable.
   - Allows the use of a single library definition for both static and shared library cases.
2. Installation of public header files
   - Installs the public header files for the vmlib target to the include/iwasm directory.
   - Ensures that the vmlib target includes the appropriate directories for installation.
3. Installation of the CMake package

   - Adds the necessary CMake configuration files (iwasmConfig.cmake and iwasmConfigVersion.cmake) for the product-mini project.
   - Configures the installation of these files to the appropriate directory (lib/cmake/iwasm).
   - Ensures compatibility with the same major version.