### PR TITLE
fix: WASM_API_EXTERN should get visibility("default") on gcc and clang

### DIFF
--- a/core/iwasm/include/wasm_c_api.h
+++ b/core/iwasm/include/wasm_c_api.h
@@ -22,6 +22,8 @@
 #else
 #define WASM_API_EXTERN __declspec(dllimport)
 #endif
+#elif defined(__GNUC__) || defined(__clang__)
+#define WASM_API_EXTERN __attribute__((visibility("default")))
 #else
 #define WASM_API_EXTERN
 #endif


### PR DESCRIPTION
This allows the wasm_c_api to work in shared libraries on non-Windows platforms.

closes #4850