### PR TITLE
Fix parsing of multiple IPs in --addr-pool option

### DIFF
--- a/product-mini/platforms/common/libc_wasi.c
+++ b/product-mini/platforms/common/libc_wasi.c
@@ -141,7 +141,7 @@ libc_wasi_parse(char *arg, libc_wasi_parse_context_t *ctx)
             }
 
             ctx->addr_pool[ctx->addr_pool_size++] = token;
-            token = strtok(NULL, ";");
+            token = strtok(NULL, ",");
         }
     }
     else if (!strncmp(arg, "--allow-resolve=", 16)) {


### PR DESCRIPTION
>  --addr-pool=<addr/mask>  Grant wasi access to the given network addresses in
>                            CIDR notation to the program, separated with ',',
>                            for example:
>                              --addr-pool=1.2.3.4/15,2.3.4.5/16

The docs say `--addr-pool` accepts multiple comma-separated CIDR addresses, but only the first two are currently parsed.  
This changes the delimiter to `,` to match the documentation.

For example, using the code from [samples/socket-api](https://github.com/bytecodealliance/wasm-micro-runtime/tree/main/samples/socket-api).

```sh
$ ./iwasm --addr-pool=1.1.1.1/32,2.2.2.2/32,0.0.0.0/15 tcp_server.wasm 
[Server] Create socket
Bind failed: Permission denied
[Server] Bind socket
[Server] Shutting down ..
```