### PR TITLE
fix return types of our 64-bit clz/ctz/popcount intrinsics

### DIFF
--- a/core/iwasm/aot/aot_intrinsic.c
+++ b/core/iwasm/aot/aot_intrinsic.c
@@ -194,7 +194,7 @@ aot_intrinsic_clz_i32(uint32 type)
     return num;
 }
 
-uint32
+uint64
 aot_intrinsic_clz_i64(uint64 type)
 {
     uint32 num = 0;
@@ -220,7 +220,7 @@ aot_intrinsic_ctz_i32(uint32 type)
     return num;
 }
 
-uint32
+uint64
 aot_intrinsic_ctz_i64(uint64 type)
 {
     uint32 num = 0;
@@ -244,7 +244,7 @@ aot_intrinsic_popcnt_i32(uint32 u)
     return ret;
 }
 
-uint32
+uint64
 aot_intrinsic_popcnt_i64(uint64 u)
 {
     uint32 ret = 0;

--- a/core/iwasm/aot/aot_intrinsic.h
+++ b/core/iwasm/aot/aot_intrinsic.h
@@ -186,19 +186,19 @@ aot_intrinsic_fmax_f64(float64 a, float64 b);
 uint32
 aot_intrinsic_clz_i32(uint32 type);
 
-uint32
+uint64
 aot_intrinsic_clz_i64(uint64 type);
 
 uint32
 aot_intrinsic_ctz_i32(uint32 type);
 
-uint32
+uint64
 aot_intrinsic_ctz_i64(uint64 type);
 
 uint32
 aot_intrinsic_popcnt_i32(uint32 u);
 
-uint32
+uint64
 aot_intrinsic_popcnt_i64(uint64 u);
 
 float32


### PR DESCRIPTION
the corresponding LLVM intrinsics' return types are same as their first argument. eg. i64 for llvm.cttz.i64.
cf. https://llvm.org/docs/LangRef.html#llvm-cttz-intrinsic

this commit changes the return types of our versions of the intrinsics to match llvm versions as our aot compiler, specifically __call_llvm_intrinsic, assumes.

strictly speaking, this is a potential AOT ABI change. however, I suppose it isn't a problem for many of 64-bit ABIs out there, where (lower half of) a 64-bit register is used to return a 32-bit value anyway.  (for such ABIs, this commit would fix the upper 32-bit value of the register.)