### PR TITLE
Upgrade macos runner of CIs to 15 (#4770)

### DIFF
--- a/.github/actions/install-wasi-sdk-wabt/action.yml
+++ b/.github/actions/install-wasi-sdk-wabt/action.yml
@@ -50,18 +50,18 @@ runs:
         echo "::notice::wasi-sdk-25 and wabt-1.0.37 installed on ubuntu"
       working-directory: /opt
 
-    - name: Set up wasi-sdk and wabt on macOS-13 (intel)
-      if: ${{ inputs.os == 'macos-13' }}
+    - name: Set up wasi-sdk and wabt on macOS on Intel
+      if: ${{ inputs.os == 'macos-15-intel' }}
       shell: bash
       run: |
-        echo "Downloading wasi-sdk for macOS-13..."
+        echo "Downloading wasi-sdk for macOS on Intel..."
         sudo wget -O wasi-sdk.tar.gz --progress=dot:giga https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-25/wasi-sdk-25.0-x86_64-macos.tar.gz
 
         echo "Extracting wasi-sdk..."
         sudo tar -xf wasi-sdk.tar.gz
         sudo ln -sf  wasi-sdk-25.0-x86_64-macos wasi-sdk
 
-        echo "Downloading wabt for macOS-13..."
+        echo "Downloading wabt for macOS on Intel..."
         sudo wget -O wabt.tar.gz     --progress=dot:giga https://github.com/WebAssembly/wabt/releases/download/1.0.36/wabt-1.0.36-macos-12.tar.gz
 
         echo "Extracting wabt..."
@@ -71,21 +71,21 @@ runs:
         /opt/wasi-sdk/bin/clang --version
         /opt/wabt/bin/wasm-interp --version
 
-        echo "::notice::wasi-sdk-25 and wabt-1.0.36 installed on macos-13"
+        echo "::notice::wasi-sdk-25 and wabt-1.0.36 installed on ${{ inputs.os }}"
       working-directory: /opt
 
-    - name: Set up wasi-sdk and wabt on macOS-14 (arm64)
-      if: ${{ inputs.os == 'macos-14' }}
+    - name: Set up wasi-sdk and wabt on macOS on ARM
+      if: ${{ inputs.os == 'macos-15' }}
       shell: bash
       run: |
-        echo "Downloading wasi-sdk for macOS-14..."
+        echo "Downloading wasi-sdk for macOS on ARM..."
         sudo wget -O wasi-sdk.tar.gz --progress=dot:giga https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-25/wasi-sdk-25.0-arm64-macos.tar.gz
 
         echo "Extracting wasi-sdk..."
         sudo tar -xf wasi-sdk.tar.gz
         sudo ln -sf  wasi-sdk-25.0-arm64-macos wasi-sdk
 
-        echo "Downloading wabt for macOS-14..."
+        echo "Downloading wabt for macOS on ARM..."
         sudo wget -O wabt.tar.gz     --progress=dot:giga https://github.com/WebAssembly/wabt/releases/download/1.0.37/wabt-1.0.37-macos-14.tar.gz
 
         echo "Extracting wabt..."
@@ -95,7 +95,7 @@ runs:
         /opt/wasi-sdk/bin/clang --version
         /opt/wabt/bin/wasm-interp --version
 
-        echo "::notice::wasi-sdk-25 and wabt-1.0.37 installed on macos-14"
+        echo "::notice::wasi-sdk-25 and wabt-1.0.37 installed on ${{ inputs.os }}"
       working-directory: /opt
 
     - name: Set up wasi-sdk and wabt on Windows

--- a/.github/workflows/build_llvm_libraries.yml
+++ b/.github/workflows/build_llvm_libraries.yml
@@ -47,14 +47,14 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - name: install dependencies for non macos-14
-        if: inputs.os != 'macos-14'
+      - name: install dependencies for non macos
+        if: ${{ !startsWith(inputs.os, 'macos') }}
         shell: bash
         run: /usr/bin/env python3 -m pip install -r requirements.txt
         working-directory: build-scripts
 
-      - name: install dependencies for macos-14
-        if: inputs.os == 'macos-14'
+      - name: install dependencies for macos
+        if: startsWith(inputs.os, 'macos')
         run: /usr/bin/env python3 -m pip install -r requirements.txt --break-system-packages
         working-directory: build-scripts
 

--- a/.github/workflows/compilation_on_macos.yml
+++ b/.github/workflows/compilation_on_macos.yml
@@ -65,7 +65,7 @@ jobs:
       actions: write
     uses: ./.github/workflows/build_llvm_libraries.yml
     with:
-      os: "macos-13"
+      os: "macos-15-intel"
       arch: "X86"
   build_llvm_libraries_on_arm_macos:
     permissions:
@@ -73,17 +73,20 @@ jobs:
       actions: write
     uses: ./.github/workflows/build_llvm_libraries.yml
     with:
-      os: "macos-14"
+      os: "macos-15"
       arch: "AArch64 ARM"
 
   build_wamrc:
-    needs: [build_llvm_libraries_on_intel_macos]
+    needs: [build_llvm_libraries_on_intel_macos, build_llvm_libraries_on_arm_macos]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [macos-15, macos-15-intel]
         include:
-          - os: macos-13
+          - os: macos-15-intel
             llvm_cache_key: ${{ needs.build_llvm_libraries_on_intel_macos.outputs.cache_key }}
+          - os: macos-15
+            llvm_cache_key: ${{ needs.build_llvm_libraries_on_arm_macos.outputs.cache_key }}
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -112,7 +115,7 @@ jobs:
         working-directory: wamr-compiler
 
   build_iwasm:
-    needs: [build_llvm_libraries_on_intel_macos]
+    needs: [build_llvm_libraries_on_intel_macos, build_llvm_libraries_on_arm_macos]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -144,7 +147,7 @@ jobs:
             "-DWAMR_DISABLE_HW_BOUND_CHECK=1",
             "-DWAMR_BUILD_EXTENDED_CONST_EXPR=1",
           ]
