### PR TITLE
Fix alignment calculation for large offsets

### DIFF
--- a/core/iwasm/compilation/aot_emit_memory.c
+++ b/core/iwasm/compilation/aot_emit_memory.c
@@ -676,7 +676,7 @@ aot_check_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                 *alignp = max_align;
             }
             else {
-                unsigned int align = 1 << (shift - 1);
+                unsigned int align = 1U << (shift - 1);
                 if (align > max_align) {
                     align = max_align;
                 }


### PR DESCRIPTION
Use unsigned literal (1U) instead of signed literal (1) in left shift
operation to avoid potential UB when shift equals 32.