### PR TITLE
Add missing functions from thumb arch

### DIFF
--- a/core/iwasm/aot/arch/aot_reloc_thumb.c
+++ b/core/iwasm/aot/arch/aot_reloc_thumb.c
@@ -52,6 +52,10 @@ void __aeabi_idivmod(void);
 void __aeabi_l2d(void);
 void __aeabi_l2f(void);
 void __aeabi_ldivmod(void);
+void __aeabi_memclr(void);
+void __aeabi_memcpy(void);
+void __aeabi_memmove(void);
+void __aeabi_memset(void);
 void __aeabi_llsl(void);
 void __aeabi_llsr(void);
 void __aeabi_lmul(void);
@@ -171,6 +175,10 @@ static SymbolMap target_sym_map[] = {
     REG_SYM(__aeabi_l2d),
     REG_SYM(__aeabi_l2f),
     REG_SYM(__aeabi_ldivmod),
+    REG_SYM(__aeabi_memclr),
+    REG_SYM(__aeabi_memcpy),
+    REG_SYM(__aeabi_memmove),
+    REG_SYM(__aeabi_memset),
     REG_SYM(__aeabi_llsl),
     REG_SYM(__aeabi_llsr),
     REG_SYM(__aeabi_lmul),


### PR DESCRIPTION
Target hardware: https://www.st.com/en/evaluation-tools/b-u585i-iot02a.html
(cortex-m33, thumbv8m.main, eabihf)
When running it in Zephyr with AoT enabled, without my changes, it raises following error:
`AOT module load failed: resolve symbol __aeabi_memmove failed`

After adding these functions, runtime can pass this check and normally load the application.