### PR TITLE
wasi_nn_types.h: remove a seemingly stale comment

### DIFF
--- a/core/iwasm/libraries/wasi-nn/include/wasi_nn_types.h
+++ b/core/iwasm/libraries/wasi-nn/include/wasi_nn_types.h
@@ -134,8 +134,6 @@ typedef enum execution_target { cpu = 0, gpu, tpu } execution_target;
 // Bind a `graph` to the input and output tensors for an inference.
 typedef uint32_t graph_execution_context;
 
-/* Definition of 'wasi_nn.h' structs in WASM app format (using offset) */
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
to me, the comment doesn't seem to make sense even in the PR where it originally has been introduced:
https://github.com/bytecodealliance/wasm-micro-runtime/pull/1834 probably it was a leftover from unpublished earlier versions?