### PR TITLE
fix: Multi-module settings not work on cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,8 @@ endif ()
 if (NOT DEFINED WAMR_BUILD_MULTI_MODULE)
   # Disable multiple modules by default
   set (WAMR_BUILD_MULTI_MODULE 0)
+else ()
+  add_definitions(-DWASM_ENABLE_MULTI_MODULE=1)
 endif ()
 
 if (NOT DEFINED WAMR_BUILD_LIB_PTHREAD)


### PR DESCRIPTION
The cmake option `WAMR_BUILD_MULTI_MODULE` is provided, but source code use `WASM_ENABLE_MULTI_MODULE` macro as condition. I think it's maybe a mistake for not add correct definitions?