### PR TITLE
Fix iwasm build error when WAMR_BUILD_WASI_NN enabled

### DIFF
--- a/core/iwasm/libraries/wasi-nn/cmake/wasi_nn.cmake
+++ b/core/iwasm/libraries/wasi-nn/cmake/wasi_nn.cmake
@@ -39,7 +39,7 @@ if(WAMR_BUILD_WASI_NN_TFLITE EQUAL 1)
   target_link_libraries(
     wasi_nn_tflite
     PUBLIC
-      libiwasm
+      vmlib
       tensorflow-lite
   )
 
@@ -71,7 +71,7 @@ if(WAMR_BUILD_WASI_NN_OPENVINO EQUAL 1)
   target_link_libraries(
     wasi_nn_openvino
     PUBLIC
-      libiwasm
+      vmlib
       openvino::runtime
       openvino::runtime::c
   )
@@ -100,7 +100,7 @@ if(WAMR_BUILD_WASI_NN_LLAMACPP EQUAL 1)
   target_link_libraries(
     wasi_nn_llamacpp
     PUBLIC
-      libiwasm
+      vmlib
       cjson
       common
       ggml


### PR DESCRIPTION
A recent change on ./product-mini/platforms/linux/CMakeLists.txt renamed libiwasm to vmlib, but wasi-nn.cmake still wants to link libiwasm.so. Replace libiwasm with vmlib in wasi-nn.cmake to resolve iwasm build error when WAMR_BUILD_WASI_NN enabled.