### PR TITLE
zephyr: including fs_interface.h

### DIFF
--- a/core/shared/platform/zephyr/platform_internal.h
+++ b/core/shared/platform/zephyr/platform_internal.h
@@ -38,6 +38,7 @@
 
 #if KERNEL_VERSION_NUMBER < 0x030200 /* version 3.2.0 */
 #include <zephyr.h>
+#include <fs/fs_interface.h>
 #include <net/net_pkt.h>
 #include <net/net_if.h>
 #include <net/net_ip.h>
@@ -45,6 +46,7 @@
 #include <net/net_context.h>
 #else /* else of KERNEL_VERSION_NUMBER < 0x030200 */
 #include <zephyr/kernel.h>
+#include <zephyr/fs/fs_interface.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_ip.h>


### PR DESCRIPTION
`fs_file_t` and `fs_dir_t` is defined in fs_interface.h. However, platform_internal.h does not currently include it, so the symbols can't be resolved.
We include it to resolve these definitions with
platform_internal.h standalone.