### PR TITLE
Fix a compilation error about calling os_atomic_cmpxchg

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -4699,7 +4699,7 @@ static bool
 cmpxchg_ptr(void **ptr, void *old_val, void *new_val)
 {
 #if defined(os_atomic_cmpxchg)
-    return os_atomic_cmpxchg(ptr, &old_val, new_val);
+    return os_atomic_cmpxchg((_Atomic(void *) *)ptr, &old_val, new_val);
 #else
     /* TODO: add lock when thread-manager is enabled */
     void *read = *ptr;


### PR DESCRIPTION
```
/workspaces/wasm-micro-runtime/core/iwasm/aot/aot_runtime.c:4701:30: error: expected expression
return os_atomic_cmpxchg(_Atomic(void *)ptr, &old_val, new_val);
^
/workspaces/wasm-micro-runtime/core/shared/utils/../platform/include/platform_api_extension.h:135:27: note: expanded from macro 'os_atomic_cmpxchg'
```