### PR TITLE
[AOT] Memory Info Restore Mechanism with Better Performance

### DIFF
--- a/core/iwasm/compilation/aot_compiler.c
+++ b/core/iwasm/compilation/aot_compiler.c
@@ -999,6 +999,7 @@ static bool
 aot_compile_func(AOTCompContext *comp_ctx, uint32 func_index)
 {
     AOTFuncContext *func_ctx = comp_ctx->func_ctxes[func_index];
+    WASMModule *module = comp_ctx->comp_data->wasm_module;
     LLVMValueRef func_index_ref;
     uint8 *frame_ip = func_ctx->aot_func->code, opcode, *p_f32, *p_f64;
     uint8 *frame_ip_end = frame_ip + func_ctx->aot_func->code_size;
@@ -1230,6 +1231,8 @@ aot_compile_func(AOTCompContext *comp_ctx, uint32 func_index)
                 read_leb_uint32(frame_ip, frame_ip_end, func_idx);
                 if (!aot_compile_op_call(comp_ctx, func_ctx, func_idx, false))
                     return false;
+                if (module->functions[func_index]->has_memory_operations)
+                    restore_memory_info(comp_ctx, func_ctx);
                 break;
             }
 
@@ -1250,6 +1253,8 @@ aot_compile_func(AOTCompContext *comp_ctx, uint32 func_index)
                 if (!aot_compile_op_call_indirect(comp_ctx, func_ctx, type_idx,
                                                   tbl_idx))
                     return false;
+                if (module->functions[func_index]->has_memory_operations)
+                    restore_memory_info(comp_ctx, func_ctx);
                 break;
             }
 
@@ -1420,6 +1425,8 @@ aot_compile_func(AOTCompContext *comp_ctx, uint32 func_index)
                 if (!aot_compile_op_call_ref(comp_ctx, func_ctx, type_idx,
                                              false))
                     return false;
+                if (module->functions[func_index]->has_memory_operations)
+                    restore_memory_info(comp_ctx, func_ctx);
                 break;
             }
 
@@ -2092,6 +2099,8 @@ aot_compile_func(AOTCompContext *comp_ctx, uint32 func_index)
                 read_leb_uint32(frame_ip, frame_ip_end, mem_idx);
                 if (!aot_compile_op_memory_grow(comp_ctx, func_ctx))
                     return false;
+                if (module->functions[func_index]->has_memory_operations)
+                    restore_memory_info(comp_ctx, func_ctx);
                 break;
 
             case WASM_OP_I32_CONST:

--- a/core/iwasm/compilation/aot_llvm.h
+++ b/core/iwasm/compilation/aot_llvm.h
@@ -215,13 +215,21 @@ typedef struct AOTCheckedAddr {
 
 typedef struct AOTMemInfo {
     LLVMValueRef mem_base_addr;
+    LLVMValueRef mem_base_addr_addr;
+    LLVMValueRef mem_data_size;
     LLVMValueRef mem_data_size_addr;
+    LLVMValueRef mem_cur_page_count;
     LLVMValueRef mem_cur_page_count_addr;
     LLVMValueRef mem_bound_check_1byte;
+    LLVMValueRef mem_bound_check_1byte_addr;
     LLVMValueRef mem_bound_check_2bytes;
+    LLVMValueRef mem_bound_check_2bytes_addr;
     LLVMValueRef mem_bound_check_4bytes;
+    LLVMValueRef mem_bound_check_4bytes_addr;
     LLVMValueRef mem_bound_check_8bytes;
+    LLVMValueRef mem_bound_check_8bytes_addr;
     LLVMValueRef mem_bound_check_16bytes;
+    LLVMValueRef mem_bound_check_16bytes_addr;
 } AOTMemInfo;
 
 typedef struct AOTFuncContext {
@@ -251,7 +259,6 @@ typedef struct AOTFuncContext {
     LLVMValueRef wasm_stack_top_bound;
     LLVMValueRef wasm_stack_top_ptr;
 
-    bool mem_space_unchanged;
     AOTCheckedAddrList checked_addr_list;
 
     LLVMValueRef shared_heap_base_addr_adj;
@@ -652,6 +659,9 @@ aot_target_precheck_can_use_musttail(const AOTCompContext *comp_ctx);
 unsigned int
 aot_estimate_stack_usage_for_function_call(const AOTCompContext *comp_ctx,
                                            const AOTFuncType *callee_func_type);
+
+bool
+restore_memory_info(const AOTCompContext *comp_ctx, AOTFuncContext *func_ctx);
 
 #ifdef __cplusplus
 } /* end of extern "C" */


### PR DESCRIPTION
I found that my program runs slower in WAMR AOT mode compared to other WASM runtimes, e.g., WAVM. I compared their LLVM IRs and found that WAMR emits more load operations of memory base.

In WAMR, functions with `mem_space_unchanged` keep memory base address in `mem_base_addr` of `AOTMemInfo`, while others keep **the address of** memory base address in that field. When emit instructions like load/store, the former use the base address directly, while the later should load base address from its address at first. This reload is redundant when there is no possibility of changing memory between two consecutive load/store instructions:
```llvm ir
%mem_base0 = load ptr, ptr %mem_base_addr_offset, align 8 ; reload
; load/store on %mem_base0
%mem_base1 = load ptr, ptr %mem_base_addr_offset, align 8 ; redundant reload
; load/store on %mem_base1
```

Optimization passes won’t recognize this redundancy because the reloaded memory base is accessed within the context.

In WAVM, the base address is reloaded when the memory possibly changes, e.g., after calling another function or after `memory.grow`. This can be redundant if there are no subsequent load/store instructions, but the dead code elimination pass handles this：
```llvm ir
%mem_base0 = load ptr, ptr %mem_base_addr_offset, align 8 ; reload
; load/store on %mem_base0
; emit memory.grow
%mem_base1 = load ptr, ptr %mem_base_addr_offset, align 8 ; reload
; load/store on %mem_base1
```

## Performance

Here is a sample C++ program `substr.cc`:

```C++
#include <string>
extern "C" void TestPerformance(const std::string& s) {
    s.substr(5);
}

int main() {
    for (int i = 0; i < 10007989; i++) {
        TestPerformance("Hello World");
    }
    return 0;
}
```

Compiled with emcc (version: `3.1.59 (0e4c5994eb5b8defd38367a416d0703fd506ad81)`)

```
emcc -O3 -g2 -s EXPORTED_FUNCTIONS='["_TestPerformance"]' ./substr.cc -o substr.wasm
```

Then ran wamrc and iwasm(linux) and compared the performance:

product-mini/platforms/posix/main.c:
```c
#include <time.h>
static const void *
app_instance_main(wasm_module_inst_t module_inst)
{
    const char *exception;
    struct timespec s, e;
    clock_gettime(CLOCK_MONOTONIC, &s);
    wasm_application_execute_main(module_inst, app_argc, app_argv);
    clock_gettime(CLOCK_MONOTONIC, &e);
    printf("cost: %ld us", e.tv_sec * 1000000 + e.tv_nsec / 1000 - s.tv_sec * 1000000 - s.tv_nsec / 1000);
    exception = wasm_runtime_get_exception(module_inst);
    return exception;
}
```

### result:

commit e3dcf4f8acfe58a04d54319bef5fc3728bd612bf
```
cost: 349913 us
```

commit 3f268e5150ad2e592f02ac0d467452c38aaa6ae7
```
cost: 308787 us
```

IR(optimized) comparison:

![image](https://github.com/user-attachments/assets/654f339e-f308-4afe-9456-8365feac88e2)



