### PR TITLE
build-scripts/build_llvm.py: bump to llvm 18

### DIFF
--- a/build-scripts/build_llvm.py
+++ b/build-scripts/build_llvm.py
@@ -294,17 +294,17 @@ def main():
         "arc": {
             "repo": "https://github.com/llvm/llvm-project.git",
             "repo_ssh": "git@github.com:llvm/llvm-project.git",
-            "branch": "release/15.x",
+            "branch": "release/18.x",
         },
         "xtensa": {
             "repo": "https://github.com/espressif/llvm-project.git",
             "repo_ssh": "git@github.com:espressif/llvm-project.git",
-            "branch": "xtensa_release_17.0.1",
+            "branch": "xtensa_release_18.1.2",
         },
         "default": {
             "repo": "https://github.com/llvm/llvm-project.git",
             "repo_ssh": "git@github.com:llvm/llvm-project.git",
-            "branch": "release/15.x",
+            "branch": "release/18.x",
         },
     }
 

--- a/tests/wamr-test-suites/spec-test-script/runtest.py
+++ b/tests/wamr-test-suites/spec-test-script/runtest.py
@@ -46,7 +46,8 @@ temp_module_table = {}
 aot_target_options_map = {
     "i386": ["--target=i386"],
     "x86_32": ["--target=i386"],
-    "x86_64": ["--target=x86_64", "--cpu=skylake"],
+    # cf. https://github.com/bytecodealliance/wasm-micro-runtime/issues/3035
+    "x86_64": ["--target=x86_64", "--cpu=skylake", "--size-level=0"],
     "aarch64": ["--target=aarch64", "--target-abi=eabi", "--cpu=cortex-a53"],
     "aarch64_vfp": ["--target=aarch64", "--target-abi=gnueabihf", "--cpu=cortex-a53"],
     "armv7": ["--target=armv7", "--target-abi=eabi", "--cpu=cortex-a9", "--cpu-features=-neon"],

--- a/wamr-compiler/main.c
+++ b/wamr-compiler/main.c
@@ -712,7 +712,7 @@ main(int argc, char *argv[])
     }
 
     if (sgx_mode) {
-        option.size_level = 1;
+        option.size_level = 0;
         option.is_sgx_platform = true;
     }
 


### PR DESCRIPTION
cf. https://github.com/bytecodealliance/wasm-micro-runtime/issues/4210

why not 20?
because, as of writing this, 19 is the latest released version for
the xtensa fork of llvm: https://github.com/espressif/llvm-project

why not 19?
because of a bug in the xtensa fork of llvm:
https://github.com/espressif/llvm-project/issues/112

while we can use different versions for different targets,
it's nicer to use the same version everywhere when possible.
