### PR TITLE
wamr-compiler/build_llvm.sh: use dot instead of source

### DIFF
--- a/wamr-compiler/build_llvm.sh
+++ b/wamr-compiler/build_llvm.sh
@@ -14,6 +14,6 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 /usr/bin/env python3 -m venv --clear "$TEMP_DIR"
-source "$TEMP_DIR/bin/activate"
+. "$TEMP_DIR/bin/activate"
 /usr/bin/env python3 -m pip install -r ../build-scripts/requirements.txt
 /usr/bin/env python3 ../build-scripts/build_llvm.py "$@"


### PR DESCRIPTION
note that dot is in posix and more portable than source.