### PR TITLE
Remove warnings relevant to Zephyr platform

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -2213,7 +2213,7 @@ wasmtime_ssp_poll_oneoff(wasm_exec_env_t exec_env, struct fd_table *curfds,
 
 // Temporary workaround (see PR#4377)
 #ifdef BH_PLATFORM_ZEPHYR
-                    os_file_handle tfd = fos[i]->file_handle->fd;
+                    int tfd = fos[i]->file_handle->fd;
 #else
                     os_file_handle tfd = fos[i]->file_handle;
 #endif

--- a/core/shared/platform/zephyr/platform_internal.h
+++ b/core/shared/platform/zephyr/platform_internal.h
@@ -290,7 +290,9 @@ typedef struct timespec os_timespec;
 #define CLOCK_REALTIME 1
 #endif
 
+#ifndef CLOCK_MONOTONIC
 #define CLOCK_MONOTONIC 4
+#endif
 
 static inline int
 os_sched_yield(void)

--- a/core/shared/platform/zephyr/zephyr_file.c
+++ b/core/shared/platform/zephyr/zephyr_file.c
@@ -6,6 +6,7 @@
 #include "platform_api_vmcore.h"
 #include "platform_api_extension.h"
 #include "libc_errno.h"
+#include "bh_common.h"
 
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
This PR is intended to remove following warnings, when build in Zephyr application:
```c
wasm-micro-runtime/core/shared/platform/zephyr/platform_internal.h:293: warning: "CLOCK_MONOTONIC" redefined
  293 | #define CLOCK_MONOTONIC 4
wasm-micro-runtime/core/shared/platform/zephyr/zephyr_file.c: In function 'zephyr_fs_alloc_obj':
wasm-micro-runtime/core/shared/platform/zephyr/zephyr_file.c:123:25: warning: implicit declaration of function 'bh_strdup' [-Wimplicit-function-declaration]
  123 |             ptr->path = bh_strdup(path);
      |                         ^~~~~~~~~
wasm-micro-runtime/core/shared/platform/zephyr/zephyr_file.c:123:23: warning: assignment to 'char *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
  123 |             ptr->path = bh_strdup(path);
      |                       ^
wasm-micro-runtime/core/shared/platform/zephyr/zephyr_file.c: In function 'os_renameat':
wasm-micro-runtime/core/shared/platform/zephyr/zephyr_file.c:853:35: warning: initialization of 'char *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
  853 |             char *new_path_copy = bh_strdup(new_path);
      |                                   ^~~~~~~~~
[45/462] Building C object CMakeFiles/app.dir/wasm-micro-runtime/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c.obj
wasm-micro-runtime/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c: In function 'wasmtime_ssp_poll_oneoff':
wasm-micro-runtime/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c:2216:42: warning: initialization of 'os_file_handle' {aka 'struct zephyr_handle *'} from 'int' makes pointer from integer without a cast [-Wint-conversion]
 2216 |                     os_file_handle tfd = fos[i]->file_handle->fd;
      |                                          ^~~
wasm-micro-runtime/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c:2222:31: warning: initialization of 'int' from 'os_file_handle' {aka 'struct zephyr_handle *'} makes integer from pointer without a cast [-Wint-conversion]
 2222 |                         .fd = tfd,
      |                               ^~~
wasm-micro-runtime/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c:2222:31: note: (near initialization for '(anonymous).fd')
```

Result - no warnings. 

Tested in [ocre](https://github.com/project-ocre/ocre-runtime) as a [zephyr](https://github.com/zephyrproject-rtos/zephyr) application.
