### PR TITLE
Fix: initialize record_frame in aot_copy_callstack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+
 .cache
 .clangd
 .vs

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -4332,6 +4332,7 @@ aot_copy_callstack_tiny_frame(WASMExecEnv *exec_env, WASMCApiFrame *buffer,
 
     AOTTinyFrame *frame = (AOTTinyFrame *)(top - sizeof(AOTTinyFrame));
     WASMCApiFrame record_frame;
+    memset(&record_frame, 0, sizeof(WASMCApiFrame));
     while (frame && (uint8_t *)frame >= bottom && count < (skip_n + length)) {
         if (count < skip_n) {
             ++count;
@@ -4374,6 +4375,7 @@ aot_copy_callstack_standard_frame(WASMExecEnv *exec_env, WASMCApiFrame *buffer,
     uint32 frame_size = (uint32)offsetof(AOTFrame, lp);
 
     WASMCApiFrame record_frame;
+    memset(&record_frame, 0, sizeof(WASMCApiFrame));
     while (cur_frame && (uint8_t *)cur_frame >= bottom
            && (uint8_t *)cur_frame + frame_size <= top_boundary
            && count < (skip_n + length)) {


### PR DESCRIPTION
This PR fixes an issue where the `record_frame` variable in `aot_copy_callstack_tiny_frame` and `aot_copy_callstack_standard_frame` was being used before it was initialized.

The fix initializes the struct with `memset(&record_frame, 0, sizeof(WASMCApiFrame));` to prevent potential uninitialized memory usage.