### PR TITLE
Stop pretending to support extended-const proposal

### DIFF
--- a/build-scripts/config_common.cmake
+++ b/build-scripts/config_common.cmake
@@ -677,7 +677,6 @@ endif ()
 message (
 "-- About Wasm Proposals:\n"
 "     Always-on:\n"
-"       \"Extended Constant Expressions\"\n"
 "       \"Multi-value\"\n"
 "       \"Non-trapping float-to-int conversions\"\n"
 "       \"Sign-extension operators\"\n"
@@ -698,6 +697,7 @@ message (
 "       \"Branch Hinting\"\n"
 "       \"Custom Annotation Syntax in the Text Format\"\n"
 "       \"Exception handling\"\n"
+"       \"Extended Constant Expressions\"\n"
 "       \"Import/Export of Mutable Globals\"\n"
 "       \"JS String Builtins\"\n"
 "       \"Relaxed SIMD\"\n"

--- a/doc/stability_wasm_proposals.md
+++ b/doc/stability_wasm_proposals.md
@@ -15,7 +15,6 @@ Users can turn those features on or off by using compilation options. If a relev
 | Proposal                              | >= Phase 4 | Compilation Option       |
 | ------------------------------------- | ---------- | ------------------------ |
 | Bulk memory operations                | Yes        | `WAMR_BUILD_BULK_MEMORY` |
-| Extended Constant Expressions         | Yes        | N/A                      |
 | Fixed-width SIMD[^1]                  | Yes        | `WAMR_BUILD_SIMD`        |
 | Multi-value                           | Yes        | N/A                      |
 | Non-trapping float-to-int conversions | Yes        | N/A                      |
@@ -54,6 +53,7 @@ Users can turn those features on or off by using compilation options. If a relev
 | Branch Hinting                              | Yes        |
 | Custom Annotation Syntax in the Text Format | Yes        |
 | Exception handling[^5]                      | Yes        |
+| Extended Constant Expressions               | Yes        |
 | Import/Export of Mutable Globals            | Yes        |
 | JS String Builtins                          | Yes        |
 | Relaxed SIMD                                | Yes        |

--- a/product-mini/platforms/common/wasm_proposal.c
+++ b/product-mini/platforms/common/wasm_proposal.c
@@ -12,7 +12,6 @@ wasm_proposal_print_status(void)
 {
     printf("About Wasm Proposals:\n");
     printf("  Always-on:\n");
-    printf("    - Extended Constant Expressions\n");
     printf("    - Multi-value\n");
     printf("    - Non-trapping float-to-int conversions\n");
     printf("    - Sign-extension operators\n");
@@ -44,6 +43,7 @@ wasm_proposal_print_status(void)
     printf("    - Branch Hinting\n");
     printf("    - Custom Annotation Syntax in the Text Format\n");
     printf("    - Exception handling\n");
+    printf("    - Extended Constant Expressions\n");
     printf("    - Import/Export of Mutable Globals\n");
     printf("    - JS String Builtins\n");
     printf("    - Relaxed SIMD\n");


### PR DESCRIPTION
As far as I know, we don't implement the proposal at all.

At least, we don't implement even very basic cases like:

```
spacetanuki% wasm2wat --enable-all data.28.wasm
(module
  (memory (;0;) 1)
  (data (;0;) (i32.const 42
    i32.const 0
    i32.sub) ""))
spacetanuki% toywasm --load data.28.wasm
spacetanuki% ~/git/wasm-micro-runtime/product-mini/platforms/darwin/b.classic/iwasm data.28.wasm
WASM module load failed: illegal opcode or constant expression required or type mismatch
spacetanuki%
```

data.28.wasm in the above example is a binary version of: https://github.com/WebAssembly/extended-const/blob/8d4f6aa2b00a8e7c0174410028625c6a176db8a1/test/core/data.wast#L184-L187