### PR TITLE
wasi-nn: remove unused wasi_nn_dump_tensor_dimension prototype

### DIFF
--- a/core/iwasm/libraries/wasi-nn/include/wasi_nn_types.h
+++ b/core/iwasm/libraries/wasi-nn/include/wasi_nn_types.h
@@ -160,10 +160,6 @@ typedef struct {
     BACKEND_DEINITIALIZE deinit;
 } api_function;
 
-void
-wasi_nn_dump_tensor_dimension(tensor_dimensions *dim, int32_t output_len,
-                              char *output);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
it has been added by the following commit.
i guess it's debug code slipped in by a mistake.
```
commit 058bc47102ea0a97159ef7f9c4c1d471af6a8e9a
Author: liang.he <liang.he@intel.com>
Date:   Mon Jul 22 17:16:41 2024 +0800

    [wasi-nn] Add a new wasi-nn backend openvino (#3603)
```