### PR TITLE
Fix LLVM ORC JIT relocation failure caused by InternalLinkage stack_sizes

### DIFF
--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -1834,18 +1834,12 @@ aot_create_stack_sizes(const AOTCompData *comp_data, AOTCompContext *comp_ctx)
         return false;
     }
 
-    /*
-     * make the original symbol internal. we mainly use this version to
-     * avoid creating extra relocations in the precheck functions.
-     */
-    LLVMSetLinkage(stack_sizes, LLVMInternalLinkage);
-    /*
-     * for AOT, place it into a dedicated section for the convenience
-     * of the AOT file generation and symbol resolutions.
-     *
-     * for JIT, it doesn't matter.
-     */
     if (!comp_ctx->is_jit_mode) {
+        LLVMSetLinkage(stack_sizes, LLVMInternalLinkage);
+        /*
+         * for AOT, place it into a dedicated section for the convenience
+         * of the AOT file generation and symbol resolutions.
+         */
         LLVMSetSection(stack_sizes, aot_stack_sizes_section_name);
     }
     comp_ctx->stack_sizes_type = stack_sizes_type;


### PR DESCRIPTION
Resolve: https://github.com/bytecodealliance/wasm-micro-runtime/issues/4832