### PR TITLE
windows: fix vectored exception handler lifecycle for repeated thread env init/destroy

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -418,9 +418,7 @@ runtime_exception_handler(EXCEPTION_POINTERS *exce_info)
 #ifdef BH_PLATFORM_WINDOWS
 static PVOID runtime_exception_handler_handle = NULL;
 static int32 runtime_exception_handler_ref_count = 0;
-#if defined(OS_THREAD_MUTEX_INITIALIZER)
-static korp_mutex runtime_exception_handler_lock = OS_THREAD_MUTEX_INITIALIZER;
-#endif
+static korp_mutex runtime_exception_handler_lock = NULL;
 #endif
 
 static bool
@@ -429,14 +427,10 @@ runtime_signal_init()
 #ifndef BH_PLATFORM_WINDOWS
     return os_thread_signal_init(runtime_signal_handler) == 0 ? true : false;
 #else
-#if defined(OS_THREAD_MUTEX_INITIALIZER)
     os_mutex_lock(&runtime_exception_handler_lock);
-#endif
 
     if (os_thread_signal_init() != 0) {
-#if defined(OS_THREAD_MUTEX_INITIALIZER)
         os_mutex_unlock(&runtime_exception_handler_lock);
-#endif
         return false;
     }
 
@@ -447,17 +441,13 @@ runtime_signal_init()
 
     if (!runtime_exception_handler_handle) {
         os_thread_signal_destroy();
-#if defined(OS_THREAD_MUTEX_INITIALIZER)
         os_mutex_unlock(&runtime_exception_handler_lock);
-#endif
         return false;
     }
 
     runtime_exception_handler_ref_count++;
 
-#if defined(OS_THREAD_MUTEX_INITIALIZER)
     os_mutex_unlock(&runtime_exception_handler_lock);
-#endif
 #endif
     return true;
 }
@@ -466,9 +456,7 @@ static void
 runtime_signal_destroy()
 {
 #ifdef BH_PLATFORM_WINDOWS
-#if defined(OS_THREAD_MUTEX_INITIALIZER)
     os_mutex_lock(&runtime_exception_handler_lock);
-#endif
 
     if (runtime_exception_handler_ref_count > 0) {
         runtime_exception_handler_ref_count--;
@@ -486,9 +474,7 @@ runtime_signal_destroy()
         }
     }
 
-#if defined(OS_THREAD_MUTEX_INITIALIZER)
     os_mutex_unlock(&runtime_exception_handler_lock);
-#endif
 #endif
     os_thread_signal_destroy();
 }


### PR DESCRIPTION
## Summary

This PR fixes Windows VEH lifecycle handling for repeated runtime/thread-env init-destroy cycles.

On Windows host integrations that repeatedly unload/reload WASM runtime users, stale VEH state could remain and later crash in `ntdll` exception dispatch.

## Reproduction (before)

On Windows, in a host-like lifecycle that repeatedly creates/destroys runtime usage contexts (including thread env init/destroy churn), intermittent crashes were observed in exception dispatch (`ntdll`, access violation path) after unload/reload cycles.

## Changes

File:
- `core/iwasm/common/wasm_runtime_common.c`

What changed:
- add Windows-only VEH ref count
- guard VEH lifecycle updates with a mutex
- register VEH only when ref count transitions `0 -> 1`
- remove VEH only when ref count transitions `1 -> 0`
- if `RemoveVectoredExceptionHandler` fails, keep retry-able ownership state instead of dropping handler state

## Behavior change

- Before: VEH lifecycle could become inconsistent under repeated init/destroy cycles, leading to intermittent post-unload crash behavior.
- After: VEH registration/removal is reference-counted and synchronized, with robust failure handling on removal.

## Validation

- rebuilt WAMR on Windows
- rebuilt downstream integration
- passed downstream C++ tests
- reran host-style repeated unload/reload + open/close loop; crash no longer reproduced in the previously failing scenario

## Notes

No new WAMR-internal test is included in this patch; validation was performed in the integration lifecycle where the issue reproduces.  
If maintainers prefer, I can submit a follow-up PR with a WAMR-side regression test for this lifecycle pattern.
