### PR TITLE
Refactor AOTObjectData definition to use a forward declaration

### DIFF
--- a/core/iwasm/compilation/aot_emit_aot_file.c
+++ b/core/iwasm/compilation/aot_emit_aot_file.c
@@ -48,7 +48,7 @@ typedef struct AOTSymbolList {
 } AOTSymbolList;
 
 /* AOT object data */
-typedef struct AOTObjectData {
+struct AOTObjectData {
     AOTCompContext *comp_ctx;
 
     LLVMMemoryBufferRef mem_buf;
@@ -82,7 +82,7 @@ typedef struct AOTObjectData {
     const char *stack_sizes_section_name;
     uint32 stack_sizes_offset;
     uint32 *stack_sizes;
-} AOTObjectData;
+};
 
 #if 0
 static void dump_buf(uint8 *buf, uint32 size, char *title)


### PR DESCRIPTION
> core/iwasm/compilation/aot_emit_aot_file.c:85:3:
    error: redefinition of typedef 'AOTObjectData' is a C11 feature