### PR TITLE
Fix potential overflow in memory size calculation

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -1026,14 +1026,14 @@ memory_instantiate(AOTModuleInstance *module_inst, AOTModuleInstance *parent,
         /* If only one page and at most one page, we just append
            the app heap to the end of linear memory, enlarge the
            num_bytes_per_page, and don't change the page count */
-        heap_offset = num_bytes_per_page;
-        num_bytes_per_page += heap_size;
-        if (num_bytes_per_page < heap_size) {
+        if (heap_size > UINT32_MAX - num_bytes_per_page) {
             set_error_buf(error_buf, error_buf_size,
                           "failed to insert app heap into linear memory, "
                           "try using `--heap-size=0` option");
             return NULL;
         }
+        heap_offset = num_bytes_per_page;
+        num_bytes_per_page += heap_size;
     }
     else if (heap_size > 0) {
         if (init_page_count == max_page_count && init_page_count == 0) {

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -335,14 +335,14 @@ memory_instantiate(WASMModuleInstance *module_inst, WASMModuleInstance *parent,
             /* If only one page and at most one page, we just append
                the app heap to the end of linear memory, enlarge the
                num_bytes_per_page, and don't change the page count */
-            heap_offset = num_bytes_per_page;
-            num_bytes_per_page += heap_size;
-            if (num_bytes_per_page < heap_size) {
+            if (heap_size > UINT32_MAX - num_bytes_per_page) {
                 set_error_buf(error_buf, error_buf_size,
                               "failed to insert app heap into linear memory, "
                               "try using `--heap-size=0` option");
                 return NULL;
             }
+            heap_offset = num_bytes_per_page;
+            num_bytes_per_page += heap_size;
         }
         else if (heap_size > 0) {
             if (init_page_count == max_page_count && init_page_count == 0) {


### PR DESCRIPTION
After resizing memory size, `num_bytes_per_page` might be greater than `DEFAULT_NUM_BYTES_PER_PAGE`, 
hence check for integer overflow before `num_bytes_per_page += heap_size`.

Here is the detail error log:
```shell
wasm-micro-runtime/core/iwasm/interpreter/wasm_runtime.c:339:32: runtime error: unsigned integer overflow: 4294836224 + 16777216 cannot be represented in type 'unsigned int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/zhenwei/project/wasm-micro-runtime/core/iwasm/interpreter/wasm_runtime.c:339:32
```