### PR TITLE
samples/wasm-c-api: remove unused valgrind detection

### DIFF
--- a/samples/wasm-c-api/CMakeLists.txt
+++ b/samples/wasm-c-api/CMakeLists.txt
@@ -205,12 +205,3 @@ foreach(EX ${EXAMPLES})
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 endforeach()
-
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-  find_program(VALGRIND
-    valgrind
-    REQUIRED
-  )
-
-  # run `ctest -T memcheck -V --test-dir build`
-endif()


### PR DESCRIPTION
* it's unused

* valgrind is basically a linux-only software. it isn't a good idea to make it a hard requirement. if we want to use valgrind, it's better to introduce a separate option to control it.