### PR TITLE
check buffer before reading branch hint data byte

### DIFF
--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -5681,6 +5681,7 @@ handle_branch_hint_section(const uint8 *buf, const uint8 *buf_end,
                 goto fail;
             }
 
+            CHECK_BUF(buf, buf_end, 1);
             uint8 data = *buf++;
             if (data == 0x00)
                 new_hint->is_likely = false;


### PR DESCRIPTION
1. handle_branch_hint_section reads each hints size field with a bounds-checked LEB read, then reads the following 1-byte hint value with a raw `*buf++` that does not check whether a byte is still available.
2. a `metadata.code.branch_hint` section that declares size=1 but ends right after the size field reads one byte past the section, and past the end of the module buffer when the branch hint section is the last one. Under ASAN this is a heap-buffer-overflow read at wasm_loader.c:5684.

Added a CHECK_BUF before the read so the value is bounded the same way as the other fields parsed in this loop.

Validation: built with WAMR_BUILD_BRANCH_HINTS=1 under ASAN. Before the change a crafted module with a truncated branch hint reports the overflow read at handle_branch_hint_section; after the change the same module fails to load with "unexpected end of section or function", and a well-formed branch hint section still loads.
