### PR TITLE
wasm_export.h: Use "default" visibility for gcc and clang (#3957)

### DIFF
--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -23,6 +23,8 @@
 #else
 #define WASM_RUNTIME_API_EXTERN __declspec(dllimport)
 #endif
+#elif defined(__GNUC__) || defined(__clang__)
+#define WASM_RUNTIME_API_EXTERN __attribute__((visibility("default")))
 #else
 #define WASM_RUNTIME_API_EXTERN
 #endif


### PR DESCRIPTION
Since the top-level CMakelists.txt is appending `-fvisibility=hidden` to the compile options, no public symbols are exported by default. This forbids users from linking against the shared library.

Using `gcc/clang` attributes [1], it is possible to override the definition for `WASM_RUNTIME_API_EXTERN` so that only required symbols are correctly exported.

[1]: https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#Common-Function-Attributes