### PR TITLE
Don't fail to compile if feature macros aren't defined

### DIFF
--- a/product-mini/platforms/common/wasm_proposal.c
+++ b/product-mini/platforms/common/wasm_proposal.c
@@ -5,6 +5,8 @@
 
 #include <stdio.h>
 
+#include "bh_platform.h"
+
 void
 wasm_proposal_print_status(void)
 {


### PR DESCRIPTION
This makes the output assume the feature is not enabled if the macro is not defined at all, rather than just being set to zero.

I know of at least one build that does not use CMake and does not set the macro if the feature is not enabled.