### PR TITLE
add a sample to use cmake package

### DIFF
--- a/.github/workflows/compilation_on_android_ubuntu.yml
+++ b/.github/workflows/compilation_on_android_ubuntu.yml
@@ -437,6 +437,11 @@ jobs:
           ctest --test-dir build --output-on-failure
         working-directory: samples/wasm-c-api
 
+      - name: Build Sample [printversion]
+        run: |
+          ./test.sh
+        working-directory: samples/printversion
+
   build_samples_others:
     needs:
       [

--- a/.github/workflows/compilation_on_macos.yml
+++ b/.github/workflows/compilation_on_macos.yml
@@ -282,6 +282,11 @@ jobs:
           ctest --test-dir build --output-on-failure
         working-directory: samples/wasm-c-api
 
+      - name: Build Sample [printversion]
+        run: |
+          ./test.sh
+        working-directory: samples/printversion
+
   build_samples_others:
     needs: [build_iwasm, build_wamrc, build_llvm_libraries_on_intel_macos, build_llvm_libraries_on_arm_macos]
     runs-on: ${{ matrix.os }}

--- a/samples/printversion/CMakeLists.txt
+++ b/samples/printversion/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (C) 2025 Midokura Japan KK.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+cmake_minimum_required(VERSION 3.16)
+
+project(printversion LANGUAGES C)
+
+add_executable(printversion printversion.c)
+find_package(iwasm REQUIRED)
+target_link_libraries(printversion iwasm::vmlib)

--- a/samples/printversion/printversion.c
+++ b/samples/printversion/printversion.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2025 Midokura Japan KK.  All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include <wasm_export.h>
+
+int
+main(int argc, char **argv)
+{
+    uint32_t major;
+    uint32_t minor;
+    uint32_t patch;
+    wasm_runtime_get_version(&major, &minor, &patch);
+    printf("wasm-micro-runtime %" PRIu32 ".%" PRIu32 ".%" PRIu32 "\n", major,
+           minor, patch);
+}

--- a/samples/printversion/test.sh
+++ b/samples/printversion/test.sh
@@ -1,0 +1,24 @@
+#! /bin/sh
+
+# Copyright (C) 2025 Midokura Japan KK.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set -e
+
+DIST=$(mktemp -d)
+
+# WAMR_BUILD_SIMD=0 to avoid fetching simde, which is
+# not relevant to this particular test.
+cmake -B build-wamr \
+-D CMAKE_INSTALL_PREFIX=${DIST} \
+-D WAMR_BUILD_SIMD=0 \
+../..
+cmake --build build-wamr -t install
+
+cmake -B build-app \
+-D CMAKE_PREFIX_PATH=${DIST} \
+-D CMAKE_INSTALL_PREFIX=${DIST} \
+.
+cmake --build build-app
+
+./build-app/printversion


### PR DESCRIPTION

this sample specifically aims to test the top-level CMakeLists.txt,
which traditionally has weak coverage.

cf.
https://github.com/bytecodealliance/wasm-micro-runtime/issues/2686
https://github.com/bytecodealliance/wasm-micro-runtime/issues/4290
