### PR TITLE
doc/build_wasm_app.md: restore the recommendation of exact version match

### DIFF
--- a/doc/build_wasm_app.md
+++ b/doc/build_wasm_app.md
@@ -382,9 +382,11 @@ a non-compatible`AOT_CURRENT_VERSION`.
 We try our best to maintain our runtime ABI for AoT-compiled modules
 compatible among WAMR versions with compatible `AOT_CURRENT_VERSION`
 so that combinations of older wamrc and newer runtime usually work.
-However, there might be minor incompatibilities time to time.
-For productions, we recommend to use compatible versions of
-wamrc and the runtime.
+
+However, there might be minor incompatibilities from time to time. For
+example, we usually avoid bumping the version when making a change which
+affects only a small fraction of users. For productions, we recommend
+using exactly same versions of wamrc and the runtime.
 
 | WAMR version | AOT_CURRENT_VERSION | Compatible AOT version |                        |
 | ------------ | ------------------- | ---------------------- | ---------------------- |


### PR DESCRIPTION
the intention of the original text was to recommend to use the exactly same version (eg. 2.4.1) regardless of AOT_CURRENT_VERSION.