### PR TITLE
fix: Broken string cast in Windows GetModuleHandle{A,W} call

### DIFF
--- a/core/shared/platform/windows/win_thread.c
+++ b/core/shared/platform/windows/win_thread.c
@@ -159,7 +159,7 @@ os_thread_sys_init()
     if (os_mutex_init(&thread_data_list_lock) != BHT_OK)
         goto fail5;
 
-    if ((module = GetModuleHandle((LPCTSTR) "kernel32"))) {
+    if ((module = GetModuleHandle(TEXT("kernel32")))) {
         *(void **)&GetCurrentThreadStackLimits_Kernel32 =
             GetProcAddress(module, "GetCurrentThreadStackLimits");
     }


### PR DESCRIPTION
`GetModuleHandle` can end up calling either the A (default chars / ANSI) or W (2-byte wide chars / UTF-16) variant, which requires its parameter to be the matching type. The current implementation interprets a 1-byte-per-char string as `LPCTSTR`, instead of using the [`TEXT` macro](https://learn.microsoft.com/en-us/windows/win32/api/winnt/nf-winnt-text), which properly passes the string as either ANSI or UTF-16 (string prefixed with `L`), depending on the `UNICODE` preprocessor definition.