### PR TITLE
Namespace generated headers with zephyr/

### DIFF
--- a/core/shared/platform/zephyr/platform_internal.h
+++ b/core/shared/platform/zephyr/platform_internal.h
@@ -14,16 +14,16 @@
  * which we're trying to include. Must use feature detection instead.
  */
 #ifdef __has_include
-    #if __has_include(<zephyr/autoconf.h>)
-        #include <zephyr/autoconf.h>
-        #include <zephyr/version.h>
-    #else
-        #include <autoconf.h>
-        #include <version.h>
-    #endif
+#if __has_include(<zephyr/autoconf.h>)
+#include <zephyr/autoconf.h>
+#include <zephyr/version.h>
 #else
-    #include <autoconf.h>
-    #include <version.h>
+#include <autoconf.h>
+#include <version.h>
+#endif
+#else
+#include <autoconf.h>
+#include <version.h>
 #endif
 
 #if KERNEL_VERSION_NUMBER < 0x030200 /* version 3.2.0 */


### PR DESCRIPTION
> **Problem description**
> Some of the generated headers have pretty generic names, i.e.: version.h, and can potentially conflict with other library / user applications. Ideally, all Zephyr's headers, in-tree or generated, should be namespaced with zephyr/.
> 
> **Proposed change**
> To avoid potential conflicts with other library or user application headers due to generic names, introduce a zephyr/ namespace for all Zephyr-generated and in-tree headers. This can be achieved by modifying the CMake files and scripts responsible for generating these headers to include the zephyr/ prefix in their file names and updating the include paths in source files accordingly.
> 
> Additionally, ensure that the legacy include paths remains compatible during this transition and update the migration and release notes with details about this change and any necessary mitigation steps for users.

Please check: https://github.com/zephyrproject-rtos/zephyr/issues/73114

Relevant migration notes: https://docs.zephyrproject.org/latest/releases/migration-guide-3.7.html#build-system

Real-time issue: 
While trying to build modern zephyr (4.2) with wamr via --sysbuild (check this: https://docs.zephyrproject.org/latest/build/sysbuild/index.html) , following error is thrown:
```bash
wasm-micro-runtime/core/shared/platform/zephyr/platform_internal.h:10:10: fatal error: autoconf.h: No such file or directory
   10 | #include <autoconf.h>
      |          ^~~~~~~~~~~~
compilation terminated.
```
because it hasn't been generated yet. 

This PR solves this issue and follows earlier migration guide.