### PR TITLE
Remove unnecessary conversion of __wasi_addr_t to bh_sockaddr_t in sock_recv_from()

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -2840,8 +2840,6 @@ wasmtime_ssp_sock_recv_from(wasm_exec_env_t exec_env, struct fd_table *curfds,
         return error;
     }
 
-    wasi_addr_to_bh_sockaddr(src_addr, &sockaddr);
-
     /* Consume bh_sockaddr_t instead of __wasi_addr_t */
     ret = blocking_op_socket_recv_from(exec_env, fo->file_handle, buf, buf_len,
                                        0, &sockaddr);


### PR DESCRIPTION
`src_addr` will be filled upon return. Before the call, its content is unpredictable.

fix a ci issue. https://github.com/bytecodealliance/wasm-micro-runtime/actions/runs/15731466177/job/44333440562#step:14:349