### PR TITLE
fix false native stack overflow detections with HW_BOUND_CHECK

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -2315,13 +2315,6 @@ invoke_native_with_hw_bound_check(WASMExecEnv *exec_env, void *func_ptr,
 #endif
     bool ret;
 
-    /* Check native stack overflow firstly to ensure we have enough
-       native stack to run the following codes before actually calling
-       the aot function in invokeNative function. */
-    if (!wasm_runtime_detect_native_stack_overflow(exec_env)) {
-        return false;
-    }
-
     if (!exec_env_tls) {
         if (!os_thread_signal_inited()) {
             aot_set_exception(module_inst, "thread signal env not inited");
@@ -2338,6 +2331,13 @@ invoke_native_with_hw_bound_check(WASMExecEnv *exec_env, void *func_ptr,
             aot_set_exception(module_inst, "invalid exec env");
             return false;
         }
+    }
+
+    /* Check native stack overflow firstly to ensure we have enough
+       native stack to run the following codes before actually calling
+       the aot function in invokeNative function. */
+    if (!wasm_runtime_detect_native_stack_overflow(exec_env)) {
+        return false;
     }
 
     wasm_exec_env_push_jmpbuf(exec_env, &jmpbuf_node);

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -3523,13 +3523,6 @@ call_wasm_with_hw_bound_check(WASMModuleInstance *module_inst,
 #endif
     bool ret = true;
 
-    /* Check native stack overflow firstly to ensure we have enough
-       native stack to run the following codes before actually calling
-       the aot function in invokeNative function. */
-    if (!wasm_runtime_detect_native_stack_overflow(exec_env)) {
-        return;
-    }
-
     if (!exec_env_tls) {
         if (!os_thread_signal_inited()) {
             wasm_set_exception(module_inst, "thread signal env not inited");
@@ -3546,6 +3539,13 @@ call_wasm_with_hw_bound_check(WASMModuleInstance *module_inst,
             wasm_set_exception(module_inst, "invalid exec env");
             return;
         }
+    }
+
+    /* Check native stack overflow firstly to ensure we have enough
+       native stack to run the following codes before actually calling
+       the aot function in invokeNative function. */
+    if (!wasm_runtime_detect_native_stack_overflow(exec_env)) {
+        return;
     }
 
     wasm_exec_env_push_jmpbuf(exec_env, &jmpbuf_node);


### PR DESCRIPTION
In call_wasm_with_hw_bound_check/call_native_with_hw_bound_check, ensure to set up the stack boundary (wasm_exec_env_set_thread_info) before checking the overflow.

It seems that the problem was introduced by:
https://github.com/bytecodealliance/wasm-micro-runtime/pull/2940