### PR TITLE
Fix typo in aot_loader.c's comment section

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -4422,7 +4422,7 @@ aot_compatible_version(uint32 version)
 {
     /*
      * refer to "AoT-compiled module compatibility among WAMR versions" in
-     * ./doc/biuld_wasm_app.md
+     * ./doc/build_wasm_app.md
      */
     return version == AOT_CURRENT_VERSION;
 }


### PR DESCRIPTION
While the CI is failing, this is just a typo fix in a comment section, which shouldn't have any functional or other effect.