### PR TITLE
fix: correct boundary check in dynamic_offset check

### DIFF
--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -442,7 +442,7 @@ wasm_interp_get_frame_ref(WASMInterpFrame *frame)
         opnd_off = *(int16 *)(frame_ip + off); \
         addr_tmp = frame_lp + opnd_off;        \
         PUT_REF_TO_ADDR(addr_tmp, value);      \
-        SET_FRAME_REF(ond_off);                \
+        SET_FRAME_REF(opnd_off);               \
     } while (0)
 
 #define SET_OPERAND(op_type, off, value) SET_OPERAND_##op_type(off, value)

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -8545,8 +8545,7 @@ check_offset_pop(WASMLoaderContext *ctx, uint32 cells)
 static bool
 check_dynamic_offset_pop(WASMLoaderContext *ctx, uint32 cells)
 {
-    if (ctx->dynamic_offset < 0
-        || (ctx->dynamic_offset > 0 && (uint32)ctx->dynamic_offset < cells))
+    if (ctx->dynamic_offset < 0 || (uint32)ctx->dynamic_offset < cells)
         return false;
     return true;
 }

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -4345,8 +4345,7 @@ check_offset_pop(WASMLoaderContext *ctx, uint32 cells)
 static bool
 check_dynamic_offset_pop(WASMLoaderContext *ctx, uint32 cells)
 {
-    if (ctx->dynamic_offset < 0
-        || (ctx->dynamic_offset > 0 && (uint32)ctx->dynamic_offset < cells))
+    if (ctx->dynamic_offset < 0 || (uint32)ctx->dynamic_offset < cells)
         return false;
     return true;
 }


### PR DESCRIPTION
correct boundary check in check_dynamic_offset_pop when dynamic_offset is 0. When `dynamic_offset = 0`, `check_dynamic_offset_pop` will always return true, which may wrongly update `dynamic_offset`.
also include a typo fix in `SET_OPERAND_REF`