### PR TITLE
Generic exceptions handling callback included

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -91,6 +91,9 @@ wasm_runtime_destroy_registered_module_list(void);
 
 #define E_TYPE_XIP 4
 
+static generic_error_callback_t generic_error_cb;
+static void *generic_error_user_data;
+
 static uint8
 val_type_to_val_kind(uint8 value_type);
 
@@ -3016,6 +3019,8 @@ wasm_set_exception_local(WASMModuleInstance *module_inst, const char *exception)
         module_inst->cur_exception[0] = '\0';
     }
     exception_unlock(module_inst);
+    if (generic_error_cb)
+      generic_error_cb((WASMModuleInstanceCommon *)module_inst, ((AOTModuleInstance *)module_inst)->cur_exec_env, "");
 }
 
 void
@@ -7869,4 +7874,12 @@ wasm_runtime_is_underlying_binary_freeable(WASMModuleCommon *const module)
 #endif /* WASM_ENABLE_AOT != 0 */
 
     return true;
+}
+
+void
+wasm_runtime_set_generic_error_callback(
+  const generic_error_callback_t callback, void *user_data)
+{
+    generic_error_cb = callback;
+    generic_error_user_data = user_data;
 }

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -3020,7 +3020,8 @@ wasm_set_exception_local(WASMModuleInstance *module_inst, const char *exception)
     }
     exception_unlock(module_inst);
     if (generic_error_cb)
-      generic_error_cb((WASMModuleInstanceCommon *)module_inst, ((AOTModuleInstance *)module_inst)->cur_exec_env, "");
+        generic_error_cb((WASMModuleInstanceCommon *)module_inst,
+                         ((AOTModuleInstance *)module_inst)->cur_exec_env, "");
 }
 
 void
@@ -7877,8 +7878,8 @@ wasm_runtime_is_underlying_binary_freeable(WASMModuleCommon *const module)
 }
 
 void
-wasm_runtime_set_generic_error_callback(
-  const generic_error_callback_t callback, void *user_data)
+wasm_runtime_set_generic_error_callback(const generic_error_callback_t callback,
+                                        void *user_data)
 {
     generic_error_cb = callback;
     generic_error_user_data = user_data;

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -2102,12 +2102,19 @@ typedef void (*enlarge_memory_error_callback_t)(
     uint32_t memory_index, enlarge_memory_error_reason_t failure_reason,
     wasm_module_inst_t instance, wasm_exec_env_t exec_env, void *user_data);
 
+
+typedef void (*generic_error_callback_t)(
+    wasm_module_inst_t instance, wasm_exec_env_t exec_env, void *user_data);
 /**
  * Setup callback invoked when memory.grow fails
  */
 WASM_RUNTIME_API_EXTERN void
 wasm_runtime_set_enlarge_mem_error_callback(
     const enlarge_memory_error_callback_t callback, void *user_data);
+
+WASM_RUNTIME_API_EXTERN void
+wasm_runtime_set_generic_error_callback(
+    const generic_error_callback_t callback, void *user_data);
 
 /*
  * module instance context APIs

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -2102,9 +2102,9 @@ typedef void (*enlarge_memory_error_callback_t)(
     uint32_t memory_index, enlarge_memory_error_reason_t failure_reason,
     wasm_module_inst_t instance, wasm_exec_env_t exec_env, void *user_data);
 
-
-typedef void (*generic_error_callback_t)(
-    wasm_module_inst_t instance, wasm_exec_env_t exec_env, void *user_data);
+typedef void (*generic_error_callback_t)(wasm_module_inst_t instance,
+                                         wasm_exec_env_t exec_env,
+                                         void *user_data);
 /**
  * Setup callback invoked when memory.grow fails
  */
@@ -2113,8 +2113,8 @@ wasm_runtime_set_enlarge_mem_error_callback(
     const enlarge_memory_error_callback_t callback, void *user_data);
 
 WASM_RUNTIME_API_EXTERN void
-wasm_runtime_set_generic_error_callback(
-    const generic_error_callback_t callback, void *user_data);
+wasm_runtime_set_generic_error_callback(const generic_error_callback_t callback,
+                                        void *user_data);
 
 /*
  * module instance context APIs


### PR DESCRIPTION
In order to be able to catch  "trap" errors from native side and reload the WAMR application or trigger corrective actions such as "reload factory settings" for us this type of notifications are very usefull. We took as reference the "enlarge memory exception" mechanism and try to keep it simple.
