### PR TITLE
Fix frame_offset calculation to match actual frame_ref stack changes

### DIFF
--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -9720,6 +9720,16 @@ preserve_local_for_block(WASMLoaderContext *loader_ctx, uint8 opcode,
 
     /* preserve locals before blocks to ensure that "tee/set_local" inside
         blocks will not influence the value of these locals */
+    uint32 frame_offset_cell =
+        (uint32)(loader_ctx->frame_offset - loader_ctx->frame_offset_bottom);
+    uint32 frame_ref_cell =
+        (uint32)(loader_ctx->frame_ref - loader_ctx->frame_ref_bottom);
+    if (frame_offset_cell < loader_ctx->stack_cell_num
+        || frame_ref_cell < loader_ctx->stack_cell_num) {
+        set_error_buf(error_buf, error_buf_size, "stack cell num error");
+        return false;
+    }
+
     while (i < loader_ctx->stack_cell_num) {
         int16 cur_offset = loader_ctx->frame_offset_bottom[i];
         uint8 cur_type = loader_ctx->frame_ref_bottom[i];
@@ -12105,14 +12115,13 @@ re_scan:
                             j--;
                         }
 #endif
-
+                        uint8 *frame_ref_before_pop = loader_ctx->frame_ref;
                         POP_TYPE(
                             wasm_type->types[wasm_type->param_count - i - 1]);
 #if WASM_ENABLE_FAST_INTERP != 0
                         /* decrease the frame_offset pointer accordingly to keep
                          * consistent with frame_ref stack */
-                        cell_num = wasm_value_type_cell_num(
-                            wasm_type->types[wasm_type->param_count - i - 1]);
+                        cell_num = frame_ref_before_pop - loader_ctx->frame_ref;
                         loader_ctx->frame_offset -= cell_num;
 
                         if (loader_ctx->frame_offset


### PR DESCRIPTION
Use `frame_ref` pointer difference instead of `wasm_value_type_cell_num()`
to calculate `cell_num`, ensuring `frame_offset` stays consistent with
the actual `frame_ref` stack after POP_TYPE operations.