### PR TITLE
wasi_nn_openvino.c: remove the tensor layout adjustment logic

### DIFF
--- a/core/iwasm/libraries/wasi-nn/src/wasi_nn_openvino.c
+++ b/core/iwasm/libraries/wasi-nn/src/wasi_nn_openvino.c
@@ -310,17 +310,6 @@ set_input(void *ctx, graph_execution_context exec_ctx, uint32_t index,
         if (ret != success)
             goto fail;
 
-        /* NCHW -> NHWC */
-        if (wasi_nn_tensor->dimensions->size == 4 || ov_dims[1] == 3) {
-            /* N */
-            /* H */
-            ov_dims[1] = ov_dims[2];
-            /* W */
-            ov_dims[2] = ov_dims[3];
-            /* C */
-            ov_dims[3] = 3;
-        }
-
         CHECK_OV_STATUS(ov_shape_create(wasi_nn_tensor->dimensions->size,
                                         ov_dims, &input_shape),
                         ret);
@@ -355,11 +344,6 @@ set_input(void *ctx, graph_execution_context exec_ctx, uint32_t index,
                         ret);
         CHECK_OV_STATUS(ov_preprocess_input_tensor_info_set_from(
                             input_tensor_info, ov_ctx->input_tensor),
-                        ret);
-        /* ! HAS TO BE NHWC. Match previous layout conversion */
-        CHECK_OV_STATUS(ov_layout_create("NHWC", &input_layout), ret);
-        CHECK_OV_STATUS(ov_preprocess_input_tensor_info_set_layout(
-                            input_tensor_info, input_layout),
                         ret);
 
         /* add RESIZE */


### PR DESCRIPTION
the logic in question seems like an attempt to work around some application bugs.
my wild guess is that it was for classification-example. cf. https://github.com/bytecodealliance/wasmtime/issues/10867

because wasi-nn api doesn't provide a way for users to express their intended layout, it seems impossible to "fix" it here without risking to break other applications.

btw, i suspect the condition
"if (wasi_nn_tensor->dimensions->size == 4 || ov_dims[1] == 3)" in the code in question was meant
"if (wasi_nn_tensor->dimensions->size == 4 && ov_dims[1] == 3)". this commit fixes it by removing it.

after this change, the classification-example mentioned above produces similar inferences as with wasmtime.
(i used the fixed version of tensor.bgr mentioned in https://github.com/bytecodealliance/wasmtime/issues/10867)

wasm-micro-runtime with this commit:
```
Found results, sorted top 5: [InferenceResult(963, 0.71130574), InferenceResult(762, 0.07070772), InferenceResult(909, 0.036355656), InferenceResult(926, 0.015456188), InferenceResult(567, 0.015344019)]
```

wasmtime:
```
Found results, sorted top 5: [InferenceResult(963, 0.7113058), InferenceResult(762, 0.070707425), InferenceResult(909, 0.036355816), InferenceResult(926, 0.01545616), InferenceResult(567, 0.015344027)]
```

wasm-micro-runtime without this commit:
```
Found results, sorted top 5: [InferenceResult(505, 0.097339325), InferenceResult(459, 0.053065795), InferenceResult(849, 0.03836019), InferenceResult(582, 0.036462624), InferenceResult(725, 0.030435428)]
```