### PR TITLE
ci: bump clang-format 14 → 20 and reformat

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
-# using [clang-formt-12 options](https://releases.llvm.org/12.0.0/tools/clang/docs/ClangFormatStyleOptions.html)
+# using [clang-format-20 options](https://releases.llvm.org/20.1.0/tools/clang/docs/ClangFormatStyleOptions.html)
 RawStringFormats:
   - Language: Cpp
     Delimiters:

--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -26,6 +26,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: install clang-format-20
+        run: |
+          # clang-format 20 is not preinstalled on the runner; install it (and
+          # git-clang-format-20) from apt.llvm.org for the running Ubuntu
+          # release so the pinned version does not drift with the image.
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+            | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc >/dev/null
+          . /etc/os-release
+          echo "deb http://apt.llvm.org/${VERSION_CODENAME}/ llvm-toolchain-${VERSION_CODENAME}-20 main" \
+            | sudo tee /etc/apt/sources.list.d/llvm.list >/dev/null
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq clang-format-20
+          clang-format-20 --version
+
       # github.event.pull_request.base.label = ${{github.repository}}/${{github.base_ref}}
       - name: Run Coding Guidelines Checks
         run: /usr/bin/env python3 ./ci/coding_guidelines_check.py --commits ${{ github.event.pull_request.base.sha }}..HEAD

--- a/ci/coding_guidelines_check.py
+++ b/ci/coding_guidelines_check.py
@@ -12,8 +12,8 @@ import subprocess
 import sys
 import unittest
 
