### PR TITLE
fix(aot_emit_aot_file): prevent buffer emission for zero byte_count

### DIFF
--- a/core/iwasm/compilation/aot_emit_aot_file.c
+++ b/core/iwasm/compilation/aot_emit_aot_file.c
@@ -1790,7 +1790,9 @@ aot_emit_mem_info(uint8 *buf, uint8 *buf_end, uint32 *p_offset,
                                 &init_datas[i]->offset))
             return false;
         EMIT_U32(init_datas[i]->byte_count);
-        EMIT_BUF(init_datas[i]->bytes, init_datas[i]->byte_count);
+        if (init_datas[i]->byte_count) {
+            EMIT_BUF(init_datas[i]->bytes, init_datas[i]->byte_count);
+        }
     }
 
     if (offset - *p_offset != get_mem_info_size(comp_ctx, comp_data)) {


### PR DESCRIPTION
if using a debug building of wamrc to run spec test. there will be: core/iwasm/compilation/aot_emit_aot_file.c:1794:13: runtime error: null pointer passed as argument 2, which is declared to never be null

```wat
(module binary
  "\00asm" "\01\00\00\00"
  "\05\03\01"                          ;; Memory section with 1 entry
  "\00\00"                             ;; no max, minimum 0
  "\0b\07\01"                          ;; Data section with 1 entry
  "\80\00"                             ;; Memory index 0, encoded with 2 bytes
  "\41\00\0b\00"                       ;; (i32.const 0) with contents ""
)
```