### PR TITLE
Revert the location to install public headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,7 @@ add_library (vmlib ${WAMR_RUNTIME_LIB_SOURCE})
 set_target_properties (vmlib PROPERTIES OUTPUT_NAME iwasm)
 target_include_directories(vmlib INTERFACE
   $<BUILD_INTERFACE:${WAMR_ROOT_DIR}/core/iwasm/include>
-  $<INSTALL_INTERFACE:include/iwasm>
+  $<INSTALL_INTERFACE:include>
 )
 
 target_link_libraries (vmlib PUBLIC ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl ${CMAKE_THREAD_LIBS_INIT})
@@ -189,7 +189,7 @@ set_version_info (vmlib)
 install (TARGETS vmlib
   EXPORT iwasmTargets
   LIBRARY DESTINATION lib
-  PUBLIC_HEADER DESTINATION include/iwasm
+  PUBLIC_HEADER DESTINATION include
 )
 
 install_iwasm_package ()

--- a/product-mini/platforms/darwin/CMakeLists.txt
+++ b/product-mini/platforms/darwin/CMakeLists.txt
@@ -132,7 +132,7 @@ add_library (vmlib ${WAMR_RUNTIME_LIB_SOURCE})
 set_version_info (vmlib)
 
 target_include_directories(vmlib INTERFACE
-  $<INSTALL_INTERFACE:include/iwasm>
+  $<INSTALL_INTERFACE:include>
 )
 
 set (WAMR_PUBLIC_HEADERS
@@ -151,7 +151,7 @@ target_link_libraries (vmlib ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl -lpthr
 install (TARGETS vmlib
   EXPORT iwasmTargets
   DESTINATION lib
-  PUBLIC_HEADER DESTINATION include/iwasm
+  PUBLIC_HEADER DESTINATION include
 )
 
 install_iwasm_package ()

--- a/product-mini/platforms/linux/CMakeLists.txt
+++ b/product-mini/platforms/linux/CMakeLists.txt
@@ -177,7 +177,7 @@ add_library (vmlib ${WAMR_RUNTIME_LIB_SOURCE})
 set_version_info (vmlib)
 
 target_include_directories(vmlib INTERFACE
-  $<INSTALL_INTERFACE:include/iwasm>
+  $<INSTALL_INTERFACE:include>
 )
 
 set (WAMR_PUBLIC_HEADERS
@@ -197,7 +197,7 @@ target_link_libraries (vmlib ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl -lpthr
 install (TARGETS vmlib
   EXPORT iwasmTargets
   DESTINATION lib
-  PUBLIC_HEADER DESTINATION include/iwasm
+  PUBLIC_HEADER DESTINATION include
 )
 
 install_iwasm_package ()

--- a/product-mini/platforms/windows/CMakeLists.txt
+++ b/product-mini/platforms/windows/CMakeLists.txt
@@ -147,7 +147,7 @@ add_library (vmlib ${WAMR_RUNTIME_LIB_SOURCE})
 set_version_info (vmlib)
 
 target_include_directories(vmlib INTERFACE
-  $<INSTALL_INTERFACE:include/iwasm>
+  $<INSTALL_INTERFACE:include>
 )
 
 set (WAMR_PUBLIC_HEADERS
@@ -174,7 +174,7 @@ endif()
 install (TARGETS vmlib
   EXPORT iwasmTargets
   DESTINATION lib
-  PUBLIC_HEADER DESTINATION include/iwasm
+  PUBLIC_HEADER DESTINATION include
 )
 
 install_iwasm_package ()


### PR DESCRIPTION
This partly reverts "Cmake improvements".
(https://github.com/bytecodealliance/wasm-micro-runtime/pull/4076)

Recently we changed the location to install public headers. For example,
Old: include/wasm_export.h
New: include/iwasm/wasm_export.h

For cmake-based user applications using find_package(iwasm), the cmake package, namely target_include_directories(INSTALL_INTERFACE), is expected to add necessary compiler options like -isystem automatically. (See samples/printversion for an example of such user applications.)

However, in reality, not every user application uses cmake. This commit reverts the location to install public headers for now, to avoid breakage for non-cmake user applications.

In case we want to re-apply the location change in future, we should better communicate to the users. (eg. document migration proceduces in release notes.)

Fixes: https://github.com/bytecodealliance/wasm-micro-runtime/issues/4290

References:
https://cmake.org/cmake/help/latest/prop_tgt/INTERFACE_INCLUDE_DIRECTORIES.html