### PR TITLE
wasi_nn_openvino.c: fix a debug build

### DIFF
--- a/core/iwasm/libraries/wasi-nn/src/wasi_nn_openvino.c
+++ b/core/iwasm/libraries/wasi-nn/src/wasi_nn_openvino.c
@@ -287,7 +287,7 @@ load(void *ctx, graph_builder_array *builder, graph_encoding encoding,
                         graph->weights_tensor, &graph->model),
                     ret);
 #ifndef NDEBUG
-    print_model_input_output_info(ov_ctx->model);
+    print_model_input_output_info(graph->model);
 #endif
 
     CHECK_OV_STATUS(ov_core_compile_model(ov_ctx->core, graph->model, "CPU", 0,


### PR DESCRIPTION
after "wasi_nn_openvino.c: implement multiple models per instance" change. (https://github.com/bytecodealliance/wasm-micro-runtime/pull/4380)