### PR TITLE
feat(aot/riscv): Enhance PCREL relocation handling with HI20/LO12 cac…

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -3202,6 +3202,14 @@ do_text_relocation(AOTModule *module, AOTRelocationGroup *group,
         return false;
     }
 
+#if defined(BUILD_TARGET_RISCV32_ILP32)     \
+    || defined(BUILD_TARGET_RISCV32_ILP32F) \
+    || defined(BUILD_TARGET_RISCV32_ILP32D) \
+    || defined(BUILD_TARGET_RISCV64_LP64)   \
+    || defined(BUILD_TARGET_RISCV64_LP64D)
+    aot_reloc_reset_cache();
+#endif
+
     for (i = 0; i < group->relocation_count; i++, relocation++) {
         int32 symbol_index = -1;
         symbol_len = (uint32)strlen(relocation->symbol_name);

--- a/core/iwasm/aot/aot_reloc.h
+++ b/core/iwasm/aot/aot_reloc.h
@@ -252,6 +252,17 @@ apply_relocation(AOTModule *module,
                  uint64 reloc_offset, int64 reloc_addend,
                  uint32 reloc_type, void *symbol_addr, int32 symbol_index,
                  char *error_buf, uint32 error_buf_size);
+
+/**
+ * Reset any target-specific relocation state.
+ *
+ * Some targets (e.g. RISC-V) need to cache information across multiple
+ * relocation entries (such as PC-relative HI20/LO12 pairs). This function must
+ * be called by the relocation loader before applying a relocation group/section
+ * to avoid stale state leaking between groups.
+ */
+void
+aot_reloc_reset_cache(void);
 /* clang-format off */
 
 #ifdef __cplusplus


### PR DESCRIPTION
…hing

Implement proper R_RISCV_PCREL_HI20/R_RISCV_PCREL_LO12_{I,S} pairing mechanism for RISC-V AOT relocation processing.

Changes:
- Add PCREL cache to match HI20 relocations with their corresponding LO12 entries, ensuring correct PC-relative offset computation
- Export aot_reloc_reset_cache() to clear cache state
- Implement proper LO12 relocation handling that uses cached HI20 offset
- Add overflow detection for PCREL cache to fail gracefully with error
- Add RV64 immediate validation for HI20 relocations

This enhances the RISC-V relocation system to correctly handle PC-relative relocations used by LLVM for position-independent code generation.