### PR TITLE
Add wasm_runtime_get_func_name_from_index() api

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -1215,6 +1215,11 @@ void
 wasm_runtime_set_linux_perf(bool flag);
 #endif
 
+#if WASM_ENABLE_CUSTOM_NAME_SECTION != 0
+WASM_RUNTIME_API_EXTERN const char *
+wasm_runtime_get_func_name_from_index(WASMModuleCommon *module, uint32 func_index);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -2249,6 +2249,17 @@ WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_is_underlying_binary_freeable(const wasm_module_t module);
 
 /**
+ * Get function name from its index
+ *
+ * @param module the target module
+ * @param func_index the function's index
+ *
+ * @return the function name, NULL if failed
+ */
+WASM_RUNTIME_API_EXTERN const char *
+wasm_runtime_get_func_name_from_index(const wasm_module_t module, uint32 func_index);
+
+/**
  * Create a shared heap
  *
  * @param init_args the initialization arguments


### PR DESCRIPTION
WAMR already implements this function, but its scope is limited to the source file and only applies to the module instance. I reimplemented this because it is clearer to obtain function names in the following scenarios, where the (WASM/AOT) module has not yet been instantiated:

1. `aot_create_perf_map()` This creates /tmp/perf-<pid>.map for linux-perf.
2. `aot_add_llvm_func1()` By doing so, LLVM can include function names in the IR and machine code, allowing us to see them in the call stack when debugging AOT with LLDB/GDB. 

If this is useful, I would be happy to submit PRs for these two scenarios.
