### PR TITLE
Modifying build flags to ensure libiwasm.so is built

### DIFF
--- a/language-bindings/python/utils/create_lib.sh
+++ b/language-bindings/python/utils/create_lib.sh
@@ -17,6 +17,7 @@ cmake \
     -DWAMR_BUILD_LIB_PTHREAD=1 \
     -DWAMR_BUILD_LIB_WASI_THREADS=1 \
     -DWAMR_BUILD_LIB_WASI=1 \
+    -DBUILD_SHARED_LIBS=ON \
     ..
 make -j
 


### PR DESCRIPTION
I added the ` -DBUILD_SHARED_LIBS=ON \` flag to the bash script to ensure that the `libiwasm.so` file was built. This seems to resolve the issues highlighted in issue https://github.com/bytecodealliance/wasm-micro-runtime/issues/4244

I *think* that with this PR we can now close this issue.

The language bindings appear to be correctly generated.

(Just a thought ) -> Do we need any testing for these built scripts? - Perhaps this should be another issue?