### PR TITLE
wasi-nn: add minimum serialization on WASINNContext

### DIFF
--- a/core/iwasm/libraries/wasi-nn/src/wasi_nn_private.h
+++ b/core/iwasm/libraries/wasi-nn/src/wasi_nn_private.h
@@ -9,7 +9,11 @@
 #include "wasi_nn_types.h"
 #include "wasm_export.h"
 
+#include "bh_platform.h"
+
 typedef struct {
+    korp_mutex lock;
+    bool busy;
     bool is_backend_ctx_initialized;
     bool is_model_loaded;
     graph_encoding backend;


### PR DESCRIPTION
currently this is not necessary because context (WASINNContext) is local to instance. (wasm_module_instance_t)

i plan to make a context shared among instances in a cluster when fixing https://github.com/bytecodealliance/wasm-micro-runtime/issues/4313. this is a preparation for that direction.

an obvious alternative is to tweak the module instance context APIs to allow declaring some kind of contexts instance-local. but i feel, in this particular case, it's more natural to make "wasi-nn handles" shared among threads within a "process".

note that, spec-wise, how wasi-nn behaves wrt threads is not defined at all because wasi officially doesn't have threads yet. i suppose, at this point, that how wasi-nn interacts with wasi-threads is something we need to define by ourselves, especially when we are using an outdated wasi-nn version.

with this change, if a thread attempts to access a context while another thread is using it, we simply make the operation fail with the "busy" error. this is intended for the mimimum serialization to avoid problems like crashes/leaks/etc. this is not intended to allow parallelism or such.

no functional changes are intended at this point yet.

cf.
https://github.com/bytecodealliance/wasm-micro-runtime/issues/4313
https://github.com/bytecodealliance/wasm-micro-runtime/issues/2430