### PR TITLE
wasi-nn: fix the size of tensor->type

### DIFF
--- a/core/iwasm/libraries/wasi-nn/include/wasi_nn_types.h
+++ b/core/iwasm/libraries/wasi-nn/include/wasi_nn_types.h
@@ -79,7 +79,8 @@ typedef struct {
     // dimensions.
     tensor_dimensions *dimensions;
     // Describe the type of element in the tensor (e.g., f32).
-    tensor_type type;
+    uint8_t type;
+    uint8_t _pad[3];
     // Contains the tensor data.
     tensor_data data;
 } tensor;


### PR DESCRIPTION
* this enum is (@witx tag u8) in witx

* it seems that some wasm modules actually use non-zero padding and cause errors

* it's a bad practice to use C enum for ABI description anyway