### PR TITLE
LLVMCreateTargetMachineWithOpts: disable large data

### DIFF
--- a/core/iwasm/compilation/aot_llvm_extra2.cpp
+++ b/core/iwasm/compilation/aot_llvm_extra2.cpp
@@ -159,6 +159,17 @@ LLVMCreateTargetMachineWithOpts(LLVMTargetRef ctarget, const char *triple,
     auto cm = convert(code_model, &jit);
     auto targetmachine = target->createTargetMachine(triple, cpu, features,
                                                      opts, rm, cm, ol, jit);
+#if LLVM_VERSION_MAJOR >= 18
+    // always place data in normal data section.
+    //
+    // note that:
+    // - our aot file emitter/loader doesn't support x86-64 large data
+    //   sections. (eg .lrodata)
+    // - for our purposes, "data" is usually something the compiler
+    //   generated. (eg. jump tables) we probably never benefit from
+    //   large data sections.
+    targetmachine->setLargeDataThreshold(UINT64_MAX);
+#endif
     return reinterpret_cast<LLVMTargetMachineRef>(targetmachine);
 }
 


### PR DESCRIPTION
for x86-64, llvm 17 and later sometimes uses "l" prefix for data sections.
cf. https://github.com/llvm/llvm-project/commit/43249378da67319906cf04f2c6cd38df141f3bf6

because our aot file emitter/loader doesn't support such sections, it ends up with load-time errors solving symbols like ".lrodata".

this commit fixes it by avoid placing data in the large data sections.

references:
https://groups.google.com/g/x86-64-abi/c/jnQdJeabxiU https://github.com/llvm/llvm-project/commit/1feb00a28c9fdab162da08a15fcc9d088a36c352