### PR TITLE
feat(core): Support pthread using SPIRAM as stack

### DIFF
--- a/core/shared/platform/esp-idf/espidf_thread.c
+++ b/core/shared/platform/esp-idf/espidf_thread.c
@@ -110,6 +110,13 @@ os_thread_create_with_prio(korp_tid *tid, thread_start_routine_t start,
     targ->start = start;
     targ->arg = arg;
 
+#ifdef CONFIG_FREERTOS_TASK_CREATE_ALLOW_EXT_MEM
+    esp_pthread_cfg_t default_config = esp_pthread_get_default_config();
+
+    default_config.stack_alloc_caps = MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM;
+    ESP_ERROR_CHECK(esp_pthread_set_cfg(&default_config));
+#endif
+
     if (pthread_create(tid, &tattr, os_thread_wrapper, targ) != 0) {
         pthread_attr_destroy(&tattr);
         os_free(targ);


### PR DESCRIPTION
- Pthread can now use SPIRAM as stack, the implementation in ESP-IDF is in this PR: https://github.com/espressif/esp-idf/commit/be59c9491749205bf72bb8e165057f366cba1c42