### PR TITLE
wamrc: add --disable-llvm-jump-tables option

### DIFF
--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -711,8 +711,7 @@ aot_add_llvm_func(AOTCompContext *comp_ctx, LLVMModuleRef module,
                                     prefix)))
         goto fail;
 
-    if (comp_ctx->is_indirect_mode) {
-        /* avoid LUT relocations ("switch-table") */
+    if (comp_ctx->disable_llvm_jump_tables) {
         LLVMAttributeRef attr_no_jump_tables = LLVMCreateStringAttribute(
             comp_ctx->context, "no-jump-tables",
             (uint32)strlen("no-jump-tables"), "true", (uint32)strlen("true"));
@@ -2664,11 +2663,17 @@ aot_create_comp_context(const AOTCompData *comp_data, aot_comp_option_t option)
     if (option->enable_aux_stack_check)
         comp_ctx->enable_aux_stack_check = true;
 
-    if (option->is_indirect_mode)
+    if (option->is_indirect_mode) {
         comp_ctx->is_indirect_mode = true;
+        /* avoid LUT relocations ("switch-table") */
+        comp_ctx->disable_llvm_jump_tables = true;
+    }
 
     if (option->disable_llvm_intrinsics)
         comp_ctx->disable_llvm_intrinsics = true;
+
+    if (option->disable_llvm_jump_tables)
+        comp_ctx->disable_llvm_jump_tables = true;
 
     if (option->disable_llvm_lto)
         comp_ctx->disable_llvm_lto = true;

--- a/core/iwasm/compilation/aot_llvm.h
+++ b/core/iwasm/compilation/aot_llvm.h
@@ -448,6 +448,9 @@ typedef struct AOTCompContext {
     /* Disable LLVM built-in intrinsics */
     bool disable_llvm_intrinsics;
 
+    /* Disable LLVM jump tables */
+    bool disable_llvm_jump_tables;
+
     /* Disable LLVM link time optimization */
     bool disable_llvm_lto;
 

--- a/core/iwasm/include/aot_comp_option.h
+++ b/core/iwasm/include/aot_comp_option.h
@@ -73,6 +73,7 @@ typedef struct AOTCompOption {
     bool enable_perf_profiling;
     bool enable_memory_profiling;
     bool disable_llvm_intrinsics;
+    bool disable_llvm_jump_tables;
     bool disable_llvm_lto;
     bool enable_llvm_pgo;
     bool enable_stack_estimation;

--- a/wamr-compiler/main.c
+++ b/wamr-compiler/main.c
@@ -180,6 +180,7 @@ print_help()
     printf("                            Available flags: all, i32.common, i64.common, f32.common, f64.common,\n");
     printf("                              i32.clz, i32.ctz, etc, refer to doc/xip.md for full list\n");
     printf("                            Use comma to separate, please refer to doc/xip.md for full list.\n");
+    printf("  --disable-llvm-jump-tables Disable the LLVM jump tables similarly to clang's -fno-jump-tables\n");
     printf("  --disable-llvm-lto        Disable the LLVM link time optimization\n");
     printf("  --enable-llvm-pgo         Enable LLVM PGO (Profile-Guided Optimization)\n");
     printf("  --enable-llvm-passes=<passes>\n");
@@ -569,6 +570,9 @@ main(int argc, char *argv[])
             if (argv[0][28] == '\0')
                 PRINT_HELP_AND_EXIT();
             option.builtin_intrinsics = argv[0] + 28;
+        }
+        else if (!strcmp(argv[0], "--disable-llvm-jump-tables")) {
+            option.disable_llvm_jump_tables = true;
         }
         else if (!strcmp(argv[0], "--disable-llvm-lto")) {
             option.disable_llvm_lto = true;


### PR DESCRIPTION
while ideally a user should not need to care this kind of optimization details, in reality i guess it's sometimes useful. both of clang and GCC expose a similar option.  (-fno-jump-tables)