### PR TITLE
riscv: avoid llvm.cttz.i32/i64 for xip

### DIFF
--- a/core/iwasm/aot/aot_intrinsic.c
+++ b/core/iwasm/aot/aot_intrinsic.c
@@ -898,6 +898,17 @@ aot_intrinsic_fill_capability_flags(AOTCompContext *comp_ctx)
         if (!strncmp(comp_ctx->target_arch, "riscv32", 7)) {
             add_i64_common_intrinsics(comp_ctx);
         }
+        /*
+         * LLVM 16 and later expands cttz intrinsic to a table lookup,
+         * which involves some relocations. (unless ZBB is available,
+         * in which case the native instructions are preferred over
+         * the table-based lowering.)
+         * https://reviews.llvm.org/D128911
+         */
+#if LLVM_VERSION_MAJOR >= 16
+        add_intrinsic_capability(comp_ctx, AOT_INTRINSIC_FLAG_I32_CTZ);
+        add_intrinsic_capability(comp_ctx, AOT_INTRINSIC_FLAG_I64_CTZ);
+#endif
     }
     else if (!strncmp(comp_ctx->target_arch, "xtensa", 6)) {
         /*


### PR DESCRIPTION
LLVM 16 and later expands cttz intrinsic to a table lookup, which involves some relocations. (unless ZBB is available, in which case the native instructions are preferred over the table-based lowering.)

cf. https://reviews.llvm.org/D128911