### PR TITLE
docs: clarify that * in signatures does address conversion

### DIFF
--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -1746,7 +1746,9 @@ wasm_table_type_get_max_size(const wasm_table_type_t table_type);
  *          '~': the parameter is the pointer's length with i32 type, and must
  *               follow after '*'
  *          '$': the parameter is a string (i32 in WASM), and runtime will
- *               auto check its boundary before calling the native function
+ *               auto check its boundary before calling the native function.
+ *               Like '*', the runtime will also convert the app pointer to a
+ *               native pointer.
  * @param n_native_symbols specifies the number of native symbols in the array
  *
  * @return true if success, false otherwise


### PR DESCRIPTION
It was non-obvious that `*` means the runtime does the app to native conversion automatically. With the current docstring, one might assume that the runtime only does boundary checks and not address conversion. Under this assumption, passing the already-native address to `wasm_runtime_addr_app_to_native` will lead to unexpected behavior