### PR TITLE
Use venv to install llvm dependencies and run build script

### DIFF
--- a/wamr-compiler/build_llvm.sh
+++ b/wamr-compiler/build_llvm.sh
@@ -3,5 +3,17 @@
 # Copyright (C) 2020 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-/usr/bin/env python3 -m pip install --user -r ../build-scripts/requirements.txt
+TEMP_DIR=$(mktemp -d)
+
+cleanup() {
+    local exit_code=$?
+    rm -rf "$TEMP_DIR"
+    exit $exit_code
+}
+
+trap cleanup EXIT INT TERM
+
+/usr/bin/env python3 -m venv --clear "$TEMP_DIR"
+source "$TEMP_DIR/bin/activate"
+/usr/bin/env python3 -m pip install -r ../build-scripts/requirements.txt
 /usr/bin/env python3 ../build-scripts/build_llvm.py "$@"

--- a/wamr-compiler/build_llvm_arc.sh
+++ b/wamr-compiler/build_llvm_arc.sh
@@ -3,5 +3,5 @@
 # Copyright (C) 2020 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-/usr/bin/env python3 -m pip install --user -r ../build-scripts/requirements.txt
-/usr/bin/env python3 ../build-scripts/build_llvm.py --platform arc "$@"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+$SCRIPT_DIR/build_llvm.sh --platform arc "$@"

--- a/wamr-compiler/build_llvm_xtensa.sh
+++ b/wamr-compiler/build_llvm_xtensa.sh
@@ -3,5 +3,5 @@
 # Copyright (C) 2020 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-/usr/bin/env python3 -m pip install --user -r ../build-scripts/requirements.txt
-/usr/bin/env python3 ../build-scripts/build_llvm.py --platform xtensa "$@"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+$SCRIPT_DIR/build_llvm.sh --platform xtensa "$@"


### PR DESCRIPTION
Installing pip packages system-wide is no longer recommended, therefore we create virtual environment for setting up the build environment for LLVM.