### PR TITLE
Improve shared_heap test cases.

### DIFF
--- a/core/iwasm/common/wasm_memory.c
+++ b/core/iwasm/common/wasm_memory.c
@@ -241,6 +241,11 @@ wasm_runtime_create_shared_heap(SharedHeapInitArgs *init_args)
     }
 
     size = align_uint(size, os_getpagesize());
+    if (size != init_args->size) {
+        LOG_WARNING("Shared heap size aligned from %u to %u", init_args->size,
+                    size);
+    }
+
     if (size > APP_HEAP_SIZE_MAX || size < APP_HEAP_SIZE_MIN) {
         LOG_WARNING("Invalid size of shared heap");
         goto fail2;

--- a/tests/unit/shared-heap/shared_heap_test.cc
+++ b/tests/unit/shared-heap/shared_heap_test.cc
@@ -8,6 +8,7 @@
 
 #include "bh_read_file.h"
 #include "wasm_runtime_common.h"
+#include "bh_platform.h"
 
 #include <gtest/gtest-spi.h>
 
@@ -145,7 +146,7 @@ TEST_F(shared_heap_test, test_shared_heap_basic)
     WASMSharedHeap *shared_heap = nullptr;
     uint32 argv[1] = {};
 
-    args.size = 1024;
+    args.size = os_getpagesize();
     shared_heap = wasm_runtime_create_shared_heap(&args);
 
     if (!shared_heap) {
@@ -168,20 +169,23 @@ TEST_F(shared_heap_test, test_shared_heap_malloc_fail)
     WASMSharedHeap *shared_heap = nullptr;
     uint32 argv[1] = {};
 
-    args.size = 1024;
+    args.size = os_getpagesize();
     shared_heap = wasm_runtime_create_shared_heap(&args);
 
     if (!shared_heap) {
         FAIL() << "Failed to create shared heap";
     }
 
-    test_shared_heap(shared_heap, "test.wasm", "test_malloc_fail", 0, argv);
+    argv[0] = os_getpagesize();
+    test_shared_heap(shared_heap, "test.wasm", "test_malloc_fail", 1, argv);
     EXPECT_EQ(1, argv[0]);
 
-    test_shared_heap(shared_heap, "test.aot", "test_malloc_fail", 0, argv);
+    argv[0] = os_getpagesize();
+    test_shared_heap(shared_heap, "test.aot", "test_malloc_fail", 1, argv);
     EXPECT_EQ(1, argv[0]);
 
-    test_shared_heap(shared_heap, "test_chain.aot", "test_malloc_fail", 0,
+    argv[0] = os_getpagesize();
+    test_shared_heap(shared_heap, "test_chain.aot", "test_malloc_fail", 1,
                      argv);
     EXPECT_EQ(1, argv[0]);
 }

--- a/tests/unit/shared-heap/wasm-apps/test.c
+++ b/tests/unit/shared-heap/wasm-apps/test.c
@@ -22,9 +22,9 @@ test()
 }
 
 int
-test_malloc_fail()
+test_malloc_fail(int size)
 {
-    int *ptr = (int *)shared_heap_malloc(8192);
+    int *ptr = (int *)shared_heap_malloc(size + 1);
 
     if (ptr == NULL) {
         return 1;


### PR DESCRIPTION
Aligned allocation size can be significantly greater than the original size, and page size varies across platforms.

> macOS on M1 (Apple Silicon) uses a memory page size of 16,384 bytes (16 KB).
> This differs from the traditional 4 KB page size used on Intel Macs and many
> other ARM64 systems, and is designed to improve performance by reducing page
> table overhead and allowing for better cache utilization.