### PR TITLE
LLVM: don't verify instcombine fixpoint

### DIFF
--- a/core/iwasm/compilation/aot_llvm_extra.cpp
+++ b/core/iwasm/compilation/aot_llvm_extra.cpp
@@ -318,10 +318,15 @@ aot_apply_llvm_new_pass_manager(AOTCompContext *comp_ctx, LLVMModuleRef module)
     ModulePassManager MPM;
 
     if (comp_ctx->is_jit_mode) {
+#if LLVM_VERSION_MAJOR >= 18
+#define INSTCOMBINE "instcombine<no-verify-fixpoint>"
+#else
+#define INSTCOMBINE "instcombine"
+#endif
         const char *Passes =
             "loop-vectorize,slp-vectorizer,"
             "load-store-vectorizer,vector-combine,"
-            "mem2reg,instcombine,simplifycfg,jump-threading,indvars";
+            "mem2reg," INSTCOMBINE ",simplifycfg,jump-threading,indvars";
         ExitOnErr(PB.parsePassPipeline(MPM, Passes));
     }
     else {


### PR DESCRIPTION
LLVM 18 and later, instcombine perfoms only one iteration. it performs extra "verify fixpoint" operation when instcombine is specified in certain ways, including how we do so here. a problem is that the verification raises a fatal error when it finds we didn't reach a fixpoint:

    LLVM ERROR: Instruction Combining did not reach a fixpoint
    after 1 iterations

while it should be rare, it's quite normal not to reach a fixpoint. this commit fixes the issue by simply disabing the verification.

cf. https://github.com/llvm/llvm-project/commit/41895843b5915bb78e9d02aa711fa10f7174db43