### PR TITLE
ci: add raspberrypi-pico-2 to nuttx build matrix

### DIFF
--- a/.github/workflows/compilation_on_nuttx.yml
+++ b/.github/workflows/compilation_on_nuttx.yml
@@ -64,6 +64,8 @@ jobs:
           "boards/arm/rp2040/raspberrypi-pico/configs/nsh",
           # cortex-m7
           "boards/arm/stm32h7/nucleo-h743zi/configs/nsh",
+          # cortex-m33
+          "boards/arm/rp23xx/raspberrypi-pico-2/configs/nsh",
           # riscv32gc
           "boards/risc-v/qemu-rv/rv-virt/configs/nsh",
           # riscv64gc


### PR DESCRIPTION
Add Raspberry Pi Pico 2 (Cortex-M33) board configuration to the NuttX CI build matrix to ensure WAMR compatibility testing covers the Cortex-M33 platform. The board configuration path "boards/arm/rp23xx/raspberrypi-pico-2/configs/nsh" is inserted after the cortex-m7 configuration to maintain logical architecture ordering.