### PR TITLE
Fix potential integer overflow issues

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -3639,7 +3639,7 @@ aot_get_module_inst_mem_consumption(const AOTModuleInstance *module_inst,
     for (i = 0; i < module_inst->memory_count; i++) {
         AOTMemoryInstance *mem_inst = module_inst->memories[i];
         mem_conspn->memories_size +=
-            mem_inst->num_bytes_per_page * mem_inst->cur_page_count;
+            (uint64)mem_inst->num_bytes_per_page * mem_inst->cur_page_count;
         mem_conspn->app_heap_size =
             mem_inst->heap_data_end - mem_inst->heap_data;
         /* size of app heap structure */

--- a/core/iwasm/compilation/aot_emit_aot_file.c
+++ b/core/iwasm/compilation/aot_emit_aot_file.c
@@ -302,8 +302,8 @@ get_init_expr_size(const AOTCompContext *comp_ctx, const AOTCompData *comp_data,
 
             /* array_elem_type + type_index + len + elems */
             size += sizeof(uint32) * 3
-                    + wasm_value_type_size_internal(array_type->elem_type,
-                                                    comp_ctx->pointer_size)
+                    + (uint64)wasm_value_type_size_internal(
+                          array_type->elem_type, comp_ctx->pointer_size)
                           * value_count;
             break;
         }

--- a/core/iwasm/compilation/aot_emit_function.c
+++ b/core/iwasm/compilation/aot_emit_function.c
@@ -347,7 +347,8 @@ call_aot_invoke_c_api_native(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
 
     /* Get &c_api_func_imports[func_idx], note size of CApiFuncImport
        is pointer_size * 3 */
-    offset = I32_CONST((comp_ctx->pointer_size * 3) * import_func_idx);
+    offset = I32_CONST((unsigned long long)comp_ctx->pointer_size * 3
+                       * import_func_idx);
     CHECK_LLVM_CONST(offset);
     c_api_func_import =
         LLVMBuildInBoundsGEP2(comp_ctx->builder, INT8_TYPE, c_api_func_imports,

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -4161,7 +4161,7 @@ wasm_get_module_inst_mem_consumption(const WASMModuleInstance *module_inst,
         sizeof(WASMMemoryInstance *) * module_inst->memory_count;
     for (i = 0; i < module_inst->memory_count; i++) {
         WASMMemoryInstance *memory = module_inst->memories[i];
-        size = memory->num_bytes_per_page * memory->cur_page_count;
+        size = (uint64)memory->num_bytes_per_page * memory->cur_page_count;
         mem_conspn->memories_size += size;
         mem_conspn->app_heap_size += memory->heap_data_end - memory->heap_data;
         /* size of app heap structure */

--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -301,7 +301,8 @@ wasm_cluster_create(WASMExecEnv *exec_env)
         aux_stack_start -= cluster->stack_size;
 
         for (i = 0; i < cluster_max_thread_num; i++) {
-            cluster->stack_tops[i] = aux_stack_start - cluster->stack_size * i;
+            cluster->stack_tops[i] =
+                aux_stack_start - (uint64)cluster->stack_size * i;
         }
     }
 #endif


### PR DESCRIPTION
It is reported as "Multiplication result converted to larger type". And "Multiplication result may overflow 'Type A' before it is converted to 'Type B'." Type A is a larger type than Type B.

Since the conversion applies after the multiplication, arithmetic overflow may still occur.

> The rule flags every multiplication of two non-constant integer expressions
> that is (explicitly or implicitly) converted to a larger integer type. The
> conversion is an indication that the expression would produce a result that
> would be too large to fit in the smaller integer type.