### PR TITLE
Add NULL check in ns_lookup_list_search for DNS resolution

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -74,6 +74,9 @@ ns_lookup_list_search(char **list, const char *host)
 {
     size_t host_len = strlen(host), suffix_len;
 
+    if (!list)
+        return false;
+
     while (*list) {
         if (*list[0] == '*') {
             suffix_len = strlen(*list) - 1;


### PR DESCRIPTION
## Summary

Fix a NULL pointer dereference in `ns_lookup_list_search()` that causes a crash when no DNS allowlist is configured.

## Problem

When the WASI runtime is started without `--allow-resolve`, `wasi_ctx->ns_lookup_list` is NULL. When a guest WASM module calls `sock_addr_resolve`, the call chain eventually reaches `ns_lookup_list_search()` in `posix.c`, which dereferences the `list` parameter unconditionally at `while (*list)` (line 77). This causes a segmentation fault.

## Fix

Add a NULL check for the `list` parameter before the `while (*list)` loop. If `list` is NULL (no DNS allowlist configured), the function returns `false`, correctly denying the DNS lookup without crashing.

## Test

Verified that without `--allow-resolve`, calling `sock_addr_resolve` from a WASM module no longer crashes the runtime and instead returns an appropriate error.