### PR TITLE
Fix Compiler Error C2491

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -1504,7 +1504,7 @@ wasm_runtime_load_ex(uint8 *buf, uint32 size, const LoadArgs *args,
                                           error_buf_size);
 }
 
-WASM_RUNTIME_API_EXTERN bool
+bool
 wasm_runtime_resolve_symbols(WASMModuleCommon *module)
 {
 #if WASM_ENABLE_INTERP != 0
@@ -7836,7 +7836,7 @@ wasm_runtime_detect_native_stack_overflow_size(WASMExecEnv *exec_env,
     return true;
 }
 
-WASM_RUNTIME_API_EXTERN bool
+bool
 wasm_runtime_is_underlying_binary_freeable(WASMModuleCommon *const module)
 {
 #if WASM_ENABLE_INTERP != 0


### PR DESCRIPTION
> Data, static data members, and functions can be declared as `dllimports`
  but not defined as `dllimports`.

https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2491?view=msvc-170