-CLANG_FORMAT_CMD = "clang-format-14"
-GIT_CLANG_FORMAT_CMD = "git-clang-format-14"
+CLANG_FORMAT_CMD = "clang-format-20"
+GIT_CLANG_FORMAT_CMD = "git-clang-format-20"
 
 # glob style patterns
 EXCLUDE_PATHS = [

--- a/ci/pre_commit_hook_sample
+++ b/ci/pre_commit_hook_sample
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # This is a sample of pre-commit hook that can be used to make your code fit the WAMR CI code style requirements.
-# You need to have clang-format-12 installed to use this hook.
+# You need to have clang-format-20 installed to use this hook.
 # To add this pre-commit hook, copy it to <path_to_wamr>/.git/hooks/pre-commit
 # (you don't need any extensions here)
 
@@ -22,10 +22,10 @@ is_c_or_cpp_file() {
 # Loop through staged files and apply command "abc" to C and C++ files
 for staged_file in $(git diff --cached --name-only); do
     if is_c_or_cpp_file "$staged_file"; then
-        clang-format-12 -Werror --style file --dry-run "$staged_file" 2>/dev/null
-        if [ $? -ne 0 ]; then 
-            echo "Issues are found in $staged_file. Applying the fix" 
-            clang-format-12 --style file -i "$staged_file"
+        clang-format-20 -Werror --style file --dry-run "$staged_file" 2>/dev/null
+        if [ $? -ne 0 ]; then
+            echo "Issues are found in $staged_file. Applying the fix"
+            clang-format-20 --style file -i "$staged_file"
         fi
         git add "$staged_file"  # Add the modified file back to staging
     fi

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -5553,7 +5553,8 @@ aot_const_str_set_insert(const uint8 *str, int32 len, AOTModule *module,
 #if WASM_ENABLE_DYNAMIC_AOT_DEBUG != 0
 AOTModule *g_dynamic_aot_module = NULL;
 
-void __attribute__((noinline)) __enable_dynamic_aot_debug(void)
+void __attribute__((noinline))
+__enable_dynamic_aot_debug(void)
 {
     /* empty implementation. */
 }

--- a/core/iwasm/aot/arch/aot_reloc_riscv.c
+++ b/core/iwasm/aot/arch/aot_reloc_riscv.c
@@ -325,10 +325,7 @@ typedef struct RelocTypeStrMap {
     char *reloc_str;
 } RelocTypeStrMap;
 
-#define RELOC_TYPE_MAP(reloc_type) \
-    {                              \
-        reloc_type, #reloc_type    \
-    }
+#define RELOC_TYPE_MAP(reloc_type) { reloc_type, #reloc_type }
 
 static RelocTypeStrMap reloc_type_str_maps[] = {
     RELOC_TYPE_MAP(R_RISCV_32),           RELOC_TYPE_MAP(R_RISCV_64),

--- a/core/iwasm/aot/arch/aot_reloc_x86_64.c
+++ b/core/iwasm/aot/arch/aot_reloc_x86_64.c
@@ -157,7 +157,7 @@ apply_relocation(AOTModule *module, uint8 *target_section_addr,
         case R_X86_64_GOTPCRELX:
         case R_X86_64_REX_GOTPCRELX:
         {
-            intptr_t target_addr = (intptr_t) /* S + A - P */
+            intptr_t target_addr = (intptr_t)/* S + A - P */
                 ((uintptr_t)symbol_addr + reloc_addend
                  - (uintptr_t)(target_section_addr + reloc_offset));
 
@@ -176,7 +176,7 @@ apply_relocation(AOTModule *module, uint8 *target_section_addr,
         }
         case R_X86_64_PC64:
         {
-            intptr_t target_addr = (intptr_t) /* S + A - P */
+            intptr_t target_addr = (intptr_t)/* S + A - P */
                 ((uintptr_t)symbol_addr + reloc_addend
                  - (uintptr_t)(target_section_addr + reloc_offset));
 
@@ -226,12 +226,12 @@ apply_relocation(AOTModule *module, uint8 *target_section_addr,
                 plt = (uint8 *)module->code + module->code_size
                       - get_plt_table_size()
                       + get_plt_item_size() * symbol_index;
-                target_addr = (intptr_t) /* L + A - P */
+                target_addr = (intptr_t)/* L + A - P */
                     ((uintptr_t)plt + reloc_addend
                      - (uintptr_t)(target_section_addr + reloc_offset));
             }
             else {
-                target_addr = (intptr_t) /* S + A - P */
+                target_addr = (intptr_t)/* S + A - P */
                     ((uintptr_t)symbol_addr + reloc_addend
                      - (uintptr_t)(target_section_addr + reloc_offset));
             }

--- a/core/iwasm/aot/debug/elf.h
+++ b/core/iwasm/aot/debug/elf.h
@@ -104,10 +104,7 @@
 /* EI_NIDENT is defined in "Included Files" section */
 
 #define EI_MAGIC_SIZE 4
-#define EI_MAGIC            \
-    {                       \
-        0x7f, 'E', 'L', 'F' \
-    }
+#define EI_MAGIC { 0x7f, 'E', 'L', 'F' }
 
 #define ELFMAG0 0x7f /* EI_MAG */
 #define ELFMAG1 'E'

--- a/core/iwasm/aot/debug/elf32.h
+++ b/core/iwasm/aot/debug/elf32.h
@@ -32,14 +32,14 @@
  ****************************************************************************/
 
 #define ELF32_ST_BIND(i) ((i) >> 4)
-#define ELF32_ST_TYPE(i) ((i)&0xf)
-#define ELF32_ST_INFO(b, t) (((b) << 4) | ((t)&0xf))
+#define ELF32_ST_TYPE(i) ((i) & 0xf)
+#define ELF32_ST_INFO(b, t) (((b) << 4) | ((t) & 0xf))
 
 /* Definitions for Elf32_Rel*::r_info */
 
 #define ELF32_R_SYM(i) ((i) >> 8)
-#define ELF32_R_TYPE(i) ((i)&0xff)
-#define ELF32_R_INFO(s, t) (((s) << 8) | ((t)&0xff))
+#define ELF32_R_TYPE(i) ((i) & 0xff)
+#define ELF32_R_INFO(s, t) (((s) << 8) | ((t) & 0xff))
 
 #if 0
 #define ELF_R_SYM(i) ELF32_R_SYM(i)

--- a/core/iwasm/aot/debug/elf64.h
+++ b/core/iwasm/aot/debug/elf64.h
@@ -36,8 +36,8 @@
 /* Definitions for Elf64_Rel*::r_info */
 
 #define ELF64_R_SYM(i) ((i) >> 32)
-#define ELF64_R_TYPE(i) ((i)&0xffffffffL)
-#define ELF64_R_INFO(s, t) (((s) << 32) + ((t)&0xffffffffL))
+#define ELF64_R_TYPE(i) ((i) & 0xffffffffL)
+#define ELF64_R_INFO(s, t) (((s) << 32) + ((t) & 0xffffffffL))
 
 #if 0
 #define ELF_R_SYM(i) ELF64_R_SYM(i)

--- a/core/iwasm/common/gc/stringref/stringref_stub.c
+++ b/core/iwasm/common/gc/stringref/stringref_stub.c
@@ -11,7 +11,8 @@
 /******************* gc finalizer *****************/
 void
 wasm_string_destroy(WASMString str_obj)
-{}
+{
+}
 
 /******************* opcode functions *****************/
 
@@ -133,4 +134,5 @@ wasm_string_rewind(WASMString str_obj, uint32 pos, uint32 count,
 
 void
 wasm_string_dump(WASMString str_obj)
-{}
+{
+}

--- a/core/iwasm/common/wasm_blocking_op.c
+++ b/core/iwasm/common/wasm_blocking_op.c
@@ -87,6 +87,7 @@ wasm_runtime_begin_blocking_op(wasm_exec_env_t env)
 
 void
 wasm_runtime_end_blocking_op(wasm_exec_env_t env)
-{}
+{
+}
 
 #endif /* WASM_ENABLE_THREAD_MGR && OS_ENABLE_WAKEUP_BLOCKING_OP */

--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -3248,11 +3248,12 @@ wasm_func_copy(const wasm_func_t *func)
         return NULL;
     }
 
-    if (!(cloned = func->with_env ? wasm_func_new_with_env_basic(
-                       func->store, func->type, func->u.cb_env.cb,
-                       func->u.cb_env.env, func->u.cb_env.finalizer)
-                                  : wasm_func_new_basic(func->store, func->type,
-                                                        func->u.cb))) {
+    if (!(cloned =
+              func->with_env
+                  ? wasm_func_new_with_env_basic(
+                        func->store, func->type, func->u.cb_env.cb,
+                        func->u.cb_env.env, func->u.cb_env.finalizer)
+                  : wasm_func_new_basic(func->store, func->type, func->u.cb))) {
         goto failed;
     }
 

--- a/core/iwasm/compilation/aot_emit_aot_file.c
+++ b/core/iwasm/compilation/aot_emit_aot_file.c
@@ -19,9 +19,9 @@
 
 #define CHECK_SIZE(size)                                   \
     do {                                                   \
-        if (size == (uint32)-1) {                          \
+        if (size == (uint32) - 1) {                        \
             aot_set_last_error("get symbol size failed."); \
-            return (uint32)-1;                             \
+            return (uint32) - 1;                           \
         }                                                  \
     } while (0)
 
@@ -3674,7 +3674,7 @@ aot_resolve_stack_sizes(AOTCompContext *comp_ctx, AOTObjectData *obj_data)
                 unsigned int stack_consumption_to_call_wrapped_func =
                     musttail ? 0
                              : aot_estimate_stack_usage_for_function_call(
-                                 comp_ctx, func_ctx->aot_func->func_type);
+                                   comp_ctx, func_ctx->aot_func->func_type);
 
                 /*
                  * LLVM seems to eliminate calls to an empty function

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -2520,7 +2520,7 @@ jit_stack_size_callback(void *user_data, const char *name, size_t namelen,
     stack_consumption_to_call_wrapped_func =
         musttail ? 0
                  : aot_estimate_stack_usage_for_function_call(
-                     comp_ctx, func_ctx->aot_func->func_type);
+                       comp_ctx, func_ctx->aot_func->func_type);
     LOG_VERBOSE("func %.*s stack %u + %zu + %u", (int)namelen, name,
                 stack_consumption_to_call_wrapped_func, stack_size, call_size);
 

--- a/core/iwasm/compilation/aot_orc_extra2.cpp
+++ b/core/iwasm/compilation/aot_orc_extra2.cpp
@@ -41,7 +41,8 @@ MyCompiler::MyCompiler(llvm::orc::JITTargetMachineBuilder JTMB, cb_t cb,
   , JTMB(std::move(JTMB))
   , cb(cb)
   , cb_data(cb_data)
-{}
+{
+}
 
 class PrintStackSizes : public llvm::MachineFunctionPass
 {
@@ -59,7 +60,8 @@ PrintStackSizes::PrintStackSizes(cb_t cb, void *cb_data)
   : MachineFunctionPass(ID)
   , cb(cb)
   , cb_data(cb_data)
-{}
+{
+}
 
 char PrintStackSizes::ID = 0;
 

--- a/core/iwasm/compilation/debug/dwarf_extractor.h
+++ b/core/iwasm/compilation/debug/dwarf_extractor.h
@@ -14,7 +14,7 @@ extern "C" {
 
 typedef unsigned int LLDBLangType;
 #define LLDB_TO_LLVM_LANG_TYPE(lldb_lang_type) \
-    (LLVMDWARFSourceLanguage)(((lldb_lang_type) > 0 ? (lldb_lang_type)-1 : 1))
+    (LLVMDWARFSourceLanguage)(((lldb_lang_type) > 0 ? (lldb_lang_type) - 1 : 1))
 
 struct AOTCompData;
 typedef struct AOTCompData *aot_comp_data_t;

--- a/core/iwasm/fast-jit/cg/x86-64/jit_codegen_x86_64.cpp
+++ b/core/iwasm/fast-jit/cg/x86-64/jit_codegen_x86_64.cpp
@@ -298,7 +298,8 @@ class JitErrorHandler : public ErrorHandler
 
     JitErrorHandler()
       : err(kErrorOk)
-    {}
+    {
+    }
 
     void handleError(Error e, const char *msg, BaseEmitter *base) override
     {

--- a/core/iwasm/fast-jit/jit_ir.h
+++ b/core/iwasm/fast-jit/jit_ir.h
@@ -1866,14 +1866,14 @@ jit_cc_update_cfg(JitCompContext *cc);
  */
 #define JIT_FOREACH_BLOCK_REVERSE(CC, I, B)           \
     for ((I) = (CC)->_ann._label_num; (I) > 2; (I)--) \
-        if (((B) = (CC)->_ann._label_basic_block[(I)-1]))
+        if (((B) = (CC)->_ann._label_basic_block[(I) - 1]))
 
 /**
  * The version that includes entry and exit block.
  */
 #define JIT_FOREACH_BLOCK_REVERSE_ENTRY_EXIT(CC, I, B) \
     for ((I) = (CC)->_ann._label_num; (I) > 0; (I)--)  \
-        if (((B) = (CC)->_ann._label_basic_block[(I)-1]))
+        if (((B) = (CC)->_ann._label_basic_block[(I) - 1]))
 
 #ifdef __cplusplus
 }

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -2438,7 +2438,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 else
                     cur_func_type = cur_func->u.func->func_type;
 
-                    /* clang-format off */
+                /* clang-format off */
 #if WASM_ENABLE_GC == 0
                 if (cur_type != cur_func_type) {
                     wasm_set_exception(module, "indirect call type mismatch");

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -1814,7 +1814,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 else
                     cur_func_type = cur_func->u.func->func_type;
 
-                    /* clang-format off */
+                /* clang-format off */
 #if WASM_ENABLE_GC == 0
                 if (cur_type != cur_func_type) {
                     wasm_set_exception(module, "indirect call type mismatch");

--- a/core/iwasm/libraries/debug-engine/debug_engine.h
+++ b/core/iwasm/libraries/debug-engine/debug_engine.h
@@ -109,8 +109,8 @@ typedef enum WasmAddressType {
 #define WASM_ADDR(type, id, offset) \
     (((uint64)type << 62) | ((uint64)0 << 32) | ((uint64)offset << 0))
 
-#define WASM_ADDR_TYPE(addr) (((addr)&0xC000000000000000) >> 62)
-#define WASM_ADDR_OFFSET(addr) (((addr)&0x00000000FFFFFFFF))
+#define WASM_ADDR_TYPE(addr) (((addr) & 0xC000000000000000) >> 62)
+#define WASM_ADDR_OFFSET(addr) (((addr) & 0x00000000FFFFFFFF))
 
 #define INVALIED_ADDR (0xFFFFFFFFFFFFFFFF)
 

--- a/core/shared/mem-alloc/ems/ems_gc_internal.h
+++ b/core/shared/mem-alloc/ems/ems_gc_internal.h
@@ -77,7 +77,7 @@ hmu_verify(void *vheap, hmu_t *hmu);
 
 #endif /* end of BH_ENABLE_GC_VERIFY */
 
-#define hmu_obj_size(s) ((s)-OBJ_EXTRA_SIZE)
+#define hmu_obj_size(s) ((s) - OBJ_EXTRA_SIZE)
 
 #define GC_ALIGN_8(s) (((uint32)(s) + 7) & (uint32)~7)
 
@@ -201,11 +201,11 @@ hmu_verify(void *vheap, hmu_t *hmu);
 
 /* Get magic pointer from aligned object pointer */
 #define ALIGNED_ALLOC_GET_MAGIC_PTR(obj) \
-    ((uint32_t *)((char *)(obj)-ALIGNED_ALLOC_MAGIC_SIZE))
+    ((uint32_t *)((char *)(obj) - ALIGNED_ALLOC_MAGIC_SIZE))
 
 /* Get offset pointer from aligned object pointer */
 #define ALIGNED_ALLOC_GET_OFFSET_PTR(obj) \
-    ((uint32_t *)((char *)(obj)-ALIGNED_ALLOC_METADATA_SIZE))
+    ((uint32_t *)((char *)(obj) - ALIGNED_ALLOC_METADATA_SIZE))
 
 /* Extra overhead for aligned allocations beyond normal OBJ_EXTRA_SIZE */
 #define ALIGNED_ALLOC_EXTRA_OVERHEAD ALIGNED_ALLOC_METADATA_SIZE

--- a/core/shared/platform/alios/alios_platform.c
+++ b/core/shared/platform/alios/alios_platform.c
@@ -38,7 +38,8 @@ os_realloc(void *ptr, unsigned size)
 
 void
 os_free(void *ptr)
-{}
+{
+}
 
 int
 os_dumps_proc_mem_info(char *out, unsigned int size)
@@ -74,11 +75,13 @@ os_mprotect(void *addr, size_t size, int prot)
 
 void
 os_dcache_flush()
-{}
+{
+}
 
 void
 os_icache_flush(void *start, size_t len)
-{}
+{
+}
 
 os_raw_file_handle
 os_invalid_raw_handle(void)

--- a/core/shared/platform/alios/alios_thread.c
+++ b/core/shared/platform/alios/alios_thread.c
@@ -362,4 +362,5 @@ os_thread_get_stack_boundary()
 
 void
 os_thread_jit_write_protect_np(bool enabled)
-{}
+{
+}

--- a/core/shared/platform/android/platform_init.c
+++ b/core/shared/platform/android/platform_init.c
@@ -19,7 +19,8 @@ bh_platform_init()
 
 void
 bh_platform_destroy()
-{}
+{
+}
 
 int
 os_printf(const char *fmt, ...)

--- a/core/shared/platform/common/freertos/freertos_malloc.c
+++ b/core/shared/platform/common/freertos/freertos_malloc.c
@@ -19,7 +19,8 @@ os_realloc(void *ptr, unsigned size)
 
 void
 os_free(void *ptr)
-{}
+{
+}
 
 int
 os_dumps_proc_mem_info(char *out, unsigned int size)

--- a/core/shared/platform/common/posix/posix_memmap.c
+++ b/core/shared/platform/common/posix/posix_memmap.c
@@ -288,7 +288,8 @@ os_mprotect(void *addr, size_t size, int prot)
 
 void
 os_dcache_flush(void)
-{}
+{
+}
 
 void
 os_icache_flush(void *start, size_t len)

--- a/core/shared/platform/cosmopolitan/platform_init.c
+++ b/core/shared/platform/cosmopolitan/platform_init.c
@@ -13,7 +13,8 @@ bh_platform_init()
 
 void
 bh_platform_destroy()
-{}
+{
+}
 
 int
 os_printf(const char *format, ...)

--- a/core/shared/platform/darwin/platform_init.c
+++ b/core/shared/platform/darwin/platform_init.c
@@ -13,7 +13,8 @@ bh_platform_init()
 
 void
 bh_platform_destroy()
-{}
+{
+}
 
 int
 os_printf(const char *format, ...)

--- a/core/shared/platform/esp-idf/espidf_memmap.c
+++ b/core/shared/platform/esp-idf/espidf_memmap.c
@@ -127,7 +127,8 @@ void
 
 void
 os_icache_flush(void *start, size_t len)
-{}
+{
+}
 
 #if (WASM_MEM_DUAL_BUS_MIRROR != 0)
 void *

--- a/core/shared/platform/esp-idf/espidf_platform.c
+++ b/core/shared/platform/esp-idf/espidf_platform.c
@@ -30,7 +30,8 @@ bh_platform_init()
 
 void
 bh_platform_destroy()
-{}
+{
+}
 
 int
 os_printf(const char *format, ...)
@@ -86,7 +87,8 @@ os_thread_get_stack_boundary(void)
 
 void
 os_thread_jit_write_protect_np(bool enabled)
-{}
+{
+}
 
 int
 os_usleep(uint32 usec)

--- a/core/shared/platform/freebsd/platform_init.c
+++ b/core/shared/platform/freebsd/platform_init.c
@@ -13,7 +13,8 @@ bh_platform_init()
 
 void
 bh_platform_destroy()
-{}
+{
+}
 
 int
 os_printf(const char *format, ...)

--- a/core/shared/platform/include/platform_common.h
+++ b/core/shared/platform/include/platform_common.h
@@ -19,11 +19,11 @@ extern "C" {
 #define BHT_TIMED_OUT (1)
 #define BHT_OK (0)
 
-#define BHT_WAIT_FOREVER ((uint64)-1LL)
+#define BHT_WAIT_FOREVER ((uint64) - 1LL)
 
 #define BH_KB (1024)
-#define BH_MB ((BH_KB)*1024)
-#define BH_GB ((BH_MB)*1024)
+#define BH_MB ((BH_KB) * 1024)
+#define BH_GB ((BH_MB) * 1024)
 
 #ifndef BH_MALLOC
 #define BH_MALLOC os_malloc
@@ -39,11 +39,15 @@ extern "C" {
 
 #if defined(_MSC_BUILD)
 #if defined(COMPILING_WASM_RUNTIME_API)
-__declspec(dllexport) void *BH_MALLOC(unsigned int size);
-__declspec(dllexport) void BH_FREE(void *ptr);
+__declspec(dllexport) void *
+BH_MALLOC(unsigned int size);
+__declspec(dllexport) void
+BH_FREE(void *ptr);
 #else
-__declspec(dllimport) void *BH_MALLOC(unsigned int size);
-__declspec(dllimport) void BH_FREE(void *ptr);
+__declspec(dllimport) void *
+BH_MALLOC(unsigned int size);
+__declspec(dllimport) void
+BH_FREE(void *ptr);
 #endif
 #else
 void *
@@ -54,7 +58,8 @@ BH_FREE(void *ptr);
 
 #if defined(BH_VPRINTF)
 #if defined(MSVC)
-__declspec(dllimport) int BH_VPRINTF(const char *format, va_list ap);
+__declspec(dllimport) int
+BH_VPRINTF(const char *format, va_list ap);
 #else
 int
 BH_VPRINTF(const char *format, va_list ap);

--- a/core/shared/platform/linux-sgx/sgx_file.h
+++ b/core/shared/platform/linux-sgx/sgx_file.h
@@ -63,13 +63,13 @@ extern "C" {
 #define SEEK_CUR 1
 #define SEEK_END 2
 
-#define S_ISDIR(mode) (((mode)&S_IFMT) == S_IFDIR)
-#define S_ISCHR(mode) (((mode)&S_IFMT) == S_IFCHR)
-#define S_ISBLK(mode) (((mode)&S_IFMT) == S_IFBLK)
-#define S_ISREG(mode) (((mode)&S_IFMT) == S_IFREG)
-#define S_ISFIFO(mode) (((mode)&S_IFMT) == S_IFIFO)
-#define S_ISLNK(mode) (((mode)&S_IFMT) == S_IFLNK)
-#define S_ISSOCK(mode) (((mode)&S_IFMT) == S_IFSOCK)
+#define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
+#define S_ISCHR(mode) (((mode) & S_IFMT) == S_IFCHR)
+#define S_ISBLK(mode) (((mode) & S_IFMT) == S_IFBLK)
+#define S_ISREG(mode) (((mode) & S_IFMT) == S_IFREG)
+#define S_ISFIFO(mode) (((mode) & S_IFMT) == S_IFIFO)
+#define S_ISLNK(mode) (((mode) & S_IFMT) == S_IFLNK)
+#define S_ISSOCK(mode) (((mode) & S_IFMT) == S_IFSOCK)
 
 #define DT_UNKNOWN 0
 #define DT_FIFO 1

--- a/core/shared/platform/linux-sgx/sgx_thread.c
+++ b/core/shared/platform/linux-sgx/sgx_thread.c
@@ -213,7 +213,8 @@ os_thread_get_stack_boundary()
 
 void
 os_thread_jit_write_protect_np(bool enabled)
-{}
+{
+}
 
 int
 os_rwlock_init(korp_rwlock *lock)

--- a/core/shared/platform/linux/platform_init.c
+++ b/core/shared/platform/linux/platform_init.c
@@ -13,7 +13,8 @@ bh_platform_init()
 
 void
 bh_platform_destroy()
-{}
+{
+}
 
 int
 os_printf(const char *format, ...)

--- a/core/shared/platform/nuttx/nuttx_platform.c
+++ b/core/shared/platform/nuttx/nuttx_platform.c
@@ -20,7 +20,8 @@ bh_platform_init()
 
 void
 bh_platform_destroy()
-{}
+{
+}
 
 void *
 os_malloc(unsigned size)
@@ -287,7 +288,8 @@ getaddrinfo(FAR const char *nodename, FAR const char *servname,
 
 void
 freeaddrinfo(FAR struct addrinfo *ai)
-{}
+{
+}
 
 int
 setsockopt(int sockfd, int level, int option, FAR const void *value,

--- a/core/shared/platform/riot/riot_platform.c
+++ b/core/shared/platform/riot/riot_platform.c
@@ -94,7 +94,8 @@ os_dcache_flush(void)
 
 void
 os_icache_flush(void *start, size_t len)
-{}
+{
+}
 
 os_raw_file_handle
 os_invalid_raw_handle(void)

--- a/core/shared/platform/riot/riot_thread.c
+++ b/core/shared/platform/riot/riot_thread.c
@@ -433,4 +433,5 @@ os_thread_get_stack_boundary()
 
 void
 os_thread_jit_write_protect_np(bool enabled)
-{}
+{
+}

--- a/core/shared/platform/rt-thread/rtt_platform.c
+++ b/core/shared/platform/rt-thread/rtt_platform.c
@@ -21,7 +21,8 @@ bh_platform_init(void)
 
 void
 bh_platform_destroy(void)
-{}
+{
+}
 
 void *
 os_malloc(unsigned size)
@@ -179,11 +180,13 @@ os_mprotect(void *addr, size_t size, int prot)
 
 void
 os_dcache_flush(void)
-{}
+{
+}
 
 void
 os_icache_flush(void *start, size_t len)
-{}
+{
+}
 
 int
 os_getpagesize(void)

--- a/core/shared/platform/rt-thread/rtt_thread.c
+++ b/core/shared/platform/rt-thread/rtt_thread.c
@@ -186,7 +186,8 @@ os_thread_get_stack_boundary(void)
 
 void
 os_thread_jit_write_protect_np(bool enabled)
-{}
+{
+}
 
 int
 os_mutex_init(korp_mutex *mutex)

--- a/core/shared/platform/vxworks/platform_init.c
+++ b/core/shared/platform/vxworks/platform_init.c
@@ -13,7 +13,8 @@ bh_platform_init()
 
 void
 bh_platform_destroy()
-{}
+{
+}
 
 int
 os_printf(const char *format, ...)

--- a/core/shared/platform/windows/platform_init.c
+++ b/core/shared/platform/windows/platform_init.c
@@ -72,8 +72,10 @@ os_getpagesize()
 
 void
 os_dcache_flush(void)
-{}
+{
+}
 
 void
 os_icache_flush(void *start, size_t len)
-{}
+{
+}

--- a/core/shared/platform/windows/win_thread.c
+++ b/core/shared/platform/windows/win_thread.c
@@ -830,7 +830,8 @@ os_thread_get_stack_boundary()
 
 void
 os_thread_jit_write_protect_np(bool enabled)
-{}
+{
+}
 
 #ifdef OS_ENABLE_HW_BOUND_CHECK
 static os_thread_local_attribute bool thread_signal_inited = false;

--- a/core/shared/platform/zephyr/zephyr_thread.c
+++ b/core/shared/platform/zephyr/zephyr_thread.c
@@ -586,7 +586,8 @@ os_thread_get_stack_boundary()
 
 void
 os_thread_jit_write_protect_np(bool enabled)
-{}
+{
+}
 
 int
 os_rwlock_init(korp_rwlock *lock)


### PR DESCRIPTION
## Summary

Bumps the coding-guidelines formatter from **clang-format-14 to clang-format-20** and reformats the tree to match. This is the clang-**format** half of #4983's tooling modernization; the clang-tidy bump and the runner / native-LLVM parts follow separately.

## What changed

- **Commit 1 (config):** `ci/coding_guidelines_check.py` and `ci/pre_commit_hook_sample` pin clang-format-20; `coding_guidelines.yml` installs it from `apt.llvm.org` for the running Ubuntu release (it isn't preinstalled), so the pinned version no longer drifts with the runner image — the rot behind today's `-12`/`-14` mix. `.clang-format`'s version note is updated (it also fixes the `clang-formt` typo).
- **Commit 2 (reformat):** mechanical `clang-format-20 -i` over the coding-guidelines-checked sources, as a standalone commit for easy review.

## Noise: small

Only **42 of 441 files (~209 lines)** change — the code was already close to the clang-format-20 style, and `.clang-format` needed no option changes (zero config warnings at 20). The reformat is also version-flat: 39 files at clang-format-18, 43 at 21/22, so pinning 20 carries no penalty over the runner-preinstalled 18 while being an explicitly-pinned latest stable.

## Scope

Intentionally just clang-**format**. The clang-**tidy** bump to 20 is separate: at 20 the current `.clang-tidy` wildcards surface ~3,300 diagnostics on the tree (53% `misc-include-cleaner`), which needs config curation plus incremental cleanup — a follow-up tied to #4982, not bundled here.
