### PR TITLE
handle multi-byte types correctly in ref.null const expr

### DIFF
--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -820,7 +820,8 @@ load_init_expr(WASMModule *module, const uint8 **p_buf, const uint8 *buf_end,
 #else
                 cur_value.gc_obj = NULL_REF;
 
-                if (!is_byte_a_type(type1)) {
+                if (!is_byte_a_type(type1)
+                    || wasm_is_type_multi_byte_type(type1)) {
                     p--;
                     read_leb_uint32(p, p_end, type_idx);
                     if (!check_type_index(module, module->type_count, type_idx,


### PR DESCRIPTION
When processing `ref.null` constant expressions, multi-byte types were incorrectly
being handled even though they are valid types. This could lead to
incorrect reftype initialization for multi-byte types.

This change ensures that both invalid types (!is_byte_a_type) AND valid multi-byte
types are processed through the `type_idx` initialization path