### PR TITLE
Implement a thread-level-singleton WASMRuntime

### DIFF
--- a/core/iwasm/common/wasm_memory.h
+++ b/core/iwasm/common/wasm_memory.h
@@ -70,12 +70,40 @@ wasm_runtime_shared_heap_free(WASMModuleInstanceCommon *module_inst,
                               uint64 ptr);
 #endif
 
+// TODO: remove this when all the code is migrated to use the new API
 bool
 wasm_runtime_memory_init(mem_alloc_type_t mem_alloc_type,
                          const MemAllocOption *alloc_option);
 
 void
 wasm_runtime_memory_destroy(void);
+
+typedef struct WASMRuntimeAllocator {
+    uint8 memory_mode;
+    //TODO: maybe, we can use a unionto save space
+
+    void *pool_allocator;
+    unsigned int pool_size;
+
+    //TODO: maybe, we can just save the malloc/realloc/free function pointers
+    void *(*malloc_func)(unsigned int size);
+    void *(*realloc_func)(void *ptr, unsigned int size);
+    void (*free_func)(void *ptr);
+} WASMRuntimeAllocator;
+
+bool
+wasm_runtime_memory_init2(mem_alloc_type_t mem_alloc_type,
+                          const MemAllocOption *alloc_option,
+                          WASMRuntimeAllocator *allocator);
+
+void *
+wasm_runtime_malloc2(WASMRuntimeAllocator *allocator, unsigned int size);
+
+void
+wasm_runtime_free2(WASMRuntimeAllocator *allocator, void *ptr);
+
+void
+wasm_runtime_memory_destroy2(WASMRuntimeAllocator *allocator);
 
 unsigned
 wasm_runtime_memory_pool_size(void);

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -11,6 +11,7 @@
 #include "wasm_exec_env.h"
 #include "wasm_native.h"
 #include "../include/wasm_export.h"
+#include "../include/wasm_export2.h"
 #include "../interpreter/wasm.h"
 #if WASM_ENABLE_GC != 0
 #include "gc/gc_object.h"
@@ -23,6 +24,10 @@
 #include "uvwasi.h"
 #endif
 #endif
