### PR TITLE
fix wasi-nn abi definitions

### DIFF
--- a/core/iwasm/libraries/wasi-nn/README.md
+++ b/core/iwasm/libraries/wasi-nn/README.md
@@ -37,7 +37,7 @@ There is a big difference between the two sets of functions, `tensor_type`.
 
 ```c
 #if WASM_ENABLE_WASI_EPHEMERAL_NN != 0
-typedef enum { fp16 = 0, fp32, fp64, bf16, u8, i32, i64 } tensor_type;
+typedef enum { fp16 = 0, fp32, fp64, u8, i32, i64 } tensor_type;
 #else
 typedef enum { fp16 = 0, fp32, up8, ip32 } tensor_type;
 #endif /* WASM_ENABLE_WASI_EPHEMERAL_NN != 0 */

--- a/core/iwasm/libraries/wasi-nn/include/wasi_nn_types.h
+++ b/core/iwasm/libraries/wasi-nn/include/wasi_nn_types.h
@@ -19,30 +19,19 @@ extern "C" {
  */
 
 // sync up with
-// https://github.com/WebAssembly/wasi-nn/blob/main/wit/wasi-nn.wit#L136 Error
-// codes returned by functions in this API.
+// https://github.com/WebAssembly/wasi-nn/blob/71320d95b8c6d43f9af7f44e18b1839db85d89b4/wasi-nn.witx#L5-L17
+// Error codes returned by functions in this API.
 typedef enum {
-    // No error occurred.
     success = 0,
-    // Caller module passed an invalid argument.
     invalid_argument,
-    // Invalid encoding.
     invalid_encoding,
-    // The operation timed out.
-    timeout,
-    // Runtime Error.
+    missing_memory,
+    busy,
     runtime_error,
-    // Unsupported operation.
     unsupported_operation,
-    // Graph is too large.
     too_large,
-    // Graph not found.
     not_found,
-    // The operation is insecure or has insufficient privilege to be performed.
-    // e.g., cannot access a hardware feature requested
-    security,
-    // The operation failed for an unspecified reason.
-    unknown,
+
     // for WasmEdge-wasi-nn
     end_of_sequence = 100,  // End of Sequence Found.
     context_full = 101,     // Context Full.
@@ -66,9 +55,9 @@ typedef struct {
 
 #if WASM_ENABLE_WASI_EPHEMERAL_NN != 0
 // sync up with
-// https://github.com/WebAssembly/wasi-nn/blob/main/wit/wasi-nn.wit#L27
+// https://github.com/WebAssembly/wasi-nn/blob/71320d95b8c6d43f9af7f44e18b1839db85d89b4/wasi-nn.witx#L19-L28
 // The type of the elements in a tensor.
-typedef enum { fp16 = 0, fp32, fp64, bf16, u8, i32, i64 } tensor_type;
+typedef enum { fp16 = 0, fp32, fp64, u8, i32, i64 } tensor_type;
 #else
 typedef enum { fp16 = 0, fp32, up8, ip32 } tensor_type;
 #endif /* WASM_ENABLE_WASI_EPHEMERAL_NN != 0 */

--- a/core/iwasm/libraries/wasi-nn/src/wasi_nn_openvino.c
+++ b/core/iwasm/libraries/wasi-nn/src/wasi_nn_openvino.c
@@ -161,8 +161,6 @@ wasi_nn_tensor_type_to_openvino_element_type(tensor_type wasi_nn_type)
 #if WASM_ENABLE_WASI_EPHEMERAL_NN != 0
         case fp64:
             return F64;
-        case bf16:
-            return BF16;
         case i64:
             return I64;
         case u8:


### PR DESCRIPTION
sync with a more appropriate version of the definitions.

as we use the "wasi_ephemeral_nn", which is p1-based, it seems
more appropriate to use definitions from witx, not wit.

it's a bit unfortunate p2-based wasi-nn made gratuitous changes
like this from p1.

note: this is an ABI change.
