### PR TITLE
Enable support for version specification inside `samples/cmake/FindWASISDK.cmake`

### DIFF
--- a/samples/cmake/FindWASISDK.cmake
+++ b/samples/cmake/FindWASISDK.cmake
@@ -4,9 +4,23 @@
 include(FindPackageHandleStandardArgs)
 
 file(GLOB WASISDK_SEARCH_PATH "/opt/wasi-sdk-*")
+
+function(check_version validator_result_var item)
+  if(WASISDK_FIND_VERSION)
+    if(item MATCHES "${WASISDK_FIND_VERSION}")
+      set(${validator_result_var} TRUE PARENT_SCOPE)
+    else()
+      set(${validator_result_var} FALSE PARENT_SCOPE)
+    endif()
+  else()
+    set(${validator_result_var} TRUE PARENT_SCOPE)
+  endif()
+endfunction()
+
 find_path(WASISDK_HOME
   NAMES share/wasi-sysroot
   PATHS ${WASISDK_SEARCH_PATH}
+  VALIDATOR check_version
   NO_DEFAULT_PATH
   REQUIRED
 )


### PR DESCRIPTION
Currently, it is not possible to select a specific WASI SDK version to use in a sample. Thus, I modified the `FindWASISDK.cmake` to let me do this. 

I'm no CMake expert, so feedback is greatly appreciated.