### PR TITLE
enh: conditionally include JIT-related code

### DIFF
--- a/core/iwasm/compilation/aot_compiler.c
+++ b/core/iwasm/compilation/aot_compiler.c
@@ -4065,6 +4065,7 @@ aot_compile_wasm(AOTCompContext *comp_ctx)
     os_printf("\n");
 #endif
 
+#if WAMR_BUILD_JIT != 0
     if (comp_ctx->is_jit_mode) {
         LLVMErrorRef err;
         LLVMOrcJITDylibRef orc_main_dylib;
@@ -4104,7 +4105,7 @@ aot_compile_wasm(AOTCompContext *comp_ctx)
             comp_ctx->jit_stack_sizes = (uint32 *)addr;
         }
     }
-
+#endif /* WAMR_BUILD_JIT != 0*/
     return true;
 }
 

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -2416,6 +2416,7 @@ aot_handle_llvm_errmsg(const char *string, LLVMErrorRef err)
     LLVMDisposeErrorMessage(err_msg);
 }
 
+#if WAMR_BUILD_JIT != 0
 static bool
 create_target_machine_detect_host(AOTCompContext *comp_ctx)
 {
@@ -2599,6 +2600,7 @@ fail:
         LLVMOrcDisposeLLLazyJIT(orc_jit);
     return ret;
 }
+#endif /* WAMR_BUILD_JIT != 0*/
 
 bool
 aot_compiler_init(void)
@@ -2809,6 +2811,7 @@ aot_create_comp_context(const AOTCompData *comp_data, aot_comp_option_t option)
     comp_ctx->custom_sections_wp = option->custom_sections;
     comp_ctx->custom_sections_count = option->custom_sections_count;
 
+#if WASM_ENABLE_JIT != 0
     if (option->is_jit_mode) {
         comp_ctx->is_jit_mode = true;
 
@@ -2840,7 +2843,9 @@ aot_create_comp_context(const AOTCompData *comp_data, aot_comp_option_t option)
         if (!orc_jit_create(comp_ctx))
             goto fail;
     }
-    else {
+    else 
+#endif /*WASM_ENABLE_JIT != 0*/
+    {
         /* Create LLVM target machine */
         if (!option->target_arch || !strstr(option->target_arch, "-")) {
             /* Retrieve the target triple based on user input */
@@ -3484,9 +3489,11 @@ aot_destroy_comp_context(AOTCompContext *comp_ctx)
     /* Note: don't dispose comp_ctx->context and comp_ctx->module as
        they are disposed when disposing the thread safe context */
 
+#if WAMR_BUILD_JIT != 0
     /* Has to be the last one */
     if (comp_ctx->orc_jit)
         LLVMOrcDisposeLLLazyJIT(comp_ctx->orc_jit);
+#endif
 
     if (comp_ctx->func_ctxes)
         aot_destroy_func_contexts(comp_ctx, comp_ctx->func_ctxes,

--- a/core/iwasm/compilation/iwasm_compl.cmake
+++ b/core/iwasm/compilation/iwasm_compl.cmake
@@ -3,17 +3,36 @@ set (IWASM_COMPL_DIR ${CMAKE_CURRENT_LIST_DIR})
 include_directories(${IWASM_COMPL_DIR})
 enable_language(CXX)
 
+file (GLOB source_all
+  ${IWASM_COMPL_DIR}/aot.c
+  ${IWASM_COMPL_DIR}/aot_compiler.c
+  ${IWASM_COMPL_DIR}/aot_llvm.c
+  ${IWASM_COMPL_DIR}/aot_llvm_extra*.cpp
+  ${IWASM_COMPL_DIR}/aot_stack_frame*.c
+  ${IWASM_COMPL_DIR}/aot_emit_*.c
+)
+
 if (WAMR_BUILD_DEBUG_AOT EQUAL 1)
-    file (GLOB_RECURSE source_all
-                    ${IWASM_COMPL_DIR}/*.c
-                    ${IWASM_COMPL_DIR}/*.cpp)
-else()
-    file (GLOB source_all
-                    ${IWASM_COMPL_DIR}/simd/*.c
-                    ${IWASM_COMPL_DIR}/simd/*.cpp
-                    ${IWASM_COMPL_DIR}/*.c
-                    ${IWASM_COMPL_DIR}/*.cpp)
-endif()
+  file(GLOB debug_sources
+    ${IWASM_COMPL_DIR}/debug/*.c
+  )
+  list(APPEND source_all ${debug_sources})
+endif ()
+
+if (WAMR_BUILD_SIMD EQUAL 1)
+  file(GLOB simd_sources
+    ${IWASM_COMPL_DIR}/simd/*.c
+  )
+  list(APPEND source_all ${simd_sources})
+endif ()
+
+if (WAMR_BUILD_LLVM EQUAL 1)
+  message("Build with LLVM ORC JIT support")
+  file(GLOB orc_jit_sources
+    ${IWASM_COMPL_DIR}/aot_orc_extra*.cpp
+  )
+  list(APPEND source_all ${orc_jit_sources})
+endif ()
 
 set (IWASM_COMPL_SOURCE ${source_all})
 

--- a/wamr-compiler/CMakeLists.txt
+++ b/wamr-compiler/CMakeLists.txt
@@ -32,11 +32,17 @@ set (CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
 set (CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
 
 # Turn on SIMD by default, can be turned off by setting WAMR_BUILD_SIMD to 0
+if (NOT WAMR_BUILD_SIMD)
+  set (WAMR_BUILD_SIMD 1)
+endif ()
+
 if (WAMR_BUILD_SIMD EQUAL 0)
   add_definitions(-DWASM_ENABLE_SIMD=0)
 else()
   add_definitions(-DWASM_ENABLE_SIMD=1)
 endif()
+
+set(WAMR_BUILD_JIT 0)
 
 add_definitions(-DWASM_ENABLE_INTERP=1)
 add_definitions(-DWASM_ENABLE_WAMR_COMPILER=1)


### PR DESCRIPTION
The initial idea is to exclude LLVM-JIT related code when compiling WAMRC.