### PR TITLE
ci: update nuttx and nuttx-apps commits to fix CI build

### DIFF
--- a/.github/workflows/compilation_on_nuttx.yml
+++ b/.github/workflows/compilation_on_nuttx.yml
@@ -90,14 +90,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: apache/nuttx
-          ref: releases/12.11
+          ref: 09a71ec7c16c43398d5acbdcbeee7b08736c3170
           path: nuttx
 
       - name: Checkout NuttX Apps
         uses: actions/checkout@v6
         with:
           repository: apache/nuttx-apps
-          ref: releases/12.11
+          ref: 6bd593459c4af3cef325c3d22bccd5537a8ed755
           path: apps
 
       - name: Checkout WAMR

--- a/.github/workflows/spec_test_on_nuttx.yml
+++ b/.github/workflows/spec_test_on_nuttx.yml
@@ -146,14 +146,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: apache/nuttx
-          ref: ${{ matrix.target_config.target == 'xtensa' && '985d395b025cf2012b22f6bb4461959fa6d87645' || 'releases/12.11' }}
+          ref: ${{ matrix.target_config.target == 'xtensa' && '985d395b025cf2012b22f6bb4461959fa6d87645' || '09a71ec7c16c43398d5acbdcbeee7b08736c3170' }}
           path: nuttx
 
       - name: Checkout NuttX Apps
         uses: actions/checkout@v6
         with:
           repository: apache/nuttx-apps
-          ref: ${{ matrix.target_config.target == 'xtensa' && '2ef3eb25c0cec944b13792185f7e5d5a05990d5f' || 'releases/12.11' }}
+          ref: ${{ matrix.target_config.target == 'xtensa' && '2ef3eb25c0cec944b13792185f7e5d5a05990d5f' || '6bd593459c4af3cef325c3d22bccd5537a8ed755' }}
           path: apps
 
       - name: Checkout WAMR


### PR DESCRIPTION
Update NuttX and nuttx-apps repository references from release tags to specific commit hashes to resolve CI build failures.

* Updated nuttx from releases/12.11 to 09a71ec7c16c43398d5acbdcbeee7b08736c3170
* Updated nuttx-apps from releases/12.11 to 6bd593459c4af3cef325c3d22bccd5537a8ed755
* Preserved xtensa-specific commit logic in spec_test_on_nuttx.yml
* Applied changes to both compilation and spec test workflows