### PR TITLE
tests: escape regex patterns in gc-aot runner

### DIFF
--- a/tests/requirement-engineering/gc-aot/runtest.py
+++ b/tests/requirement-engineering/gc-aot/runtest.py
@@ -563,7 +563,7 @@ def parse_assertion_value(val):
     if not val:
         return None, ""
 
-    splitted = re.split('\s+', val)
+    splitted = re.split('\\s+', val)
     splitted = [s for s in splitted if s]
     type = splitted[0].split(".")[0]
     lane_type = splitted[1] if len(splitted) > 2 else ""
@@ -832,41 +832,41 @@ def test_assert_return(r, opts, form):
     """
     # params, return
     m = re.search(
-        '^\(assert_return\s+\(invoke\s+"((?:[^"]|\\\")*)"\s+(\(.*\))\s*\)\s*(\(.*\))\s*\)\s*$', form, re.S)
+        '^\\(assert_return\\s+\\(invoke\\s+"((?:[^"]|\\\")*)"\\s+(\\(.*\\))\\s*\\)\\s*(\\(.*\\))\\s*\\)\\s*$', form, re.S)
     # judge if assert_return cmd includes the module name
     n = re.search(
-        '^\(assert_return\s+\(invoke\s+\$((?:[^\s])*)\s+"((?:[^"]|\\\")*)"\s+(\(.*\))\s*\)\s*(\(.*\))\s*\)\s*$', form, re.S)
+        '^\\(assert_return\\s+\\(invoke\\s+\\$((?:[^\\s])*)\\s+"((?:[^"]|\\\")*)"\\s+(\\(.*\\))\\s*\\)\\s*(\\(.*\\))\\s*\\)\\s*$', form, re.S)
 
     # print("assert_return with {}".format(form))
 
     if not m:
         # no params, return
         m = re.search(
-            '^\(assert_return\s+\(invoke\s+"((?:[^"]|\\\")*)"\s*\)\s+()(\(.*\))\s*\)\s*$', form, re.S)
+            '^\\(assert_return\\s+\\(invoke\\s+"((?:[^"]|\\\")*)"\\s*\\)\\s+()(\\(.*\\))\\s*\\)\\s*$', form, re.S)
     if not m:
         # params, no return
         m = re.search(
-            '^\(assert_return\s+\(invoke\s+"([^"]*)"\s+(\(.*\))()\s*\)\s*\)\s*$', form, re.S)
+            '^\\(assert_return\\s+\\(invoke\\s+"([^"]*)"\\s+(\\(.*\\))()\\s*\\)\\s*\\)\\s*$', form, re.S)
     if not m:
         # no params, no return
         m = re.search(
-            '^\(assert_return\s+\(invoke\s+"([^"]*)"\s*()()\)\s*\)\s*$', form, re.S)
+            '^\\(assert_return\\s+\\(invoke\\s+"([^"]*)"\\s*()()\\)\\s*\\)\\s*$', form, re.S)
     if not m:
         # params, return
         if not n:
             # no params, return
             n = re.search(
-                '^\(assert_return\s+\(invoke\s+\$((?:[^\s])*)\s+"((?:[^"]|\\\")*)"\s*\)\s+()(\(.*\))\s*\)\s*$', form, re.S)
+                '^\\(assert_return\\s+\\(invoke\\s+\\$((?:[^\\s])*)\\s+"((?:[^"]|\\\")*)"\\s*\\)\\s+()(\\(.*\\))\\s*\\)\\s*$', form, re.S)
         if not n:
             # params, no return
             n = re.search(
-                '^\(assert_return\s+\(invoke\s+\$((?:[^\s])*)\s+"([^"]*)"\s+(\(.*\))()\s*\)\s*\)\s*$', form, re.S)
+                '^\\(assert_return\\s+\\(invoke\\s+\\$((?:[^\\s])*)\\s+"([^"]*)"\\s+(\\(.*\\))()\\s*\\)\\s*\\)\\s*$', form, re.S)
         if not n:
             # no params, no return
             n = re.search(
-                '^\(assert_return\s+\(invoke\s+\$((?:[^\s])*)\s+"([^"]*)"*()()\)\s*\)\s*$', form, re.S)
+                '^\\(assert_return\\s+\\(invoke\\s+\\$((?:[^\\s])*)\\s+"([^"]*)"*()()\\)\\s*\\)\\s*$', form, re.S)
     if not m and not n:
-        if re.search('^\(assert_return\s+\(get.*\).*\)$', form, re.S):
+        if re.search('^\\(assert_return\\s+\\(get.*\\).*\\)$', form, re.S):
             log("ignoring assert_return get")
             return
         else:
@@ -891,7 +891,7 @@ def test_assert_return(r, opts, form):
             for arg in args_type_and_value:
                 # remove leading and tailing spaces, it might confuse following assertions
                 arg = arg.strip()
-                splitted = re.split('\s+', arg)
+                splitted = re.split('\\s+', arg)
                 splitted = [s for s in splitted if s]
 
                 if splitted[0] in ["i32.const", "i64.const"]:
@@ -915,7 +915,7 @@ def test_assert_return(r, opts, form):
 
                     assert (len(numbers) ==
                             2), "has to reform arguments into i64x2"
-                    args.append(f"{numbers[0]:#x}\{numbers[1]:#x}")
+                    args.append(f"{numbers[0]:#x}\\{numbers[1]:#x}")
                 elif "ref.null" == splitted[0]:
                     args.append("null")
                 elif "ref.extern" == splitted[0]:
@@ -932,7 +932,7 @@ def test_assert_return(r, opts, form):
         if m.group(3) == '':
             returns = []
         else:
-            returns = re.split("\)\s*\(", m.group(3)[1:-1])
+            returns = re.split("\\)\\s*\\(", m.group(3)[1:-1])
         # processed numbers in strings
         if len(returns) == 1 and returns[0] in ["ref.array", "ref.struct", "ref.i31",
                                                 "ref.eq", "ref.any", "ref.extern",
@@ -982,7 +982,7 @@ def test_assert_return(r, opts, form):
             n1 = n.group(3).replace("(ref.null extern)", "(ref.null null)")
             n1 = n1.replace("ref.null func)", "(ref.null null)")
             args = [re.split(' +', v)[1]
-                    for v in re.split("\)\s*\(", n1[1:-1])]
+                    for v in re.split("\\)\\s*\\(", n1[1:-1])]
 
         _, expected = parse_assertion_value(n.group(4)[1:-1])
         test_assert(r, opts, "return", "%s %s" %
@@ -992,19 +992,19 @@ def test_assert_return(r, opts, form):
 def test_assert_trap(r, opts, form):
     # params
     m = re.search(
-        '^\(assert_trap\s+\(invoke\s+"([^"]*)"\s+(\(.*\))\s*\)\s*"([^"]+)"\s*\)\s*$', form)
+        '^\\(assert_trap\\s+\\(invoke\\s+"([^"]*)"\\s+(\\(.*\\))\\s*\\)\\s*"([^"]+)"\\s*\\)\\s*$', form)
     # judge if assert_return cmd includes the module name
     n = re.search(
-        '^\(assert_trap\s+\(invoke\s+\$((?:[^\s])*)\s+"([^"]*)"\s+(\(.*\))\s*\)\s*"([^"]+)"\s*\)\s*$', form, re.S)
+        '^\\(assert_trap\\s+\\(invoke\\s+\\$((?:[^\\s])*)\\s+"([^"]*)"\\s+(\\(.*\\))\\s*\\)\\s*"([^"]+)"\\s*\\)\\s*$', form, re.S)
     if not m:
         # no params
         m = re.search(
-            '^\(assert_trap\s+\(invoke\s+"([^"]*)"\s*()\)\s*"([^"]+)"\s*\)\s*$', form)
+            '^\\(assert_trap\\s+\\(invoke\\s+"([^"]*)"\\s*()\\)\\s*"([^"]+)"\\s*\\)\\s*$', form)
     if not m:
         if not n:
             # no params
             n = re.search(
-                '^\(assert_trap\s+\(invoke\s+\$((?:[^\s])*)\s+"([^"]*)"\s*()\)\s*"([^"]+)"\s*\)\s*$', form, re.S)
+                '^\\(assert_trap\\s+\\(invoke\\s+\\$((?:[^\\s])*)\\s+"([^"]*)"\\s*()\\)\\s*"([^"]+)"\\s*\\)\\s*$', form, re.S)
     if not m and not n:
         raise Exception("unparsed assert_trap: '%s'" % form)
 
@@ -1017,7 +1017,7 @@ def test_assert_trap(r, opts, form):
             m1 = m.group(2).replace("(ref.null extern)", "(ref.null null)")
             m1 = m1.replace("ref.null func)", "(ref.null null)")
             args = [re.split(' +', v)[1]
-                    for v in re.split("\)\s*\(", m1[1:-1])]
+                    for v in re.split("\\)\\s*\\(", m1[1:-1])]
 
         expected = "Exception: %s" % m.group(3)
         test_assert(r, opts, "trap", "%s %s" %
@@ -1055,7 +1055,7 @@ def test_assert_trap(r, opts, form):
             args = []
         else:
             args = [re.split(' +', v)[1]
-                    for v in re.split("\)\s*\(", n.group(3)[1:-1])]
+                    for v in re.split("\\)\\s*\\(", n.group(3)[1:-1])]
         expected = "Exception: %s" % n.group(4)
         test_assert(r, opts, "trap", "%s %s" %
                     (func, " ".join(args)), expected)
@@ -1064,11 +1064,11 @@ def test_assert_trap(r, opts, form):
 def test_assert_exhaustion(r, opts, form):
     # params
     m = re.search(
-        '^\(assert_exhaustion\s+\(invoke\s+"([^"]*)"\s+(\(.*\))\s*\)\s*"([^"]+)"\s*\)\s*$', form)
+        '^\\(assert_exhaustion\\s+\\(invoke\\s+"([^"]*)"\\s+(\\(.*\\))\\s*\\)\\s*"([^"]+)"\\s*\\)\\s*$', form)
     if not m:
         # no params
         m = re.search(
-            '^\(assert_exhaustion\s+\(invoke\s+"([^"]*)"\s*()\)\s*"([^"]+)"\s*\)\s*$', form)
+            '^\\(assert_exhaustion\\s+\\(invoke\\s+"([^"]*)"\\s*()\\)\\s*"([^"]+)"\\s*\\)\\s*$', form)
     if not m:
         raise Exception("unparsed assert_exhaustion: '%s'" % form)
     func = m.group(1)
@@ -1076,7 +1076,7 @@ def test_assert_exhaustion(r, opts, form):
         args = []
     else:
         args = [re.split(' +', v)[1]
-                for v in re.split("\)\s*\(", m.group(2)[1:-1])]
+                for v in re.split("\\)\\s*\\(", m.group(2)[1:-1])]
     expected = "Exception: %s\n" % m.group(3)
     test_assert(r, opts, "exhaustion", "%s %s" %
                 (func, " ".join(args)), expected)
@@ -1084,10 +1084,10 @@ def test_assert_exhaustion(r, opts, form):
 
 def do_invoke(r, opts, form):
     # params
-    m = re.search('^\(invoke\s+"([^"]+)"\s+(\(.*\))\s*\)\s*$', form)
+    m = re.search('^\\(invoke\\s+"([^"]+)"\\s+(\\(.*\\))\\s*\\)\\s*$', form)
     if not m:
         # no params
-        m = re.search('^\(invoke\s+"([^"]+)"\s*()\)\s*$', form)
+        m = re.search('^\\(invoke\\s+"([^"]+)"\\s*()\\)\\s*$', form)
     if not m:
         raise Exception("unparsed invoke: '%s'" % form)
     func = m.group(1)
@@ -1099,7 +1099,7 @@ def do_invoke(r, opts, form):
         args = []
     else:
         args = [re.split(' +', v)[1]
-                for v in re.split("\)\s*\(", m.group(2)[1:-1])]
+                for v in re.split("\\)\\s*\\(", m.group(2)[1:-1])]
 
     log("Invoking %s(%s)" % (
         func, ", ".join([str(a) for a in args])))
@@ -1348,19 +1348,19 @@ if __name__ == "__main__":
                 log(form)
             elif skip_test(form, SKIP_TESTS):
                 log("Skipping test: %s" % form[0:60])
-            elif re.match("^\(assert_trap\s+\(module", form):
+            elif re.match("^\\(assert_trap\\s+\\(module", form):
                 test_assert_with_exception(
                     form, wast_tempfile, wasm_tempfile, aot_tempfile if test_aot else None, opts, r)
-            elif re.match("^\(assert_exhaustion\\b.*", form):
+            elif re.match("^\\(assert_exhaustion\\b.*", form):
                 test_assert_exhaustion(r, opts, form)
-            elif re.match("^\(assert_unlinkable\\b.*", form):
+            elif re.match("^\\(assert_unlinkable\\b.*", form):
                 test_assert_with_exception(
                     form, wast_tempfile, wasm_tempfile, aot_tempfile if test_aot else None, opts, r, False)
-            elif re.match("^\(assert_malformed\\b.*", form):
+            elif re.match("^\\(assert_malformed\\b.*", form):
                 # remove comments in wast
                 form, n = re.subn(";;.*\n", "", form)
                 m = re.match(
-                    "^\(assert_malformed\s*\(module binary\s*(\".*\").*\)\s*\"(.*)\"\s*\)$", form, re.DOTALL)
+                    "^\\(assert_malformed\\s*\\(module binary\\s*(\".*\").*\\)\\s*\"(.*)\"\\s*\\)$", form, re.DOTALL)
 
                 if m:
                     # workaround: spec test changes error message to "malformed" while iwasm still use "invalid"
@@ -1435,25 +1435,25 @@ if __name__ == "__main__":
                     r = run_wasm_with_repl(
                         wasm_tempfile, aot_tempfile if test_aot else None, opts, r)
 
-                elif re.match("^\(assert_malformed\s*\(module quote", form):
+                elif re.match("^\\(assert_malformed\\s*\\(module quote", form):
                     log("ignoring assert_malformed module quote")
                 else:
                     log("unrecognized assert_malformed")
-            elif re.match("^\(assert_return[_a-z]*_nan\\b.*", form):
+            elif re.match("^\\(assert_return[_a-z]*_nan\\b.*", form):
                 log("ignoring assert_return_.*_nan")
                 pass
-            elif re.match(".*\(invoke\s+\$\\b.*", form):
+            elif re.match(".*\\(invoke\\s+\\$\\b.*", form):
                 # invoke a particular named module's function
                 if form.startswith("(assert_return"):
                     test_assert_return(r, opts, form)
                 elif form.startswith("(assert_trap"):
                     test_assert_trap(r, opts, form)
-            elif re.match("^\(module\\b.*", form):
+            elif re.match("^\\(module\\b.*", form):
                 # if the module includes the particular name startswith $
-                m = re.search("^\(module\s+\$.\S+", form)
+                m = re.search("^\\(module\\s+\\$.\\S+", form)
                 if m:
                     # get module name
-                    module_name = re.split('\$', m.group(0).strip())[1]
+                    module_name = re.split('\\$', m.group(0).strip())[1]
                     if module_name:
                         # create temporal files
                         temp_files = create_tmpfiles(module_name)
@@ -1502,18 +1502,18 @@ if __name__ == "__main__":
                     raise Exception("Failed:\n  expected: '%s'\n  got: '%s'" %
                                     (repr(exc), r.buf))
 
-            elif re.match("^\(assert_return\\b.*", form):
+            elif re.match("^\\(assert_return\\b.*", form):
                 assert (r), "iwasm repl runtime should be not null"
                 test_assert_return(r, opts, form)
-            elif re.match("^\(assert_trap\\b.*", form):
+            elif re.match("^\\(assert_trap\\b.*", form):
                 test_assert_trap(r, opts, form)
-            elif re.match("^\(invoke\\b.*", form):
+            elif re.match("^\\(invoke\\b.*", form):
                 assert (r), "iwasm repl runtime should be not null"
                 do_invoke(r, opts, form)
-            elif re.match("^\(assert_invalid\\b.*", form):
+            elif re.match("^\\(assert_invalid\\b.*", form):
                 test_assert_with_exception(
                     form, wast_tempfile, wasm_tempfile, aot_tempfile if test_aot else None, opts, r)
-            elif re.match("^\(register\\b.*", form):
+            elif re.match("^\\(register\\b.*", form):
                 # get module's new name from the register cmd
                 name_new = re.split('\"', re.search(
                     '\".*\"', form).group(0))[1]


### PR DESCRIPTION
## Summary
- escape invalid Python string literal backslashes in the gc-aot test runner regex patterns
- escape the vector argument f-string separator so Python no longer warns about `\{`
- keep the parsed AST unchanged from `origin/main`, so the runtime strings remain the same

## Verification
- warning scan for `tests/requirement-engineering/gc-aot/runtest.py` reports `TOTAL 0`
- AST comparison against `origin/main` reports `AST_EQUAL True`
- `python tests/requirement-engineering/gc-aot/runtest.py --help` exits with `0`
- `git diff --check`
- `git ls-files --eol tests/requirement-engineering/gc-aot/runtest.py`

I also checked for open duplicate PRs/issues mentioning `invalid escape`, `SyntaxWarning`, `gc-aot`, and `runtest.py`, and found no matches.

I did not run the full gc-aot suite because it requires the WebAssembly test toolchain/interpreter/AOT compiler setup that is not available locally.