### PR TITLE
Fix potential memory leak  when discarding FreeMachineFunction

### DIFF
--- a/core/iwasm/compilation/aot_orc_extra2.cpp
+++ b/core/iwasm/compilation/aot_orc_extra2.cpp
@@ -85,6 +85,7 @@ MyPassManager::add(llvm::Pass *P)
     // a hack to avoid having a copy of the whole addPassesToEmitMC.
     // we want to add PrintStackSizes before FreeMachineFunctionPass.
     if (P->getPassName() == "Free MachineFunction") {
+        delete P;
         return;
     }
     llvm::legacy::PassManager::add(P);


### PR DESCRIPTION
In `MyPassManager::add()`, when intercepting and discarding the
`FreeMachineFunctionPass` to reorder passes, the pass object was
not deleted, may causing a memory leak per pass instance.

The fix properly deletes the discarded pass before returning.