### PR TITLE
Add validation for rec indices in aot loader

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -1805,7 +1805,12 @@ load_types(const uint8 **p_buf, const uint8 *buf_end, AOTModule *module,
         read_uint32(buf, buf_end, parent_type_idx);
         read_uint16(buf, buf_end, rec_count);
         read_uint16(buf, buf_end, rec_idx);
-
+#if WASM_ENABLE_AOT_VALIDATOR != 0
+        if (rec_idx > i) {
+            set_error_buf(error_buf, error_buf_size, "invalid rec_idx");
+            goto fail;
+        }
+#endif
         if (type_flag == WASM_TYPE_FUNC) {
             AOTFuncType *func_type;
 


### PR DESCRIPTION
Ensure `rec_idx` within valid ranges to prevent accessing invalid type references.