### PR TITLE
Always use release builds of pre-built dependency libraries on Windows

### DIFF
--- a/build-scripts/config_common.cmake
+++ b/build-scripts/config_common.cmake
@@ -99,6 +99,12 @@ if (WAMR_BUILD_JIT EQUAL 1)
     # Enable Lazy JIT by default
     set (WAMR_BUILD_LAZY_JIT 1)
   endif ()
+
+  # In Debug mode, always use release builds of pre-built dependency libraries
+  if (WAMR_BUILD_PLATFORM STREQUAL "windows" AND MSVC)
+    add_compile_options($<$<CONFIG:Debug>:/MD>)
+  endif()
+
   if (NOT DEFINED LLVM_DIR)
     set (LLVM_SRC_ROOT "${WAMR_ROOT_DIR}/core/deps/llvm")
     set (LLVM_BUILD_ROOT "${LLVM_SRC_ROOT}/build")

--- a/wamr-compiler/CMakeLists.txt
+++ b/wamr-compiler/CMakeLists.txt
@@ -159,6 +159,11 @@ if (WAMR_BUILD_DEBUG_AOT EQUAL 1)
 endif()
 
 # Enable LLVM
+# In Debug mode, always use release builds of pre-built dependency libraries
+if (WAMR_BUILD_PLATFORM STREQUAL "windows" AND MSVC)
+  add_compile_options($<$<CONFIG:Debug>:/MD>)
+endif()
+
 if (NOT WAMR_BUILD_WITH_CUSTOM_LLVM)
   set (LLVM_SRC_ROOT "${PROJECT_SOURCE_DIR}/../core/deps/llvm")
   if (NOT EXISTS "${LLVM_SRC_ROOT}/build")


### PR DESCRIPTION
On Windows platform, Debug builds of wamrc now use Release runtime 
library (/MD) instead of Debug runtime library (/MDd) to avoid 
linking conflicts with Release LLVM libraries.

This workaround resolves LNK2038 errors like:
- RuntimeLibrary mismatch: 'MD_DynamicRelease' vs 'MDd_DynamicDebug'

A better way would be to using debug LLVM libraries for debug wamrc builds, 
but debug LLVM builds cause CPack failures in GitHub CI, likely due to size constraints.

The change only affects Windows builds and preserves debugging 
capabilities for wamrc code while ensuring compatibility with 
pre-built Release LLVM libraries.