### PR TITLE
teach aot emitter/loader about .srodata and .srodata.cst* sections

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -3189,10 +3189,12 @@ do_text_relocation(AOTModule *module, AOTRelocationGroup *group,
             symbol_addr = module->code;
         }
         else if (!strcmp(symbol, ".data") || !strcmp(symbol, ".sdata")
-                 || !strcmp(symbol, ".rdata")
-                 || !strcmp(symbol, ".rodata")
+                 || !strcmp(symbol, ".rdata") || !strcmp(symbol, ".rodata")
+                 || !strcmp(symbol, ".srodata")
                  /* ".rodata.cst4/8/16/.." */
                  || !strncmp(symbol, ".rodata.cst", strlen(".rodata.cst"))
+                 /* ".srodata.cst4/8/16/.." */
+                 || !strncmp(symbol, ".srodata.cst", strlen(".srodata.cst"))
                  /* ".rodata.strn.m" */
                  || !strncmp(symbol, ".rodata.str", strlen(".rodata.str"))
                  || !strcmp(symbol, AOT_STACK_SIZES_SECTION_NAME)

--- a/core/iwasm/compilation/aot_emit_aot_file.c
+++ b/core/iwasm/compilation/aot_emit_aot_file.c
@@ -3270,8 +3270,17 @@ is_data_section(AOTObjectData *obj_data, LLVMSectionIteratorRef sec_itr,
 
     return (!strcmp(section_name, ".data") || !strcmp(section_name, ".sdata")
             || !strcmp(section_name, ".rodata")
+#if LLVM_VERSION_MAJOR >= 19
+            /* https://github.com/llvm/llvm-project/pull/82214 */
+            || !strcmp(section_name, ".srodata")
+#endif
             /* ".rodata.cst4/8/16/.." */
             || !strncmp(section_name, ".rodata.cst", strlen(".rodata.cst"))
+#if LLVM_VERSION_MAJOR >= 19
+            /* https://github.com/llvm/llvm-project/pull/82214
+             * ".srodata.cst4/8/16/.." */
+            || !strncmp(section_name, ".srodata.cst", strlen(".srodata.cst"))
+#endif
             /* ".rodata.strn.m" */
             || !strncmp(section_name, ".rodata.str", strlen(".rodata.str"))
             || (!strcmp(section_name, ".rdata")


### PR DESCRIPTION
LLVM 19 and later started to use srodata ("small read only data") sections for RISCV.  cf. https://github.com/llvm/llvm-project/pull/82214 this commit makes our aot emitter/loader deal with those sections.

an alternative would be to disable small data sections completely by setting the "SmallDataLimit" module attribute to zero. however, i feel this commit is more straightforward and consisitent as we are already dealing with sdata sections.