### PR TITLE
posix os_socket_addr_resolve: return the consistent max_info_size

### DIFF
--- a/core/shared/platform/common/posix/posix_socket.c
+++ b/core/shared/platform/common/posix/posix_socket.c
@@ -406,12 +406,11 @@ os_socket_addr_resolve(const char *host, const char *service,
 
     res = result;
     while (res) {
+        if (!is_addrinfo_supported(res)) {
+            res = res->ai_next;
+            continue;
+        }
         if (addr_info_size > pos) {
-            if (!is_addrinfo_supported(res)) {
-                res = res->ai_next;
-                continue;
-            }
-
             ret =
                 sockaddr_to_bh_sockaddr(res->ai_addr, &addr_info[pos].sockaddr);
 


### PR DESCRIPTION
return the same value for max_info_size regardless of addr_info_size.