### PR TITLE
debug-engine: fix a few type mismatches

### DIFF
--- a/core/iwasm/libraries/debug-engine/debug_engine.c
+++ b/core/iwasm/libraries/debug-engine/debug_engine.c
@@ -58,7 +58,7 @@ static WASMDebugEngine *g_debug_engine;
 static uint32 current_instance_id = 1;
 
 static uint32
-allocate_instance_id()
+allocate_instance_id(void)
 {
     uint32 id;
 
@@ -302,7 +302,7 @@ wasm_debug_control_thread_destroy(WASMDebugInstance *debug_instance)
 }
 
 static WASMDebugEngine *
-wasm_debug_engine_create()
+wasm_debug_engine_create(void)
 {
     WASMDebugEngine *engine;
 
@@ -326,7 +326,7 @@ wasm_debug_engine_create()
 }
 
 void
-wasm_debug_engine_destroy()
+wasm_debug_engine_destroy(void)
 {
     if (g_debug_engine) {
         wasm_debug_handler_deinit();

--- a/core/iwasm/libraries/debug-engine/debug_engine.h
+++ b/core/iwasm/libraries/debug-engine/debug_engine.h
@@ -133,7 +133,7 @@ bool
 wasm_debug_engine_init(char *ip_addr, int32 process_port);
 
 void
-wasm_debug_engine_destroy();
+wasm_debug_engine_destroy(void);
 
 WASMExecEnv *
 wasm_debug_instance_get_current_env(WASMDebugInstance *instance);

--- a/core/iwasm/libraries/debug-engine/gdbserver.c
+++ b/core/iwasm/libraries/debug-engine/gdbserver.c
@@ -38,7 +38,7 @@ static const struct packet_handler_elem packet_handler_table[255] = {
 };
 
 WASMGDBServer *
-wasm_create_gdbserver(const char *host, int32 *port)
+wasm_create_gdbserver(const char *host, int *port)
 {
     bh_socket_t listen_fd = (bh_socket_t)-1;
     WASMGDBServer *server;

--- a/core/iwasm/libraries/debug-engine/gdbserver.h
+++ b/core/iwasm/libraries/debug-engine/gdbserver.h
@@ -51,7 +51,7 @@ typedef struct WASMGDBServer {
 } WASMGDBServer;
 
 WASMGDBServer *
-wasm_create_gdbserver(const char *host, int32 *port);
+wasm_create_gdbserver(const char *host, int *port);
 
 bool
 wasm_gdbserver_listen(WASMGDBServer *server);

--- a/core/iwasm/libraries/debug-engine/handler.c
+++ b/core/iwasm/libraries/debug-engine/handler.c
@@ -34,7 +34,7 @@ static char *tmpbuf;
 static korp_mutex tmpbuf_lock;
 
 int
-wasm_debug_handler_init()
+wasm_debug_handler_init(void)
 {
     int ret;
     tmpbuf = wasm_runtime_malloc(MAX_PACKET_SIZE);
@@ -51,7 +51,7 @@ wasm_debug_handler_init()
 }
 
 void
-wasm_debug_handler_deinit()
+wasm_debug_handler_deinit(void)
 {
     wasm_runtime_free(tmpbuf);
     tmpbuf = NULL;

--- a/core/iwasm/libraries/debug-engine/handler.c
+++ b/core/iwasm/libraries/debug-engine/handler.c
@@ -204,8 +204,7 @@ handle_general_query(WASMGDBServer *server, char *payload)
     if (!strcmp(name, "Supported")) {
         os_mutex_lock(&tmpbuf_lock);
         snprintf(tmpbuf, MAX_PACKET_SIZE,
-                 "qXfer:libraries:read+;PacketSize=%" PRIx32 ";",
-                 MAX_PACKET_SIZE);
+                 "qXfer:libraries:read+;PacketSize=%x;", MAX_PACKET_SIZE);
         write_packet(server, tmpbuf);
         os_mutex_unlock(&tmpbuf_lock);
     }
@@ -384,7 +383,7 @@ send_thread_stop_status(WASMGDBServer *server, uint32 status, korp_tid tid)
 
     if (status == 0) {
         os_mutex_lock(&tmpbuf_lock);
-        snprintf(tmpbuf, MAX_PACKET_SIZE, "W%02x", status);
+        snprintf(tmpbuf, MAX_PACKET_SIZE, "W%02" PRIx32, status);
         write_packet(server, tmpbuf);
         os_mutex_unlock(&tmpbuf_lock);
         return;
@@ -400,8 +399,9 @@ send_thread_stop_status(WASMGDBServer *server, uint32 status, korp_tid tid)
 
     os_mutex_lock(&tmpbuf_lock);
     // TODO: how name a wasm thread?
-    len += snprintf(tmpbuf, MAX_PACKET_SIZE, "T%02xthread:%" PRIx64 ";name:%s;",
-                    gdb_status, (uint64)(uintptr_t)tid, "nobody");
+    len += snprintf(tmpbuf, MAX_PACKET_SIZE,
+                    "T%02" PRIx32 "thread:%" PRIx64 ";name:%s;", gdb_status,
+                    (uint64)(uintptr_t)tid, "nobody");
     if (tids_count > 0) {
         len += snprintf(tmpbuf + len, MAX_PACKET_SIZE - len, "threads:");
         while (i < tids_count) {
@@ -624,7 +624,8 @@ void
 handle_get_write_memory(WASMGDBServer *server, char *payload)
 {
     size_t hex_len;
-    int32 offset, act_len;
+    int offset;
+    int32 act_len;
     uint64 maddr, mlen;
     char *buff;
     bool ret;

--- a/core/iwasm/libraries/debug-engine/handler.h
+++ b/core/iwasm/libraries/debug-engine/handler.h
@@ -9,10 +9,10 @@
 #include "gdbserver.h"
 
 int
-wasm_debug_handler_init();
+wasm_debug_handler_init(void);
 
 void
-wasm_debug_handler_deinit();
+wasm_debug_handler_deinit(void);
 
 void
 handle_interrupt(WASMGDBServer *server);


### PR DESCRIPTION
debug-engine: fix a few type mismatches

Note: on some targets, int32_t is a long.
for example, GCC shipped with the recent ESP-IDF has such a
configuration. [1]

[1] https://github.com/apache/nuttx/issues/15755#issuecomment-2635652808

cf.
https://github.com/apache/nuttx/pull/16022
https://docs.espressif.com/projects/esp-idf/en/stable/esp32/migration-guides/release-5.x/5.0/gcc.html#espressif-toolchain-changes

also, use strict prototypes as it's complained by the same version of GCC.
