### PR TITLE
Improve zephyr's networking code

### DIFF
--- a/core/shared/platform/zephyr/zephyr_socket.c
+++ b/core/shared/platform/zephyr/zephyr_socket.c
@@ -698,21 +698,18 @@ os_socket_get_linger(bh_socket_t socket, bool *is_enabled, int *linger_s)
     return BHT_ERROR;
 }
 
-// TCP_NODELAY Disable TCP buffering (ignored, for compatibility)
 int
 os_socket_set_tcp_no_delay(bh_socket_t socket, bool is_enabled)
 {
-    errno = ENOSYS;
-
-    return BHT_ERROR;
+    return os_socket_setbooloption(socket, IPPROTO_TCP, TCP_NODELAY,
+                                   is_enabled);
 }
 
 int
 os_socket_get_tcp_no_delay(bh_socket_t socket, bool *is_enabled)
 {
-    errno = ENOSYS;
-
-    return BHT_ERROR;
+    return os_socket_getbooloption(socket, IPPROTO_TCP, TCP_NODELAY,
+                                   is_enabled);
 }
 
 int
@@ -861,17 +858,37 @@ os_socket_get_tcp_fastopen_connect(bh_socket_t socket, bool *is_enabled)
 int
 os_socket_set_ip_multicast_loop(bh_socket_t socket, bool ipv6, bool is_enabled)
 {
-    errno = ENOSYS;
-
-    return BHT_ERROR;
+    if (ipv6) {
+#ifdef IPPROTO_IPV6
+        return os_socket_setbooloption(socket, IPPROTO_IPV6,
+                                       IPV6_MULTICAST_LOOP, is_enabled);
+#else
+        errno = EAFNOSUPPORT;
+        return BHT_ERROR;
+#endif
+    }
+    else {
+        return os_socket_setbooloption(socket, IPPROTO_IP, IP_MULTICAST_LOOP,
+                                       is_enabled);
+    }
 }
 
 int
 os_socket_get_ip_multicast_loop(bh_socket_t socket, bool ipv6, bool *is_enabled)
 {
-    errno = ENOSYS;
-
-    return BHT_ERROR;
+    if (ipv6) {
+#ifdef IPPROTO_IPV6
+        return os_socket_getbooloption(socket, IPPROTO_IPV6,
+                                       IPV6_MULTICAST_LOOP, is_enabled);
+#else
+        errno = EAFNOSUPPORT;
+        return BHT_ERROR;
+#endif
+    }
+    else {
+        return os_socket_getbooloption(socket, IPPROTO_IP, IP_MULTICAST_LOOP,
+                                       is_enabled);
+    }
 }
 
 int


### PR DESCRIPTION
I am submitting this PR as two separate commits;
- [fix: zephyr sockets: fix get/set sockopt usages.](https://github.com/bytecodealliance/wasm-micro-runtime/commit/6d8a33cda626050e44b325b75f2ff16acc1c40da)


is intended to fix multiple get/set sockopt functions, where the wrong one is used (get instead of set, and set instead of get). I believe this is necessary to fix, otherwise it just won't work correclty. 

- [feat: zephyr sockets: implement missing networking functions](https://github.com/bytecodealliance/wasm-micro-runtime/commit/271a930e80ff4da80dcfd64530052fd6cd5c4565)

Here I propose instead of failing the function right away, we let Zephyr decide whether it's implemented in its internals or not. With newer Zephyr versions, more and more of this optvals are getting implemented. I recommend that we call the abstract os_socket_(set/get)booloption and if it returns with errno, than we just return that. I just did few of these out of all, but if this solution is accepted, we can turn all of these with the next PRs.

Ultimately tho, with the POSIX support of Zephyr, we just need to be aiming to use common/posix code for most zephyr operations as well.

P.S. I am open to further cleanup, or make two separate PRs, but this seemed to me the most appropriate way to do this right now.