### PR TITLE
disable compiler to prevent get_current_target() crash

### DIFF
--- a/tests/fuzz/wasm-mutator-fuzz/aot-compiler/CMakeLists.txt
+++ b/tests/fuzz/wasm-mutator-fuzz/aot-compiler/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT WAMR_BUILD_INTERP)
 endif()
 
 set(WAMR_BUILD_WAMR_COMPILER 1)
-set(WAMR_BUILD_AOT 1)
+set(WAMR_BUILD_AOT 0)
 set(WAMR_BUILD_INTERP 1)
 set(WAMR_BUILD_JIT 0)
 
@@ -69,7 +69,7 @@ target_link_libraries(aotclib PUBLIC ${REQUIRED_LLVM_LIBS})
 
 if(NOT IN_OSS_FUZZ)
   message(STATUS "Enable ASan and UBSan in non-oss-fuzz environment")
-  target_compile_options(aotclib PUBLIC 
+  target_compile_options(aotclib PUBLIC
     -fprofile-instr-generate -fcoverage-mapping
     -fno-sanitize-recover=all
     -fsanitize=address,undefined

--- a/tests/fuzz/wasm-mutator-fuzz/aot-compiler/aot_compiler_fuzz.cc
+++ b/tests/fuzz/wasm-mutator-fuzz/aot-compiler/aot_compiler_fuzz.cc
@@ -35,6 +35,12 @@ LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     /* libfuzzer don't allow to modify the given Data, so make a copy here */
     std::vector<uint8_t> myData(Data, Data + Size);
 
+    if (Size >= 4
+        && get_package_type(myData.data(), Size) != Wasm_Module_Bytecode) {
+        printf("Invalid wasm file: magic header not detected\n");
+        return 0;
+    }
+
     wasm_runtime_init();
 
     module = wasm_runtime_load((uint8_t *)myData.data(), Size, error_buf, 120);


### PR DESCRIPTION
 fixes a crash issue discovered  where the runtime
aborts when WAMR_BUILD_AOT=1 and WAMR_BUILD_WAMR_COMPILER=1 are both enabled.