### PR TITLE
fix print_help when libc wasi is enabled

### DIFF
--- a/product-mini/platforms/posix/main.c
+++ b/product-mini/platforms/posix/main.c
@@ -52,7 +52,11 @@ print_help(void)
     printf("  --multi-tier-jit         Run the wasm app with multi-tier jit mode\n");
 #endif
     printf("  --stack-size=n           Set maximum stack size in bytes, default is 64 KB\n");
-    printf("  --heap-size=n            Set maximum heap size in bytes, default is 16 KB\n");
+#if WASM_ENABLE_LIBC_WASI !=0
+    printf("  --heap-size=n            Set maximum heap size in bytes, default is 0 KB when libc wasi is enabled\n");
+#else
+    printf("  --heap-size=n            Set maximum heap size in bytes, default is 16 KB when libc wasi is diabled\n");
+#endif
 #if WASM_ENABLE_FAST_JIT != 0
     printf("  --jit-codecache-size=n   Set fast jit maximum code cache size in bytes,\n");
     printf("                           default is %u KB\n", FAST_JIT_DEFAULT_CODE_CACHE_SIZE / 1024);

--- a/product-mini/platforms/windows/main.c
+++ b/product-mini/platforms/windows/main.c
@@ -44,7 +44,11 @@ print_help()
     printf("  --multi-tier-jit       Run the wasm app with multi-tier jit mode\n");
 #endif
     printf("  --stack-size=n         Set maximum stack size in bytes, default is 64 KB\n");
-    printf("  --heap-size=n          Set maximum heap size in bytes, default is 16 KB\n");
+#if WASM_ENABLE_LIBC_WASI !=0
+    printf("  --heap-size=n            Set maximum heap size in bytes, default is 0 KB when libc wasi is enabled\n");
+#else
+    printf("  --heap-size=n            Set maximum heap size in bytes, default is 16 KB when libc wasi is diabled\n");
+#endif
 #if WASM_ENABLE_GC != 0
     printf("  --gc-heap-size=n         Set maximum gc heap size in bytes,\n");
     printf("                           default is %u KB\n", GC_HEAP_SIZE_DEFAULT / 1024);


### PR DESCRIPTION
With WASI libc enabled, the default maximum heap size in bytes  is 0 KB. Therefore, I updated `print_help` to improve the accuracy of the help message.