### PR TITLE
wasi_socket_ext.c: fix error reporting

### DIFF
--- a/core/iwasm/libraries/lib-socket/src/wasi/wasi_socket_ext.c
+++ b/core/iwasm/libraries/lib-socket/src/wasi/wasi_socket_ext.c
@@ -191,7 +191,7 @@ bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
     error = __wasi_sock_bind(sockfd, &wasi_addr);
     HANDLE_ERROR(error)
 
-    return __WASI_ERRNO_SUCCESS;
+    return 0;
 }
 
 int
@@ -212,7 +212,7 @@ connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
     error = __wasi_sock_connect(sockfd, &wasi_addr);
     HANDLE_ERROR(error)
 
-    return __WASI_ERRNO_SUCCESS;
+    return 0;
 }
 
 int
@@ -220,7 +220,7 @@ listen(int sockfd, int backlog)
 {
     __wasi_errno_t error = __wasi_sock_listen(sockfd, backlog);
     HANDLE_ERROR(error)
-    return __WASI_ERRNO_SUCCESS;
+    return 0;
 }
 
 ssize_t
@@ -375,7 +375,7 @@ socket(int domain, int type, int protocol)
         af = INET6;
     }
     else {
-        return __WASI_ERRNO_NOPROTOOPT;
+        HANDLE_ERROR(__WASI_ERRNO_NOPROTOOPT)
     }
 
     if (SOCK_DGRAM == type) {
@@ -385,7 +385,7 @@ socket(int domain, int type, int protocol)
         socktype = SOCKET_STREAM;
     }
     else {
-        return __WASI_ERRNO_NOPROTOOPT;
+        HANDLE_ERROR(__WASI_ERRNO_NOPROTOOPT)
     }
 
     error = __wasi_sock_open(poolfd, af, socktype, &sockfd);
@@ -408,7 +408,7 @@ getsockname(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
     error = wasi_addr_to_sockaddr(&wasi_addr, addr, addrlen);
     HANDLE_ERROR(error)
 
-    return __WASI_ERRNO_SUCCESS;
+    return 0;
 }
 
 int
