### PR TITLE
Fix potential memcpy overlap issue in RECOVER_BR_INFO for i64/v128 copy

### DIFF
--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -999,9 +999,9 @@ fail:
                     }                                                      \
                 }                                                          \
                 else if (cells[0] == 2) {                                  \
-                    PUT_I64_TO_ADDR(                                       \
-                        frame_lp + dst_offsets[0],                         \
-                        GET_I64_FROM_ADDR(frame_lp + src_offsets[0]));     \
+                    int64 tmp_i64 =                                        \
+                        GET_I64_FROM_ADDR(frame_lp + src_offsets[0]);      \
+                    PUT_I64_TO_ADDR(frame_lp + dst_offsets[0], tmp_i64);   \
                     /* Ignore constants because they are not reference */  \
                     if (src_offsets[0] >= 0) {                             \
                         CLEAR_FRAME_REF((unsigned)src_offsets[0]);         \
@@ -1011,9 +1011,9 @@ fail:
                     }                                                      \
                 }                                                          \
                 else if (cells[0] == 4) {                                  \
-                    PUT_V128_TO_ADDR(                                      \
-                        frame_lp + dst_offsets[0],                         \
-                        GET_V128_FROM_ADDR(frame_lp + src_offsets[0]));    \
+                    V128 tmp_v128 =                                        \
+                        GET_V128_FROM_ADDR(frame_lp + src_offsets[0]);     \
+                    PUT_V128_TO_ADDR(frame_lp + dst_offsets[0], tmp_v128); \
                     /* Ignore constants because they are not reference */  \
                     if (src_offsets[0] >= 0) {                             \
                         CLEAR_FRAME_REF((unsigned)src_offsets[0]);         \
@@ -1062,14 +1062,14 @@ fail:
                 if (cells[0] == 1)                                          \
                     frame_lp[dst_offsets[0]] = frame_lp[src_offsets[0]];    \
                 else if (cells[0] == 2) {                                   \
-                    PUT_I64_TO_ADDR(                                        \
-                        frame_lp + dst_offsets[0],                          \
-                        GET_I64_FROM_ADDR(frame_lp + src_offsets[0]));      \
+                    int64 tmp_i64 =                                         \
+                        GET_I64_FROM_ADDR(frame_lp + src_offsets[0]);       \
+                    PUT_I64_TO_ADDR(frame_lp + dst_offsets[0], tmp_i64);    \
                 }                                                           \
                 else if (cells[0] == 4) {                                   \
-                    PUT_V128_TO_ADDR(                                       \
-                        frame_lp + dst_offsets[0],                          \
-                        GET_V128_FROM_ADDR(frame_lp + src_offsets[0]));     \
+                    V128 tmp_v128 =                                         \
+                        GET_V128_FROM_ADDR(frame_lp + src_offsets[0]);      \
+                    PUT_V128_TO_ADDR(frame_lp + dst_offsets[0], tmp_v128);  \
                 }                                                           \
             }                                                               \
             else {                                                          \


### PR DESCRIPTION
When copying single i64 or V128 values in `RECOVER_BR_INFO`, source and
destination memory regions may overlap, causing memcpy-param-overlap errors

Use temporary variables to separate read and write operations, preventing
the overlap issue. 

This fix references the approach used in the other path (when arity != 1), which calls `copy_stack_values`, that function explicitly handles memcpy overlap.