### PR TITLE
libc-wasi: add missing pointer validations to socket functions

### DIFF
--- a/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
+++ b/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
@@ -1159,6 +1159,9 @@ wasi_sock_accept(wasm_exec_env_t exec_env, wasi_fd_t fd, wasi_fdflags_t flags,
     if (!wasi_ctx)
         return __WASI_EACCES;
 
+    if (!validate_native_addr(fd_new, sizeof(*fd_new)))
+        return __WASI_EINVAL;
+
     curfds = wasi_ctx_get_curfds(wasi_ctx);
 
     return wasi_ssp_sock_accept(exec_env, curfds, fd, flags, fd_new);
@@ -1217,6 +1220,19 @@ wasi_sock_addr_resolve(wasm_exec_env_t exec_env, const char *host,
     if (!wasi_ctx)
         return __WASI_EACCES;
 
+    if (!validate_native_addr(hints, sizeof(*hints)))
+        return __WASI_EINVAL;
+
+    uint64_t addr_info_byte_size = sizeof(*addr_info) * addr_info_size;
+    if (addr_info_byte_size / addr_info_size != sizeof(*addr_info))
+        return __WASI_EINVAL;
+
+    if (!validate_native_addr(addr_info, addr_info_byte_size))
+        return __WASI_EINVAL;
+
+    if (!validate_native_addr(max_info_size, sizeof(*max_info_size)))
+        return __WASI_EINVAL;
+
     curfds = wasi_ctx_get_curfds(wasi_ctx);
     ns_lookup_list = wasi_ctx_get_ns_lookup_list(wasi_ctx);
 
@@ -1235,6 +1251,9 @@ wasi_sock_bind(wasm_exec_env_t exec_env, wasi_fd_t fd, wasi_addr_t *addr)
 
     if (!wasi_ctx)
         return __WASI_EACCES;
+
+    if (!validate_native_addr(addr, sizeof(*addr)))
+        return __WASI_EINVAL;
 
     curfds = wasi_ctx_get_curfds(wasi_ctx);
     addr_pool = wasi_ctx_get_addr_pool(wasi_ctx);
@@ -1261,6 +1280,9 @@ wasi_sock_connect(wasm_exec_env_t exec_env, wasi_fd_t fd, wasi_addr_t *addr)
 
     if (!wasi_ctx)
         return __WASI_EACCES;
+
+    if (!validate_native_addr(addr, sizeof(*addr)))
+        return __WASI_EINVAL;
 
     curfds = wasi_ctx_get_curfds(wasi_ctx);
     addr_pool = wasi_ctx_get_addr_pool(wasi_ctx);
@@ -1640,6 +1662,9 @@ wasi_sock_open(wasm_exec_env_t exec_env, wasi_fd_t poolfd,
 
     if (!wasi_ctx)
         return __WASI_EACCES;
+
+    if (!validate_native_addr(sockfd, sizeof(*sockfd)))
+        return __WASI_EINVAL;
 
     curfds = wasi_ctx_get_curfds(wasi_ctx);
 
@@ -2080,6 +2105,10 @@ wasi_sock_recv_from(wasm_exec_env_t exec_env, wasi_fd_t sock,
         return __WASI_EINVAL;
     }
 
+    /* note: src_addr is NULL when called by wasi_sock_recv */
+    if (src_addr != NULL && !validate_native_addr(src_addr, sizeof(*src_addr)))
+        return __WASI_EINVAL;
+
     if (!validate_native_addr(ro_data_len, (uint64)sizeof(uint32)))
         return __WASI_EINVAL;
 
@@ -2117,6 +2146,9 @@ wasi_sock_recv(wasm_exec_env_t exec_env, wasi_fd_t sock, iovec_app_t *ri_data,
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     wasi_errno_t error;
+
+    if (!validate_native_addr(ro_data_len, sizeof(*ro_data_len)))
+        return __WASI_EINVAL;
 
     if (!validate_native_addr(ro_flags, (uint64)sizeof(wasi_roflags_t)))
         return __WASI_EINVAL;
@@ -2226,6 +2258,9 @@ wasi_sock_send_to(wasm_exec_env_t exec_env, wasi_fd_t sock,
     if (!wasi_ctx) {
         return __WASI_EINVAL;
     }
+
+    if (!validate_native_addr((void *)dest_addr, sizeof(*dest_addr)))
+        return __WASI_EINVAL;
 
     if (!validate_native_addr(so_data_len, (uint64)sizeof(uint32)))
         return __WASI_EINVAL;


### PR DESCRIPTION
cf. https://github.com/bytecodealliance/wasm-micro-runtime/issues/4463

the fix for sock_addr_resolve is incomplete.
cf. https://github.com/bytecodealliance/wasm-micro-runtime/issues/4610