### PR TITLE
Revert "libc-wasi: Make rights of STDIN/STDOUT/STDERR fixed and overl…

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -459,27 +459,8 @@ fd_determine_type_rights(os_file_handle fd, __wasi_filetype_t *type,
                          __wasi_rights_t *rights_inheriting)
 {
     struct __wasi_filestat_t buf;
-    __wasi_errno_t error;
+    __wasi_errno_t error = os_fstat(fd, &buf);
 
-    if (os_is_stdin_handle(fd)) {
-        *rights_base = RIGHTS_STDIN;
-        *rights_inheriting = RIGHTS_STDIN;
-        return __WASI_ESUCCESS;
-    }
-
-    if (os_is_stdout_handle(fd)) {
-        *rights_base = RIGHTS_STDOUT;
-        *rights_inheriting = RIGHTS_STDOUT;
-        return __WASI_ESUCCESS;
-    }
-
-    if (os_is_stderr_handle(fd)) {
-        *rights_base = RIGHTS_STDERR;
-        *rights_inheriting = RIGHTS_STDERR;
-        return __WASI_ESUCCESS;
-    }
-
-    error = os_fstat(fd, &buf);
     if (error != __WASI_ESUCCESS)
         return error;
 

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/rights.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/rights.h
@@ -47,19 +47,6 @@
 #define RIGHTS_CHARACTER_DEVICE_BASE RIGHTS_ALL
 #define RIGHTS_CHARACTER_DEVICE_INHERITING RIGHTS_ALL
 
-#define RIGHTS_STDIN \
-  (__WASI_RIGHT_FD_ADVISE | __WASI_RIGHT_FD_FILESTAT_GET | \
-  __WASI_RIGHT_FD_READ | __WASI_RIGHT_FD_WRITE | \
-  __WASI_RIGHT_POLL_FD_READWRITE)
-
-#define RIGHTS_STDOUT \
-  (__WASI_RIGHT_FD_ADVISE | __WASI_RIGHT_FD_DATASYNC | \
-  __WASI_RIGHT_FD_FILESTAT_GET | __WASI_RIGHT_FD_SYNC | \
-  __WASI_RIGHT_FD_READ | __WASI_RIGHT_FD_WRITE | \
-  __WASI_RIGHT_POLL_FD_READWRITE)
-
-#define RIGHTS_STDERR RIGHTS_STDOUT
-
 // Only allow directory operations on directories. Directories can only
 // yield file descriptors to other directories and files.
 #define RIGHTS_DIRECTORY_BASE                                          \

--- a/core/shared/platform/common/posix/posix_file.c
+++ b/core/shared/platform/common/posix/posix_file.c
@@ -54,18 +54,6 @@
 #define CONFIG_HAS_O_SYNC
 #endif
 
-#ifndef STDIN_FILENO
-#define STDIN_FILENO 0
-#endif
-
-#ifndef STDOUT_FILENO
-#define STDOUT_FILENO 1
-#endif
-
-#ifndef STDERR_FILENO
-#define STDERR_FILENO 2
-#endif
-
 // Converts a POSIX timespec to a WASI timestamp.
 static __wasi_timestamp_t
 convert_timespec(const struct timespec *ts)
@@ -870,39 +858,30 @@ os_isatty(os_file_handle handle)
 #endif
 }
 
-bool
-os_is_stdin_handle(os_file_handle fd)
-{
-    return fd == STDIN_FILENO;
-}
-
-bool
-os_is_stdout_handle(os_file_handle fd)
-{
-    return fd == STDOUT_FILENO;
-}
-
-bool
-os_is_stderr_handle(os_file_handle fd)
-{
-    return fd == STDERR_FILENO;
-}
-
 os_file_handle
 os_convert_stdin_handle(os_raw_file_handle raw_stdin)
 {
+#ifndef STDIN_FILENO
+#define STDIN_FILENO 0
+#endif
     return raw_stdin >= 0 ? raw_stdin : STDIN_FILENO;
 }
 
 os_file_handle
 os_convert_stdout_handle(os_raw_file_handle raw_stdout)
 {
+#ifndef STDOUT_FILENO
+#define STDOUT_FILENO 1
+#endif
     return raw_stdout >= 0 ? raw_stdout : STDOUT_FILENO;
 }
 
 os_file_handle
 os_convert_stderr_handle(os_raw_file_handle raw_stderr)
 {
+#ifndef STDERR_FILENO
+#define STDERR_FILENO 2
+#endif
     return raw_stderr >= 0 ? raw_stderr : STDERR_FILENO;
 }
 

