### PR TITLE
Check for WASM_ENABLE_SIMDE in a couple more places

### DIFF
--- a/core/iwasm/interpreter/wasm_opcode.h
+++ b/core/iwasm/interpreter/wasm_opcode.h
@@ -790,15 +790,14 @@ typedef enum WASMAtomicEXTOpcode {
 #endif
 #define SET_GOTO_TABLE_ELEM(opcode) [opcode] = HANDLE_OPCODE(opcode)
 
-#if (WASM_ENABLE_JIT != 0 || WASM_ENABLE_FAST_INTERP != 0) \
-    && WASM_ENABLE_SIMD != 0
+#if WASM_ENABLE_SIMDE != 0
 #define SET_GOTO_TABLE_SIMD_PREFIX_ELEM() \
     SET_GOTO_TABLE_ELEM(WASM_OP_SIMD_PREFIX),
 #else
 #define SET_GOTO_TABLE_SIMD_PREFIX_ELEM()
 #endif
 
-#if (WASM_ENABLE_FAST_INTERP != 0) && WASM_ENABLE_SIMD != 0
+#if WASM_ENABLE_SIMD != 0 && WASM_ENABLE_SIMDE != 0
 #define DEF_EXT_V128_HANDLE()                                       \
     SET_GOTO_TABLE_ELEM(EXT_OP_SET_LOCAL_FAST_V128),     /* 0xdd */ \
         SET_GOTO_TABLE_ELEM(EXT_OP_TEE_LOCAL_FAST_V128), /* 0xde */ \


### PR DESCRIPTION
For WAMR users who don't use cmake, it's possible that WASM_ENABLE_SIMD is set when WASM_ENABLE_SIMDE isn't. This was causing build failures.