### PR TITLE
Enhance type checking for function types in loader

### DIFF
--- a/core/iwasm/interpreter/wasm.h
+++ b/core/iwasm/interpreter/wasm.h
@@ -1243,7 +1243,7 @@ wasm_value_type_size_internal(uint8 value_type, uint8 pointer_size)
         return sizeof(int16);
 #endif
     else {
-        bh_assert(0);
+        bh_assert(0 && "Unknown value type. It should be handled ahead.");
     }
 #if WASM_ENABLE_GC == 0
     (void)pointer_size;

--- a/tests/fuzz/wasm-mutator-fuzz/CMakeLists.txt
+++ b/tests/fuzz/wasm-mutator-fuzz/CMakeLists.txt
@@ -181,7 +181,12 @@ add_link_options(-fsanitize=fuzzer -fno-sanitize=vptr)
 
 # Enable sanitizers if not in oss-fuzz environment
 set(CFLAGS_ENV $ENV{CFLAGS})
-string(FIND "${CFLAGS_ENV}" "-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION" IN_OSS_FUZZ)
+string(FIND "${CFLAGS_ENV}" "-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION" FUZZ_POS)
+if (FUZZ_POS GREATER -1)
+  set(IN_OSS_FUZZ 1)
+else()
+  set(IN_OSS_FUZZ 0)
+endif()
 
 add_subdirectory(aot-compiler)
 add_subdirectory(wasm-mutator)

--- a/tests/fuzz/wasm-mutator-fuzz/aot-compiler/CMakeLists.txt
+++ b/tests/fuzz/wasm-mutator-fuzz/aot-compiler/CMakeLists.txt
@@ -68,7 +68,7 @@ target_link_directories(aotclib PUBLIC ${LLVM_LIBRARY_DIR})
 target_link_libraries(aotclib PUBLIC ${REQUIRED_LLVM_LIBS})
 
 if(NOT IN_OSS_FUZZ)
-  message(STATUS "Enable ASan and UBSan in non-oss-fuzz environment")
+  message(STATUS "Enable ASan and UBSan in non-oss-fuzz environment for aotclib")
   target_compile_options(aotclib PUBLIC
     -fprofile-instr-generate -fcoverage-mapping
     -fno-sanitize-recover=all

--- a/tests/fuzz/wasm-mutator-fuzz/wasm-mutator/CMakeLists.txt
+++ b/tests/fuzz/wasm-mutator-fuzz/wasm-mutator/CMakeLists.txt
@@ -58,7 +58,7 @@ add_executable(wasm_mutator_fuzz wasm_mutator_fuzz.cc)
 target_link_libraries(wasm_mutator_fuzz PRIVATE vmlib m)
 
 if(NOT IN_OSS_FUZZ)
-  message(STATUS "Enable ASan and UBSan in non-oss-fuzz environment")
+  message(STATUS "Enable ASan and UBSan in non-oss-fuzz environment for vmlib")
   target_compile_options(vmlib PUBLIC
     -fprofile-instr-generate -fcoverage-mapping
     -fno-sanitize-recover=all

--- a/wamr-compiler/CMakeLists.txt
+++ b/wamr-compiler/CMakeLists.txt
@@ -315,6 +315,7 @@ if (WAMR_BUILD_LIB_WASI_THREADS EQUAL 1)
   include (${IWASM_DIR}/libraries/lib-wasi-threads/lib_wasi_threads.cmake)
 endif ()
 
+#TODO: sync up WAMR_BUILD_SANITIZER in config_common.cmake
 # set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wconversion -Wsign-conversion")
 if (WAMR_BUILD_TARGET MATCHES "X86_.*" OR WAMR_BUILD_TARGET STREQUAL "AMD_64")
   if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang" OR MSVC))


### PR DESCRIPTION
Especially when GC is enabled, a valid item of `module->types` needs additional checks before casting to `WASMFuncType`.

Also, avoid overflowing if reftype_map_count is 0.

Additionally, correctly set IN_OSS_FUZZ based on CFLAGS_ENV for sanitizer configuration. Update ASan and UBSan messages for clarity in non-oss-fuzz environments.

Since GC hasn't been enabled in it, the mini loader doesn't share the same problem.