### PR TITLE
fix(ems): avoid abort in gc_migrate when heap metadata is corrupted

### DIFF
--- a/core/shared/mem-alloc/ems/ems_kfc.c
+++ b/core/shared/mem-alloc/ems/ems_kfc.c
@@ -286,13 +286,13 @@ gc_migrate(gc_handle_t handle, char *pool_buf_new, gc_size_t pool_buf_size)
     while (cur < end) {
         size = hmu_get_size(cur);
 
-#if BH_ENABLE_GC_CORRUPTION_CHECK != 0
         if (size <= 0 || size > (uint32)((uint8 *)end - (uint8 *)cur)) {
             LOG_ERROR("[GC_ERROR]Heap is corrupted, heap migrate failed.\n");
+#if BH_ENABLE_GC_CORRUPTION_CHECK != 0
             heap->is_heap_corrupted = true;
+#endif
             return GC_ERROR;
         }
-#endif
 
         if (hmu_get_ut(cur) == HMU_FC && !HMU_IS_FC_NORMAL(size)) {
             tree_node = (hmu_tree_node_t *)cur;
@@ -315,15 +315,13 @@ gc_migrate(gc_handle_t handle, char *pool_buf_new, gc_size_t pool_buf_size)
         cur = (hmu_t *)((char *)cur + size);
     }
 
-#if BH_ENABLE_GC_CORRUPTION_CHECK != 0
     if (cur != end) {
         LOG_ERROR("[GC_ERROR]Heap is corrupted, heap migrate failed.\n");
+#if BH_ENABLE_GC_CORRUPTION_CHECK != 0
         heap->is_heap_corrupted = true;
+#endif
         return GC_ERROR;
     }
-#else
-    bh_assert(cur == end);
-#endif
 
     return 0;
 }


### PR DESCRIPTION
When app heap lives inside linear memory (e.g. heap_offset=0), wasm code
can overwrite HMU headers. During `memory.grow`, gc_migrate walks the
heap and may read a corrupted size, causing cur to overshoot end. The
`bh_assert(cur == end)` then aborts the process.

Make the integrity checks unconditional in `gc_migrate`: validate size
before advancing (size <= 0 || size > remaining) and cur == end after
the walk. Return GC_ERROR instead of asserting.