@@ -425,7 +425,7 @@ getpeername(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
     error = wasi_addr_to_sockaddr(&wasi_addr, addr, addrlen);
     HANDLE_ERROR(error)
 
-    return __WASI_ERRNO_SUCCESS;
+    return 0;
 }
 
 struct aibuf {
@@ -614,38 +614,38 @@ get_sol_socket_option(int sockfd, int optname, void *__restrict optval,
             error = __wasi_sock_get_recv_timeout(sockfd, &timeout_us);
             HANDLE_ERROR(error);
             *(struct timeval *)optval = time_us_to_timeval(timeout_us);
-            return error;
+            return 0;
         case SO_SNDTIMEO:
             assert(*optlen == sizeof(struct timeval));
             error = __wasi_sock_get_send_timeout(sockfd, &timeout_us);
             HANDLE_ERROR(error);
             *(struct timeval *)optval = time_us_to_timeval(timeout_us);
-            return error;
+            return 0;
         case SO_SNDBUF:
             assert(*optlen == sizeof(int));
             error = __wasi_sock_get_send_buf_size(sockfd, (size_t *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         case SO_RCVBUF:
             assert(*optlen == sizeof(int));
             error = __wasi_sock_get_recv_buf_size(sockfd, (size_t *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         case SO_KEEPALIVE:
             assert(*optlen == sizeof(int));
             error = __wasi_sock_get_keep_alive(sockfd, (bool *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         case SO_REUSEADDR:
             assert(*optlen == sizeof(int));
             error = __wasi_sock_get_reuse_addr(sockfd, (bool *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         case SO_REUSEPORT:
             assert(*optlen == sizeof(int));
             error = __wasi_sock_get_reuse_port(sockfd, (bool *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         case SO_LINGER:
             assert(*optlen == sizeof(struct linger));
             error =
@@ -653,12 +653,12 @@ get_sol_socket_option(int sockfd, int optname, void *__restrict optval,
             HANDLE_ERROR(error);
             ((struct linger *)optval)->l_onoff = (int)is_linger_enabled;
             ((struct linger *)optval)->l_linger = linger_s;
-            return error;
+            return 0;
         case SO_BROADCAST:
             assert(*optlen == sizeof(int));
             error = __wasi_sock_get_broadcast(sockfd, (bool *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         case SO_TYPE:
             assert(*optlen == sizeof(int));
             error = __wasi_fd_fdstat_get(sockfd, &sb);
@@ -678,7 +678,7 @@ get_sol_socket_option(int sockfd, int optname, void *__restrict optval,
         default:
             error = __WASI_ERRNO_NOTSUP;
             HANDLE_ERROR(error);
-            return error;
+            return 0;
     }
 }
 
@@ -692,32 +692,32 @@ get_ipproto_tcp_option(int sockfd, int optname, void *__restrict optval,
             assert(*optlen == sizeof(uint32_t));
             error = __wasi_sock_get_tcp_keep_idle(sockfd, (uint32_t *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         case TCP_KEEPINTVL:
             assert(*optlen == sizeof(uint32_t));
             error = __wasi_sock_get_tcp_keep_intvl(sockfd, (uint32_t *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         case TCP_FASTOPEN_CONNECT:
             assert(*optlen == sizeof(int));
             error =
                 __wasi_sock_get_tcp_fastopen_connect(sockfd, (bool *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         case TCP_NODELAY:
             assert(*optlen == sizeof(int));
             error = __wasi_sock_get_tcp_no_delay(sockfd, (bool *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         case TCP_QUICKACK:
             assert(*optlen == sizeof(int));
             error = __wasi_sock_get_tcp_quick_ack(sockfd, (bool *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         default:
             error = __WASI_ERRNO_NOTSUP;
             HANDLE_ERROR(error);
-            return error;
+            return 0;
     }
 }
 
@@ -733,21 +733,21 @@ get_ipproto_ip_option(int sockfd, int optname, void *__restrict optval,
             error = __wasi_sock_get_ip_multicast_loop(sockfd, false,
                                                       (bool *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         case IP_TTL:
             assert(*optlen == sizeof(int));
             error = __wasi_sock_get_ip_ttl(sockfd, (uint8_t *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         case IP_MULTICAST_TTL:
             assert(*optlen == sizeof(int));
             error = __wasi_sock_get_ip_multicast_ttl(sockfd, (uint8_t *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         default:
             error = __WASI_ERRNO_NOTSUP;
             HANDLE_ERROR(error);
-            return error;
+            return 0;
     }
 }
 
@@ -762,17 +762,17 @@ get_ipproto_ipv6_option(int sockfd, int optname, void *__restrict optval,
             assert(*optlen == sizeof(int));
             error = __wasi_sock_get_ipv6_only(sockfd, (bool *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         case IPV6_MULTICAST_LOOP:
             assert(*optlen == sizeof(int));
             error =
                 __wasi_sock_get_ip_multicast_loop(sockfd, true, (bool *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         default:
             error = __WASI_ERRNO_NOTSUP;
             HANDLE_ERROR(error);
-            return error;
+            return 0;
     }
 }
 
@@ -794,7 +794,7 @@ getsockopt(int sockfd, int level, int optname, void *__restrict optval,
         default:
             error = __WASI_ERRNO_NOTSUP;
             HANDLE_ERROR(error);
-            return error;
+            return 0;
     }
 }
 
@@ -812,7 +812,7 @@ set_sol_socket_option(int sockfd, int optname, const void *optval,
             timeout_us = timeval_to_time_us(*(struct timeval *)optval);
             error = __wasi_sock_set_recv_timeout(sockfd, timeout_us);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         }
         case SO_SNDTIMEO:
         {
@@ -820,42 +820,42 @@ set_sol_socket_option(int sockfd, int optname, const void *optval,
             timeout_us = timeval_to_time_us(*(struct timeval *)optval);
             error = __wasi_sock_set_send_timeout(sockfd, timeout_us);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         }
         case SO_SNDBUF:
         {
             assert(optlen == sizeof(int));
             error = __wasi_sock_set_send_buf_size(sockfd, *(size_t *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         }
         case SO_RCVBUF:
         {
             assert(optlen == sizeof(int));
             error = __wasi_sock_set_recv_buf_size(sockfd, *(size_t *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         }
         case SO_KEEPALIVE:
         {
             assert(optlen == sizeof(int));
             error = __wasi_sock_set_keep_alive(sockfd, *(bool *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         }
         case SO_REUSEADDR:
         {
             assert(optlen == sizeof(int));
             error = __wasi_sock_set_reuse_addr(sockfd, *(bool *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         }
         case SO_REUSEPORT:
         {
             assert(optlen == sizeof(int));
             error = __wasi_sock_set_reuse_port(sockfd, *(bool *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         }
         case SO_LINGER:
         {
@@ -864,20 +864,20 @@ set_sol_socket_option(int sockfd, int optname, const void *optval,
             error = __wasi_sock_set_linger(sockfd, (bool)linger_opt->l_onoff,
                                            linger_opt->l_linger);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         }
         case SO_BROADCAST:
         {
             assert(optlen == sizeof(int));
             error = __wasi_sock_set_broadcast(sockfd, *(bool *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         }
         default:
         {
             error = __WASI_ERRNO_NOTSUP;
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         }
     }
 }
@@ -893,32 +893,32 @@ set_ipproto_tcp_option(int sockfd, int optname, const void *optval,
             assert(optlen == sizeof(int));
             error = __wasi_sock_set_tcp_no_delay(sockfd, *(bool *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         case TCP_KEEPIDLE:
             assert(optlen == sizeof(uint32_t));
             error = __wasi_sock_set_tcp_keep_idle(sockfd, *(uint32_t *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         case TCP_KEEPINTVL:
             assert(optlen == sizeof(uint32_t));
             error = __wasi_sock_set_tcp_keep_intvl(sockfd, *(uint32_t *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         case TCP_FASTOPEN_CONNECT:
             assert(optlen == sizeof(int));
             error =
                 __wasi_sock_set_tcp_fastopen_connect(sockfd, *(bool *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         case TCP_QUICKACK:
             assert(optlen == sizeof(int));
             error = __wasi_sock_set_tcp_quick_ack(sockfd, *(bool *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         default:
             error = __WASI_ERRNO_NOTSUP;
             HANDLE_ERROR(error);
-            return error;
+            return 0;
     }
 }
 
@@ -936,7 +936,7 @@ set_ipproto_ip_option(int sockfd, int optname, const void *optval,
             error = __wasi_sock_set_ip_multicast_loop(sockfd, false,
                                                       *(bool *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         case IP_ADD_MEMBERSHIP:
             assert(optlen == sizeof(struct ip_mreq));
             ip_mreq_opt = (struct ip_mreq *)optval;
@@ -946,7 +946,7 @@ set_ipproto_ip_option(int sockfd, int optname, const void *optval,
             error = __wasi_sock_set_ip_add_membership(
                 sockfd, &imr_multiaddr, ip_mreq_opt->imr_interface.s_addr);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         case IP_DROP_MEMBERSHIP:
             assert(optlen == sizeof(struct ip_mreq));
             ip_mreq_opt = (struct ip_mreq *)optval;
@@ -956,22 +956,22 @@ set_ipproto_ip_option(int sockfd, int optname, const void *optval,
             error = __wasi_sock_set_ip_drop_membership(
                 sockfd, &imr_multiaddr, ip_mreq_opt->imr_interface.s_addr);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         case IP_TTL:
             assert(optlen == sizeof(int));
             error = __wasi_sock_set_ip_ttl(sockfd, *(uint8_t *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         case IP_MULTICAST_TTL:
             assert(optlen == sizeof(int));
             error =
                 __wasi_sock_set_ip_multicast_ttl(sockfd, *(uint8_t *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         default:
             error = __WASI_ERRNO_NOTSUP;
             HANDLE_ERROR(error);
-            return error;
+            return 0;
     }
 }
 
@@ -988,13 +988,13 @@ set_ipproto_ipv6_option(int sockfd, int optname, const void *optval,
             assert(optlen == sizeof(int));
             error = __wasi_sock_set_ipv6_only(sockfd, *(bool *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         case IPV6_MULTICAST_LOOP:
             assert(optlen == sizeof(int));
             error = __wasi_sock_set_ip_multicast_loop(sockfd, true,
                                                       *(bool *)optval);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         case IPV6_JOIN_GROUP:
             assert(optlen == sizeof(struct ipv6_mreq));
             ipv6_mreq_opt = (struct ipv6_mreq *)optval;
@@ -1005,7 +1005,7 @@ set_ipproto_ipv6_option(int sockfd, int optname, const void *optval,
             error = __wasi_sock_set_ip_add_membership(
                 sockfd, &imr_multiaddr, ipv6_mreq_opt->ipv6mr_interface);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         case IPV6_LEAVE_GROUP:
             assert(optlen == sizeof(struct ipv6_mreq));
             ipv6_mreq_opt = (struct ipv6_mreq *)optval;
@@ -1016,11 +1016,11 @@ set_ipproto_ipv6_option(int sockfd, int optname, const void *optval,
             error = __wasi_sock_set_ip_drop_membership(
                 sockfd, &imr_multiaddr, ipv6_mreq_opt->ipv6mr_interface);
             HANDLE_ERROR(error);
-            return error;
+            return 0;
         default:
             error = __WASI_ERRNO_NOTSUP;
             HANDLE_ERROR(error);
-            return error;
+            return 0;
     }
 }
 
@@ -1042,6 +1042,6 @@ setsockopt(int sockfd, int level, int optname, const void *optval,
         default:
             error = __WASI_ERRNO_NOTSUP;
             HANDLE_ERROR(error);
-            return error;
+            return 0;
     }
 }


### PR DESCRIPTION
do not return __WASI_ERRNO_xxx error code where 0/-1 is more appropriate.

most of them were not harmful because the value of __WASI_ERRNO_SUCCESS is 0.

the one with __WASI_ERRNO_NOPROTOOPT in socket() is a user-visible bug.

tested with wamr-wasi-extensions/samples/socket-tcp-udp.

cf. https://github.com/bytecodealliance/wasm-micro-runtime/issues/4474