### PR TITLE
aot: pin host CPU features for the default native target (fix SIGILL on AVX-512-masked runners)

### DIFF
--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -2632,7 +2632,7 @@ aot_create_comp_context(const AOTCompData *comp_data, aot_comp_option_t option)
     LLVMTargetRef target;
     char *triple = NULL, *triple_norm, *arch, *abi;
     char *cpu = NULL, *features, buf[128];
-    char *triple_norm_new = NULL, *cpu_new = NULL;
+    char *triple_norm_new = NULL, *cpu_new = NULL, *features_new = NULL;
     char *err = NULL, *fp_round = "round.tonearest",
          *fp_exce = "fpexcept.strict";
     char triple_buf[128] = { 0 }, features_buf[128] = { 0 };
@@ -3115,6 +3115,15 @@ aot_create_comp_context(const AOTCompData *comp_data, aot_comp_option_t option)
                 aot_set_last_error("llvm get host cpu name failed.");
                 goto fail;
             }
+            /* Also pin the host CPU's actually-enabled features. The CPU name
+             * alone (e.g. "znver4") makes LLVM enable every feature that model
+             * implies, including AVX-512; but a virtualized host can have those
+             * masked out of cpuid, so without the real feature string the AOT
+             * code may emit instructions the running CPU rejects with SIGILL.
+             * LLVMGetHostCPUFeatures() reflects what is actually enabled, and
+             * this mirrors the JIT target-machine setup. */
+            if (!features)
+                features = features_new = LLVMGetHostCPUFeatures();
         }
         else if (triple) {
             /* Normalize a target triple */
@@ -3499,6 +3508,9 @@ fail:
 
     if (cpu_new)
         LLVMDisposeMessage(cpu_new);
+
+    if (features_new)
+        LLVMDisposeMessage(features_new);
 
     if (!ret)
         aot_destroy_comp_context(comp_ctx);


### PR DESCRIPTION
## Problem

On the current ubuntu-22.04 (and macOS) GitHub-hosted runners, AOT-compiled modules that use SIMD crash at runtime with **SIGILL**. It shows up in `build_regression_tests` — four `ba-issues` SIMD cases (#2833, #270801, #270802, #2702) fail with exit `-4` — and is tracked in #4997.

## Root cause

When `wamrc` runs with no `--target` and no `--cpu`, `aot_create_comp_context` picks the target CPU with `LLVMGetHostCPUName()` but leaves the feature string empty:

```c
if (!triple && !cpu) {
    triple = LLVMGetDefaultTargetTriple();
    cpu    = LLVMGetHostCPUName();   /* e.g. "znver4" */
    /* features left empty */
}
```

Given a CPU *name* but no feature string, LLVM turns on **every feature that model implies — including AVX-512**. GitHub now backs some ubuntu-22.04 runners with **AMD EPYC 9V74 (Zen 4)** VMs whose reported CPU name implies AVX-512 but which have AVX-512 **masked out of cpuid**, so the AOT module ends up with AVX-512 instructions the running CPU can't execute.

Captured on a runner under gdb:

```
Program received signal SIGILL, Illegal instruction.
=> 0x40006878:  vcmpordpd %xmm1,%xmm0,%k1      # writes an AVX-512 mask register
```

with `vmovdqa64 %zmm0{%k1}{z}`, `vpternlogd`, `vextracti64x4` in the emitted object, while `/proc/cpuinfo` on that VM lists no `avx512*` flags.

## Fix

In that default native path, also query `LLVMGetHostCPUFeatures()` so the emitted code matches the features **actually enabled** on the host (AVX-512 masked off) — mirroring what the JIT target-machine setup already does. Explicit `--cpu` / `--cpu-features` and cross-target (`--target`) builds are unaffected.

## Verification

Rebuilt `wamrc` with the fix on an EPYC 9V74 runner and recompiled the failing case:

- **no AVX-512** instructions remain in the emitted object;
- the AOT runs to completion (**exit 0**) with the expected `…:v128` output — no SIGILL.

Fixes #4997.
