### PR TITLE
Avoid executable stack by marking that it's not required. (release/1.3.x)

### DIFF
--- a/core/iwasm/common/arch/invokeNative_em64.s
+++ b/core/iwasm/common/arch/invokeNative_em64.s
@@ -62,3 +62,6 @@ push_args_end:
     leave
     ret
 
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
Also refer to: https://github.com/fluent/fluent-bit/issues/10513