### PR TITLE
Fix sock_connect using wrong rights constant

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -2585,7 +2585,7 @@ wasi_ssp_sock_connect(wasm_exec_env_t exec_env, struct fd_table *curfds,
         return __WASI_EACCES;
     }
 
-    error = fd_object_get(curfds, &fo, fd, __WASI_RIGHT_SOCK_BIND, 0);
+    error = fd_object_get(curfds, &fo, fd, __WASI_RIGHT_SOCK_CONNECT, 0);
     if (error != __WASI_ESUCCESS) {
         return error;
     }


### PR DESCRIPTION
## Summary

`wasi_ssp_sock_connect` in `posix.c` checks `__WASI_RIGHT_SOCK_BIND` instead of `__WASI_RIGHT_SOCK_CONNECT` when validating file descriptor rights via `fd_object_get`. This was a copy-paste error from the adjacent `wasi_ssp_sock_bind` function.

As a result, `sock_connect` operations validate the wrong capability on the file descriptor — checking for bind rights rather than connect rights.

## Fix

Changed the rights constant from `__WASI_RIGHT_SOCK_BIND` to `__WASI_RIGHT_SOCK_CONNECT` in the `fd_object_get` call within `wasi_ssp_sock_connect`.

## Test plan

- Verified that the `wasi_ssp_sock_bind` function still correctly uses `__WASI_RIGHT_SOCK_BIND`
- Verified that only the single occurrence in `wasi_ssp_sock_connect` was changed
- Existing socket test cases should continue to pass