--- a/core/shared/platform/esp-idf/espidf_file.c
+++ b/core/shared/platform/esp-idf/espidf_file.c
@@ -54,18 +54,6 @@
 #define CONFIG_HAS_O_SYNC
 #endif
 
-#ifndef STDIN_FILENO
-#define STDIN_FILENO 0
-#endif
-
-#ifndef STDOUT_FILENO
-#define STDOUT_FILENO 1
-#endif
-
-#ifndef STDERR_FILENO
-#define STDERR_FILENO 2
-#endif
-
 // Converts a POSIX timespec to a WASI timestamp.
 static __wasi_timestamp_t
 convert_timespec(const struct timespec *ts)
@@ -870,39 +858,30 @@ os_isatty(os_file_handle handle)
 #endif
 }
 
-bool
-os_is_stdin_handle(os_file_handle fd)
-{
-    return fd == STDIN_FILENO;
-}
-
-bool
-os_is_stdout_handle(os_file_handle fd)
-{
-    return fd == STDOUT_FILENO;
-}
-
-bool
-os_is_stderr_handle(os_file_handle fd)
-{
-    return fd == STDERR_FILENO;
-}
-
 os_file_handle
 os_convert_stdin_handle(os_raw_file_handle raw_stdin)
 {
+#ifndef STDIN_FILENO
+#define STDIN_FILENO 0
+#endif
     return raw_stdin >= 0 ? raw_stdin : STDIN_FILENO;
 }
 
 os_file_handle
 os_convert_stdout_handle(os_raw_file_handle raw_stdout)
 {
+#ifndef STDOUT_FILENO
+#define STDOUT_FILENO 1
+#endif
     return raw_stdout >= 0 ? raw_stdout : STDOUT_FILENO;
 }
 
 os_file_handle
 os_convert_stderr_handle(os_raw_file_handle raw_stderr)
 {
+#ifndef STDERR_FILENO
+#define STDERR_FILENO 2
+#endif
     return raw_stderr >= 0 ? raw_stderr : STDERR_FILENO;
 }
 

--- a/core/shared/platform/include/platform_api_extension.h
+++ b/core/shared/platform/include/platform_api_extension.h
@@ -1504,33 +1504,6 @@ os_file_handle
 os_convert_stderr_handle(os_raw_file_handle raw_stderr);
 
 /**
- *
- * @param fd a file handle
- *
- * @return true if it is stdin
- */
-bool
-os_is_stdin_handle(os_file_handle fd);
-
-/**
- *
- * @param fd a file handle
- *
- * @return true if it is stdout
- */
-bool
-os_is_stdout_handle(os_file_handle fd);
-
-/**
- *
- * @param fd a file handle
- *
- * @return true if it is stderr
- */
-bool
-os_is_stderr_handle(os_file_handle fd);
-
-/**
  * Open a directory stream for the provided directory handle. The returned
  * directory stream will be positioned at the first entry in the directory.
  *

--- a/core/shared/platform/windows/win_file.c
+++ b/core/shared/platform/windows/win_file.c
@@ -1540,24 +1540,6 @@ create_stdio_handle(HANDLE raw_stdio_handle, DWORD stdio)
     return stdio_handle;
 }
 
-bool
-os_is_stdin_handle(os_file_handle fd)
-{
-    return fd->raw.handle == GetStdHandle(STD_INPUT_HANDLE);
-}
-
-bool
-os_is_stdout_handle(os_file_handle fd)
-{
-    return fd->raw.handle == GetStdHandle(STD_OUTPUT_HANDLE);
-}
-
-bool
-os_is_stderr_handle(os_file_handle fd)
-{
-    return fd->raw.handle == GetStdHandle(STD_ERROR_HANDLE);
-}
-
 os_file_handle
 os_convert_stdin_handle(os_raw_file_handle raw_stdin)
 {


### PR DESCRIPTION
…ook their access modes (#3694)"

This reverts commit 67fa155878861699336380980c3601f733f56194.

because it broke certain use cases while
it isn't clear what it fixed.

tested with:
https://github.com/yamt/garbage/tree/master/wasm/httpd
https://github.com/yamt/garbage/tree/master/wasm/tty

cf.
https://github.com/bytecodealliance/wasm-micro-runtime/issues/4447
https://github.com/bytecodealliance/wasm-micro-runtime/issues/3686#issuecomment-2998903186