+
+#ifndef WASM_RUNTIME_API_INTERN
+#define WASM_RUNTIME_API_INTERN
+#endif /* WASM_RUNTIME_API_INTERN*/
 
 #ifdef __cplusplus
 extern "C" {
@@ -483,6 +488,8 @@ LOAD_I16(void *addr)
 
 #define CLAMP_U64_TO_U32(value) \
     ((value) > UINT32_MAX ? UINT32_MAX : (uint32)(value))
+
+typedef struct WASMRuntime WASMRuntime;
 
 typedef struct WASMModuleCommon {
     /* Module type, for module loaded from WASM bytecode binary,
@@ -1327,6 +1334,63 @@ wasm_runtime_get_linux_perf(void);
 void
 wasm_runtime_set_linux_perf(bool flag);
 #endif
+
+/* ============================================================ */
+
+// TODO: need to be rearranged after the new runtime API is ready
+
+#define DEPRECATED_API(old, new)                                    \
+    do {                                                            \
+        bh_assert(false                                             \
+                  && "Warning:" #old                                \
+                     "is deprecated, please use " #new " instead"); \
+    } while (0)
+
+#define CHECK_AND_RETURN_VOID(cond) \
+    do { \
+        if (!(cond)) { \
+            return; \
+        } \
+    } while (0)
+
+#define CHECK_AND_RETURN(cond, ret) \
+    do { \
+        if (!(cond)) { \
+            return (ret); \
+        } \
+    } while (0)
+
+#define CHECK_NULL_AND_RETURN_VOID(var) CHECK_AND_RETURN_VOID((var) != NULL)
+#define CHECK_NULL_AND_RETURN(var, ret) CHECK_AND_RETURN((var) != NULL, ret)
+
+WASM_RUNTIME_API_EXTERN WASMRuntime *
+wasm_runtime_init2(void);
+
+WASM_RUNTIME_API_EXTERN void
+wasm_runtime_destroy2(void *runtime);
+
+WASM_RUNTIME_API_EXTERN WASMRuntime *
+wasm_runtime_full_init2(RuntimeInitArgs *init_args);
+
+typedef struct WASMRuntimeAllocator WASMRuntimeAllocator;
+
+WASM_RUNTIME_API_INTERN WASMRuntime *
+wasm_runtime_get_local_runtime(void);
+
+WASM_RUNTIME_API_INTERN
+bool
+wasm_runtime_env_init(void);
+
+WASM_RUNTIME_API_INTERN void
+wasm_runtime_destroy_internal(void);
+
+WASM_RUNTIME_API_INTERN
+bool
+wasm_runtime_full_init_internal(RuntimeInitArgs *init_args);
+
+WASM_RUNTIME_API_INTERN
+WASMRuntimeAllocator *
+wasm_runtime_get_local_allocator();
 
 #ifdef __cplusplus
 }

--- a/core/iwasm/common/wasm_runtime_impl.c
+++ b/core/iwasm/common/wasm_runtime_impl.c
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2019 Intel Corporation.  All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#include "wasm_runtime_common.h"
+#include "wasm_memory.h"
+
+typedef struct WASMRuntime {
+    // TODO: do we really need this?
+    int32 ref_count;
+    WASMRuntimeAllocator allocator;
+} WASMRuntime;
+
+/* SHOULD BE the only global variable */
+static korp_key runtime_key;
+
+static WASMRuntime *
+wasm_runtime_init_prologue(void)
+{
+    WASMRuntimeAllocator allocator;
+    bool ret;
+    int ret_i;
+    WASMRuntime *runtime;
+
+    LOG_DEBUG("WASMRuntime init prologue");
+
+    // TODO: Enable loging system
+    LOG_DEBUG("WASMRuntime init setup log");
+
+    /* Initialize memory allocator firstly */
+    LOG_DEBUG("WASMRuntime init setup memory allocator");
+    ret = wasm_runtime_memory_init2(Alloc_With_Pool, NULL, &allocator);
+    if (!ret) {
+        /* Failed to initialize memory allocator */
+        LOG_ERROR("Failed to initialize memory allocator");
+        return NULL;
+    }
+
+    /* Now it is able to use allocation */
+    LOG_DEBUG("WASMRuntime init allocate memory for runtime");
+    runtime = wasm_runtime_malloc2(&allocator, sizeof(WASMRuntime));
+    if (!runtime) {
+        /* Failed to allocate memory for runtime */
+        LOG_ERROR("Failed to allocate memory for runtime");
+        wasm_runtime_memory_destroy2(&allocator);
+        return NULL;
+    }
+
+    // TODO: remove me if not needed like wasm_runtime_malloc2() will do this
+    LOG_DEBUG("WASMRuntime init initialize runtime");
+    memset(runtime, 0, sizeof(WASMRuntime));
+    runtime->allocator = allocator;
+
+    LOG_DEBUG("WASMRuntime init set thread local key");
+    ret_i = os_thread_setspecific(runtime_key, runtime);
+    if (ret_i != 0) {
+        /* Failed to set thread local key */
+        LOG_ERROR("Failed to set thread local key");
+        wasm_runtime_free2(&allocator, runtime);
+        wasm_runtime_memory_destroy2(&allocator);
+        return NULL;
+    }
+
+    return runtime;
+}
+
+static void
+wasm_runtime_destroy_epilogue(WASMRuntime *runtime)
+{
+    WASMRuntimeAllocator allocator;
+
+    LOG_DEBUG("WASMRuntime destroy epilogue(%d)", runtime->ref_count);
+    bh_assert(runtime->ref_count == 0);
+
+    allocator = runtime->allocator;
+
+    /* Destroy thread local key */
+    LOG_DEBUG("WASMRuntime destroy thread local key");
+    os_thread_key_delete(runtime_key);
+
+    /* Free the runtime */
+    LOG_DEBUG("WASMRuntime destroy memory for runtime");
+    wasm_runtime_free2(&allocator, runtime);
+    wasm_runtime_memory_destroy2(&allocator);
+}
+
+/* =========================== Exported Functions =========================== */
+
+/*
+ * make sure you call this function in the main thread at the beginning
+ * of the program
+ */
+int
+wasm_runtime_create_runtime_key()
+{
+    return os_thread_key_create(&runtime_key, wasm_runtime_destroy2);
+}
+
+WASMRuntime *
+wasm_runtime_get_local_runtime()
+{
+    WASMRuntime *runtime;
+
+    runtime = os_thread_getspecific(runtime_key);
+    if (!runtime) {
+        return NULL;
+    }
+
+    LOG_DEBUG("WASMRuntime ref_count(%d)", runtime->ref_count);
+    runtime->ref_count++;
+    return runtime;
+}
+
+
+WASMRuntime *
+wasm_runtime_init2(void)
+{
+    WASMRuntime *runtime;
+    bool ret;
+
+    LOG_DEBUG("WASMRuntime init");
+
+    runtime = wasm_runtime_init_prologue();
+    if (!runtime) {
+        /* Failed to initialize runtime */
+        LOG_ERROR("Failed to prepare runtime");
+        return NULL;
+    }
+
+    /*TODO: goes to wasm_runtime_full_init_internal(RuntimeInitArgs*) with
+     * default args*/
+    ret = wasm_runtime_env_init();
+    if (!ret) {
+        /* Failed to initialize runtime environment */
+        LOG_ERROR("Failed to initialize runtime environment");
+        wasm_runtime_destroy_epilogue(runtime);
+        return NULL;
+    }
+
+    return runtime;
+}
+
+WASMRuntime *
+wasm_runtime_full_init2(RuntimeInitArgs *init_args)
+{
+    WASMRuntime *runtime;
+    bool ret;
+
+    LOG_DEBUG("WASMRuntime full init");
+
+    runtime = wasm_runtime_init_prologue();
+    if (!runtime) {
+        /* Failed to initialize runtime */
+        LOG_ERROR("Failed to prepare runtime");
+        return NULL;
+    }
+
+    ret = wasm_runtime_full_init_internal(init_args);
+    if (!ret) {
+        /* Failed to fully initialize runtime */
+        LOG_ERROR("Failed to fully initialize runtime with args");
+        wasm_runtime_destroy_epilogue(runtime);
+        return NULL;
+    }
+
+    return runtime;
+}
+
+void
+wasm_runtime_destroy2(void *data)
+{
+    CHECK_NULL_AND_RETURN_VOID(data);
+
+    int ret;
+    WASMRuntime *runtime;
+    WASMRuntimeAllocator allocator;
+
+    runtime = (WASMRuntime *)data;
+    allocator = runtime->allocator;
+
+    LOG_DEBUG("WASMRuntime destroy(%d)", runtime->ref_count);
+
+    if (runtime->ref_count > 0) {
+        /* Not the last one, just return */
+        LOG_DEBUG("WASMRuntime ref_count(%d) > 0", runtime->ref_count);
+        runtime->ref_count--;
+        return;
+    }
+
+    if (runtime->ref_count < 0) {
+        /* This is an error, should not happen */
+        LOG_WARNING("WASMRuntime ref_count < 0");
+        return;
+    }
+
+    LOG_DEBUG("WASMRuntime ref_count = 0, free it");
+
+    wasm_runtime_destroy_internal();
+    wasm_runtime_destroy_epilogue(runtime);
+}
+
+WASMRuntimeAllocator *
+wasm_runtime_get_local_allocator(WASMRuntime *runtime)
+{
+    CHECK_NULL_AND_RETURN(runtime, NULL);
+    return &runtime->allocator;
+}

--- a/core/iwasm/include/wasm_export2.h
+++ b/core/iwasm/include/wasm_export2.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2019 Intel Corporation.  All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#ifndef _WASM_EXPORT_2_H
+#define _WASM_EXPORT_2_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _WASM_EXPORT_2_H */

--- a/core/shared/platform/common/posix/posix_thread.c
+++ b/core/shared/platform/common/posix/posix_thread.c
@@ -781,4 +781,29 @@ os_sigreturn()
 #endif
 #endif
 }
+
+int
+os_thread_key_create(korp_key *key, void (*destructor)(void *))
+{
+    return pthread_key_create(key, destructor);
+}
+
+int
+os_thread_key_delete(korp_key key)
+{
+    return pthread_key_delete(key);
+}
+
+void *
+os_thread_getspecific(korp_key key)
+{
+    return pthread_getspecific(key);
+
+}
+
+int
+os_thread_setspecific(korp_key key, const void *value)
+{
+    return pthread_setspecific(key, value);
+}
 #endif /* end of OS_ENABLE_HW_BOUND_CHECK */

--- a/core/shared/platform/include/platform_api_extension.h
+++ b/core/shared/platform/include/platform_api_extension.h
@@ -403,6 +403,18 @@ os_end_blocking_op(void);
 int
 os_wakeup_blocking_op(korp_tid tid);
 
+int
+os_thread_key_create(korp_key *key, void (*destructor)(void *));
+
+int
+os_thread_key_delete(korp_key key);
+
+void *
+os_thread_getspecific(korp_key key);
+
+int
+os_thread_setspecific(korp_key key, const void *value);
+
 /****************************************************
  *                     Section 2                    *
  *                   Socket support                 *

--- a/core/shared/platform/linux/platform_internal.h
+++ b/core/shared/platform/linux/platform_internal.h
@@ -57,6 +57,7 @@ typedef pthread_cond_t korp_cond;
 typedef pthread_t korp_thread;
 typedef pthread_rwlock_t korp_rwlock;
 typedef sem_t korp_sem;
+typedef pthread_key_t korp_key;
 
 #define OS_THREAD_MUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER
 


### PR DESCRIPTION
Plan to replace process-level global variables with thread-local variables. The reason for not using the variable attribute `__thread` is due to concerns that it is a GCC extension and requires significant support from the linker (ld), dynamic linker (ld.so), and system libraries (libc.so and libpthread.so), making it not available everywhere.

Plus, memory initialization