### PR TITLE
Add validation for struct field type in loader

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -1787,7 +1787,7 @@ load_types(const uint8 **p_buf, const uint8 *buf_end, AOTModule *module,
             read_uint32(buf, buf_end, j);
 #if WASM_ENABLE_AOT_VALIDATOR != 0
             /* an equivalence type should be before the type it refers to */
-            if (j > i) {
+            if (j >= i) {
                 set_error_buf(error_buf, error_buf_size, "invalid type index");
                 goto fail;
             }
@@ -1964,6 +1964,13 @@ load_types(const uint8 **p_buf, const uint8 *buf_end, AOTModule *module,
 
                 read_uint8(buf, buf_end, struct_type->fields[j].field_flags);
                 read_uint8(buf, buf_end, field_type);
+#if WASM_ENABLE_AOT_VALIDATOR != 0
+                if (!is_valid_field_type(field_type)) {
+                    set_error_buf(error_buf, error_buf_size,
+                                  "invalid field type");
+                    goto fail;
+                }
+#endif
                 struct_type->fields[j].field_type = field_type;
                 struct_type->fields[j].field_size = field_size =
                     (uint8)wasm_reftype_size(field_type);

--- a/core/iwasm/common/wasm_loader_common.c
+++ b/core/iwasm/common/wasm_loader_common.c
@@ -179,6 +179,20 @@ is_valid_func_type(const WASMFuncType *func_type)
     return true;
 }
 
+bool
+is_valid_packed_type(uint8 packed_type)
+{
+    return packed_type == PACKED_TYPE_I8 || packed_type == PACKED_TYPE_I16;
+}
+
+bool
+is_valid_field_type(uint8 field_type)
+{
+    if (is_valid_value_type(field_type) || is_valid_packed_type(field_type))
+        return true;
+    return false;
+}
+
 /*
  * Indices are represented as a u32.
  */

--- a/core/iwasm/common/wasm_loader_common.h
+++ b/core/iwasm/common/wasm_loader_common.h
@@ -39,6 +39,12 @@ bool
 is_valid_func_type(const WASMFuncType *func_type);
 
 bool
+is_valid_packed_type(uint8 packed_type);
+
+bool
+is_valid_field_type(uint8 field_type);
+
+bool
 is_indices_overflow(uint32 import, uint32 other, char *error_buf,
                     uint32 error_buf_size);
 

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -1961,6 +1961,10 @@ resolve_struct_type(const uint8 **p_buf, const uint8 *buf_end,
                                 error_buf_size)) {
             goto fail;
         }
+        if (!is_valid_field_type(ref_type.ref_type)) {
+            set_error_buf(error_buf, error_buf_size, "invalid field type");
+            goto fail;
+        }
         type->fields[i].field_type = ref_type.ref_type;
         if (need_ref_type_map) {
             type->ref_type_maps[j].index = i;


### PR DESCRIPTION
Add a method `is_valid_field_type` to validate whether field types in a `struct`  are valid.