### PR TITLE
fix: Remove unused variables in SIMD_v128_const case

### DIFF
--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -15624,7 +15624,9 @@ re_scan:
                     /* basic operation */
                     case SIMD_v128_const:
                     {
+#if WASM_ENABLE_FAST_INTERP != 0
                         uint64 high, low;
+#endif
                         CHECK_BUF1(p, p_end, 16);
 #if WASM_ENABLE_FAST_INTERP != 0
                         wasm_runtime_read_v128(p, &high, &low);


### PR DESCRIPTION
Fix compiler warnings about unused variables `high` and `low` in the `SIMD_v128_const` case. These variables are only needed inside the `WASM_ENABLE_FAST_INTERP != 0` conditional block, but were incorrectly declared outside of it, causing unused variable warnings.