### PR TITLE
windows: fix MinGW-w64 build of win_file.c

### DIFF
--- a/core/shared/platform/windows/win_file.c
+++ b/core/shared/platform/windows/win_file.c
@@ -7,7 +7,7 @@
 #include "libc_errno.h"
 #include "win_util.h"
 
-#include "PathCch.h"
+#include "pathcch.h"
 
 #pragma comment(lib, "Pathcch.lib")
 
@@ -1295,26 +1295,25 @@ os_readlinkat(os_file_handle handle, const char *path, char *buf,
 
         if (wbufsize >= 4 && wbuf[0] == L'\\' && wbuf[1] == L'?'
             && wbuf[2] == L'?' && wbuf[3] == L'\\') {
-            // Starts with \??\ 
+            // Starts with \??\ prefix
             if (wbufsize >= 6
                 && ((wbuf[4] >= L'A' && wbuf[4] <= L'Z')
                     || (wbuf[4] >= L'a' && wbuf[4] <= L'z'))
-                && wbuf[5] == L':' && (wbufsize == 6 || wbuf[6] == L'\\'))
-                {
-                    // \??\<drive>:\ 
-                    wbuf += 4;
-                    wbufsize -= 4;
-                }
-                else if (wbufsize >= 8 && (wbuf[4] == L'U' || wbuf[4] == L'u')
-                         && (wbuf[5] == L'N' || wbuf[5] == L'n')
-                         && (wbuf[6] == L'C' || wbuf[6] == L'c')
-                         && wbuf[7] == L'\\')
-                {
-                    // \??\UNC\<server>\<share>\ - make sure the final path looks like \\<server>\<share>\ 
-                    wbuf += 6;
-                    wbuf[0] = L'\\';
-                    wbufsize -= 6;
-                }
+                && wbuf[5] == L':' && (wbufsize == 6 || wbuf[6] == L'\\')) {
+                // \??\<drive>:\ form
+                wbuf += 4;
+                wbufsize -= 4;
+            }
+            else if (wbufsize >= 8 && (wbuf[4] == L'U' || wbuf[4] == L'u')
+                     && (wbuf[5] == L'N' || wbuf[5] == L'n')
+                     && (wbuf[6] == L'C' || wbuf[6] == L'c')
+                     && wbuf[7] == L'\\') {
+                // \??\UNC\<server>\<share>\ - make sure the final path looks
+                // like \\<server>\<share>\ afterwards
+                wbuf += 6;
+                wbuf[0] = L'\\';
+                wbufsize -= 6;
+            }
         }
     }
     else if (reparse_data->ReparseTag == IO_REPARSE_TAG_MOUNT_POINT) {


### PR DESCRIPTION
`core/shared/platform/windows/win_file.c` does not compile with the MinGW-w64 (GCC) toolchain, which WAMR documents as a supported Windows toolchain. Two issues:

1. **Header case.** `#include "PathCch.h"` fails on a case-sensitive filesystem (e.g. cross-compiling from Linux); the MinGW SDK installs the header lowercase as `pathcch.h`. Lowercasing the include is a no-op on the case-insensitive Windows filesystem MSVC uses.

2. **Comment line-continuation.** Three `//` comments in `os_readlinkat()` end with a backslash (`\??\`). GCC treats a backslash at the end of a `//` comment line as a line continuation, so the following line of code is spliced into the comment and the function fails to parse (`-Wcomment: multi-line comment`, then a cascade of syntax errors). MSVC does not do this. Appending a trailing word to each comment so it no longer ends in a backslash removes the hazard while keeping the documented NT paths intact (and matches the existing style of the nearby `// ... \??\<drive>:\ as a symlink.` comment).

Neither change alters behavior; both are inert for the MSVC build.

The enclosing `if`/`else if` block is also reformatted — brace placement, indentation, and reflowing the one comment that exceeded the column limit — so the modified lines pass the `clang-format` check. That part of the diff is whitespace/comment-only.

### Testing

Verified by cross-compiling a project that bundles WAMR (Fluent Bit) for Windows from Linux with the Fedora MinGW-w64 UCRT toolchain: `vmlib`/`win_file.c` compile and link into a working `fluent-bit.exe` (PE32+ x86-64). `git clang-format` (clang-format-14) reports the changed lines clean.