### PR TITLE
Add custom data setter for InstantiationArgs2

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -1963,6 +1963,8 @@ aot_instantiate(AOTModule *module, AOTModuleInstance *parent,
     module_inst->e =
         (WASMModuleInstanceExtra *)((uint8 *)module_inst + extra_info_offset);
     extra = (AOTModuleInstanceExtra *)module_inst->e;
+    wasm_runtime_set_custom_data_internal(
+        (WASMModuleInstanceCommon *)module_inst, args->custom_data);
 #if WASM_ENABLE_THREAD_MGR != 0
     if (os_mutex_init(&extra->common.exception_lock) != 0) {
         wasm_runtime_free(module_inst);

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -1755,6 +1755,13 @@ wasm_runtime_instantiation_args_set_max_memory_pages(
     p->v1.max_memory_pages = v;
 }
 
+void
+wasm_runtime_instantiation_args_set_custom_data(struct InstantiationArgs2 *p,
+                                                void *custom_data)
+{
+    p->custom_data = custom_data;
+}
+
 #if WASM_ENABLE_LIBC_WASI != 0
 void
 wasm_runtime_instantiation_args_set_wasi_arg(struct InstantiationArgs2 *p,

--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -617,6 +617,7 @@ wasm_runtime_get_exec_env_tls(void);
 
 struct InstantiationArgs2 {
     InstantiationArgs v1;
+    void *custom_data;
 #if WASM_ENABLE_LIBC_WASI != 0
     WASIArguments wasi;
 #endif
@@ -740,6 +741,11 @@ WASM_RUNTIME_API_EXTERN
 void
 wasm_runtime_instantiation_args_set_max_memory_pages(
     struct InstantiationArgs2 *p, uint32 v);
+
+/* See wasm_export.h for description */
+WASM_RUNTIME_API_EXTERN void
+wasm_runtime_instantiation_args_set_custom_data(struct InstantiationArgs2 *p,
+                                                void *custom_data);
 
 /* See wasm_export.h for description */
 WASM_RUNTIME_API_EXTERN void

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -781,6 +781,10 @@ wasm_runtime_instantiation_args_set_max_memory_pages(
     struct InstantiationArgs2 *p, uint32_t v);
 
 WASM_RUNTIME_API_EXTERN void
+wasm_runtime_instantiation_args_set_custom_data(struct InstantiationArgs2 *p,
+                                                void *custom_data);
+
+WASM_RUNTIME_API_EXTERN void
 wasm_runtime_instantiation_args_set_wasi_arg(struct InstantiationArgs2 *p,
                                              char *argv[], int argc);
 

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -2512,6 +2512,8 @@ wasm_instantiate(WASMModule *module, WASMModuleInstance *parent,
     module_inst->module = module;
     module_inst->e =
         (WASMModuleInstanceExtra *)((uint8 *)module_inst + extra_info_offset);
+    wasm_runtime_set_custom_data_internal(
+        (WASMModuleInstanceCommon *)module_inst, args->custom_data);
 #if WASM_ENABLE_THREAD_MGR != 0
     if (os_mutex_init(&module_inst->e->common.exception_lock) != 0) {
         wasm_runtime_free(module_inst);

--- a/core/iwasm/libraries/lib-pthread/lib_pthread_wrapper.c
+++ b/core/iwasm/libraries/lib-pthread/lib_pthread_wrapper.c
@@ -582,13 +582,11 @@ pthread_create_wrapper(wasm_exec_env_t exec_env,
 
     wasm_runtime_instantiation_args_set_defaults(&args);
     wasm_runtime_instantiation_args_set_default_stack_size(&args, stack_size);
+    wasm_runtime_instantiation_args_set_custom_data(
+        &args, wasm_runtime_get_custom_data(module_inst));
     if (!(new_module_inst = wasm_runtime_instantiate_internal(
               module, module_inst, exec_env, &args, NULL, 0)))
         return -1;
-
-    /* Set custom_data to new module instance */
-    wasm_runtime_set_custom_data_internal(
-        new_module_inst, wasm_runtime_get_custom_data(module_inst));
 
     wasm_native_inherit_contexts(new_module_inst, module_inst);
 

--- a/core/iwasm/libraries/lib-wasi-threads/lib_wasi_threads_wrapper.c
+++ b/core/iwasm/libraries/lib-wasi-threads/lib_wasi_threads_wrapper.c
@@ -89,12 +89,11 @@ thread_spawn_wrapper(wasm_exec_env_t exec_env, uint32 start_arg)
 
     wasm_runtime_instantiation_args_set_defaults(&args);
     wasm_runtime_instantiation_args_set_default_stack_size(&args, stack_size);
+    wasm_runtime_instantiation_args_set_custom_data(
+        &args, wasm_runtime_get_custom_data(module_inst));
     if (!(new_module_inst = wasm_runtime_instantiate_internal(
               module, module_inst, exec_env, &args, NULL, 0)))
         return -1;
-
-    wasm_runtime_set_custom_data_internal(
-        new_module_inst, wasm_runtime_get_custom_data(module_inst));
 
     if (!(wasm_cluster_dup_c_api_imports(new_module_inst, module_inst)))
         goto thread_preparation_fail;

--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -502,14 +502,12 @@ wasm_cluster_spawn_exec_env(WASMExecEnv *exec_env)
 
     wasm_runtime_instantiation_args_set_defaults(&args);
     wasm_runtime_instantiation_args_set_default_stack_size(&args, stack_size);
+    wasm_runtime_instantiation_args_set_custom_data(
+        &args, wasm_runtime_get_custom_data(module_inst));
     if (!(new_module_inst = wasm_runtime_instantiate_internal(
               module, module_inst, exec_env, &args, NULL, 0))) {
         return NULL;
     }
-
-    /* Set custom_data to new module instance */
-    wasm_runtime_set_custom_data_internal(
-        new_module_inst, wasm_runtime_get_custom_data(module_inst));
 
     wasm_native_inherit_contexts(new_module_inst, module_inst);
 


### PR DESCRIPTION
Add custom data setter for InsantiationArgs2, so user can provide custom data before post-instantiation code (such as `_initialize`) runs.
