### PR TITLE
Switch from deprecated overload of createTargetMachine

### DIFF
--- a/core/iwasm/compilation/aot_llvm_extra2.cpp
+++ b/core/iwasm/compilation/aot_llvm_extra2.cpp
@@ -157,8 +157,13 @@ LLVMCreateTargetMachineWithOpts(LLVMTargetRef ctarget, const char *triple,
     auto ol = convert(opt_level);
     bool jit;
     auto cm = convert(code_model, &jit);
+#if LLVM_VERSION_MAJOR >= 21
+    auto targetmachine = target->createTargetMachine(
+        llvm::Triple(triple), cpu, features, opts, rm, cm, ol, jit);
+#else
     auto targetmachine = target->createTargetMachine(triple, cpu, features,
                                                      opts, rm, cm, ol, jit);
+#endif
 #if LLVM_VERSION_MAJOR >= 18
     // always place data in normal data section.
     //


### PR DESCRIPTION
The overload accepting the string version of a triple will be removed soon, so switch over to the one that accepts a triple object.