### PR TITLE
Expose WAMR_BUILD_GC_HEAP_SIZE_DEFAULT as a CMake option

### DIFF
--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -392,8 +392,8 @@ wasm_engine_new_internal(wasm_config_t *config)
 
     WASM_C_DUMP_PROC_MEM();
 
-    /* wasm_config_t->MemAllocOption -> RuntimeInitArgs->MemAllocOption */
     init_args.gc_heap_size = GC_HEAP_SIZE_DEFAULT;
+    /* wasm_config_t->MemAllocOption -> RuntimeInitArgs->MemAllocOption */
     init_args.mem_alloc_type = config->mem_alloc_type;
     memcpy(&init_args.mem_alloc_option, &config->mem_alloc_option,
            sizeof(MemAllocOption));

--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -392,7 +392,6 @@ wasm_engine_new_internal(wasm_config_t *config)
 
     WASM_C_DUMP_PROC_MEM();
 
-    init_args.gc_heap_size = GC_HEAP_SIZE_DEFAULT;
     /* wasm_config_t->MemAllocOption -> RuntimeInitArgs->MemAllocOption */
     init_args.mem_alloc_type = config->mem_alloc_type;
     memcpy(&init_args.mem_alloc_option, &config->mem_alloc_option,

--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -393,6 +393,7 @@ wasm_engine_new_internal(wasm_config_t *config)
     WASM_C_DUMP_PROC_MEM();
 
     /* wasm_config_t->MemAllocOption -> RuntimeInitArgs->MemAllocOption */
+    init_args.gc_heap_size = GC_HEAP_SIZE_DEFAULT;
     init_args.mem_alloc_type = config->mem_alloc_type;
     memcpy(&init_args.mem_alloc_option, &config->mem_alloc_option,
            sizeof(MemAllocOption));

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -757,7 +757,10 @@ wasm_runtime_full_init_internal(RuntimeInitArgs *init_args)
 #endif
 
 #if WASM_ENABLE_GC != 0
-    gc_heap_size_default = init_args->gc_heap_size;
+    uint32 gc_heap_size = init_args->gc_heap_size;
+    if (gc_heap_size > 0) {
+        gc_heap_size_default = gc_heap_size;
+    }
 #endif
 
 #if WASM_ENABLE_JIT != 0

--- a/core/shared/mem-alloc/mem_alloc.cmake
+++ b/core/shared/mem-alloc/mem_alloc.cmake
@@ -24,6 +24,10 @@ if (WAMR_BUILD_GC_CORRUPTION_CHECK EQUAL 0)
     add_definitions (-DBH_ENABLE_GC_CORRUPTION_CHECK=0)
 endif ()
 
+if (DEFINED WAMR_BUILD_GC_HEAP_SIZE_DEFAULT)
+    add_definitions ("-DGC_HEAP_SIZE_DEFAULT=${WAMR_BUILD_GC_HEAP_SIZE_DEFAULT}")
+endif ()
+
 file (GLOB_RECURSE source_all
       ${MEM_ALLOC_DIR}/ems/*.c
       ${MEM_ALLOC_DIR}/tlsf/*.c

--- a/doc/build_wamr.md
+++ b/doc/build_wamr.md
@@ -141,6 +141,8 @@ cmake -DWAMR_BUILD_PLATFORM=linux -DWAMR_BUILD_TARGET=ARM
 
 ### **Enable Garbage Collection**
 - **WAMR_BUILD_GC**=1/0, default to disable if not set
+
+### **Set the Garbage Collection heap size**
 - **WAMR_BUILD_GC_HEAP_SIZE_DEFAULT**=n, default to 128 kB (131072) if not set
 
 ### **Configure Debug**

--- a/doc/build_wamr.md
+++ b/doc/build_wamr.md
@@ -141,6 +141,7 @@ cmake -DWAMR_BUILD_PLATFORM=linux -DWAMR_BUILD_TARGET=ARM
 
 ### **Enable Garbage Collection**
 - **WAMR_BUILD_GC**=1/0, default to disable if not set
+- **WAMR_BUILD_GC_HEAP_SIZE_DEFAULT**=n, default to 128 kB (131072) if not set
 
 ### **Configure Debug**
 


### PR DESCRIPTION
This is wired through to the GC_HEAP_SIZE_DEFAULT constant.

Also honor this value when configuring the engine with the wasm_c_api.