### PR TITLE
fix regression running_config.json

### DIFF
--- a/tests/regression/ba-issues/running_config.json
+++ b/tests/regression/ba-issues/running_config.json
@@ -96,7 +96,7 @@
             "argument": "",
             "expected return": {
                 "ret code": 255,
-                "stdout content": "WASM module load failed: END opcode expected",
+                "stdout content": "WASM module load failed: unexpected end opcodes from unbalanced control flow structures",
                 "description": "no sanitizer 'Heap Buffer Overflow'"
             }
         },
@@ -979,7 +979,7 @@
             "argument": "",
             "expected return": {
                 "ret code": 255,
-                "stdout content": "WASM module load failed: unexpected end of section or function",
+                "stdout content": "WASM module load failed: section size mismatch: function body END opcode expected",
                 "description": "no 'Heap out of bound read of size 1 in wasm_loader_prepare_bytecode function'"
             }
         },


### PR DESCRIPTION
Modify the expected output information of issues 2726 and 2863 in `running_conifg.json` to adapt to the changes to log information in #3892.