### PR TITLE
Add a conditional check for the macro __STDC_VERSION__

### DIFF
--- a/core/iwasm/include/wasm_c_api.h
+++ b/core/iwasm/include/wasm_c_api.h
@@ -46,7 +46,7 @@ extern "C" {
 // Auxiliaries
 
 // Machine types
-#if (__STDC_VERSION__) > 199901L
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__) > 199901L
 inline void assertions(void) {
   static_assert(sizeof(float) == sizeof(uint32_t), "incompatible float type");
   static_assert(sizeof(double) == sizeof(uint64_t), "incompatible double type");

--- a/core/shared/utils/bh_assert.h
+++ b/core/shared/utils/bh_assert.h
@@ -26,7 +26,7 @@ bh_assert_internal(int64 v, const char *file_name, int line_number,
 #define __has_extension(a) 0
 #endif
 
-#if __STDC_VERSION__ >= 201112L                                          \
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L)           \
     || (defined(__GNUC__) && __GNUC__ * 0x100 + __GNUC_MINOR__ >= 0x406) \
     || __has_extension(c_static_assert)
 


### PR DESCRIPTION
In some cases, if __cplusplus is defined, it may cause the warning "__STDC_VERSION__" not defined, it's better to check whether the macro __STDC_VERSION__  is defined firstly.