### PR TITLE
CI: use windows-2022 image for now

### DIFF
--- a/.github/workflows/build_iwasm_release.yml
+++ b/.github/workflows/build_iwasm_release.yml
@@ -151,7 +151,7 @@ jobs:
         working-directory: ${{ inputs.cwd }}
 
       - name: Compress the binary on Windows
-        if: inputs.runner == 'windows-latest'
+        if: inputs.runner == 'windows-2022'
         run: |
           tar -czf iwasm${{ matrix.suffix }}-${{ inputs.ver_num }}-${{ inputs.runner }}.tar.gz iwasm.exe
           Compress-Archive -Path iwasm.exe -DestinationPath iwasm${{ matrix.suffix }}-${{ inputs.ver_num }}-${{ inputs.runner }}.zip
@@ -159,7 +159,7 @@ jobs:
         working-directory: ${{ inputs.cwd }}/build/Release
 
       - name: compress the binary on non-Windows
-        if: inputs.runner != 'windows-latest'
+        if: inputs.runner != 'windows-2022'
         run: |
           # Follow the symlink to the actual binary file
           tar --dereference -czf iwasm${{ matrix.suffix }}-${{ inputs.ver_num }}-${{ inputs.runner }}.tar.gz iwasm

--- a/.github/workflows/build_llvm_libraries.yml
+++ b/.github/workflows/build_llvm_libraries.yml
@@ -118,11 +118,11 @@ jobs:
           key: 0-ccache-${{ inputs.os }}-${{ steps.get_last_commit.outputs.last_commit }}
           restore-keys: |
             0-ccache-${{ inputs.os }}
-        if: steps.retrieve_llvm_libs.outputs.cache-hit != 'true' && inputs.os == 'windows-latest'
+        if: steps.retrieve_llvm_libs.outputs.cache-hit != 'true' && inputs.os == 'windows-2022'
 
       # Install tools on Windows
       - run: choco install -y ccache ninja
-        if: steps.retrieve_llvm_libs.outputs.cache-hit != 'true' && inputs.os == 'windows-latest'
+        if: steps.retrieve_llvm_libs.outputs.cache-hit != 'true' && inputs.os == 'windows-2022'
 
       - name: Build LLVM libraries
         if: steps.retrieve_llvm_libs.outputs.cache-hit != 'true'

--- a/.github/workflows/build_wamrc.yml
+++ b/.github/workflows/build_wamrc.yml
@@ -87,7 +87,7 @@ jobs:
         working-directory: wamr-compiler
 
       - name: Compress the binary on Windows
-        if: inputs.runner == 'windows-latest' && inputs.release
+        if: inputs.runner == 'windows-2022' && inputs.release
         run: |
           tar -czf wamrc-${{ inputs.ver_num }}-${{ inputs.runner }}.tar.gz wamrc.exe
           Compress-Archive -Path wamrc.exe -DestinationPath wamrc-${{ inputs.ver_num }}-${{ inputs.runner }}.zip
@@ -95,7 +95,7 @@ jobs:
         working-directory: wamr-compiler/build/Release
 
       - name: compress the binary on non-Windows
-        if: inputs.runner != 'windows-latest' && inputs.release
+        if: inputs.runner != 'windows-2022' && inputs.release
         run: |
           # Follow the symlink to the actual binary file
           tar --dereference -czf wamrc-${{ inputs.ver_num }}-${{ inputs.runner }}.tar.gz wamrc

--- a/.github/workflows/compilation_on_windows.yml
+++ b/.github/workflows/compilation_on_windows.yml
@@ -1,7 +1,7 @@
 # Copyright (C) 2019 Intel Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-name: compilation on windows-latest
+name: compilation on windows-2022
 
 on:
   # will be triggered on PR events
@@ -63,11 +63,11 @@ jobs:
       actions: write
     uses: ./.github/workflows/build_llvm_libraries.yml
     with:
-      os: "windows-latest"
+      os: "windows-2022"
       arch: "AArch64 ARM Mips RISCV X86"
 
   build_iwasm:
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       matrix:
         build_options:
@@ -105,7 +105,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-latest
+          - os: windows-2022
             llvm_cache_key: ${{ needs.build_llvm_libraries_on_windows.outputs.cache_key }}
     steps:
       - name: checkout
@@ -136,7 +136,7 @@ jobs:
         working-directory: wamr-compiler
 
   test:
-    runs-on: windows-latest
+    runs-on: windows-2022
     needs: [build_iwasm, build_wamrc]
     strategy:
       fail-fast: false

--- a/.github/workflows/release_process.yml
+++ b/.github/workflows/release_process.yml
@@ -105,7 +105,7 @@ jobs:
     needs: [create_tag, create_release]
     uses: ./.github/workflows/build_llvm_libraries.yml
     with:
-      os: "windows-latest"
+      os: "windows-2022"
       arch: "AArch64 ARM Mips RISCV X86"
 
   #
@@ -142,7 +142,7 @@ jobs:
     with:
       llvm_cache_key: ${{ needs.build_llvm_libraries_on_windows.outputs.cache_key }}
       release: true
-      runner: windows-latest
+      runner: windows-2022
       upload_url: ${{ needs.create_release.outputs.upload_url }}
       ver_num: ${{ needs.create_tag.outputs.new_ver }}
 
@@ -180,7 +180,7 @@ jobs:
     with:
       cwd: product-mini/platforms/windows
       llvm_cache_key: ${{ needs.build_llvm_libraries_on_windows.outputs.cache_key }}
-      runner: windows-latest
+      runner: windows-2022
       upload_url: ${{ needs.create_release.outputs.upload_url }}
       ver_num: ${{ needs.create_tag.outputs.new_ver}}
 


### PR DESCRIPTION
github is currently rolling out windows-2025 image.
for some reasons, the "path_symlink_trailing_slashes" test case in
wasi testsuite fails on windows-2025 image.
someone familar with windows need to investigate what was the
key difference between 2022 and 2025.
until that happens, this commit makes our CI use windows-2022 image.

cf.
https://github.com/bytecodealliance/wasm-micro-runtime/issues/4632
https://github.com/actions/runner-images/issues/12677
