### PR TITLE
platform/nuttx: Flush icache/dcache properly

### DIFF
--- a/core/shared/platform/nuttx/nuttx_platform.c
+++ b/core/shared/platform/nuttx/nuttx_platform.c
@@ -10,6 +10,8 @@
 #include <nuttx/arch.h>
 #endif
 
+#include <nuttx/cache.h>
+
 int
 bh_platform_init()
 {
@@ -115,11 +117,14 @@ os_dcache_flush()
     && defined(CONFIG_ARCH_HAVE_TEXT_HEAP_SEPARATE_DATA_ADDRESS)
     up_textheap_data_sync();
 #endif
+    up_invalidate_dcache_all();
 }
 
 void
 os_icache_flush(void *start, size_t len)
-{}
+{
+    up_invalidate_icache((uintptr_t)start, (uintptr_t)start + len);
+}
 
 #if (WASM_MEM_DUAL_BUS_MIRROR != 0)
 void *


### PR DESCRIPTION

Enhance the os_dcache_flush and os_icache_flush functions to ensure proper cache invalidation, improving memory management efficiency.
* Added cache invalidation for data cache
* Implemented cache invalidation for instruction cache
