### PR TITLE
feat(zephyr): v4.4 migration fixes/improvements

### DIFF
--- a/core/iwasm/aot/arch/aot_reloc_thumb.c
+++ b/core/iwasm/aot/arch/aot_reloc_thumb.c
@@ -438,7 +438,7 @@ apply_relocation(AOTModule *module, uint8 *target_section_addr,
                      | ((lower & 0x7000) >> 4) | (lower & 0x00ff);
             offset = (offset ^ 0x8000) - 0x8000;
 
-            offset += (symbol_addr + reloc_addend);
+            offset += ((intptr_t)symbol_addr + reloc_addend);
 
             if (reloc_type == R_ARM_THM_MOVT_PREL
                 || reloc_type == R_ARM_THM_MOVW_PREL_NC)

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -2215,15 +2215,15 @@ wasmtime_ssp_poll_oneoff(wasm_exec_env_t exec_env, struct fd_table *curfds,
                                          __WASI_RIGHT_POLL_FD_READWRITE, 0);
                 if (error == 0) {
 
-// Temporary workaround (see PR#4377)
-#ifdef BH_PLATFORM_ZEPHYR
-                    os_file_handle tfd = fos[i]->file_handle->fd;
-#else
+                    // Temporary workaround (see PR#4377)
                     os_file_handle tfd = fos[i]->file_handle;
-#endif
                     // Proper file descriptor on which we can poll().
                     pfds[i] = (os_poll_file_handle){
+#ifdef BH_PLATFORM_ZEPHYR
+                        .fd = tfd->fd,
+#else
                         .fd = tfd,
+#endif
                         .events = s->u.type == __WASI_EVENTTYPE_FD_READ
                                       ? POLLIN
                                       : POLLOUT,

--- a/core/shared/platform/zephyr/zephyr_socket.c
+++ b/core/shared/platform/zephyr/zephyr_socket.c
@@ -24,7 +24,7 @@ textual_addr_to_sockaddr(const char *textual, int port, struct sockaddr *out,
 {
     struct sockaddr_in *v4;
 #ifdef IPPROTO_IPV6
-    struct sockaddr_in *v6;
+    struct sockaddr_in6 *v6;
 #endif
 
     assert(textual);
@@ -38,11 +38,11 @@ textual_addr_to_sockaddr(const char *textual, int port, struct sockaddr *out,
     }
 
 #ifdef IPPROTO_IPV6
-    v6 = (struct sockaddr_in *)out;
+    v6 = (struct sockaddr_in6 *)out;
     if (zsock_inet_pton(AF_INET6, textual, &v6->sin6_addr.s6_addr) == 1) {
         v6->sin6_family = AF_INET6;
         v6->sin6_port = htons(port);
-        *out_len = sizeof(struct sockaddr_in);
+        *out_len = sizeof(struct sockaddr_in6);
         return true;
     }
 #endif
@@ -67,7 +67,7 @@ sockaddr_to_bh_sockaddr(const struct sockaddr *sockaddr,
 #ifdef IPPROTO_IPV6
         case AF_INET6:
         {
-            struct sockaddr_in *addr = (struct sockaddr_in *)sockaddr;
+            struct sockaddr_in6 *addr = (struct sockaddr_in6 *)sockaddr;
             size_t i;
 
             bh_sockaddr->port = ntohs(addr->sin6_port);
@@ -245,7 +245,7 @@ os_socket_bind(bh_socket_t socket, const char *host, int *port)
     }
     else {
 #ifdef IPPROTO_IPV6
-        *port = ntohs(((struct sockaddr_in *)&addr)->sin6_port);
+        *port = ntohs(((struct sockaddr_in6 *)&addr)->sin6_port);
 #else
         return BHT_ERROR;
 #endif
@@ -906,10 +906,10 @@ os_socket_set_ip_add_membership(bh_socket_t socket,
             ((uint16_t *)mreq.ipv6mr_multiaddr.s6_addr)[i] =
                 imr_multiaddr->ipv6[i];
         }
-        mreq.ipv6mr_interface = imr_interface;
+        mreq.ipv6mr_ifindex = imr_interface;
 
-        if (setsockopt(socket->fd, IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP, &mreq,
-                       sizeof(mreq))
+        if (zsock_setsockopt(socket->fd, IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP,
+                             &mreq, sizeof(mreq))
             != 0) {
             return BHT_ERROR;
         }
@@ -947,7 +947,7 @@ os_socket_set_ip_drop_membership(bh_socket_t socket,
             ((uint16_t *)mreq.ipv6mr_multiaddr.s6_addr)[i] =
                 imr_multiaddr->ipv6[i];
         }
-        mreq.ipv6mr_interface = imr_interface;
+        mreq.ipv6mr_ifindex = imr_interface;
 
         if (zsock_setsockopt(socket->fd, IPPROTO_IPV6, IPV6_DROP_MEMBERSHIP,
                              &mreq, sizeof(mreq))


### PR DESCRIPTION
This PR would make WAMR work on Zephyr v4.4, while not breaking anything on previous versions. I have tested this extensively both on v4.3 which we were before, and on new v4.4.

For WAMR, the v4.4 mostly brings stricter policies regarding the compiler and warnings. To make it work and build, fixing some implicit casting was necessary, as well as typos around IPV6 (seems that we never tested it in previous versions, therefore we haven't' noticed those typos). 

This commit fixes following:
- fix implicit casting errors
- fix IPV6 related typos/variables/structures
- fix zephyr fd relevant implicit casting

I remember, that previously we discussed the case for file descriptors, that we shall probably refactor how we use those, instead of moving the zephyr-related header guards from one line to another. While I do agree with this, this change still solves the warning on <=v4,3 and error on v4.4, while isn't further increasing any complexity. 

Please let me know, if you want me to make some further tests or changes. I have found a zephyr-related misinformation as well, which I reported here: https://github.com/bytecodealliance/wasm-micro-runtime/issues/4913 ; but that is irrelevant to this PR's goal. 