### PR TITLE
wasi-nn: retire is_model_loaded flag

### DIFF
--- a/core/iwasm/libraries/wasi-nn/src/wasi_nn_private.h
+++ b/core/iwasm/libraries/wasi-nn/src/wasi_nn_private.h
@@ -15,7 +15,6 @@ typedef struct {
     korp_mutex lock;
     bool busy;
     bool is_backend_ctx_initialized;
-    bool is_model_loaded;
     graph_encoding backend;
     void *backend_ctx;
 } WASINNContext;


### PR DESCRIPTION
this flag doesn't make much sense anymore because:
- backends validate given graph/ctx by themselves
- some of them support loading multiple models for a context