### PR TITLE
Change linking of vmlib to shared. Allows native-libs to easily be bu…

### DIFF
--- a/product-mini/platforms/linux/CMakeLists.txt
+++ b/product-mini/platforms/linux/CMakeLists.txt
@@ -167,7 +167,7 @@ target_link_libraries(iwasm vmlib)
 
 install (TARGETS iwasm DESTINATION bin)
 
-add_library (vmlib ${WAMR_RUNTIME_LIB_SOURCE})
+add_library (vmlib SHARED ${WAMR_RUNTIME_LIB_SOURCE})
 
 set_version_info (vmlib)
 


### PR DESCRIPTION
This addresses issue Improve native-lib experience with shared linking #4741 . It turns on shared linking of vmlib, allowing native libs to easily link against WAMR functions, a necessity for adding extensions to WAMR using native-lib capabilities. 
