### PR TITLE
wasi-nn: make the host use the wasi_ephemeral_nn version of tensor_data

### DIFF
--- a/core/iwasm/libraries/wasi-nn/include/wasi_nn_types.h
+++ b/core/iwasm/libraries/wasi-nn/include/wasi_nn_types.h
@@ -99,7 +99,7 @@ typedef enum {
 // 4-byte f32 elements would have a data array of length 16). Naturally, this
 // representation requires some knowledge of how to lay out data in
 // memory--e.g., using row-major ordering--and could perhaps be improved.
-#if WASM_ENABLE_WASI_EPHEMERAL_NN != 0 && defined(__wasm__)
+#if !defined(__wasm__) || WASM_ENABLE_WASI_EPHEMERAL_NN != 0
 typedef struct {
     uint8_t *buf;
     uint32_t size;

--- a/core/iwasm/libraries/wasi-nn/src/wasi_nn_llamacpp.c
+++ b/core/iwasm/libraries/wasi-nn/src/wasi_nn_llamacpp.c
@@ -382,7 +382,7 @@ set_input(void *ctx, graph_execution_context exec_ctx, uint32_t index,
 {
     struct LlamaContext *backend_ctx = (struct LlamaContext *)ctx;
     // tensor->data is the prompt string. ends with \0
-    char *prompt_text = (char *)wasi_nn_tensor->data;
+    char *prompt_text = (char *)wasi_nn_tensor->data.buf;
 
 #ifndef NDEBUG
     NN_DBG_PRINTF("--------------------------------------------------");
@@ -549,7 +549,7 @@ fail:
 
 __attribute__((visibility("default"))) wasi_nn_error
 get_output(void *ctx, graph_execution_context exec_ctx, uint32_t index,
-           tensor_data output_tensor, uint32_t *output_tensor_size)
+           tensor_data *output_tensor, uint32_t *output_tensor_size)
 {
     struct LlamaContext *backend_ctx = (struct LlamaContext *)ctx;
 
@@ -568,7 +568,7 @@ get_output(void *ctx, graph_execution_context exec_ctx, uint32_t index,
             printf("%s\n", output_metadata);
         }
 
-        memcpy(output_tensor, output_metadata, strlen(output_metadata));
+        memcpy(output_tensor->buf, output_metadata, strlen(output_metadata));
         *output_tensor_size = strlen(output_metadata);
         return success;
     }
@@ -588,7 +588,7 @@ get_output(void *ctx, graph_execution_context exec_ctx, uint32_t index,
             printf("%s", buf);
         }
 
-        memcpy(output_tensor + end_pos, buf, strlen(buf));
+        memcpy(output_tensor->buf + end_pos, buf, strlen(buf));
         end_pos += strlen(buf);
     }
 

--- a/core/iwasm/libraries/wasi-nn/src/wasi_nn_openvino.c
+++ b/core/iwasm/libraries/wasi-nn/src/wasi_nn_openvino.c
@@ -402,7 +402,7 @@ set_input(void *ctx, graph_execution_context exec_ctx, uint32_t index,
                       shape_info);
 
         CHECK_OV_STATUS(ov_tensor_create_from_host_ptr(input_type, input_shape,
-                                                       wasi_nn_tensor->data,
+                                                       wasi_nn_tensor->data.buf,
                                                        &input_tensor),
                         ret);
     }
@@ -441,7 +441,7 @@ fail:
 
 __attribute__((visibility("default"))) wasi_nn_error
 get_output(void *ctx, graph_execution_context exec_ctx, uint32_t index,
-           tensor_data output_tensor, uint32_t *output_tensor_size)
+           tensor_data *output_tensor, uint32_t *output_tensor_size)
 {
     OpenVINOContext *ov_ctx = (OpenVINOContext *)ctx;
     struct OpenVINOExecutionContext *exec;
@@ -460,14 +460,14 @@ get_output(void *ctx, graph_execution_context exec_ctx, uint32_t index,
 
     CHECK_OV_STATUS(ov_tensor_get_byte_size(ov_tensor, &byte_size), ret);
 
-    if (byte_size > *output_tensor_size) {
+    if (byte_size > output_tensor->size) {
         ret = too_large;
         goto fail;
     }
 
     CHECK_OV_STATUS(ov_tensor_data(ov_tensor, &data), ret);
 
-    memcpy(output_tensor, data, byte_size);
+    memcpy(output_tensor->buf, data, byte_size);
 
     *output_tensor_size = (uint32_t)byte_size;
 

--- a/core/iwasm/libraries/wasi-nn/src/wasi_nn_openvino.h
+++ b/core/iwasm/libraries/wasi-nn/src/wasi_nn_openvino.h
@@ -24,7 +24,7 @@ compute(void *ctx, graph_execution_context exec_ctx);
 
 __attribute__((visibility("default"))) wasi_nn_error
 get_output(void *ctx, graph_execution_context exec_ctx, uint32_t index,
-           tensor_data output_tensor, uint32_t *output_tensor_size);
+           tensor_data *output_tensor, uint32_t *output_tensor_size);
 
 __attribute__((visibility("default"))) wasi_nn_error
 init_backend(void **ctx);

--- a/core/iwasm/libraries/wasi-nn/src/wasi_nn_private.h
+++ b/core/iwasm/libraries/wasi-nn/src/wasi_nn_private.h
@@ -32,7 +32,7 @@ typedef wasi_nn_error (*SET_INPUT)(void *, graph_execution_context, uint32_t,
                                    tensor *);
 typedef wasi_nn_error (*COMPUTE)(void *, graph_execution_context);
 typedef wasi_nn_error (*GET_OUTPUT)(void *, graph_execution_context, uint32_t,
-                                    tensor_data, uint32_t *);
+                                    tensor_data *, uint32_t *);
 /* wasi-nn general APIs */
 typedef wasi_nn_error (*BACKEND_INITIALIZE)(void **);
 typedef wasi_nn_error (*BACKEND_DEINITIALIZE)(void *);

--- a/core/iwasm/libraries/wasi-nn/src/wasi_nn_tensorflowlite.hpp
+++ b/core/iwasm/libraries/wasi-nn/src/wasi_nn_tensorflowlite.hpp
@@ -32,7 +32,7 @@ compute(void *tflite_ctx, graph_execution_context ctx);
 
 __attribute__((visibility("default"))) wasi_nn_error
 get_output(void *tflite_ctx, graph_execution_context ctx, uint32_t index,
-           tensor_data output_tensor, uint32_t *output_tensor_size);
+           tensor_data *output_tensor, uint32_t *output_tensor_size);
 
 __attribute__((visibility("default"))) wasi_nn_error
 init_backend(void **tflite_ctx);


### PR DESCRIPTION
the motivations:

* make the actual input size available to the backends. (currently the backends have to make a guess from shape/type.)

* make the host logic look a bit similar to wasi_ephemeral_nn.

this is a backend api/abi change.