### PR TITLE
Insert a missing % character into the format string.

### DIFF
--- a/core/iwasm/aot/aot_perf_map.c
+++ b/core/iwasm/aot/aot_perf_map.c
@@ -31,8 +31,15 @@ get_func_size(const AOTModule *module, struct func_info *sorted_func_ptrs,
 static int
 compare_func_ptrs(const void *f1, const void *f2)
 {
-    return (intptr_t)((struct func_info *)f1)->ptr
-           - (intptr_t)((struct func_info *)f2)->ptr;
+    uintptr_t ptr1 = (uintptr_t)((struct func_info *)f1)->ptr;
+    uintptr_t ptr2 = (uintptr_t)((struct func_info *)f2)->ptr;
+
+    if (ptr1 < ptr2)
+        return -1;
+    else if (ptr1 > ptr2)
+        return 1;
+    else
+        return 0;
 }
 
 static struct func_info *
@@ -45,8 +52,8 @@ sort_func_ptrs(const AOTModule *module, char *error_buf, uint32 error_buf_size)
     content_len = (uint64)sizeof(struct func_info) * module->func_count;
     sorted_func_ptrs = wasm_runtime_malloc(content_len);
     if (!sorted_func_ptrs) {
-        snprintf(error_buf, error_buf_size,
-                 "allocate memory failed when creating perf map");
+        (void)snprintf(error_buf, error_buf_size,
+                       "allocate memory failed when creating perf map");
         return NULL;
     }
 
@@ -77,7 +84,8 @@ aot_create_perf_map(const AOTModule *module, char *error_buf,
     if (!sorted_func_ptrs)
         goto quit;
 
-    snprintf(perf_map_path, sizeof(perf_map_path) - 1, "/tmp/perf-%d.map", pid);
+    (void)snprintf(perf_map_path, sizeof(perf_map_path) - 1, "/tmp/perf-%d.map",
+                   pid);
     perf_map = fopen(perf_map_path, "a");
     if (!perf_map) {
         LOG_WARNING("warning: can't create /tmp/perf-%d.map, because %s", pid,
@@ -88,19 +96,23 @@ aot_create_perf_map(const AOTModule *module, char *error_buf,
     const char *module_name = aot_get_module_name((AOTModule *)module);
     for (i = 0; i < module->func_count; i++) {
         memset(perf_map_info, 0, 128);
-        if (strlen(module_name) > 0)
-            snprintf(perf_map_info, 128, PRIxPTR "  %x  [%s]#aot_func#%u\n",
-                     (uintptr_t)sorted_func_ptrs[i].ptr,
-                     get_func_size(module, sorted_func_ptrs, i), module_name,
-                     sorted_func_ptrs[i].idx);
-        else
-            snprintf(perf_map_info, 128, PRIxPTR "  %x  aot_func#%u\n",
-                     (uintptr_t)sorted_func_ptrs[i].ptr,
-                     get_func_size(module, sorted_func_ptrs, i),
-                     sorted_func_ptrs[i].idx);
+        if (strlen(module_name) > 0) {
+            (void)snprintf(perf_map_info, 128,
+                           "%" PRIxPTR "  %x  [%s]#aot_func#%u\n",
+                           (uintptr_t)sorted_func_ptrs[i].ptr,
+                           get_func_size(module, sorted_func_ptrs, i),
+                           module_name, sorted_func_ptrs[i].idx);
+        }
+        else {
+            (void)snprintf(perf_map_info, 128,
+                           "%" PRIxPTR "  %x  aot_func#%u\n",
+                           (uintptr_t)sorted_func_ptrs[i].ptr,
+                           get_func_size(module, sorted_func_ptrs, i),
+                           sorted_func_ptrs[i].idx);
+        }
 
         /* fwrite() is thread safe */
-        fwrite(perf_map_info, 1, strlen(perf_map_info), perf_map);
+        (void)fwrite(perf_map_info, 1, strlen(perf_map_info), perf_map);
     }
 
     LOG_VERBOSE("write map information from %s into /tmp/perf-%d.map",
@@ -112,7 +124,7 @@ quit:
         wasm_runtime_free(sorted_func_ptrs);
 
     if (perf_map)
-        fclose(perf_map);
+        (void)fclose(perf_map);
 
     return ret;
 }


### PR DESCRIPTION
leads to wrong type of arguments to formatting function.