### PR TITLE
fix: few CI errors caused by recently enabled compilation flags

### DIFF
--- a/build-scripts/warnings.cmake
+++ b/build-scripts/warnings.cmake
@@ -22,14 +22,22 @@ else ()
   add_compile_options (
     $<$<COMPILE_LANGUAGE:C>:-Wimplicit-function-declaration>
   )
+
   # https://gcc.gnu.org/gcc-5/changes.html introduces incompatible-pointer-types
-  if (CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "5.1")
+  # https://releases.llvm.org/7.0.0/tools/clang/docs/DiagnosticsReference.html#wincompatible-pointer-types
+  #   is the earliest version that supports this option I can found.
+  # Assume AppClang versioning is compatible with Clang.
+  if ((CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "5.1")
+      OR (CMAKE_C_COMPILER_ID STREQUAL "Clang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "7.0.0")
+      OR (CMAKE_C_COMPILER_ID STREQUAL "AppClang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "7.0.0"))
     add_compile_options($<$<COMPILE_LANGUAGE:C>:-Wincompatible-pointer-types>)
   endif()
+
   # options benefit embedded system.
   add_compile_options (
     -Wdouble-promotion
   )
+
   # waivers
   add_compile_options (
     -Wno-unused

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -7495,7 +7495,7 @@ wasm_loader_unload(WASMModule *module)
 #endif
 #endif
 #if WASM_ENABLE_BRANCH_HINTS != 0
-    for (size_t i = 0; i < module->function_count; i++) {
+    for (i = 0; i < module->function_count; i++) {
         // be carefull when adding more hints. This only works as long as
         // the hint structs have been allocated all at once as an array.
         // With only branch-hints at the moment, this is the case.


### PR DESCRIPTION
- fix a shadow warning. 
- only enable implicit-function-declaration after gcc5.1.