### PR TITLE
Fixed build of Go language bindings

### DIFF
--- a/language-bindings/go/build.sh
+++ b/language-bindings/go/build.sh
@@ -21,7 +21,7 @@ cmake ${WAMR_DIR}/product-mini/platforms/${PLATFORM} \
     -DWAMR_BUILD_LIB_PTHREAD=1 -DWAMR_BUILD_DUMP_CALL_STACK=1 \
     -DWAMR_BUILD_MEMORY_PROFILING=1
 make -j ${nproc}
-cp -a libvmlib.a ${WAMR_GO_DIR}/packaged/lib/${PLATFORM}-${ARCH}
+cp -a libiwasm.a ${WAMR_GO_DIR}/packaged/lib/${PLATFORM}-${ARCH}
 
 cd ${WAMR_GO_DIR}
 go test

--- a/language-bindings/go/wamr/cgo.go
+++ b/language-bindings/go/wamr/cgo.go
@@ -6,7 +6,7 @@
 package wamr
 
 // #cgo CFLAGS: -I${SRCDIR}/packaged/include
-// #cgo LDFLAGS: -lvmlib -lm
+// #cgo LDFLAGS: -liwasm -lm
 //
 // #cgo linux,amd64 LDFLAGS: -Wl,-rpath,${SRCDIR}/packaged/lib/linux-amd64 -L${SRCDIR}/packaged/lib/linux-amd64
 // #cgo linux,arm64 LDFLAGS: -Wl,-rpath,${SRCDIR}/packaged/lib/linux-aarch64 -L${SRCDIR}/packaged/lib/linux-aarch64


### PR DESCRIPTION
This is a trivial fix of golang language binding. Just changing wamr library name from vmlib to iwasm. Testcase running is included in the end of current build.sh, and it's now passed.