### PR TITLE
Fix the currently-failing CodeQL workflow and run it on pull requests

### DIFF
--- a/.github/scripts/codeql_buildscript.sh
+++ b/.github/scripts/codeql_buildscript.sh
@@ -19,9 +19,20 @@ sudo wget --progress=dot:giga -O clang+llvm-x86_64-linux-gnu.tar.xz https://gith
 popd
 
 # libtinfo.so.5 for /opt/llvm-18.1.8/lib/libomptarget.rtl.amdgpu.so.18.1
+# Install the libtinfo5 compat package at the same ncurses version as the
+# runner's already-installed libtinfo6; fall back to the newest one in the
+# pool. A hard-coded URL 404s once the ncurses point release is bumped, which
+# then breaks the wamrc link against libomptarget (NCURSES_TINFO_5 symbols).
 sudo apt -qq update
-wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
-sudo apt install -y -qq ./libtinfo5_6.3-2ubuntu0.1_amd64.deb
+nc_pool="http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses"
+nc_ver="$(dpkg-query -W -f='${Version}' libtinfo6)"
+libtinfo5_deb="libtinfo5_${nc_ver}_amd64.deb"
+if ! wget -q "${nc_pool}/${libtinfo5_deb}"; then
+  libtinfo5_deb="$(wget -qO- "${nc_pool}/" \
+    | grep -oE 'libtinfo5_[0-9][^"]*_amd64\.deb' | sort -Vu | tail -1)"
+  wget -q "${nc_pool}/${libtinfo5_deb}"
+fi
+sudo apt install -y -qq "./${libtinfo5_deb}"
 
 # Start the build process
 WAMR_DIR=${PWD}

--- a/.github/scripts/codeql_fail_on_error.py
+++ b/.github/scripts/codeql_fail_on_error.py
@@ -61,9 +61,15 @@ def codeql_sarif_contain_error(filename, dismissed_alerts):
         s = json.load(f)
 
     for run in s.get("runs", []):
-        rules_metadata = run["tool"]["driver"]["rules"]
+        # Rule metadata isn't always in one place: CodeQL keeps it on the tool
+        # driver, but rules contributed by a query-pack extension live on that
+        # extension instead, and the driver's list is empty when nothing fired.
+        # So read the driver rules, then fall back to gathering them from the
+        # extensions rather than assuming a fixed location.
+        rules_metadata = run["tool"]["driver"].get("rules") or []
         if not rules_metadata:
-            rules_metadata = run["tool"]["extensions"][0]["rules"]
+            for ext in run["tool"].get("extensions", []):
+                rules_metadata += ext.get("rules", [])
 
         for res in run.get("results", []):
             if "ruleIndex" in res:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,17 +9,35 @@ on:
   push:
     branches:
       - dev/**
+  # scan pull requests so findings surface on the PR instead of only post-merge
+  pull_request:
   # midnight UTC on the latest commit on the main branch
   schedule:
     - cron: "0 0 * * *"
   # allow to be triggered manually
   workflow_dispatch:
 
+# Serialize CodeQL runs per PR / branch. Only a pull_request cancels its own
+# superseded run - once a PR head is replaced the old analysis is throwaway.
+# Pushes to dev/** and the nightly cron are left to finish, so branch and
+# scheduled scans are never dropped.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
-    # only run this job if the repository is not a fork
-    # if want to run this job on a fork, please remove the if condition
-    if: github.repository == 'bytecodealliance/wasm-micro-runtime'
+    # Pull requests: only scan when the head branch lives in this same
+    # repository. A pull request from a fork runs with a read-only GITHUB_TOKEN
+    # (no `security-events: write`), so uploading results and reading
+    # code-scanning alerts is not permitted and the job would fail; skip it
+    # cleanly instead. Other events (push to dev/**, the nightly cron, manual
+    # runs) keep the original behavior of running only on the upstream repo.
+    if: >-
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
+      || (github.event_name != 'pull_request' &&
+          github.repository == 'bytecodealliance/wasm-micro-runtime')
     name: Analyze
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql


### PR DESCRIPTION
## Summary

The CodeQL workflow is **currently failing on `main`** — the nightly `Analyze (cpp)` job cannot finish — for two independent reasons. This PR fixes both. Secondarily, it starts running CodeQL on pull requests so the analysis gates a change before it merges instead of only after.

## The two fixes (the point of this PR)

**1. `codeql_buildscript.sh` — stale libtinfo5 URL breaks the `wamrc` link.**
The script hard-codes `libtinfo5_6.3-2ubuntu0.1_amd64.deb`, which now 404s because the `ubuntu-22.04` runner's ncurses moved to `6.3-2ubuntu0.2`. With libtinfo5 missing, linking `wamrc` against the prebuilt LLVM 18.1.8 (`libomptarget.rtl.amdgpu`, which references the `NCURSES_TINFO_5` symbols) fails:

```
/usr/bin/ld: .../libomptarget.rtl.amdgpu.so.18.1: undefined reference to `setupterm@NCURSES_TINFO_5.0.19991023'
collect2: error: ld returned 1 exit status
Failed to build wamrc
```

Fixed by resolving the libtinfo5 compat package at the runner's actual ncurses version (matching the installed `libtinfo6`), with a pool-scrape fallback so it survives future point-release bumps.

**2. `codeql_fail_on_error.py` — `KeyError: 'rules'` on current CodeQL SARIF.**
The gate reads `run["tool"]["driver"]["rules"]` and, when that is empty (e.g. a clean scan), falls back to `run["tool"]["extensions"][0]["rules"]` — but current CodeQL emits a SARIF whose first extension has no `rules` key, so the script raises `KeyError: 'rules'` and the step fails. Fixed to read the driver rules defensively and otherwise gather rules from the extensions (which also lets it see error-level rules a query pack contributes).

Either fix alone leaves the job red; together they get `Analyze (cpp)` green again.

## Secondary: run CodeQL on pull requests

`codeql.yml` runs only on `push: dev/**`, the nightly cron, and `workflow_dispatch`, so a change isn't scanned until after it merges. This adds the `pull_request` event.

Uploading results and reading code-scanning alerts needs `security-events: write`, and a pull request from a fork gets a read-only `GITHUB_TOKEN`, so the job would fail on fork PRs. To avoid a spurious red check, it runs on `pull_request` **only when the head branch is in this repository**:

```yaml
if: >-
  (github.event_name == 'pull_request' &&
   github.event.pull_request.head.repo.full_name == github.repository)
  || (github.event_name != 'pull_request' &&
      github.repository == 'bytecodealliance/wasm-micro-runtime')
```

Non-`pull_request` events keep the original "upstream repo only" behavior. A `concurrency` group is added; only a `pull_request` cancels its own superseded run, while `dev/**` pushes and the nightly are left to finish so branch and scheduled scans are never dropped.

Consequence: external contributors' fork-head PRs will show the CodeQL job as **skipped** (not failed) — a read-only token can't upload code-scanning results — so those PRs stay covered by the nightly, while maintainer / in-repo branch PRs get the full pre-merge scan.

## Verification

Verified end-to-end on a same-repo pull request in a fork (a fork PR is needed because CodeQL upload requires a writable token, which fork-*head* PRs lack): with both fixes, `Analyze (cpp)` completes the build, performs the analysis, uploads SARIF, and the `Fail if an error is found` gate passes. `codeql_buildscript.sh` and `codeql_fail_on_error.py` here are byte-identical to `main`, so these fixes apply unchanged; the `codeql.yml` change is layered on top of the current file (action pins untouched).
