### PR TITLE
posix os_socket_addr_resolve: relax compatibility check

### DIFF
--- a/core/shared/platform/common/posix/posix_socket.c
+++ b/core/shared/platform/common/posix/posix_socket.c
@@ -373,8 +373,8 @@ is_addrinfo_supported(struct addrinfo *info)
         (info->ai_family == AF_INET || info->ai_family == AF_INET6)
         // Allow only UDP and TCP
         && (info->ai_socktype == SOCK_DGRAM || info->ai_socktype == SOCK_STREAM)
-        && (info->ai_protocol == IPPROTO_TCP
-            || info->ai_protocol == IPPROTO_UDP);
+        && (info->ai_protocol == IPPROTO_TCP || info->ai_protocol == IPPROTO_UDP
+            || info->ai_protocol == 0);
 }
 
 int


### PR DESCRIPTION
some getaddrinfo implementations sometimes return results with ai_protocol=0.

cf. https://github.com/apache/nuttx/issues/16693

standard-wise, i couldn't find anything about ai_protocol in susv4-2018 except the following text:

> The fields ai_family, ai_socktype, and ai_protocol shall be usable
> as the arguments to the socket() function to create a socket suitable
> for use with the returned address.

because ai_protocol is usually merely used to feed socket() and socket() usually accepts 0, it's probably standard-wise ok for getaddrinfo to return ai_protocol=0.
the major implementations of getaddrinfo (eg. kame) seem to return specific values like ai_protocol=IPPROTO_TCP though.

anyway, for the purpose of this function, there is little point to be strict on the host getaddrinfo behavior. this commit just relaxes the check to be friendly to those getaddrinfo implementations.