-        os: [macos-13]
+        os: [macos-15, macos-15-intel]
         platform: [darwin]
         exclude:
           # incompatible feature and platform
@@ -186,7 +189,9 @@ jobs:
           - make_options_run_mode: $LLVM_EAGER_JIT_BUILD_OPTIONS
             make_options_feature: "-DWAMR_BUILD_MINI_LOADER=1"
         include:
-          - os: macos-13
+          - os: macos-15
+            llvm_cache_key: ${{ needs.build_llvm_libraries_on_arm_macos.outputs.cache_key }}
+          - os: macos-15-intel
             llvm_cache_key: ${{ needs.build_llvm_libraries_on_intel_macos.outputs.cache_key }}
     steps:
       - name: checkout
@@ -222,6 +227,7 @@ jobs:
       [
         build_iwasm,
         build_llvm_libraries_on_intel_macos,
+        build_llvm_libraries_on_arm_macos,
         build_wamrc,
       ]
     runs-on: ${{ matrix.os }}
@@ -231,15 +237,23 @@ jobs:
             $AOT_BUILD_OPTIONS,
             $CLASSIC_INTERP_BUILD_OPTIONS,
             $FAST_INTERP_BUILD_OPTIONS,
-            $FAST_JIT_BUILD_OPTIONS,
             $LLVM_LAZY_JIT_BUILD_OPTIONS,
             $LLVM_EAGER_JIT_BUILD_OPTIONS,
-            $MULTI_TIER_JIT_BUILD_OPTIONS,
           ]
-        os: [macos-13]
+        os: [macos-15, macos-15-intel]
         include:
-          - os: macos-13
+          - os: macos-15
+            llvm_cache_key: ${{ needs.build_llvm_libraries_on_arm_macos.outputs.cache_key }}
+          - os: macos-15-intel
             llvm_cache_key: ${{ needs.build_llvm_libraries_on_intel_macos.outputs.cache_key }}
+          # classic interp doesn't support SIMD
+          - make_options: $CLASSIC_INTERP_BUILD_OPTIONS
+            extra_options: "-DWAMR_BUILD_SIMD=0"
+          # LLVM JIT doesn't support Multi-module
+          - make_options: $LLVM_LAZY_JIT_BUILD_OPTIONS
+            extra_options: "-DWAMR_BUILD_MULTI_MODULE=0"
+          - make_options: $LLVM_EAGER_JIT_BUILD_OPTIONS
+            extra_options: "-DWAMR_BUILD_MULTI_MODULE=0"
 
     steps:
       - name: checkout
@@ -293,11 +307,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-15-intel, macos-15]
         include:
-          - os: macos-13
+          - os: macos-15-intel
             llvm_cache_key: ${{ needs.build_llvm_libraries_on_intel_macos.outputs.cache_key }}
-          - os: macos-14
+          - os: macos-15
             llvm_cache_key: ${{ needs.build_llvm_libraries_on_arm_macos.outputs.cache_key }}
     steps:
       - name: checkout

--- a/.github/workflows/release_process.yml
+++ b/.github/workflows/release_process.yml
@@ -88,6 +88,7 @@ jobs:
       os: "ubuntu-22.04"
       arch: "AArch64 ARM Mips RISCV X86"
 
