### PR TITLE
fix: when load aot init expr,no type_idx set.

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -1251,6 +1251,7 @@ load_init_expr(const uint8 **p_buf, const uint8 *buf_end, AOTModule *module,
             }
             free_if_fail = true;
             init_values->count = field_count;
+            init_values->type_idx = type_idx;
             expr->u.data = init_values;
 
             if (type_idx >= module->type_count) {


### PR DESCRIPTION
     This is case error when run aot ,the type is default 0

     error at File gc_object.c line 91
     bh_assert(rtt_type->type_flag == WASM_TYPE_STRUCT;