### PR TITLE
ci: free disk before the LLVM cache restore in the linux test job

### DIFF
--- a/.github/workflows/compilation_on_android_ubuntu.yml
+++ b/.github/workflows/compilation_on_android_ubuntu.yml
@@ -707,6 +707,16 @@ jobs:
            && matrix.running_mode != 'fast-jit' && matrix.running_mode != 'jit' && matrix.running_mode != 'multi-tier-jit')
         run: echo "TEST_ON_X86_32=true" >> $GITHUB_ENV
 
+      - name: Free up disk space
+        if: env.USE_LLVM == 'true'
+        run: |
+          # Restoring the prebuilt LLVM libraries cache overflows the runner's
+          # small default free space and fails with "no space left on device".
+          # Drop preinstalled toolchains this job never uses (~20 GB freed).
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost
+          df -h /
+
       #only download llvm libraries in jit and aot mode
       - name: Get LLVM libraries
         if: env.USE_LLVM == 'true'


### PR DESCRIPTION
## Summary

The multi-tier-jit `test` job in `compilation_on_android_ubuntu.yml` restores the prebuilt LLVM libraries cache via `actions/cache`. On the standard runner that cache does not always fit alongside the preinstalled toolchains, and the restore can fail with **"no space left on device"**, which then surfaces as `##[error]can not get prebuilt llvm libraries` and fails the job.

## Fix

Free ~20 GB of preinstalled toolchains this build never uses (`dotnet`, `android`, `ghc`, the `CodeQL` bundle, `boost`) immediately before the `actions/cache` restore — and only in the legs that actually download LLVM (gated on the same `USE_LLVM == 'true'` condition as the restore step). **No test is added, removed, or skipped**; the QA coverage is unchanged.

Verified on this PR's own CI: all nine `test (ubuntu-22.04, multi-tier-jit, …)` legs pass, including `$THREADS_TEST_OPTIONS`, the leg that had been failing.

## Scope note — the containerized `spec_test_on_qemu` job

`spec_test_on_qemu` (nuttx) hits the same ENOSPC on its LLVM cache restore, but **it cannot be fixed this way**: it is a `container:` job (`ghcr.io/no1wudi/nuttx/...`), so its steps run inside a docker container and cannot free the *host* disk that the cache restore fills (a `sudo rm` there fails with `sudo: not found`, and host paths are not visible from the container). That surface is what **#4983** addresses — moving to `ubuntu-24.04` with runner-native LLVM 18 removes the large external LLVM cache entirely, so there is no multi-GB restore to overflow the disk. A larger runner (as noted for the Zephyr container job) is the other option.

## Driver

Follows from #4983.
