### PR TITLE
Remove ccache from ci

### DIFF
--- a/.github/workflows/build_llvm_libraries.yml
+++ b/.github/workflows/build_llvm_libraries.yml
@@ -89,39 +89,17 @@ jobs:
             ./core/deps/llvm/build/share
           key: ${{ steps.create_lib_cache_key.outputs.key}}
 
-      - uses: actions/cache@v5
-        with:
-          path: ~/.cache/ccache
-          key: 0-ccache-${{ inputs.os }}-${{ steps.get_last_commit.outputs.last_commit }}
-          restore-keys: |
-            0-ccache-${{ inputs.os }}
-        if: steps.retrieve_llvm_libs.outputs.cache-hit != 'true' && inputs.os == 'ubuntu-22.04'
-
       # Don't install dependencies if the cache is hit or running in docker container
-      - run: sudo apt install -y ccache ninja-build
+      # Note: ccache is not used in CI to save cache storage.
+      # Local developers can still use --use-ccache flag with build_llvm.py
+      - run: sudo apt install -y ninja-build
         if: steps.retrieve_llvm_libs.outputs.cache-hit != 'true' && startsWith(inputs.os, 'ubuntu') && inputs.container_image == ''
 
-      - uses: actions/cache@v5
-        with:
-          path: ~/Library/Caches/ccache
-          key: 0-ccache-${{ inputs.os }}-${{ steps.get_last_commit.outputs.last_commit }}
-          restore-keys: |
-            0-ccache-${{ inputs.os }}
+      - run: brew install ninja
         if: steps.retrieve_llvm_libs.outputs.cache-hit != 'true' && startsWith(inputs.os, 'macos')
-
-      - run: brew install ccache ninja
-        if: steps.retrieve_llvm_libs.outputs.cache-hit != 'true' && startsWith(inputs.os, 'macos')
-
-      - uses: actions/cache@v5
-        with:
-          path: ~/.cache/ccache
-          key: 0-ccache-${{ inputs.os }}-${{ steps.get_last_commit.outputs.last_commit }}
-          restore-keys: |
-            0-ccache-${{ inputs.os }}
-        if: steps.retrieve_llvm_libs.outputs.cache-hit != 'true' && inputs.os == 'windows-2022'
 
       # Install tools on Windows
-      - run: choco install -y ccache ninja
+      - run: choco install -y ninja
         if: steps.retrieve_llvm_libs.outputs.cache-hit != 'true' && inputs.os == 'windows-2022'
 
       - name: Build LLVM libraries


### PR DESCRIPTION
- Remove ccache cache steps for Ubuntu/macOS/Windows
- Remove ccache from dependency installation
- Add comment explaining ccache is not used in CI
- Local developers can still use --use-ccache flag