### PR TITLE
fix some `-Wcast-align` warning

### DIFF
--- a/build-scripts/warnings.cmake
+++ b/build-scripts/warnings.cmake
@@ -36,6 +36,7 @@ else ()
   # options benefit embedded system.
   add_compile_options (
     -Wdouble-promotion
+    -Wcast-align=strict
   )
 
   # waivers

--- a/core/shared/mem-alloc/ems/ems_gc_internal.h
+++ b/core/shared/mem-alloc/ems/ems_gc_internal.h
@@ -114,7 +114,7 @@ hmu_verify(void *vheap, hmu_t *hmu);
 #define HMU_SIZE (sizeof(hmu_t))
 
 #define hmu_to_obj(hmu) (gc_object_t)(SKIP_OBJ_PREFIX((hmu_t *)(hmu) + 1))
-#define obj_to_hmu(obj) ((hmu_t *)((gc_uint8 *)(obj)-OBJ_PREFIX_SIZE) - 1)
+#define obj_to_hmu(obj) ((hmu_t *)((uintptr_t)(obj)-OBJ_PREFIX_SIZE) - 1)
 
 #define HMU_UT_SIZE 2
 #define HMU_UT_OFFSET 30
@@ -188,7 +188,7 @@ static inline hmu_normal_node_t *
 get_hmu_normal_node_next(hmu_normal_node_t *node)
 {
     return node->next_offset
-               ? (hmu_normal_node_t *)((uint8 *)node + node->next_offset)
+               ? (hmu_normal_node_t *)((uintptr_t)node + node->next_offset)
                : NULL;
 }
 


### PR DESCRIPTION
- If it involves pointer arithmetic, especially with `uint8*`, use `uintptr_t`
  instead.
- If it involves pointer type conversion, such as via `char*`, use `void*`
  and implicit conversion.