### PR TITLE
Enable passing a triple to wamrc

### DIFF
--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -2736,10 +2736,23 @@ aot_create_comp_context(const AOTCompData *comp_data, aot_comp_option_t option)
     }
     else {
         /* Create LLVM target machine */
-        arch = option->target_arch;
-        abi = option->target_abi;
-        cpu = option->target_cpu;
-        features = option->cpu_features;
+        if (!option->target_arch || !strstr(option->target_arch, "-")) {
+            /* Retrieve the target triple based on user input */
+            triple = NULL;
+            arch = option->target_arch;
+            abi = option->target_abi;
+            cpu = option->target_cpu;
+            features = option->cpu_features;
+        }
+        else {
+            /* Form a target triple */
+            triple = option->target_arch;
+            arch = NULL;
+            abi = NULL;
+            cpu = NULL;
+            features = NULL;
+        }
+
         opt_level = option->opt_level;
         size_level = option->size_level;
 
@@ -2980,6 +2993,7 @@ aot_create_comp_context(const AOTCompData *comp_data, aot_comp_option_t option)
                 aot_set_last_error(buf);
                 goto fail;
             }
+            LOG_VERBOSE("triple: %s => normailized: %s", triple, triple_norm);
             if (!cpu)
                 cpu = "";
         }

--- a/wamr-compiler/main.c
+++ b/wamr-compiler/main.c
@@ -116,6 +116,9 @@ print_help()
     printf("                              Default is host arch, e.g. x86_64\n");
     printf("                            <sub> = for ex. on arm or thumb: v5, v6m, v7a, v7m, etc.\n");
     printf("                            Use --target=help to list supported targets\n");
+    printf("                            Or, provide a triple in the format of <arch>-<vendor>-<os>-<abi>.\n");
+    printf("                            By doing this, --target-abi, --cpu, and --cpu-features will be ignored.\n");
+    printf("                            The triple will only be normalized without any further verification.\n");
     printf("  --target-abi=<abi>        Set the target ABI, e.g. gnu, eabi, gnueabihf, msvc, etc.\n");
     printf("                              Default is gnu if target isn't riscv64 or riscv32\n");
     printf("                              For target riscv64 and riscv32, default is lp64d and ilp32d\n");


### PR DESCRIPTION
``` shell

$ wamrc -v=5 --target=i686-xx-mingw-eabi  -o 1.aot ./1.wasm 

[12:18:41:781 - 7FD7911C6BC0]: triple: i686-xx-mingw-eabi => normalized: i686-xx-windows-gnu

Create AoT compiler with:
  target:        i686
  target cpu:    
  target triple: i686-xx-windows-gnu   <= NORMALIZED
  cpu features:  
  opt level:     3
  size level:    3
  output format: AoT file

```