### PR TITLE
Add missing stddef.h include to lib_export.h

### DIFF
--- a/core/iwasm/include/lib_export.h
+++ b/core/iwasm/include/lib_export.h
@@ -11,6 +11,7 @@
 #ifndef _LIB_EXPORT_H_
 #define _LIB_EXPORT_H_
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
The `core/iwasm/include/lib_export.h` misses an include of `<stddef.h>`, which is required for the definition of `NULL`.

### Testing

```c
// lib_export_test.c
#include <stdint.h>
#include "lib_export.h"

struct WASMExecEnv;
typedef struct WASMExecEnv *wasm_exec_env_t;

int foo_wrapper(wasm_exec_env_t exec_env) {
  (void)exec_env;
  return 42; }

static NativeSymbol native_symbols[] = {EXPORT_WASM_API_WITH_SIG2(foo, "()i")};

uint32_t get_native_lib(char **p_module_name, NativeSymbol **p_native_symbols)
{
  *p_module_name = "env";
  *p_native_symbols = native_symbols;
  return sizeof(native_symbols) / sizeof(NativeSymbol);
}
```

```sh
$ clang -shared -I ./core/iwasm/include -o lib_export_test.so lib_export_test.c
lib_export_test.c:6:41: error: use of undeclared identifier 'NULL'
static NativeSymbol native_symbols[] = {EXPORT_WASM_API_WITH_SIG2(foo, "()i")};
                                        ^
./core/iwasm/include/lib_export.h:39:53: note: expanded from macro 'EXPORT_WASM_API_WITH_SIG2'
    { #symbol, (void *)symbol##_wrapper, signature, NULL }
                                                    ^
lib_export_test.c:12:16: error: invalid application of 'sizeof' to an incomplete type 'NativeSymbol[]' (aka 'struct NativeSymbol[]')
  return sizeof(native_symbols) / sizeof(NativeSymbol);
               ^~~~~~~~~~~~~~~~
2 errors generated.
```
