### PR TITLE
gc: complete common heap type coverage

### DIFF
--- a/core/iwasm/common/gc/gc_common.c
+++ b/core/iwasm/common/gc/gc_common.c
@@ -352,7 +352,15 @@ wasm_ref_type_set_heap_type(wasm_ref_type_t *ref_type, bool nullable,
 {
     bool ret;
 
-    bh_assert(heap_type <= HEAP_TYPE_FUNC && heap_type >= HEAP_TYPE_NONE);
+    bh_assert((heap_type >= HEAP_TYPE_ARRAY && heap_type <= HEAP_TYPE_NOFUNC)
+#if WASM_ENABLE_STRINGREF != 0
+              || heap_type == HEAP_TYPE_STRINGREF
+              || heap_type == HEAP_TYPE_STRINGVIEWWTF8
+              || heap_type == HEAP_TYPE_STRINGVIEWWTF16
+              || heap_type == HEAP_TYPE_STRINGVIEWITER
+#endif
+    );
+
     ref_type->value_type =
         nullable ? VALUE_TYPE_HT_NULLABLE_REF : VALUE_TYPE_HT_NON_NULLABLE_REF;
     ref_type->nullable = nullable;

--- a/core/iwasm/common/gc/gc_type.h
+++ b/core/iwasm/common/gc/gc_type.h
@@ -269,18 +269,20 @@ wasm_is_refheaptype_typeidx(const RefHeapType_Common *ref_heap_type)
     return ref_heap_type->heap_type >= 0 ? true : false;
 }
 
-/* Whether a ref heap type is a common type: func/any/eq/i31/data,
-   not (type i) or (rtt n i) or (rtt i) */
+/* Whether a ref heap type is a common type:
+   func/any/eq/i31/data/nofunc/noextern, not (type i) or (rtt n i) or (rtt i) */
 inline static bool
 wasm_is_refheaptype_common(const RefHeapType_Common *ref_heap_type)
 {
     return ((ref_heap_type->heap_type >= (int32)HEAP_TYPE_ARRAY
-             && ref_heap_type->heap_type <= (int32)HEAP_TYPE_NONE)
+             && ref_heap_type->heap_type <= (int32)HEAP_TYPE_NOFUNC)
 #if WASM_ENABLE_STRINGREF != 0
-            || (ref_heap_type->heap_type >= (int32)HEAP_TYPE_STRINGVIEWITER
-                && ref_heap_type->heap_type <= (int32)HEAP_TYPE_I31)
+            || ref_heap_type->heap_type == (int32)HEAP_TYPE_STRINGREF
+            || ref_heap_type->heap_type == (int32)HEAP_TYPE_STRINGVIEWWTF8
+            || ref_heap_type->heap_type == (int32)HEAP_TYPE_STRINGVIEWWTF16
+            || ref_heap_type->heap_type == (int32)HEAP_TYPE_STRINGVIEWITER
 #endif
-                )
+            )
                ? true
                : false;
 }

--- a/core/iwasm/include/gc_export.h
+++ b/core/iwasm/include/gc_export.h
@@ -51,16 +51,21 @@ typedef enum wasm_value_type_enum {
 typedef int32_t wasm_heap_type_t;
 
 typedef enum wasm_heap_type_enum {
+    HEAP_TYPE_NOFUNC = -0x0D,
+    HEAP_TYPE_NOEXTERN = -0x0E,
+    HEAP_TYPE_NONE = -0x0F,
     HEAP_TYPE_FUNC = -0x10,
     HEAP_TYPE_EXTERN = -0x11,
     HEAP_TYPE_ANY = -0x12,
     HEAP_TYPE_EQ = -0x13,
-    HEAP_TYPE_I31 = -0x16,
-    HEAP_TYPE_NOFUNC = -0x17,
-    HEAP_TYPE_NOEXTERN = -0x18,
-    HEAP_TYPE_STRUCT = -0x19,
-    HEAP_TYPE_ARRAY = -0x1A,
-    HEAP_TYPE_NONE = -0x1B
+    HEAP_TYPE_I31 = -0x14,
+    HEAP_TYPE_STRUCT = -0x15,
+    HEAP_TYPE_ARRAY = -0x16,
+    /* Stringref Types */
+    HEAP_TYPE_STRINGREF = -0x19,
+    HEAP_TYPE_STRINGVIEWWTF8 = -0x1A,
+    HEAP_TYPE_STRINGVIEWWTF16 = -0x1E,
+    HEAP_TYPE_STRINGVIEWITER = -0x1F
 } wasm_heap_type_enum;
 
 struct WASMObject;


### PR DESCRIPTION
Complete the coverage of common heap types by extending the range check
in `wasm_is_refheaptype_common()` to include HEAP_TYPE_NOEXTERN and
HEAP_TYPE_NOFUNC. Also fix the assertion condition in ` wasm_ref_type_set_heap_type()`
which had an incorrect range check that was always false.