### PR TITLE
fuzz: remove unnecessary internal headers from wasm_mutator_fuzz

### DIFF
--- a/tests/fuzz/wasm-mutator-fuzz/wasm-mutator/wasm_mutator_fuzz.cc
+++ b/tests/fuzz/wasm-mutator-fuzz/wasm-mutator/wasm_mutator_fuzz.cc
@@ -1,9 +1,7 @@
 // Copyright (C) 2019 Intel Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "wasm_runtime_common.h"
 #include "wasm_export.h"
-#include "bh_read_file.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>


### PR DESCRIPTION
## Summary

Remove unnecessary internal header includes from the `wasm_mutator_fuzz` fuzz harness (`tests/fuzz/wasm-mutator-fuzz/wasm-mutator/wasm_mutator_fuzz.cc`).

## Changes

Remove two internal headers that are not needed:

- **`wasm_runtime_common.h`** (`core/iwasm/common/`) — internal runtime implementation header not intended for external use.
- **`bh_read_file.h`** (`core/shared/utils/uncommon/`) — internal utility header whose functions (`bh_read_file_to_buffer`) are never called in this fuzzer (data comes from libFuzzer's input buffer).

All runtime APIs actually used by the harness (`wasm_runtime_init`, `wasm_runtime_load`, `wasm_runtime_instantiate`, `wasm_runtime_call_wasm_a`, `wasm_runtime_get_export_count`, `wasm_runtime_get_export_type`, `wasm_func_type_get_param_count`, `wasm_func_type_get_param_valkind`, etc.) are declared in the public `wasm_export.h` header.

## Verification

Built and tested the modified harness in OSS-Fuzz for all three build targets (classic-interp, fast-interp, llvm-jit):

- **Build**: compiles successfully for all 3 targets.
- **Fuzzing**: identical edge coverage (383 edges) with the same seed corpus.
- **Code coverage**: identical across all metrics (regions, functions, lines, branches).

| Metric | Before | After |
|--------|--------|-------|
| Regions | 3.91% | 3.91% |
| Functions | 5.65% | 5.65% |
| Lines | 4.19% | 4.19% |
| Branches | 3.33% | 3.33% |