### PR TITLE
fix: typo in AOT stack dump with GC

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -4495,7 +4495,7 @@ aot_create_call_stack(struct WASMExecEnv *exec_env)
             frame.frame_ref = (uint8 *)frame.lp + (frame_ref - (uint8 *)lp);
             /* copy local ref flags from AOT module */
             bh_memcpy_s(frame.frame_ref, local_ref_flags_cell_num,
-                        local_ref_flags, lp_size);
+                        local_ref_flags, local_ref_flags_cell_num);
 #endif
         }
 


### PR DESCRIPTION
This is a blind fix; though it fixed my local run with the MoonBit core library test suite. So I think it was a typo? Given that `lp_size` is usually larger than `local_ref_flags_cell_num`.

This definitely worth a regression test, but I'm not sure where to get started. Feel free to suggest or edit this PR.