### PR TITLE
Fast-interp should report unsupported opcode

### DIFF
--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -7528,6 +7528,9 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
         HANDLE_OP(EXT_OP_LOOP)
         HANDLE_OP(EXT_OP_IF)
         HANDLE_OP(EXT_OP_BR_TABLE_CACHE)
+#if WASM_ENABLE_SIMDE == 0
+        HANDLE_OP(WASM_OP_SIMD_PREFIX)
+#endif
         {
             wasm_set_exception(module, "unsupported opcode");
             goto got_exception;


### PR DESCRIPTION
when meeting simd opcode on non-posix platforms