### PR TITLE
Add support for esp32s2 target to idf_component.yml

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -8,6 +8,7 @@ dependencies:
   idf: ">=4.4"
 targets:
   - esp32
+  - esp32s2
   - esp32s3
   - esp32c3
   - esp32c6


### PR DESCRIPTION
Tested and worked on esp32s2 board.