### PR TITLE
fix: remove stack size check from exec_env_check

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -582,7 +582,7 @@ fail1:
 static bool
 wasm_runtime_exec_env_check(WASMExecEnv *exec_env)
 {
-    return exec_env && exec_env->module_inst && exec_env->wasm_stack_size > 0
+    return exec_env && exec_env->module_inst
            && exec_env->wasm_stack.top_boundary
                   == exec_env->wasm_stack.bottom + exec_env->wasm_stack_size
            && exec_env->wasm_stack.top <= exec_env->wasm_stack.top_boundary;


### PR DESCRIPTION
As per [this blogpost](https://bytecodealliance.github.io/wamr.dev/blog/understand-the-wamr-stacks/) WAMR does not require a WASM stack in AoT/JIT mode, but `wasm_runtime_exec_env_check` still always expects the size to be > 0