### PR TITLE
Fix mismatch of enum sizes between WASM and host

### DIFF
--- a/core/shared/platform/include/platform_wasi_types.h
+++ b/core/shared/platform/include/platform_wasi_types.h
@@ -533,19 +533,14 @@ assert_wasi_layout(offsetof(__wasi_subscription_t, userdata) == 0, "witx calcula
 assert_wasi_layout(offsetof(__wasi_subscription_t, u) == 8, "witx calculated offset");
 
 /* keep syncing with wasi_socket_ext.h */
-typedef enum {
-    /* Used only for sock_addr_resolve hints */
-    SOCKET_ANY = -1,
-    SOCKET_DGRAM = 0,
-    SOCKET_STREAM,
-} __wasi_sock_type_t;
 
 typedef uint16_t __wasi_ip_port_t;
 
 /* Ensure that __wasi_addr_type_t has a size of 4 byte (I32).
    However, it will not have the type safety of enum. */
 typedef uint32_t __wasi_addr_type_t;
-enum { IPv4 = 0, IPv6 };
+#define IPv4 (0)
+#define IPv6 (1)
 
 /* n0.n1.n2.n3 */
 typedef struct __wasi_addr_ip4_t {
@@ -592,19 +587,39 @@ typedef struct __wasi_addr_t {
     } addr;
 } __wasi_addr_t;
 
-typedef enum { INET4 = 0, INET6, INET_UNSPEC } __wasi_address_family_t;
+/* Force 32-bit wire width for cross-boundary fields */
+typedef int32_t __wasi_sock_type_t;
+#define SOCKET_ANY    (-1)
+#define SOCKET_DGRAM  (0)
+#define SOCKET_STREAM (1)
+
+typedef int32_t __wasi_address_family_t;
+#define INET4       (0)
+#define INET6       (1)
+#define INET_UNSPEC (2)
 
 typedef struct __wasi_addr_info_t {
-    __wasi_addr_t addr;
+    __wasi_addr_t      addr;
     __wasi_sock_type_t type;
 } __wasi_addr_info_t;
 
 typedef struct __wasi_addr_info_hints_t {
-   __wasi_sock_type_t type;
-   __wasi_address_family_t family;
-   // this is to workaround lack of optional parameters
-   uint8_t hints_enabled;
+    __wasi_sock_type_t        type;          // 4 bytes
+    __wasi_address_family_t   family;        // 4 bytes
+    uint8_t                   hints_enabled; // 1 byte
+    uint8_t                   _pad[3];       // enforce layout
 } __wasi_addr_info_hints_t;
+
+assert_wasi_layout(sizeof(__wasi_sock_type_t) == 4, "sock_type must be 4 bytes");
+assert_wasi_layout(sizeof(__wasi_address_family_t) == 4, "addr_family must be 4 bytes");
+
+assert_wasi_layout(sizeof(__wasi_addr_info_hints_t) == 12, "hints_t must be 12 bytes");
+assert_wasi_layout(offsetof(__wasi_addr_info_hints_t, type) == 0, "hints.type@0");
+assert_wasi_layout(offsetof(__wasi_addr_info_hints_t, family) == 4, "hints.family@4");
+assert_wasi_layout(offsetof(__wasi_addr_info_hints_t, hints_enabled) == 8, "hints.enabled@8");
+
+assert_wasi_layout(offsetof(__wasi_addr_info_t, type) == sizeof(__wasi_addr_t),
+                   "addr_info.type follows addr");
 
 #undef assert_wasi_layout
 


### PR DESCRIPTION
While working with WAMR on Zephyr, I discovered that the sizes of a couple socket enums were not consistent between the host and inside of WASM. This resulted in an inability to create a UDP socket, as the layout of the enum was compressed (enums became 1 byte instead of 4) and the offset of `hints_enabled` was incorrect, and therefore all sockets created were TCP.

In WASM: `sizes: enum=4, hints_t=12, off(type)=0 off(family)=4 off(en)=8`
In Zephyr host: `sizes: enum=1, hints_t=3, off(type)=0 off(family)=1 off(en)=2`

As a result I've enforced the struct sizes using the same method it was done for a different enum and added the appropriate assertions to validate.