### PR TITLE
Improve build scripts for bash compatibility and update README

### DIFF
--- a/wamr-compiler/README.md
+++ b/wamr-compiler/README.md
@@ -13,6 +13,7 @@ sudo apt-get install git build-essential cmake g++-multilib libgcc-9-dev lib32gc
 
 ```shell
 cd wamr-compiler
+# or explicitly with bash: bash ./build_llvm.sh
 ./build_llvm.sh (or "./build_llvm_xtensa.sh" to support xtensa target)
 mkdir build && cd build
 cmake .. (or "cmake .. -DWAMR_BUILD_PLATFORM=darwin" for MacOS)

--- a/wamr-compiler/build_llvm.sh
+++ b/wamr-compiler/build_llvm.sh
@@ -1,7 +1,9 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Copyright (C) 2020 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set -e
 
 TEMP_DIR=$(mktemp -d)
 


### PR DESCRIPTION
## Issue
Now running `./build_llvm.sh` will cause an issue: `./build_llvm.sh: 17: source: not found`. 

Because the script is executed with the system default shell (`sh`), which does not support the `source` command used in the script, it will cause the Python virtual environment not to activate actually.

## How to Fix
The script should either be explicitly run using `bash` (e.g., `bash ./build_llvm.sh`) or the script itself should specify `bash` as the default shell by adding the shebang line `#!/usr/bin/env bash` at the top.

## My improvements:

- Updated the README.
- Modified the shebang line.
- Added `set -e` to make the script exit immediately if any command fails.