+  #CLARIFY: Require to build LLVM libraries on ARM macOS?
   build_llvm_libraries_on_macos:
     permissions:
       contents: read
@@ -95,7 +96,7 @@ jobs:
     needs: [create_tag, create_release]
     uses: ./.github/workflows/build_llvm_libraries.yml
     with:
-      os: "macos-13"
+      os: "macos-15-intel"
       arch: "AArch64 ARM Mips RISCV X86"
 
   build_llvm_libraries_on_windows:
@@ -122,6 +123,7 @@ jobs:
       upload_url: ${{ needs.create_release.outputs.upload_url }}
       ver_num: ${{ needs.create_tag.outputs.new_ver }}
 
+  #CLARIFY: Require to release wamrc on ARM macOS?
   release_wamrc_on_ubuntu_macos:
     permissions:
       contents: write # upload release artifact
@@ -130,7 +132,7 @@ jobs:
     with:
       llvm_cache_key: ${{ needs.build_llvm_libraries_on_macos.outputs.cache_key }}
       release: true
-      runner: macos-13
+      runner: macos-15-intel
       upload_url: ${{ needs.create_release.outputs.upload_url }}
       ver_num: ${{ needs.create_tag.outputs.new_ver }}
 
@@ -160,6 +162,7 @@ jobs:
       upload_url: ${{ needs.create_release.outputs.upload_url }}
       ver_num: ${{ needs.create_tag.outputs.new_ver}}
 
+  #CLARIFY: Require to release iwasm on ARM macOS?
   release_iwasm_on_macos:
     permissions:
       contents: write # upload release artifact
@@ -168,7 +171,7 @@ jobs:
     with:
       cwd: product-mini/platforms/darwin
       llvm_cache_key: ${{ needs.build_llvm_libraries_on_macos.outputs.cache_key }}
-      runner: macos-13
+      runner: macos-15-intel
       upload_url: ${{ needs.create_release.outputs.upload_url }}
       ver_num: ${{ needs.create_tag.outputs.new_ver}}
 
@@ -200,6 +203,7 @@ jobs:
       wasi_sdk_url: https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-19/wasi-sdk-19.0-linux.tar.gz
       wamr_app_framework_url: https://github.com/bytecodealliance/wamr-app-framework.git
 
+  #CLARIFY: Require to release WAMR SDK on ARM macOS?
   release_wamr_sdk_on_macos:
     permissions:
       contents: write # upload release artifact
@@ -208,7 +212,7 @@ jobs:
     uses: ./.github/workflows/build_wamr_sdk.yml
     with:
       config_file: wamr_config_macos_release.cmake
-      runner: macos-13
+      runner: macos-15-intel
       upload_url: ${{ needs.create_release.outputs.upload_url }}
       ver_num: ${{ needs.create_tag.outputs.new_ver}}
       wasi_sdk_url: https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-19/wasi-sdk-19.0-macos.tar.gz
@@ -251,6 +255,7 @@ jobs:
       upload_url: ${{ needs.create_release.outputs.upload_url }}
       ver_num: ${{ needs.create_tag.outputs.new_ver}}
 
+  #CLARIFY: Require to release WAMR LLDB on ARM macOS?
   release_wamr_lldb_on_macos_universal:
     permissions:
       contents: write # upload release artifact
@@ -258,7 +263,7 @@ jobs:
     if: ${{ inputs.release_wamr_lldb }}
     uses: ./.github/workflows/build_wamr_lldb.yml
     with:
-      runner: macos-13
+      runner: macos-15-intel
       arch: universal
       upload_url: ${{ needs.create_release.outputs.upload_url }}
       ver_num: ${{ needs.create_tag.outputs.new_ver}}

--- a/.github/workflows/wamr_wasi_extensions.yml
+++ b/.github/workflows/wamr_wasi_extensions.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13, macos-14]
+        os: [ubuntu-22.04, macos-15-intel, macos-15]
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -48,9 +48,10 @@ jobs:
           ./build_samples.sh $(pwd)/dist/wamr-wasi-extensions
         working-directory: wamr-wasi-extensions
 
+      #CLARIFY: Require to upload artifact on ARM macOS?
       - name: Upload artifacts
-        if: matrix.os == 'macos-14'
-        uses: actions/upload-artifact@v4
+        if: matrix.os == 'macos-15'
+        uses: actions/upload-artifact@v6.0.0
         with:
           name: wamr-wasi-extensions
           path: wamr-wasi-extensions/dist


### PR DESCRIPTION
cherry-pick d980fe815ed777e3c283e7c659a75b56acf8cb2e from main

* fix: update macOS workflow configurations to use macos-15 and macos-15-intel
* fix: remove unsupported build options for macOS workflows