### PR TITLE
Fix a linking error caused by commit #3580d1

### DIFF
--- a/wamr-compiler/CMakeLists.txt
+++ b/wamr-compiler/CMakeLists.txt
@@ -18,6 +18,7 @@ if (NOT WAMR_BUILD_PLATFORM STREQUAL "windows")
 else()
   project (aot-compiler C ASM CXX)
   enable_language (ASM_MASM)
+  add_definitions(-DCOMPILING_WASM_RUNTIME_API=1)
 endif()
 
 set (CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
Like:
```
vmlib.lib(blocking_op.obj) : error LNK2019: unresolved external symbol
__imp_wasm_runtime_begin_blocking_op referenced in function
blocking_op_close
[D:\a\wasm-micro-runtime\wasm-micro-runtime\wamr-compiler\build\wamrc.vcxproj]
vmlib.lib(blocking_op.obj) : error LNK2019: unresolved external symbol
__imp_wasm_runtime_end_blocking_op referenced in function
blocking_op_close
[D:\a\wasm-micro-runtime\wasm-micro-runtime\wamr-compiler\build\wamrc.vcxproj]
```