### PR TITLE
platform/nuttx: Fix dcache operation in os_dcache_flush

### DIFF
--- a/core/shared/platform/nuttx/nuttx_platform.c
+++ b/core/shared/platform/nuttx/nuttx_platform.c
@@ -118,7 +118,7 @@ os_dcache_flush()
     up_textheap_data_sync();
 #endif
 #ifndef CONFIG_BUILD_KERNEL
-    up_invalidate_dcache_all();
+    up_flush_dcache_all();
 #endif
 }
 


### PR DESCRIPTION
Replace up_invalidate_dcache_all() with up_flush_dcache_all() in os_dcache_flush() to properly flush the data cache instead of just invalidating it. This ensures that any modified data in the cache is written back to memory before execution.