### PR TITLE
Collect code coverage from unit tests in CI

### DIFF
--- a/.github/workflows/compilation_on_android_ubuntu.yml
+++ b/.github/workflows/compilation_on_android_ubuntu.yml
@@ -370,6 +370,15 @@ jobs:
           sudo apt-get install -y lcov
 
       - name: Build and run unit tests
+        if: matrix.build_target == 'X86_32'
+        run: |
+          rm -rf build
+          cmake -S . -B build -DWAMR_BUILD_TARGET=${{ matrix.build_target }}
+          cmake --build build --config Release --parallel 4
+          ctest --test-dir build --output-on-failure
+
+      - name: Build and run unit tests and collect coverage-data
+        if: matrix.build_target == 'X86_64'
         run: |
           rm -rf build
           cmake -S . -B build -DWAMR_BUILD_TARGET=${{ matrix.build_target }} -DCOLLECT_CODE_COVERAGE=1
@@ -377,6 +386,7 @@ jobs:
           ctest --test-dir build --output-on-failure
 
           lcov --quiet --capture --directory build --output-file coverage.all.info
+          # only keep coverage data for platform independent code
           lcov --quiet --extract coverage.all.info "*/core/iwasm/*" "*/core/shared/*" --output-file coverage.info
           lcov --summary coverage.info >> $GITHUB_STEP_SUMMARY
         working-directory: tests/unit


### PR DESCRIPTION
Running lcov only on x86-64 is because it is the most thoroughly tested platform. With the continuous improvement of test cases, there is no longer a need to combine multiple test results to achieve higher coverage. The test report is displayed as a job summary.

<img width="1027" height="1001" alt="image" src="https://github.com/user-attachments/assets/98ce9be2-ba63-4746-b9d1-b2666944c057" />
