### PR TITLE
Enable aux stack frame for aot compiler fuzz test

### DIFF
--- a/tests/fuzz/wasm-mutator-fuzz/aot-compiler/aot_compiler_fuzz.cc
+++ b/tests/fuzz/wasm-mutator-fuzz/aot-compiler/aot_compiler_fuzz.cc
@@ -58,6 +58,7 @@ LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     option.enable_simd = true;
     option.enable_ref_types = true;
     option.enable_gc = true;
+    option.aux_stack_frame_type = AOT_STACK_FRAME_TYPE_STANDARD;
 
     comp_data =
         aot_create_comp_data(module, option.target_arch, option.enable_gc);


### PR DESCRIPTION
To improve aot compiler fuzz test coverage. 
Some ops like `WASM_OP_EXTERN_CONVERT_ANY` needs a `AOTCompFrame`
