### PR TITLE
Fix loading AOT on aarch64

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -587,7 +587,8 @@ load_target_info_section(const uint8 *buf, const uint8 *buf_end,
     }
 
     /* for backwards compatibility with previous wamrc aot files */
-    if (!strcmp(target_info.arch, "arm64"))
+    if (!strcmp(target_info.arch, "arm64")
+        || !strcmp(target_info.arch, "aarch64"))
         bh_strcpy_s(target_info.arch, sizeof(target_info.arch), "aarch64v8");
 
     /* Check machine info */

--- a/core/iwasm/aot/arch/aot_reloc_aarch64.c
+++ b/core/iwasm/aot/arch/aot_reloc_aarch64.c
@@ -63,7 +63,7 @@ get_current_target(char *target_buf, uint32 target_buf_size)
     /* Set to "aarch64v8" by default if sub version isn't specified */
     if (strcmp(s, "AARCH64") == 0) {
         s = "aarch64v8";
-        s_size = 9; /* strlen("aarch64v8"); */
+        s_size = 10; /* sizeof("aarch64v8"); */
     }
     if (target_buf_size < s_size) {
         s_size = target_buf_size;


### PR DESCRIPTION
My `target_info.arch` is "aarch64", but `check_machine_info()` compares it with "aarch64v".