### PR TITLE
Update cmake min. requirement to 3.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.14)
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
 

--- a/build-scripts/esp-idf/README.md
+++ b/build-scripts/esp-idf/README.md
@@ -11,7 +11,7 @@ You can build an ESP-IDF project with wasm-micro-runtime as a component:
 - In the newly created project folder edit the `CMakeList.txt`:
 
   ```
-  cmake_minimum_required(VERSION 3.5)
+  cmake_minimum_required(VERSION 3.14)
 
   include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 

--- a/core/iwasm/libraries/lib-socket/lib_socket_wasi.cmake
+++ b/core/iwasm/libraries/lib-socket/lib_socket_wasi.cmake
@@ -1,7 +1,7 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required (VERSION 2.8...3.16)
+cmake_minimum_required (VERSION 3.14)
 
 project(socket_wasi_ext LANGUAGES C)
 

--- a/doc/build_wasm_app.md
+++ b/doc/build_wasm_app.md
@@ -275,7 +275,7 @@ You can cross compile your project by using the toolchain provided by WAMR.
 Assume the original `CMakeLists.txt` for `test.c` likes below:
 
 ``` cmake
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.14)
 project(hello_world)
 add_executable(hello_world test.c)
 ```

--- a/product-mini/app-samples/hello-world-cmake/CMakeLists.txt
+++ b/product-mini/app-samples/hello-world-cmake/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.14)
 project(hello_world)
 
 set (CMAKE_C_FLAGS          "${CMAKE_C_FLAGS} -O3 -Wno-unused-command-line-argument")

--- a/product-mini/platforms/esp-idf/CMakeLists.txt
+++ b/product-mini/platforms/esp-idf/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # from ESP-IDF 4.0 examples/build_system/cmake/idf_as_lib
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 

--- a/product-mini/platforms/freebsd/CMakeLists.txt
+++ b/product-mini/platforms/freebsd/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required (VERSION 2.9)
+cmake_minimum_required (VERSION 3.14)
 
 project (iwasm)
 

--- a/product-mini/platforms/linux-sgx/CMakeLists.txt
+++ b/product-mini/platforms/linux-sgx/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required (VERSION 2.9)
+cmake_minimum_required (VERSION 3.14)
 
 project (iwasm)
 

--- a/product-mini/platforms/linux-sgx/CMakeLists_minimal.txt
+++ b/product-mini/platforms/linux-sgx/CMakeLists_minimal.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required (VERSION 2.9)
+cmake_minimum_required (VERSION 3.14)
 
 project (iwasm)
 

--- a/product-mini/platforms/riot/CMakeLists.txt
+++ b/product-mini/platforms/riot/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (C) 2020 TU Bergakademie Freiberg Karl Fessel
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.14)
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
 

--- a/product-mini/platforms/vxworks/CMakeLists.txt
+++ b/product-mini/platforms/vxworks/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required (VERSION 2.9)
+cmake_minimum_required (VERSION 3.14)
 
 project (iwasm)
 

--- a/product-mini/platforms/windows/CMakeLists.txt
+++ b/product-mini/platforms/windows/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required (VERSION 2.9)
+cmake_minimum_required (VERSION 3.14)
 
 project (iwasm C ASM CXX)
 # set (CMAKE_VERBOSE_MAKEFILE 1)

--- a/product-mini/platforms/zephyr/simple/CMakeLists.txt
+++ b/product-mini/platforms/zephyr/simple/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.14)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(wamr)

--- a/product-mini/platforms/zephyr/user-mode/CMakeLists.txt
+++ b/product-mini/platforms/zephyr/user-mode/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.14)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(wamr_user_mode LANGUAGES C)

--- a/product-mini/platforms/zephyr/user-mode/lib-wamr-zephyr/CMakeLists.txt
+++ b/product-mini/platforms/zephyr/user-mode/lib-wamr-zephyr/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.14)
 
 set (WAMR_BUILD_PLATFORM "zephyr")
 

--- a/samples/bh-atomic/CMakeLists.txt
+++ b/samples/bh-atomic/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2023 Midokura Japan KK.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.14)
 project(bh_atomic)
 
 string (TOLOWER ${CMAKE_HOST_SYSTEM_NAME} WAMR_BUILD_PLATFORM)

--- a/samples/file/CMakeLists.txt
+++ b/samples/file/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2022 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.14)
 project(file)
 
 ################ wasm application ###############

--- a/samples/file/wasm-app/CMakeLists.txt
+++ b/samples/file/wasm-app/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2022 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.14)
 project(wasm-app)
 
 set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../..)

--- a/samples/mem-allocator/CMakeLists.txt
+++ b/samples/mem-allocator/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2023 Midokura Japan KK.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.14)
 project(mem_allocator_create)
 
 string (TOLOWER ${CMAKE_HOST_SYSTEM_NAME} WAMR_BUILD_PLATFORM)

--- a/samples/multi-module/wasm-apps/CMakeLists.txt
+++ b/samples/multi-module/wasm-apps/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required (VERSION 2.8...3.16)
+cmake_minimum_required (VERSION 3.14)
 project(wasm-apps)
 
 message(CHECK_START "Detecting WABT")

--- a/samples/native-lib/wasm-app/CMakeLists.txt
+++ b/samples/native-lib/wasm-app/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.14)
 project(wasm-app)
 
 set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../..)

--- a/samples/sgx-ra/CMakeLists.txt
+++ b/samples/sgx-ra/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2020-2021 Alibaba Cloud
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.1.4)
+cmake_minimum_required(VERSION 3.14)
 project(sgx-ra)
 
 ################ runtime settings  ##############

--- a/samples/sgx-ra/wasm-app/CMakeLists.txt
+++ b/samples/sgx-ra/wasm-app/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2020-2021 Alibaba Cloud
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.14)
 project(wasm-app)
 
 set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../..)

--- a/samples/socket-api/wasm-src/CMakeLists.txt
+++ b/samples/socket-api/wasm-src/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 2.8...3.18)
+cmake_minimum_required(VERSION 3.14)
 project(socket_api_sample_wasm_app)
 
 message(CHECK_START "Detecting WABT")

--- a/test-tools/binarydump-tool/CMakeLists.txt
+++ b/test-tools/binarydump-tool/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required (VERSION 2.9)
+cmake_minimum_required (VERSION 3.14)
 
 project(binarydump)
 

--- a/test-tools/wamr-ide/VSCode-Extension/resource/scripts/CMakeLists.txt
+++ b/test-tools/wamr-ide/VSCode-Extension/resource/scripts/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required (VERSION 2.9)
+cmake_minimum_required (VERSION 3.14)
 
 project(Main)
 


### PR DESCRIPTION
3.14 is used and tested by liinux mini-product

it is able to fix https://github.com/bytecodealliance/wasm-micro-runtime/actions/runs/14174679441/job/39706594675?pr=4171

```
CMake Error at CMakeLists.txt:4 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```