### PR TITLE
Add "load_by_name" API at wasi-nn 

### DIFF
--- a/core/iwasm/libraries/wasi-nn/include/wasi_nn.h
+++ b/core/iwasm/libraries/wasi-nn/include/wasi_nn.h
@@ -30,7 +30,7 @@ load(graph_builder_array *builder, graph_encoding encoding,
     __attribute__((import_module("wasi_nn")));
 
 wasi_nn_error
-load_by_name(const char *name, graph *g)
+load_by_name(char *name, uint32_t name_len, graph *g)
     __attribute__((import_module("wasi_nn")));
 
 /**

--- a/core/iwasm/libraries/wasi-nn/src/wasi_nn.c
+++ b/core/iwasm/libraries/wasi-nn/src/wasi_nn.c
@@ -697,6 +697,7 @@ static NativeSymbol native_symbols_wasi_nn[] = {
     REG_NATIVE_FUNC(get_output, "(ii*i*)i"),
 #else  /* WASM_ENABLE_WASI_EPHEMERAL_NN == 0 */
     REG_NATIVE_FUNC(load, "(*ii*)i"),
+    REG_NATIVE_FUNC(load_by_name, "(*i*)i"),
     REG_NATIVE_FUNC(init_execution_context, "(i*)i"),
     REG_NATIVE_FUNC(set_input, "(ii*)i"),
     REG_NATIVE_FUNC(compute, "(i)i"),

--- a/core/iwasm/libraries/wasi-nn/src/wasi_nn_tensorflowlite.cpp
+++ b/core/iwasm/libraries/wasi-nn/src/wasi_nn_tensorflowlite.cpp
@@ -85,12 +85,9 @@ is_valid_graph(TFLiteContext *tfl_ctx, graph g)
         NN_ERR_PRINTF("Invalid graph: %d >= %d.", g, MAX_GRAPHS_PER_INST);
         return runtime_error;
     }
-    if (tfl_ctx->models[g].model_pointer == NULL) {
+    if (tfl_ctx->models[g].model_pointer == NULL
+        && tfl_ctx->models[g].model == NULL) {
         NN_ERR_PRINTF("Context (model) non-initialized.");
-        return runtime_error;
-    }
-    if (tfl_ctx->models[g].model == NULL) {
-        NN_ERR_PRINTF("Context (tflite model) non-initialized.");
         return runtime_error;
     }
     return success;

--- a/core/iwasm/libraries/wasi-nn/test/utils.c
+++ b/core/iwasm/libraries/wasi-nn/test/utils.c
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#define USE_WASM_LOAD_BY_NAME 1
 
 wasi_nn_error
 wasm_load(char *model_name, graph *g, execution_target target)
@@ -58,7 +59,7 @@ wasm_load(char *model_name, graph *g, execution_target target)
 wasi_nn_error
 wasm_load_by_name(const char *model_name, graph *g)
 {
-    wasi_nn_error res = load_by_name(model_name, g);
+    wasi_nn_error res = load_by_name(model_name, strlen(model_name), g);
     return res;
 }
 
@@ -108,7 +109,12 @@ run_inference(execution_target target, float *input, uint32_t *input_size,
               uint32_t num_output_tensors)
 {
     graph graph;
+
+#if USE_WASM_LOAD_BY_NAME == 0
     if (wasm_load(model_name, &graph, target) != success) {
+#else
+    if (wasm_load_by_name(model_name, &graph) != success) {
+#endif
         NN_ERR_PRINTF("Error when loading model.");
         exit(1);
     }


### PR DESCRIPTION
When using WASI-NN ,we want to reduce copying the AI model from the host to the WASM by using "load_by_name" API.
We also want to use it to improve the performance, keep the safety and WASI-NN also supports this method on different backends.

I test with 3 tflite models.(x86_64, Ubuntu 22.04)


![image](https://github.com/user-attachments/assets/96590394-7577-4bd3-abf1-0a6c505b7ed8)


_Both [coco_ssd_mobilenet_v1](https://storage.googleapis.com/download.tensorflow.org/models/tflite/coco_ssd_mobilenet_v1_1.0_quant_2018_06_29.zip) and [coco_ssd_mobilenet_v3](http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v3_small_coco_2020_01_14.tar.gz) are for detection, its file size and input tensor size is different.  
[mobilenet_v2](https://github.com/frogermcs/TFLite-Checker/blob/master/android/ImageClassificationTester/app/src/main/assets/mobilenet_v2_1.0_224.tflite) is for classification and size is more bigger._

The time consumed does not show a linear growth as the file size increases. 
For most cases, load_by_name will more faster whether the load tflite or the entire inference process (load+ set input +compute +get output).