### PR TITLE
Adding additional text around the test requirement for code.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,12 @@ Code changes
 ===================
 We Use Github Flow, So All Code Changes Happen Through Pull Requests. Pull requests are the best way to propose changes to the codebase. We actively welcome your pull requests:
 
-- If you've added code that should be tested, add tests. Ensure the test suite passes.
-- Avoid use macros for different platforms. Use separate folder of source files to host different platform logic.
+ - If you've added / modified code:
+   - Please provide tests to the test suite to validate the operation of your code, or point to existing test cases which do the same. 
+   - Ensure that your new tests pass. This way we ensure that your contribution continues to work as you expected as future contributions are made by other contributors.
+   - Ensure all the existing tests in the test suite pass. This way we can verify that your contribution doesn’t accidentally impact other contributions.
+   - If your contribution is minor and you feel it does not need an additional test case, i.e. updating comments, formatting, simple refactoring, etc. then provide an explanation in your PR comment, i.e. “this is a minor change *explain the change*, and as such [ “is covered by” *list existing test cases* | “is except from addition test contribution”].
+- Avoid using macros for different platforms. Use separate folders for source files to collect together different host platform logic.
 - Put macro definitions inside share_lib/include/config.h if you have to use macro.
 - Make sure your code lints and compliant to our coding style.
 - Extend the application library is highly welcome.


### PR DESCRIPTION
Speaking to @lum1n0us I was suggesting that we change our process for accepting code contributions to require testing, unless there is a good reason not to have them. At the moment supplying a test is optional. 

I suggest we should change this to be a requirement -> if you change code supply a test. We could have contributors point to existing tests which cover their contribution, or supply new testing. If the code change is super tiny, like formatting, or variable name change, then code's existing functionality is testing with the existing tests.

If the code contribution is larger or affects logic, fixes a bug etc, then we should require a test. In the case of a bug, a test case to reproduce the issue, and the fix, so we can re-run the test case to show the issue cannot be reproduced.

This is my first attempt at the text for this, it's a little all over the place. But it's a start. I'd welcome your thoughts on the idea.