### PR TITLE
Set is_binary_freeable in load_from_sections

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -3997,6 +3997,7 @@ load_from_sections(AOTModule *module, AOTSection *sections,
     AOTFuncType *func_type;
     AOTExport *exports;
     uint8 malloc_free_io_type = VALUE_TYPE_I32;
+    module->is_binary_freeable = !is_load_from_file_buf;
 
     while (section) {
         buf = section->section_body;


### PR DESCRIPTION
Hi,

I'm not sure this is the correct way to solve this crash.

When I upgraded to Wamr 2.4.1, I found that it was now crashing when calling `wasm_store_delete` with:
 `module  error for object 0x120440078: pointer being freed was not allocated`. 

I think #3983 causes this issue, because `module->is_binary_freeable` is always set to false in create_module here: https://github.com/bytecodealliance/wasm-micro-runtime/blob/main/core/iwasm/aot/aot_loader.c#L4206 - even when `clone_wasm_binary` is set to false in the load args. 

We don't set it for the module until here https://github.com/bytecodealliance/wasm-micro-runtime/blob/main/core/iwasm/common/wasm_runtime_common.c#L1492 after `aot_load_from_aot_file` has returned so it cannot be correct we use it in the loader.

Thanks

