### PR TITLE
feat: add wasm_memory_get_init_page_count()

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -53,7 +53,7 @@ bh_static_assert(offsetof(AOTModuleInstance, c_api_func_imports)
 bh_static_assert(offsetof(AOTModuleInstance, global_table_data)
                  == 13 * sizeof(uint64) + 128 + 14 * sizeof(uint64));
 
-bh_static_assert(sizeof(AOTMemoryInstance) == 120);
+bh_static_assert(sizeof(AOTMemoryInstance) == 128);
 bh_static_assert(offsetof(AOTTableInstance, elems) == 24);
 
 bh_static_assert(offsetof(AOTModuleInstanceExtra, stack_sizes) == 0);
@@ -1016,6 +1016,7 @@ memory_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
 
     memory_inst->module_type = Wasm_Module_AoT;
     memory_inst->num_bytes_per_page = num_bytes_per_page;
+    memory_inst->init_page_count = init_page_count;
     memory_inst->cur_page_count = init_page_count;
     memory_inst->max_page_count = max_page_count;
     memory_inst->memory_data_size = memory_data_size;

--- a/core/iwasm/common/wasm_memory.c
+++ b/core/iwasm/common/wasm_memory.c
@@ -1586,6 +1586,12 @@ wasm_runtime_get_default_memory(WASMModuleInstanceCommon *module_inst)
     return NULL;
 }
 
+uint64
+wasm_memory_get_init_page_count(WASMMemoryInstance *memory)
+{
+    return memory->init_page_count;
+}
+
 WASMMemoryInstance *
 wasm_runtime_get_memory(WASMModuleInstanceCommon *module_inst, uint32 index)
 {

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -997,6 +997,16 @@ WASM_RUNTIME_API_EXTERN wasm_memory_inst_t
 wasm_runtime_get_memory(const wasm_module_inst_t module_inst, uint32_t index);
 
 /**
+ * @brief Get the init number of pages for a memory instance
+ *
+ * @param memory_inst The memory instance
+ *
+ * @return The init number of pages
+ */
+WASM_RUNTIME_API_EXTERN uint64_t
+wasm_memory_get_init_page_count(const wasm_memory_inst_t memory_inst);
+
+/**
  * @brief Get the current number of pages for a memory instance
  *
  * @param memory_inst The memory instance

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -445,6 +445,7 @@ memory_instantiate(WASMModuleInstance *module_inst, WASMModuleInstance *parent,
 
     memory->module_type = Wasm_Module_Bytecode;
     memory->num_bytes_per_page = num_bytes_per_page;
+    memory->init_page_count = init_page_count;
     memory->cur_page_count = init_page_count;
     memory->max_page_count = max_page_count;
     memory->memory_data_size = memory_data_size;

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -121,6 +121,8 @@ struct WASMMemoryInstance {
 
     /* Number bytes per page */
     uint32 num_bytes_per_page;
+    /* Init page count */
+    uint32 init_page_count;
     /* Current page count */
     uint32 cur_page_count;
     /* Maximum page count */


### PR DESCRIPTION
This API provides access to the initial memory size, as a supplement to #3786.