### PR TITLE
Fix memory leak in GC when rootset enumeration fails

### DIFF
--- a/core/shared/mem-alloc/ems/ems_gc.c
+++ b/core/shared/mem-alloc/ems/ems_gc.c
@@ -308,8 +308,12 @@ reclaim_instance_heap(gc_heap_t *heap)
         return GC_SUCCESS;
     ret = gct_vm_begin_rootset_enumeration(heap->cluster, heap);
 #endif
-    if (!ret)
+    if (!ret) {
+        if (heap->root_set) {
+            rollback_mark(heap);
+        }
         return GC_ERROR;
+    }
 
 #if BH_ENABLE_GC_VERIFY != 0
     /* no matter whether the enumeration is successful or not, the data


### PR DESCRIPTION
When `gct_vm_begin_rootset_enumeration` returns failure, the mark_node
allocated during the enumeration process was not being freed, causing
a memory leak.

Fix by calling `rollback_mark()` to release any allocated mark_node
before returning GC_ERROR.