### PR TITLE
ci: run coding-guidelines on ubuntu-24.04 with clang-format-18 + reformat

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
-# using [clang-formt-12 options](https://releases.llvm.org/12.0.0/tools/clang/docs/ClangFormatStyleOptions.html)
+# using [clang-format-18 options](https://releases.llvm.org/18.1.0/tools/clang/docs/ClangFormatStyleOptions.html)
 RawStringFormats:
   - Language: Cpp
     Delimiters:

--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   compliance_job:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout
         uses: actions/checkout@v7.0.0

--- a/ci/coding_guidelines_check.py
+++ b/ci/coding_guidelines_check.py
@@ -12,8 +12,8 @@ import subprocess
 import sys
 import unittest
 
-CLANG_FORMAT_CMD = "clang-format-14"
-GIT_CLANG_FORMAT_CMD = "git-clang-format-14"
+CLANG_FORMAT_CMD = "clang-format-18"
+GIT_CLANG_FORMAT_CMD = "git-clang-format-18"
 
 # glob style patterns
 EXCLUDE_PATHS = [
@@ -92,29 +92,29 @@ def run_clang_format(file_path: Path, root: Path) -> bool:
 
 def run_clang_format_diff(root: Path, commits: str) -> bool:
     """
-    Use `clang-format-14` or `git-clang-format-14` to check code format of
+    Use `clang-format-18` or `git-clang-format-18` to check code format of
     the PR, with a commit range specified. It is required to format the
     code before committing the PR, or it might fail to pass the CI check:
 
-    1. Install clang-format-14.0.0
+    1. Install clang-format-18
 
     You can download the package from
     https://github.com/llvm/llvm-project/releases
     and install it.
 
     For Debian/Ubuntu, we can probably use
-    `sudo apt-get install clang-format-14`.
+    `sudo apt-get install clang-format-18`.
 
-    Homebrew has it as a part of llvm@14.
+    Homebrew has it as a part of llvm@18.
     ```shell
-    brew install llvm@14
-    /usr/local/opt/llvm@14/bin/clang-format
+    brew install llvm@18
+    /usr/local/opt/llvm@18/bin/clang-format
     ```
 
     2. Format the C/C++ source file
     ``` shell
     cd path/to/wamr/root
-    clang-format-14 --style file -i path/to/file
+    clang-format-18 --style file -i path/to/file
     ```
 
     The code wrapped by `/* clang-format off */` and `/* clang-format on */`

--- a/ci/pre_commit_hook_sample
+++ b/ci/pre_commit_hook_sample
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # This is a sample of pre-commit hook that can be used to make your code fit the WAMR CI code style requirements.
-# You need to have clang-format-12 installed to use this hook.
+# You need to have clang-format-18 installed to use this hook.
 # To add this pre-commit hook, copy it to <path_to_wamr>/.git/hooks/pre-commit
 # (you don't need any extensions here)
 
@@ -22,10 +22,10 @@ is_c_or_cpp_file() {
 # Loop through staged files and apply command "abc" to C and C++ files
 for staged_file in $(git diff --cached --name-only); do
     if is_c_or_cpp_file "$staged_file"; then
-        clang-format-12 -Werror --style file --dry-run "$staged_file" 2>/dev/null
+        clang-format-18 -Werror --style file --dry-run "$staged_file" 2>/dev/null
         if [ $? -ne 0 ]; then 
             echo "Issues are found in $staged_file. Applying the fix" 
-            clang-format-12 --style file -i "$staged_file"
+            clang-format-18 --style file -i "$staged_file"
         fi
         git add "$staged_file"  # Add the modified file back to staging
     fi

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -5553,7 +5553,8 @@ aot_const_str_set_insert(const uint8 *str, int32 len, AOTModule *module,
 #if WASM_ENABLE_DYNAMIC_AOT_DEBUG != 0
 AOTModule *g_dynamic_aot_module = NULL;
 
-void __attribute__((noinline)) __enable_dynamic_aot_debug(void)
+void __attribute__((noinline))
+__enable_dynamic_aot_debug(void)
 {
     /* empty implementation. */
 }

--- a/core/iwasm/aot/debug/elf32.h
+++ b/core/iwasm/aot/debug/elf32.h
@@ -32,14 +32,14 @@
  ****************************************************************************/
 
 #define ELF32_ST_BIND(i) ((i) >> 4)
-#define ELF32_ST_TYPE(i) ((i)&0xf)
-#define ELF32_ST_INFO(b, t) (((b) << 4) | ((t)&0xf))
+#define ELF32_ST_TYPE(i) ((i) & 0xf)
+#define ELF32_ST_INFO(b, t) (((b) << 4) | ((t) & 0xf))
 
 /* Definitions for Elf32_Rel*::r_info */
 
 #define ELF32_R_SYM(i) ((i) >> 8)
-#define ELF32_R_TYPE(i) ((i)&0xff)
-#define ELF32_R_INFO(s, t) (((s) << 8) | ((t)&0xff))
+#define ELF32_R_TYPE(i) ((i) & 0xff)
+#define ELF32_R_INFO(s, t) (((s) << 8) | ((t) & 0xff))
 
 #if 0
 #define ELF_R_SYM(i) ELF32_R_SYM(i)

--- a/core/iwasm/aot/debug/elf64.h
+++ b/core/iwasm/aot/debug/elf64.h
@@ -36,8 +36,8 @@
 /* Definitions for Elf64_Rel*::r_info */
 
 #define ELF64_R_SYM(i) ((i) >> 32)
-#define ELF64_R_TYPE(i) ((i)&0xffffffffL)
-#define ELF64_R_INFO(s, t) (((s) << 32) + ((t)&0xffffffffL))
+#define ELF64_R_TYPE(i) ((i) & 0xffffffffL)
+#define ELF64_R_INFO(s, t) (((s) << 32) + ((t) & 0xffffffffL))
 
 #if 0
 #define ELF_R_SYM(i) ELF64_R_SYM(i)

--- a/core/iwasm/common/gc/stringref/stringref_stub.c
+++ b/core/iwasm/common/gc/stringref/stringref_stub.c
@@ -11,7 +11,8 @@
 /******************* gc finalizer *****************/
 void
 wasm_string_destroy(WASMString str_obj)
-{}
+{
+}
 
 /******************* opcode functions *****************/
 
@@ -133,4 +134,5 @@ wasm_string_rewind(WASMString str_obj, uint32 pos, uint32 count,
 
 void
 wasm_string_dump(WASMString str_obj)
-{}
+{
+}

--- a/core/iwasm/common/wasm_blocking_op.c
+++ b/core/iwasm/common/wasm_blocking_op.c
@@ -87,6 +87,7 @@ wasm_runtime_begin_blocking_op(wasm_exec_env_t env)
 
 void
 wasm_runtime_end_blocking_op(wasm_exec_env_t env)
-{}
+{
+}
 
 #endif /* WASM_ENABLE_THREAD_MGR && OS_ENABLE_WAKEUP_BLOCKING_OP */

--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -3248,11 +3248,12 @@ wasm_func_copy(const wasm_func_t *func)
         return NULL;
     }
 
-    if (!(cloned = func->with_env ? wasm_func_new_with_env_basic(
-                       func->store, func->type, func->u.cb_env.cb,
-                       func->u.cb_env.env, func->u.cb_env.finalizer)
-                                  : wasm_func_new_basic(func->store, func->type,
-                                                        func->u.cb))) {
+    if (!(cloned =
+              func->with_env
+                  ? wasm_func_new_with_env_basic(
+                        func->store, func->type, func->u.cb_env.cb,
+                        func->u.cb_env.env, func->u.cb_env.finalizer)
+                  : wasm_func_new_basic(func->store, func->type, func->u.cb))) {
         goto failed;
     }
 

--- a/core/iwasm/compilation/aot_emit_aot_file.c
+++ b/core/iwasm/compilation/aot_emit_aot_file.c
@@ -19,9 +19,9 @@
 
 #define CHECK_SIZE(size)                                   \
     do {                                                   \
-        if (size == (uint32)-1) {                          \
+        if (size == (uint32) - 1) {                        \
             aot_set_last_error("get symbol size failed."); \
-            return (uint32)-1;                             \
+            return (uint32) - 1;                           \
         }                                                  \
     } while (0)
 
@@ -3674,7 +3674,7 @@ aot_resolve_stack_sizes(AOTCompContext *comp_ctx, AOTObjectData *obj_data)
                 unsigned int stack_consumption_to_call_wrapped_func =
                     musttail ? 0
                              : aot_estimate_stack_usage_for_function_call(
-                                 comp_ctx, func_ctx->aot_func->func_type);
+                                   comp_ctx, func_ctx->aot_func->func_type);
 
                 /*
                  * LLVM seems to eliminate calls to an empty function

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -2520,7 +2520,7 @@ jit_stack_size_callback(void *user_data, const char *name, size_t namelen,
     stack_consumption_to_call_wrapped_func =
         musttail ? 0
                  : aot_estimate_stack_usage_for_function_call(
-                     comp_ctx, func_ctx->aot_func->func_type);
+                       comp_ctx, func_ctx->aot_func->func_type);
     LOG_VERBOSE("func %.*s stack %u + %zu + %u", (int)namelen, name,
                 stack_consumption_to_call_wrapped_func, stack_size, call_size);
 

--- a/core/iwasm/compilation/aot_orc_extra2.cpp
+++ b/core/iwasm/compilation/aot_orc_extra2.cpp
@@ -41,7 +41,8 @@ MyCompiler::MyCompiler(llvm::orc::JITTargetMachineBuilder JTMB, cb_t cb,
   , JTMB(std::move(JTMB))
   , cb(cb)
   , cb_data(cb_data)
-{}
+{
+}
 
 class PrintStackSizes : public llvm::MachineFunctionPass
 {
@@ -59,7 +60,8 @@ PrintStackSizes::PrintStackSizes(cb_t cb, void *cb_data)
   : MachineFunctionPass(ID)
   , cb(cb)
   , cb_data(cb_data)
-{}
+{
+}
 
 char PrintStackSizes::ID = 0;
 

--- a/core/iwasm/compilation/debug/dwarf_extractor.h
+++ b/core/iwasm/compilation/debug/dwarf_extractor.h
@@ -14,7 +14,7 @@ extern "C" {
 
 typedef unsigned int LLDBLangType;
 #define LLDB_TO_LLVM_LANG_TYPE(lldb_lang_type) \
-    (LLVMDWARFSourceLanguage)(((lldb_lang_type) > 0 ? (lldb_lang_type)-1 : 1))
+    (LLVMDWARFSourceLanguage)(((lldb_lang_type) > 0 ? (lldb_lang_type) - 1 : 1))
 
 struct AOTCompData;
 typedef struct AOTCompData *aot_comp_data_t;

--- a/core/iwasm/fast-jit/cg/x86-64/jit_codegen_x86_64.cpp
+++ b/core/iwasm/fast-jit/cg/x86-64/jit_codegen_x86_64.cpp
@@ -298,7 +298,8 @@ class JitErrorHandler : public ErrorHandler
 
     JitErrorHandler()
       : err(kErrorOk)
-    {}
+    {
+    }
 
     void handleError(Error e, const char *msg, BaseEmitter *base) override
     {

--- a/core/iwasm/fast-jit/jit_ir.h
+++ b/core/iwasm/fast-jit/jit_ir.h
@@ -1866,14 +1866,14 @@ jit_cc_update_cfg(JitCompContext *cc);
  */
 #define JIT_FOREACH_BLOCK_REVERSE(CC, I, B)           \
     for ((I) = (CC)->_ann._label_num; (I) > 2; (I)--) \
-        if (((B) = (CC)->_ann._label_basic_block[(I)-1]))
+        if (((B) = (CC)->_ann._label_basic_block[(I) - 1]))
 
 /**
  * The version that includes entry and exit block.
  */
 #define JIT_FOREACH_BLOCK_REVERSE_ENTRY_EXIT(CC, I, B) \
     for ((I) = (CC)->_ann._label_num; (I) > 0; (I)--)  \
-        if (((B) = (CC)->_ann._label_basic_block[(I)-1]))
+        if (((B) = (CC)->_ann._label_basic_block[(I) - 1]))
 
 #ifdef __cplusplus
 }

--- a/core/iwasm/libraries/debug-engine/debug_engine.h
+++ b/core/iwasm/libraries/debug-engine/debug_engine.h
@@ -109,8 +109,8 @@ typedef enum WasmAddressType {
 #define WASM_ADDR(type, id, offset) \
     (((uint64)type << 62) | ((uint64)0 << 32) | ((uint64)offset << 0))
 
-#define WASM_ADDR_TYPE(addr) (((addr)&0xC000000000000000) >> 62)
-#define WASM_ADDR_OFFSET(addr) (((addr)&0x00000000FFFFFFFF))
+#define WASM_ADDR_TYPE(addr) (((addr) & 0xC000000000000000) >> 62)
+#define WASM_ADDR_OFFSET(addr) (((addr) & 0x00000000FFFFFFFF))
 
 #define INVALIED_ADDR (0xFFFFFFFFFFFFFFFF)
 

--- a/core/shared/mem-alloc/ems/ems_gc_internal.h
+++ b/core/shared/mem-alloc/ems/ems_gc_internal.h
@@ -77,7 +77,7 @@ hmu_verify(void *vheap, hmu_t *hmu);
 
 #endif /* end of BH_ENABLE_GC_VERIFY */
 
-#define hmu_obj_size(s) ((s)-OBJ_EXTRA_SIZE)
+#define hmu_obj_size(s) ((s) - OBJ_EXTRA_SIZE)
 
 #define GC_ALIGN_8(s) (((uint32)(s) + 7) & (uint32)~7)
 
@@ -201,11 +201,11 @@ hmu_verify(void *vheap, hmu_t *hmu);
 
 /* Get magic pointer from aligned object pointer */
 #define ALIGNED_ALLOC_GET_MAGIC_PTR(obj) \
-    ((uint32_t *)((char *)(obj)-ALIGNED_ALLOC_MAGIC_SIZE))
+    ((uint32_t *)((char *)(obj) - ALIGNED_ALLOC_MAGIC_SIZE))
 
 /* Get offset pointer from aligned object pointer */
 #define ALIGNED_ALLOC_GET_OFFSET_PTR(obj) \
-    ((uint32_t *)((char *)(obj)-ALIGNED_ALLOC_METADATA_SIZE))
+    ((uint32_t *)((char *)(obj) - ALIGNED_ALLOC_METADATA_SIZE))
 
 /* Extra overhead for aligned allocations beyond normal OBJ_EXTRA_SIZE */
 #define ALIGNED_ALLOC_EXTRA_OVERHEAD ALIGNED_ALLOC_METADATA_SIZE
@@ -433,10 +433,10 @@ __pragma(pack(pop));
 bh_static_assert(sizeof(hmu_tree_node_t) == 8 + 3 * sizeof(void *));
 bh_static_assert(offsetof(hmu_tree_node_t, left) == 4);
 
-#define ASSERT_TREE_NODE_ALIGNED_ACCESS(tree_node)                          \
-    do {                                                                    \
-        bh_assert((((uintptr_t)&tree_node->left) & (sizeof(uintptr_t) - 1)) \
-                  == 0);                                                    \
+#define ASSERT_TREE_NODE_ALIGNED_ACCESS(tree_node)                            \
+    do {                                                                      \
+        bh_assert((((uintptr_t) & tree_node->left) & (sizeof(uintptr_t) - 1)) \
+                  == 0);                                                      \
     } while (0)
 
 typedef struct gc_heap_struct {

--- a/core/shared/platform/alios/alios_platform.c
+++ b/core/shared/platform/alios/alios_platform.c
@@ -38,7 +38,8 @@ os_realloc(void *ptr, unsigned size)
 
 void
 os_free(void *ptr)
-{}
+{
+}
 
 int
 os_dumps_proc_mem_info(char *out, unsigned int size)
@@ -74,11 +75,13 @@ os_mprotect(void *addr, size_t size, int prot)
 
 void
 os_dcache_flush()
-{}
+{
+}
 
 void
 os_icache_flush(void *start, size_t len)
-{}
+{
+}
 
 os_raw_file_handle
 os_invalid_raw_handle(void)

--- a/core/shared/platform/alios/alios_thread.c
+++ b/core/shared/platform/alios/alios_thread.c
@@ -362,4 +362,5 @@ os_thread_get_stack_boundary()
 
 void
 os_thread_jit_write_protect_np(bool enabled)
-{}
+{
+}

--- a/core/shared/platform/android/platform_init.c
+++ b/core/shared/platform/android/platform_init.c
@@ -19,7 +19,8 @@ bh_platform_init()
 
 void
 bh_platform_destroy()
-{}
+{
+}
 
 int
 os_printf(const char *fmt, ...)

--- a/core/shared/platform/common/freertos/freertos_malloc.c
+++ b/core/shared/platform/common/freertos/freertos_malloc.c
@@ -19,7 +19,8 @@ os_realloc(void *ptr, unsigned size)
 
 void
 os_free(void *ptr)
-{}
+{
+}
 
 int
 os_dumps_proc_mem_info(char *out, unsigned int size)

--- a/core/shared/platform/common/posix/posix_memmap.c
+++ b/core/shared/platform/common/posix/posix_memmap.c
@@ -288,7 +288,8 @@ os_mprotect(void *addr, size_t size, int prot)
 
 void
 os_dcache_flush(void)
-{}
+{
+}
 
 void
 os_icache_flush(void *start, size_t len)

--- a/core/shared/platform/cosmopolitan/platform_init.c
+++ b/core/shared/platform/cosmopolitan/platform_init.c
@@ -13,7 +13,8 @@ bh_platform_init()
 
 void
 bh_platform_destroy()
-{}
+{
+}
 
 int
 os_printf(const char *format, ...)

--- a/core/shared/platform/darwin/platform_init.c
+++ b/core/shared/platform/darwin/platform_init.c
@@ -13,7 +13,8 @@ bh_platform_init()
 
 void
 bh_platform_destroy()
-{}
+{
+}
 
 int
 os_printf(const char *format, ...)

--- a/core/shared/platform/esp-idf/espidf_memmap.c
+++ b/core/shared/platform/esp-idf/espidf_memmap.c
@@ -127,7 +127,8 @@ void
 
 void
 os_icache_flush(void *start, size_t len)
-{}
+{
+}
 
 #if (WASM_MEM_DUAL_BUS_MIRROR != 0)
 void *

--- a/core/shared/platform/esp-idf/espidf_platform.c
+++ b/core/shared/platform/esp-idf/espidf_platform.c
@@ -30,7 +30,8 @@ bh_platform_init()
 
 void
 bh_platform_destroy()
-{}
+{
+}
 
 int
 os_printf(const char *format, ...)
@@ -86,7 +87,8 @@ os_thread_get_stack_boundary(void)
 
 void
 os_thread_jit_write_protect_np(bool enabled)
-{}
+{
+}
 
 int
 os_usleep(uint32 usec)

--- a/core/shared/platform/freebsd/platform_init.c
+++ b/core/shared/platform/freebsd/platform_init.c
@@ -13,7 +13,8 @@ bh_platform_init()
 
 void
 bh_platform_destroy()
-{}
+{
+}
 
 int
 os_printf(const char *format, ...)

--- a/core/shared/platform/include/platform_common.h
+++ b/core/shared/platform/include/platform_common.h
@@ -19,11 +19,11 @@ extern "C" {
 #define BHT_TIMED_OUT (1)
 #define BHT_OK (0)
 
-#define BHT_WAIT_FOREVER ((uint64)-1LL)
+#define BHT_WAIT_FOREVER ((uint64) - 1LL)
 
 #define BH_KB (1024)
-#define BH_MB ((BH_KB)*1024)
-#define BH_GB ((BH_MB)*1024)
+#define BH_MB ((BH_KB) * 1024)
+#define BH_GB ((BH_MB) * 1024)
 
 #ifndef BH_MALLOC
 #define BH_MALLOC os_malloc
@@ -39,11 +39,15 @@ extern "C" {
 
 #if defined(_MSC_BUILD)
 #if defined(COMPILING_WASM_RUNTIME_API)
-__declspec(dllexport) void *BH_MALLOC(unsigned int size);
-__declspec(dllexport) void BH_FREE(void *ptr);
+__declspec(dllexport) void *
+BH_MALLOC(unsigned int size);
+__declspec(dllexport) void
+BH_FREE(void *ptr);
 #else
-__declspec(dllimport) void *BH_MALLOC(unsigned int size);
-__declspec(dllimport) void BH_FREE(void *ptr);
+__declspec(dllimport) void *
+BH_MALLOC(unsigned int size);
+__declspec(dllimport) void
+BH_FREE(void *ptr);
 #endif
 #else
 void *
@@ -54,7 +58,8 @@ BH_FREE(void *ptr);
 
 #if defined(BH_VPRINTF)
 #if defined(MSVC)
-__declspec(dllimport) int BH_VPRINTF(const char *format, va_list ap);
+__declspec(dllimport) int
+BH_VPRINTF(const char *format, va_list ap);
 #else
 int
 BH_VPRINTF(const char *format, va_list ap);

--- a/core/shared/platform/linux-sgx/sgx_file.h
+++ b/core/shared/platform/linux-sgx/sgx_file.h
@@ -63,13 +63,13 @@ extern "C" {
 #define SEEK_CUR 1
 #define SEEK_END 2
 
-#define S_ISDIR(mode) (((mode)&S_IFMT) == S_IFDIR)
-#define S_ISCHR(mode) (((mode)&S_IFMT) == S_IFCHR)
-#define S_ISBLK(mode) (((mode)&S_IFMT) == S_IFBLK)
-#define S_ISREG(mode) (((mode)&S_IFMT) == S_IFREG)
-#define S_ISFIFO(mode) (((mode)&S_IFMT) == S_IFIFO)
-#define S_ISLNK(mode) (((mode)&S_IFMT) == S_IFLNK)
-#define S_ISSOCK(mode) (((mode)&S_IFMT) == S_IFSOCK)
+#define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
+#define S_ISCHR(mode) (((mode) & S_IFMT) == S_IFCHR)
+#define S_ISBLK(mode) (((mode) & S_IFMT) == S_IFBLK)
+#define S_ISREG(mode) (((mode) & S_IFMT) == S_IFREG)
+#define S_ISFIFO(mode) (((mode) & S_IFMT) == S_IFIFO)
+#define S_ISLNK(mode) (((mode) & S_IFMT) == S_IFLNK)
+#define S_ISSOCK(mode) (((mode) & S_IFMT) == S_IFSOCK)
 
 #define DT_UNKNOWN 0
 #define DT_FIFO 1

--- a/core/shared/platform/linux-sgx/sgx_thread.c
+++ b/core/shared/platform/linux-sgx/sgx_thread.c
@@ -213,7 +213,8 @@ os_thread_get_stack_boundary()
 
 void
 os_thread_jit_write_protect_np(bool enabled)
-{}
+{
+}
 
 int
 os_rwlock_init(korp_rwlock *lock)

--- a/core/shared/platform/linux/platform_init.c
+++ b/core/shared/platform/linux/platform_init.c
@@ -13,7 +13,8 @@ bh_platform_init()
 
 void
 bh_platform_destroy()
-{}
+{
+}
 
 int
 os_printf(const char *format, ...)

--- a/core/shared/platform/nuttx/nuttx_platform.c
+++ b/core/shared/platform/nuttx/nuttx_platform.c
@@ -20,7 +20,8 @@ bh_platform_init()
 
 void
 bh_platform_destroy()
-{}
+{
+}
 
 void *
 os_malloc(unsigned size)
@@ -287,7 +288,8 @@ getaddrinfo(FAR const char *nodename, FAR const char *servname,
 
 void
 freeaddrinfo(FAR struct addrinfo *ai)
-{}
+{
+}
 
 int
 setsockopt(int sockfd, int level, int option, FAR const void *value,

--- a/core/shared/platform/riot/riot_platform.c
+++ b/core/shared/platform/riot/riot_platform.c
@@ -94,7 +94,8 @@ os_dcache_flush(void)
 
 void
 os_icache_flush(void *start, size_t len)
-{}
+{
+}
 
 os_raw_file_handle
 os_invalid_raw_handle(void)

--- a/core/shared/platform/riot/riot_thread.c
+++ b/core/shared/platform/riot/riot_thread.c
@@ -433,4 +433,5 @@ os_thread_get_stack_boundary()
 
 void
 os_thread_jit_write_protect_np(bool enabled)
-{}
+{
+}

--- a/core/shared/platform/rt-thread/rtt_platform.c
+++ b/core/shared/platform/rt-thread/rtt_platform.c
@@ -21,7 +21,8 @@ bh_platform_init(void)
 
 void
 bh_platform_destroy(void)
-{}
+{
+}
 
 void *
 os_malloc(unsigned size)
@@ -179,11 +180,13 @@ os_mprotect(void *addr, size_t size, int prot)
 
 void
 os_dcache_flush(void)
-{}
+{
+}
 
 void
 os_icache_flush(void *start, size_t len)
-{}
+{
+}
 
 int
 os_getpagesize(void)

--- a/core/shared/platform/rt-thread/rtt_thread.c
+++ b/core/shared/platform/rt-thread/rtt_thread.c
@@ -186,7 +186,8 @@ os_thread_get_stack_boundary(void)
 
 void
 os_thread_jit_write_protect_np(bool enabled)
-{}
+{
+}
 
 int
 os_mutex_init(korp_mutex *mutex)

--- a/core/shared/platform/vxworks/platform_init.c
+++ b/core/shared/platform/vxworks/platform_init.c
@@ -13,7 +13,8 @@ bh_platform_init()
 
 void
 bh_platform_destroy()
-{}
+{
+}
 
 int
 os_printf(const char *format, ...)

--- a/core/shared/platform/windows/platform_init.c
+++ b/core/shared/platform/windows/platform_init.c
@@ -72,8 +72,10 @@ os_getpagesize()
 
 void
 os_dcache_flush(void)
-{}
+{
+}
 
 void
 os_icache_flush(void *start, size_t len)
-{}
+{
+}

--- a/core/shared/platform/windows/win_thread.c
+++ b/core/shared/platform/windows/win_thread.c
@@ -830,7 +830,8 @@ os_thread_get_stack_boundary()
 
 void
 os_thread_jit_write_protect_np(bool enabled)
-{}
+{
+}
 
 #ifdef OS_ENABLE_HW_BOUND_CHECK
 static os_thread_local_attribute bool thread_signal_inited = false;

--- a/core/shared/platform/zephyr/zephyr_thread.c
+++ b/core/shared/platform/zephyr/zephyr_thread.c
@@ -586,7 +586,8 @@ os_thread_get_stack_boundary()
 
 void
 os_thread_jit_write_protect_np(bool enabled)
-{}
+{
+}
 
 int
 os_rwlock_init(korp_rwlock *lock)


### PR DESCRIPTION
## Summary

Moves the coding-guidelines gate to **ubuntu-24.04** and bumps its formatter from **clang-format-14 to clang-format-18** — the version preinstalled on that runner image — and reformats the tree to match. The clang-format slice of #4983.

## What changed

- **Commit 1 (config):** `coding_guidelines.yml` runs on `ubuntu-24.04`; `coding_guidelines_check.py` and the pre-commit sample pin clang-format-18 / git-clang-format-18. **No install step** — clang-format-18 ships with the 24.04 image, exactly as clang-format-14 shipped with 22.04, so there is no external package download. `.clang-format`'s version note is updated (and its `clang-formt` typo fixed).
- **Commit 2 (reformat):** mechanical `clang-format-18 -i` over the coding-guidelines-checked sources.

## Noise: small

Only **39 of 441 files (~205 lines)** change — the code was already close to the clang-format-18 style, and `.clang-format` needs no option changes. Kept as a standalone reformat commit for easy review.

## Notes

Preferring the runner-preinstalled clang-format-18 avoids any external LLVM download (the tarball fetch behind disk-space failures elsewhere in CI). This is the clang-format half of #4983; the clang-tidy bump + curation is a separate follow-up (clang-tidy-18's `misc-include-cleaner` alone flags ~1,750 pre-existing diagnostics under the current `.clang-tidy` wildcards, so that config needs re-tuning first).
