### PR TITLE
introduce wasm_runtime_instantiate_ex2

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -1654,14 +1654,70 @@ wasm_runtime_instantiate(WASMModuleCommon *module, uint32 stack_size,
                                              error_buf_size);
 }
 
+static void
+instantiation_args_set_defaults(struct InstantiationArgs2 *args)
+{
+    memset(args, 0, sizeof(*args));
+}
+
 WASMModuleInstanceCommon *
 wasm_runtime_instantiate_ex(WASMModuleCommon *module,
                             const InstantiationArgs *args, char *error_buf,
                             uint32 error_buf_size)
 {
+    struct InstantiationArgs2 v2;
+    instantiation_args_set_defaults(&v2);
+    v2.v1 = *args;
+    return wasm_runtime_instantiate_ex2(module, &v2, error_buf, error_buf_size);
+}
+
+bool
+wasm_runtime_instantiation_args_create(struct InstantiationArgs2 **p)
+{
+    struct InstantiationArgs2 *args = wasm_runtime_malloc(sizeof(*args));
+    if (args == NULL) {
+        return false;
+    }
+    instantiation_args_set_defaults(args);
+    *p = args;
+    return true;
+}
+
+void
+wasm_runtime_instantiation_args_destroy(struct InstantiationArgs2 *p)
+{
+    wasm_runtime_free(p);
+}
+
+void
+wasm_runtime_instantiation_args_set_default_stack_size(
+    struct InstantiationArgs2 *p, uint32 v)
+{
+    p->v1.default_stack_size = v;
+}
+
+void
+wasm_runtime_instantiation_args_set_host_managed_heap_size(
+    struct InstantiationArgs2 *p, uint32 v)
+{
+    p->v1.host_managed_heap_size = v;
+}
+
+void
+wasm_runtime_instantiation_args_set_max_memory_pages(
+    struct InstantiationArgs2 *p, uint32 v)
+{
+    p->v1.max_memory_pages = v;
+}
+
+WASMModuleInstanceCommon *
+wasm_runtime_instantiate_ex2(WASMModuleCommon *module,
+                             const struct InstantiationArgs2 *args,
+                             char *error_buf, uint32 error_buf_size)
+{
     return wasm_runtime_instantiate_internal(
-        module, NULL, NULL, args->default_stack_size,
-        args->host_managed_heap_size, args->max_memory_pages, error_buf,
+        module, NULL, NULL, args->v1.default_stack_size,
+        args->v1.host_managed_heap_size, args->v1.max_memory_pages, error_buf,
         error_buf_size);
 }
 

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -612,6 +612,10 @@ WASMExecEnv *
 wasm_runtime_get_exec_env_tls(void);
 #endif
 
+struct InstantiationArgs2 {
+    InstantiationArgs v1;
+};
+
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN bool
 wasm_runtime_init(void);
@@ -699,6 +703,40 @@ WASM_RUNTIME_API_EXTERN WASMModuleInstanceCommon *
 wasm_runtime_instantiate_ex(WASMModuleCommon *module,
                             const InstantiationArgs *args, char *error_buf,
                             uint32 error_buf_size);
