### PR TITLE
Fix handling of non-nullable global_type during global import when GC enabled

### DIFF
--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -3351,7 +3351,8 @@ load_import_section(const uint8 *buf, const uint8 *buf_end, WASMModule *module,
                     /* valtype */
                     CHECK_BUF(p, p_end, 1);
                     global_type = read_uint8(p);
-                    if (wasm_is_reftype_htref_nullable(global_type)) {
+                    if (wasm_is_reftype_htref_nullable(global_type)
+                        || wasm_is_reftype_htref_non_nullable(global_type)) {
                         int32 heap_type;
                         read_leb_int32(p, p_end, heap_type);
                         (void)heap_type;


### PR DESCRIPTION
### Previous Implementation
```C
// First pass (counting imports)
switch (kind) {
    case IMPORT_KIND_GLOBAL:
        if (wasm_is_reftype_htref_nullable(global_type))
            read_leb_int32(...)
}

// second pass (resolving imports)
switch (kind) {
    case IMPORT_KIND_GLOBAL:
        load_global_import(...) // -> resolve_value_type(...)
}
```
In function `resolve_value_type`:
```C
// function resolve_value_type()
if (wasm_is_reftype_htref_nullable(type)) {
    resolve_reftype_htref(...)  // -> read_leb_int32(...)
}
else if (wasm_is_reftype_htref_non_nullable(type)) {
    resolve_reftype_htref(...)  // -> read_leb_int32(...)
}
```

### Problem
- For non_nullable `global_type`, `read_leb_int32()` is skipped in the first pass but called in the second pass.
- This causes inconsistent pointer advancement (`p`) between the two pass.
- It may lead to buffer overflows or memory corruption.

### Fix
- Ensure `read_leb_int32(...)` is called for both nullable and non-nullable cases during the first pass.