### PR TITLE
Add bounds checking to prevent local count from exceeding UINT16_MAX

### DIFF
--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -1799,6 +1799,11 @@ resolve_func_type(const uint8 **p_buf, const uint8 *buf_end, WASMModule *module,
         return false;
     }
     if (ref_type_map_count > 0) {
+        if (ref_type_map_count > UINT16_MAX) {
+            set_error_buf(error_buf, error_buf_size,
+                          "ref type count too large");
+            return false;
+        }
         total_size = sizeof(WASMRefTypeMap) * (uint64)ref_type_map_count;
         if (!(type->ref_type_maps =
                   loader_malloc(total_size, error_buf, error_buf_size))) {
@@ -1938,6 +1943,11 @@ resolve_struct_type(const uint8 **p_buf, const uint8 *buf_end,
         return false;
     }
     if (ref_type_map_count > 0) {
+        if (ref_type_map_count > UINT16_MAX) {
+            set_error_buf(error_buf, error_buf_size,
+                          "ref type count too large");
+            return false;
+        }
         total_size = sizeof(WASMRefTypeMap) * (uint64)ref_type_map_count;
         if (!(type->ref_type_maps =
                   loader_malloc(total_size, error_buf, error_buf_size))) {
@@ -3953,6 +3963,11 @@ load_function_section(const uint8 *buf, const uint8 *buf_end,
             }
 #if WASM_ENABLE_GC != 0
             if (ref_type_map_count > 0) {
+                if (ref_type_map_count > UINT16_MAX) {
+                    set_error_buf(error_buf, error_buf_size,
+                                  "ref type count too large");
+                    return false;
+                }
                 total_size =
                     sizeof(WASMRefTypeMap) * (uint64)ref_type_map_count;
                 if (!(func->local_ref_type_maps = loader_malloc(


### PR DESCRIPTION
Add bounds checking to prevent `ref_type_map_count `(which is come from the sum of every sub local count) from exceeding
UINT16_MAX.