+
+/* See wasm_export.h for description */
+WASM_RUNTIME_API_EXTERN
+bool
+wasm_runtime_instantiation_args_create(struct InstantiationArgs2 **p);
+
+/* See wasm_export.h for description */
+WASM_RUNTIME_API_EXTERN
+void
+wasm_runtime_instantiation_args_destroy(struct InstantiationArgs2 *p);
+
+/* See wasm_export.h for description */
+WASM_RUNTIME_API_EXTERN
+void
+wasm_runtime_instantiation_args_set_default_stack_size(
+    struct InstantiationArgs2 *p, uint32 v);
+
+/* See wasm_export.h for description */
+WASM_RUNTIME_API_EXTERN
+void
+wasm_runtime_instantiation_args_set_host_managed_heap_size(
+    struct InstantiationArgs2 *p, uint32 v);
+
+/* See wasm_export.h for description */
+WASM_RUNTIME_API_EXTERN
+void
+wasm_runtime_instantiation_args_set_max_memory_pages(
+    struct InstantiationArgs2 *p, uint32 v);
+
+/* See wasm_export.h for description */
+WASM_RUNTIME_API_EXTERN WASMModuleInstanceCommon *
+wasm_runtime_instantiate_ex2(WASMModuleCommon *module,
+                             const struct InstantiationArgs2 *args,
+                             char *error_buf, uint32 error_buf_size);
 
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN bool

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -289,6 +289,8 @@ typedef struct InstantiationArgs {
 } InstantiationArgs;
 #endif /* INSTANTIATION_ARGS_OPTION_DEFINED */
 
+struct InstantiationArgs2;
+
 #ifndef WASM_VALKIND_T_DEFINED
 #define WASM_VALKIND_T_DEFINED
 typedef uint8_t wasm_valkind_t;
@@ -731,6 +733,46 @@ WASM_RUNTIME_API_EXTERN wasm_module_inst_t
 wasm_runtime_instantiate_ex(const wasm_module_t module,
                             const InstantiationArgs *args, char *error_buf,
                             uint32_t error_buf_size);
+
+/**
+ * Create an InstantiationArgs2 object with default parameters.
+ *
+ * @return true if success, false otherwise
+ */
+WASM_RUNTIME_API_EXTERN bool
+wasm_runtime_instantiation_args_create(struct InstantiationArgs2 **p);
+
+/**
+ * Dispose an InstantiationArgs2 object.
+ */
+WASM_RUNTIME_API_EXTERN void
+wasm_runtime_instantiation_args_destroy(struct InstantiationArgs2 *p);
+
+/**
+ * Setter functions for the InstantiationArgs2 object.
+ */
+WASM_RUNTIME_API_EXTERN void
+wasm_runtime_instantiation_args_set_default_stack_size(
+    struct InstantiationArgs2 *p, uint32_t v);
+
+WASM_RUNTIME_API_EXTERN void
+wasm_runtime_instantiation_args_set_host_managed_heap_size(
+    struct InstantiationArgs2 *p, uint32_t v);
+
+WASM_RUNTIME_API_EXTERN void
+wasm_runtime_instantiation_args_set_max_memory_pages(
+    struct InstantiationArgs2 *p, uint32_t v);
+
+/**
+ * Instantiate a WASM module, with specified instantiation arguments
+ *
+ * Same as wasm_runtime_instantiate_ex, but this version takes
+ * InstantiationArgs2, which can be extended without breaking the ABI.
+ */
+WASM_RUNTIME_API_EXTERN wasm_module_inst_t
+wasm_runtime_instantiate_ex2(const wasm_module_t module,
+                             const struct InstantiationArgs2 *args,
+                             char *error_buf, uint32_t error_buf_size);
 
 /**
  * Set the running mode of a WASM module instance, override the


### PR DESCRIPTION
at this point, just a slightly inefficiant functionality
equivalent of wasm_runtime_instantiate_ex.
however, unlike wasm_runtime_instantiate_ex, this one is designed
to be extendable without breaking the user-visible ABI.
because the definition of InstantiationArgs2 is not exposed to
users, we can safely add new members to it.

this commit also makes wasm_runtime_instantiate_ex a wrapper
of wasm_runtime_instantiate_ex2.

if this goes well, maybe it's a good idea to apply a similar
pattern to RuntimeInitArgs, LoadArgs, SharedHeapInitArgs, etc.
i started with InstantiationArgs just because i happen to have
a need to extend it for wasi-nn.

cf.
https://github.com/bytecodealliance/wasm-micro-runtime/issues/4364
https://github.com/bytecodealliance/wasm-micro-runtime/issues/4331
