### PR TITLE
ci: align actions/cache consumers to v6 to match the LLVM cache producer

### DIFF
--- a/.github/workflows/compilation_on_android_ubuntu.yml
+++ b/.github/workflows/compilation_on_android_ubuntu.yml
@@ -106,7 +106,7 @@ jobs:
       # it is hard to use `format` to assemble the cache key
       - name: Get LLVM libraries
         id: retrieve_llvm_libs
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ./core/deps/llvm/build/bin
@@ -277,7 +277,7 @@ jobs:
       - name: Get LLVM libraries
         id: retrieve_llvm_libs
         if: endsWith(matrix.make_options_run_mode, '_JIT_BUILD_OPTIONS')
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ./core/deps/llvm/build/bin
@@ -328,7 +328,7 @@ jobs:
 
       - name: Get LLVM libraries
         id: retrieve_llvm_libs
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ./core/deps/llvm/build/bin
@@ -385,7 +385,7 @@ jobs:
 
       - name: Get LLVM libraries
         id: retrieve_llvm_libs
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ./core/deps/llvm/build/bin
@@ -451,7 +451,7 @@ jobs:
       - name: Get LLVM libraries
         id: retrieve_llvm_libs
         if: (!endsWith(matrix.make_options, '_INTERP_BUILD_OPTIONS'))
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ./core/deps/llvm/build/bin
@@ -507,7 +507,7 @@ jobs:
 
       - name: Get LLVM libraries
         id: retrieve_llvm_libs
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ./core/deps/llvm/build/bin
@@ -731,7 +731,7 @@ jobs:
       - name: Get LLVM libraries
         if: env.USE_LLVM == 'true'
         id: retrieve_llvm_libs
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ./core/deps/llvm/build/bin

--- a/.github/workflows/compilation_on_macos.yml
+++ b/.github/workflows/compilation_on_macos.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Get LLVM libraries
         id: retrieve_llvm_libs
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ./core/deps/llvm/build/bin
@@ -197,7 +197,7 @@ jobs:
       - name: Get LLVM libraries
         id: retrieve_llvm_libs
         if: endsWith(matrix.make_options_run_mode, '_JIT_BUILD_OPTIONS')
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ./core/deps/llvm/build/bin
@@ -258,7 +258,7 @@ jobs:
       - name: Get LLVM libraries
         id: retrieve_llvm_libs
         if: (!endsWith(matrix.make_options, '_INTERP_BUILD_OPTIONS'))
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ./core/deps/llvm/build/bin
@@ -366,7 +366,7 @@ jobs:
 
       - name: Get LLVM libraries
         id: retrieve_llvm_libs
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ./core/deps/llvm/build/bin

--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -73,7 +73,7 @@ jobs:
       # it is hard to use `format` to assemble the cache key
       - name: Get LLVM libraries
         id: retrieve_llvm_libs
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ./core/deps/llvm/build/bin
@@ -241,7 +241,7 @@ jobs:
       - name: Get LLVM libraries
         id: retrieve_llvm_libs
         if: endsWith(matrix.make_options_run_mode, '_JIT_BUILD_OPTIONS')
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ./core/deps/llvm/build/bin
@@ -292,7 +292,7 @@ jobs:
 
       - name: Get LLVM libraries
         id: retrieve_llvm_libs
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ./core/deps/llvm/build/bin
@@ -475,7 +475,7 @@ jobs:
       - name: Get LLVM libraries
         id: retrieve_llvm_libs
         if: (!endsWith(matrix.make_options, '_INTERP_BUILD_OPTIONS'))
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ./core/deps/llvm/build/bin
@@ -532,7 +532,7 @@ jobs:
         
       - name: Get LLVM libraries
         id: retrieve_llvm_libs
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ./core/deps/llvm/build/bin
@@ -791,7 +791,7 @@ jobs:
       - name: Get LLVM libraries
         if: env.USE_LLVM == 'true'
         id: retrieve_llvm_libs
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ./core/deps/llvm/build/bin


### PR DESCRIPTION
## Problem

On `main`, the entire `ubuntu-22.04, linux` build matrix is red — every `build_iwasm` config plus `build_wamrc (ubuntu-22.04)` and `build_regression_tests (ubuntu-22.04)` — failing with:

```
##[error]can not get prebuilt llvm libraries
```

The macOS LLVM-cache jobs fail the same way (issue #4830).

## Root cause

`build_llvm_libraries.yml` (the cache **producer**) saves the prebuilt-LLVM cache with **`actions/cache@v6`**, but three **consumer** workflows still restore it with **`actions/cache@v5`**:

| workflow | `actions/cache` |
|---|---|
| `build_llvm_libraries.yml` (producer) | **v6** |
| `compilation_on_android_ubuntu.yml` | **v5** ← ubuntu-22.04 matrix |
| `compilation_on_macos.yml` | **v5** ← #4830 |
| `nightly_run.yml` | **v5** |
| sgx / nuttx / windows / wamrc / lldb / iwasm_release | v6 (these pass) |

A cache archive written by v6 is reported to a v5 consumer as a metadata **hit**, then **fails to restore**:

```
Cache hit for: 0-llvm-libraries-ubuntu-22.04-X86-<hash>
##[warning]Failed to restore:
Cache not found for input keys: 0-llvm-libraries-ubuntu-22.04-X86-<hash>
```

…which trips the `can not get prebuilt llvm libraries` guard, so every LLVM-consuming leg fails. The consumers already on v6 restore the *same* archive without issue — which is the evidence that v6-producer + v6-consumer is the working combination.

## Fix

Bump the three lagging consumers to `actions/cache@v6` so the producer and all consumers share one cache version (17 one-line changes, no other behavior change).

Fixes the ubuntu-22.04 build matrix on `main` and the recurring macOS LLVM-cache failures tracked in #4830.
