### PR TITLE
Fix stack-passed arguments on Darwin (AArch64)

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -6127,6 +6127,61 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
 
     ints[n_ints++] = (uint64)(uintptr_t)exec_env;
 
+#if defined(BH_PLATFORM_DARWIN) && defined(BUILD_TARGET_AARCH64)
+    uint8 *stack_base = (uint8 *)stacks;
+    uint32 stack_offset = 0;
+
+#define STK_PUSH_I32(val)                                   \
+    *(uint32 *)(stack_base + stack_offset) = (uint32)(val); \
+    stack_offset += 4
+
+#define STK_PUSH_I64(val)                                   \
+    stack_offset = (stack_offset + 7) & ~7;                 \
+    *(uint64 *)(stack_base + stack_offset) = (uint64)(val); \
+    stack_offset += 8
+
+#define STK_PUSH_F32(val)                                     \
+    *(float32 *)(stack_base + stack_offset) = (float32)(val); \
+    stack_offset += 4
+
+#define STK_PUSH_F64(val)                                     \
+    stack_offset = (stack_offset + 7) & ~7;                   \
+    *(float64 *)(stack_base + stack_offset) = (float64)(val); \
+    stack_offset += 8
+
+#define STK_PUSH_PTR(val) STK_PUSH_I64((uint64)(uintptr_t)(val))
+
+#if WASM_ENABLE_SIMD != 0
+#define STK_PUSH_V128(val)                              \
+    stack_offset = (stack_offset + 15) & ~15;           \
+    *(v128 *)(stack_base + stack_offset) = (v128)(val); \
+    stack_offset += 16
+#endif
+
+#define STK_FINALIZE() (n_stacks = (stack_offset + 7) >> 3)
+
+#else
+#define STK_PUSH_I32(val) (stacks[n_stacks++] = (uint64)(val))
+#define STK_PUSH_I64(val) (stacks[n_stacks++] = (uint64)(val))
+#define STK_PUSH_F32(val) (*(float32 *)&stacks[n_stacks++] = (float32)(val))
+#define STK_PUSH_F64(val) (*(float64 *)&stacks[n_stacks++] = (float64)(val))
+#define STK_PUSH_PTR(val) (stacks[n_stacks++] = (uint64)(uintptr_t)(val))
+
+#if WASM_ENABLE_SIMD != 0
+#if defined(_WIN32) || defined(_WIN32_)
+#define STK_PUSH_V128(val)                \
+    *(v128 *)&stacks[n_stacks++] = (val); \
+    n_stacks++
+#else
+#define STK_PUSH_V128(val)                      \
+    *(v128 *)&stacks[n_stacks++] = (v128)(val); \
+    n_stacks++
+#endif
+#endif
+
+#define STK_FINALIZE()
+#endif
+
     for (i = 0; i < func_type->param_count; i++) {
         switch (func_type->types[i]) {
             case VALUE_TYPE_I32:
@@ -6134,6 +6189,7 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
             case VALUE_TYPE_FUNCREF:
 #endif
             {
+                bool is_ptr = false;
                 arg_i32 = *argv_src++;
                 arg_i64 = arg_i32;
                 if (signature
@@ -6156,6 +6212,7 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
 
                         arg_i64 = (uintptr_t)wasm_runtime_addr_app_to_native(
                             module, (uint64)arg_i32);
+                        is_ptr = true;
                     }
                     else if (signature[i + 1] == '$') {
                         /* param is a string */
@@ -6165,17 +6222,25 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
 
                         arg_i64 = (uintptr_t)wasm_runtime_addr_app_to_native(
                             module, (uint64)arg_i32);
+                        is_ptr = true;
                     }
                 }
                 if (n_ints < MAX_REG_INTS)
                     ints[n_ints++] = arg_i64;
-                else
-                    stacks[n_stacks++] = arg_i64;
+                else {
+                    if (is_ptr) {
+                        STK_PUSH_PTR(arg_i64);
+                    }
+                    else {
+                        STK_PUSH_I32(arg_i64);
+                    }
+                }
                 break;
             }
             case VALUE_TYPE_I64:
 #if WASM_ENABLE_MEMORY64 != 0
             {
+                bool is_ptr = false;
                 arg_i64 = GET_I64_FROM_ADDR(argv_src);
                 argv_src += 2;
                 if (signature && is_memory64) {
@@ -6197,6 +6262,7 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
 
                         arg_i64 = (uint64)wasm_runtime_addr_app_to_native(
                             module, arg_i64);
+                        is_ptr = true;
                     }
                     else if (signature[i + 1] == '$') {
                         /* param is a string */
@@ -6206,12 +6272,19 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
 
                         arg_i64 = (uint64)wasm_runtime_addr_app_to_native(
                             module, arg_i64);
+                        is_ptr = true;
                     }
                 }
                 if (n_ints < MAX_REG_INTS)
                     ints[n_ints++] = arg_i64;
-                else
-                    stacks[n_stacks++] = arg_i64;
+                else {
+                    if (is_ptr) {
+                        STK_PUSH_PTR(arg_i64);
+                    }
+                    else {
+                        STK_PUSH_I64(arg_i64);
+                    }
+                }
                 break;
             }
 #endif
@@ -6237,8 +6310,9 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
 #endif
                 if (n_ints < MAX_REG_INTS)
                     ints[n_ints++] = *(uint64 *)argv_src;
-                else
-                    stacks[n_stacks++] = *(uint64 *)argv_src;
+                else {
+                    STK_PUSH_I64(*(uint64 *)argv_src);
+                }
                 argv_src += 2;
                 break;
             case VALUE_TYPE_F32:
@@ -6246,7 +6320,7 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
                     *(float32 *)&fps[n_fps++] = *(float32 *)argv_src++;
                 }
                 else {
-                    *(float32 *)&stacks[n_stacks++] = *(float32 *)argv_src++;
+                    STK_PUSH_F32(*(float32 *)argv_src++);
                 }
                 break;
             case VALUE_TYPE_F64:
@@ -6254,7 +6328,7 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
                     *(float64 *)&fps[n_fps++] = *(float64 *)argv_src;
                 }
                 else {
-                    *(float64 *)&stacks[n_stacks++] = *(float64 *)argv_src;
+                    STK_PUSH_F64(*(float64 *)argv_src);
                 }
                 argv_src += 2;
                 break;
@@ -6265,8 +6339,9 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
                 if (is_aot_func) {
                     if (n_ints < MAX_REG_INTS)
                         ints[n_ints++] = externref_idx;
-                    else
-                        stacks[n_stacks++] = externref_idx;
+                    else {
+                        STK_PUSH_I32(externref_idx);
+                    }
                 }
                 else {
                     void *externref_obj;
@@ -6276,8 +6351,9 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
 
                     if (n_ints < MAX_REG_INTS)
                         ints[n_ints++] = (uintptr_t)externref_obj;
-                    else
-                        stacks[n_stacks++] = (uintptr_t)externref_obj;
+                    else {
+                        STK_PUSH_PTR(externref_obj);
+                    }
                 }
                 break;
             }
@@ -6288,8 +6364,7 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
                     *(v128 *)&fps[n_fps++] = *(v128 *)argv_src;
                 }
                 else {
-                    *(v128 *)&stacks[n_stacks++] = *(v128 *)argv_src;
-                    n_stacks++;
+                    STK_PUSH_V128(*(v128 *)argv_src);
                 }
                 argv_src += 4;
                 break;
@@ -6304,10 +6379,23 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
     for (i = 0; i < ext_ret_count; i++) {
         if (n_ints < MAX_REG_INTS)
             ints[n_ints++] = *(uint64 *)argv_src;
-        else
-            stacks[n_stacks++] = *(uint64 *)argv_src;
+        else {
+            STK_PUSH_PTR(*(uint64 *)argv_src);
+        }
         argv_src += 2;
     }
+
+    STK_FINALIZE();
+
+#undef STK_PUSH_I32
+#undef STK_PUSH_I64
+#undef STK_PUSH_F32
+#undef STK_PUSH_F64
+#undef STK_PUSH_PTR
+#if WASM_ENABLE_SIMD != 0
+#undef STK_PUSH_V128
+#endif
+#undef STK_FINALIZE
 
     exec_env->attachment = attachment;
     if (result_count == 0) {

--- a/tests/standalone/test-invoke-native/main.c
+++ b/tests/standalone/test-invoke-native/main.c
@@ -11,8 +11,7 @@
 
 static char global_heap_buf[10 * 1024 * 1024] = { 0 };
 
-void
-test_invoke_native();
+#include "test_invoke_native.h"
 
 int
 main(int argc, char *argv[])
@@ -31,9 +30,9 @@ main(int argc, char *argv[])
         return -1;
     }
 
-    test_invoke_native();
+    int failed = test_invoke_native();
 
     /* destroy runtime environment */
     wasm_runtime_destroy();
-    return 0;
+    return failed > 0 ? -1 : 0;
 }

--- a/tests/standalone/test-invoke-native/run.sh
+++ b/tests/standalone/test-invoke-native/run.sh
@@ -16,16 +16,11 @@ elif [[ $1 == "--multi-tier-jit" ]]; then
     CMAKE_FLAGS="-DWAMR_BUILD_FAST_JIT=1 -DWAMR_BUILD_JIT=1"
 fi
 
-TARGET="X86_64"
-if [[ $3 = "X86_32" ]]; then
-    TARGET="X86_32"
-fi
-
 echo "============> test dump-invoke-native"
 
 rm -fr build
 mkdir build && cd build
-cmake .. ${CMAKE_FLAGS} -DWAMR_BUILD_TARGET=${TARGET}
+cmake .. ${CMAKE_FLAGS}
 make -j ${nproc} > /dev/null 2>&1
 cd ..
 

--- a/tests/standalone/test-invoke-native/test_invoke_native.c
+++ b/tests/standalone/test-invoke-native/test_invoke_native.c
@@ -4,203 +4,605 @@
  */
 
 #include "wasm_runtime.h"
+#include "test_invoke_native.h"
+#include <string.h>
+#include <stdlib.h>
 
-static void
-test_native_args1(WASMModuleInstance *module_inst, int arg0, uint64_t arg1,
-                  float arg2, double arg3, int arg4, int64_t arg5, int64_t arg6,
-                  int arg7, double arg8, float arg9, int arg10, double arg11,
-                  float arg12, int64_t arg13, uint64_t arg14, float arg15,
-                  double arg16, int64_t arg17, uint64_t arg18, float arg19)
-{
-    printf("##test_native_args1 result:\n");
-    printf("arg0: 0x%X, arg1: 0x%X%08X, arg2: %f, arg3: %f\n", arg0,
-           (int32)(arg1 >> 32), (int32)arg1, arg2, arg3);
-    printf("arg4: 0x%X, arg5: 0x%X%08X, arg6: 0x%X%08X, arg7: 0x%X\n", arg4,
-           (int32)(arg5 >> 32), (int32)arg5, (int32)(arg6 >> 32), (int32)arg6,
-           arg7);
-    printf("arg8: %f, arg9: %f, arg10: 0x%X, arg11: %f\n", arg8, arg9, arg10,
-           arg11);
-    printf("arg12: %f, arg13: 0x%X%08X, arg14: 0x%X%08X, arg15: %f\n", arg12,
-           (int32)(arg13 >> 32), (int32)arg13, (int32)(arg14 >> 32),
-           (int32)arg14, arg15);
-    printf("arg16: %f, arg17: 0x%X%08X, arg18: 0x%X%08X, arg19: %f\n", arg16,
-           (int32)(arg17 >> 32), (int32)arg17, (int32)(arg18 >> 32),
-           (int32)arg18, arg19);
-}
+#ifdef STORE_I64
+#undef STORE_I64
+#endif
+#ifdef STORE_F64
+#undef STORE_F64
+#endif
 
-static void
-test_native_args2(WASMModuleInstance *module_inst, uint64_t arg1, float arg2,
-                  double arg3, int arg4, int64_t arg5, int64_t arg6, int arg7,
-                  double arg8, float arg9, int arg10, double arg11, float arg12,
-                  int64_t arg13, uint64_t arg14, float arg15, double arg16,
-                  int64_t arg17, uint64_t arg18, float arg19)
-{
-    printf("##test_native_args2 result:\n");
-    printf("arg1: 0x%X%08X, arg2: %f, arg3: %f\n", (int32)(arg1 >> 32),
-           (int32)arg1, arg2, arg3);
-    printf("arg4: 0x%X, arg5: 0x%X%08X, arg6: 0x%X%08X, arg7: 0x%X\n", arg4,
-           (int32)(arg5 >> 32), (int32)arg5, (int32)(arg6 >> 32), (int32)arg6,
-           arg7);
-    printf("arg8: %f, arg9: %f, arg10: 0x%X, arg11: %f\n", arg8, arg9, arg10,
-           arg11);
-    printf("arg12: %f, arg13: 0x%X%08X, arg14: 0x%X%08X, arg15: %f\n", arg12,
-           (int32)(arg13 >> 32), (int32)arg13, (int32)(arg14 >> 32),
-           (int32)arg14, arg15);
-    printf("arg16: %f, arg17: 0x%X%08X, arg18: 0x%X%08X, arg19: %f\n", arg16,
-           (int32)(arg17 >> 32), (int32)arg17, (int32)(arg18 >> 32),
-           (int32)arg18, arg19);
-}
+#define STORE_I64(addr, value)                                              \
+    ((void)(((uint32 *)(addr))[0] = (uint32)((uint64)(value) & 0xFFFFFFFF), \
+            ((uint32 *)(addr))[1] = (uint32)((uint64)(value) >> 32)))
 
-static int32
-test_return_i32(WASMModuleInstance *module_inst)
-{
-    return 0x12345678;
-}
-
-static int64
-test_return_i64(WASMModuleInstance *module_inst)
-{
-    return 0x12345678ABCDEFFFll;
-}
-
-static float32
-test_return_f32(WASMModuleInstance *module_inst)
-{
-    return 1234.5678f;
-}
-
-static float64
-test_return_f64(WASMModuleInstance *module_inst)
-{
-    return 87654321.12345678;
-}
-
-#define STORE_I64(addr, value)  \
-    do {                        \
-        union {                 \
-            int64 val;          \
-            uint32 parts[2];    \
-        } u;                    \
-        u.val = (int64)(value); \
-        (addr)[0] = u.parts[0]; \
-        (addr)[1] = u.parts[1]; \
-    } while (0)
-
-#define STORE_F64(addr, value)  \
-    do {                        \
-        union {                 \
-            float64 val;        \
-            uint32 parts[2];    \
-        } u;                    \
-        u.val = (value);        \
-        (addr)[0] = u.parts[0]; \
-        (addr)[1] = u.parts[1]; \
-    } while (0)
+#define STORE_F64(addr, value)                                       \
+    ((void)(((uint32 *)(addr))[0] = ((uint32 *)(void *)&(value))[0], \
+            ((uint32 *)(addr))[1] = ((uint32 *)(void *)&(value))[1]))
 
 #define I32 VALUE_TYPE_I32
 #define I64 VALUE_TYPE_I64
 #define F32 VALUE_TYPE_F32
 #define F64 VALUE_TYPE_F64
 
-typedef struct WASMTypeTest {
-    uint16 param_count;
-    /* only one result is supported currently */
-    uint16 result_count;
-    uint16 param_cell_num;
-    uint16 ret_cell_num;
-    /* types of params and results */
-    uint8 types[128];
-} WASMTypeTest;
+typedef struct TestVal {
+    union {
+        int32 i32;
+        int64 i64;
+        float32 f32;
+        float64 f64;
+    } u;
+    uint8 type;
+} TestVal;
 
-void
+#define T_I32(X) { { .i32 = (int32)(X) }, VALUE_TYPE_I32 }
+#define T_I64(X) { { .i64 = (int64)(X) }, VALUE_TYPE_I64 }
+#define T_F32(X) { { .f32 = (float32)(X) }, VALUE_TYPE_F32 }
+#define T_F64(X) { { .f64 = (float64)(X) }, VALUE_TYPE_F64 }
+
+static WASMFuncType *
+create_func_type(uint32 param_count, uint32 result_count,
+                 const uint8 *param_types, const uint8 *result_types)
+{
+    WASMFuncType *ft =
+        malloc(sizeof(WASMFuncType) + param_count + result_count);
+    if (!ft)
+        return NULL;
+    memset(ft, 0, sizeof(WASMFuncType) + param_count + result_count);
+    ft->param_count = param_count;
+    ft->result_count = result_count;
+    for (uint32 i = 0; i < param_count; i++) {
+        ft->types[i] = param_types[i];
+    }
+    for (uint32 i = 0; i < result_count; i++) {
+        ft->types[param_count + i] = result_types[i];
+    }
+    return ft;
+}
+
+static struct {
+    int call_count;
+    int i32_vals[16];
+    int64 i64_vals[16];
+    float f32_vals[16];
+    double f64_vals[16];
+    int mixed_i32[16];
+    int64 mixed_i64[16];
+    float mixed_f32[16];
+    double mixed_f64[16];
+} g_test_results;
+
+static int g_test_failed = 0;
+static int passed_tests = 0;
+static int failed_tests = 0;
+
+static void
+test_eq(long long val, long long expected, int line)
+{
+    if (val != expected) {
+        printf("  FAIL: line %d: expected %lld, got %lld\n", line, expected,
+               val);
+        g_test_failed = 1;
+    }
+}
+
+static void
+test_float_eq(double val, double expected, int line)
+{
+    double diff = val - expected;
+    if (diff < 0)
+        diff = -diff;
+    if (diff > 0.0001) {
+        printf("  FAIL: line %d: expected %f, got %f\n", line, expected, val);
+        g_test_failed = 1;
+    }
+}
+
+#define TEST_EQ(val, expected) \
+    test_eq((long long)(val), (long long)(expected), __LINE__)
+#define TEST_FLOAT_EQ(val, expected) \
+    test_float_eq((double)(val), (double)(expected), __LINE__)
+
+/* --- Native test functions --- */
+
+static void
+native_i32_overflow(WASMExecEnv *exec_env, int r0, int r1, int r2, int r3,
+                    int r4, int r5, int r6, int s0, int s1, int s2, int s3)
+{
+    g_test_results.call_count++;
+    g_test_results.i32_vals[0] = r0;
+    g_test_results.i32_vals[1] = r1;
+    g_test_results.i32_vals[2] = r2;
+    g_test_results.i32_vals[3] = r3;
+    g_test_results.i32_vals[4] = r4;
+    g_test_results.i32_vals[5] = r5;
+    g_test_results.i32_vals[6] = r6;
+    g_test_results.i32_vals[7] = s0;
+    g_test_results.i32_vals[8] = s1;
+    g_test_results.i32_vals[9] = s2;
+    g_test_results.i32_vals[10] = s3;
+}
+
+static void
+native_i64_overflow(WASMExecEnv *exec_env, int64 r0, int64 r1, int64 r2,
+                    int64 r3, int64 r4, int64 r5, int64 r6, int64 s0, int64 s1,
+                    int64 s2, int64 s3)
+{
+    g_test_results.call_count++;
+    g_test_results.i64_vals[0] = r0;
+    g_test_results.i64_vals[1] = r1;
+    g_test_results.i64_vals[2] = r2;
+    g_test_results.i64_vals[3] = r3;
+    g_test_results.i64_vals[4] = r4;
+    g_test_results.i64_vals[5] = r5;
+    g_test_results.i64_vals[6] = r6;
+    g_test_results.i64_vals[7] = s0;
+    g_test_results.i64_vals[8] = s1;
+    g_test_results.i64_vals[9] = s2;
+    g_test_results.i64_vals[10] = s3;
+}
+
+static void
+native_i32_i32_i64_on_stack(WASMExecEnv *exec_env, int r0, int r1, int r2,
+                            int r3, int r4, int r5, int r6, int s0, int s1,
+                            int64 s2)
+{
+    g_test_results.call_count++;
+    g_test_results.mixed_i32[0] = r0;
+    g_test_results.mixed_i32[1] = r1;
+    g_test_results.mixed_i32[2] = r2;
+    g_test_results.mixed_i32[3] = r3;
+    g_test_results.mixed_i32[4] = r4;
+    g_test_results.mixed_i32[5] = r5;
+    g_test_results.mixed_i32[6] = r6;
+    g_test_results.mixed_i32[7] = s0;
+    g_test_results.mixed_i32[8] = s1;
+    g_test_results.mixed_i64[0] = s2;
+}
+
+static void
+native_f32_overflow(WASMExecEnv *exec_env, float fr0, float fr1, float fr2,
+                    float fr3, float fr4, float fr5, float fr6, float fr7,
+                    float fs0, float fs1, float fs2, float fs3)
+{
+    g_test_results.call_count++;
+    g_test_results.f32_vals[0] = fr0;
+    g_test_results.f32_vals[1] = fr1;
+    g_test_results.f32_vals[2] = fr2;
+    g_test_results.f32_vals[3] = fr3;
+    g_test_results.f32_vals[4] = fr4;
+    g_test_results.f32_vals[5] = fr5;
+    g_test_results.f32_vals[6] = fr6;
+    g_test_results.f32_vals[7] = fr7;
+    g_test_results.f32_vals[8] = fs0;
+    g_test_results.f32_vals[9] = fs1;
+    g_test_results.f32_vals[10] = fs2;
+    g_test_results.f32_vals[11] = fs3;
+}
+
+static void
+native_f64_overflow(WASMExecEnv *exec_env, double fr0, double fr1, double fr2,
+                    double fr3, double fr4, double fr5, double fr6, double fr7,
+                    double fs0, double fs1, double fs2, double fs3)
+{
+    g_test_results.call_count++;
+    g_test_results.f64_vals[0] = fr0;
+    g_test_results.f64_vals[1] = fr1;
+    g_test_results.f64_vals[2] = fr2;
+    g_test_results.f64_vals[3] = fr3;
+    g_test_results.f64_vals[4] = fr4;
+    g_test_results.f64_vals[5] = fr5;
+    g_test_results.f64_vals[6] = fr6;
+    g_test_results.f64_vals[7] = fr7;
+    g_test_results.f64_vals[8] = fs0;
+    g_test_results.f64_vals[9] = fs1;
+    g_test_results.f64_vals[10] = fs2;
+    g_test_results.f64_vals[11] = fs3;
+}
+
+static void
+native_f32_f32_f64_on_stack(WASMExecEnv *exec_env, float fr0, float fr1,
+                            float fr2, float fr3, float fr4, float fr5,
+                            float fr6, float fr7, float fs0, float fs1,
+                            double fs2)
+{
+    g_test_results.call_count++;
+    g_test_results.f32_vals[0] = fr0;
+    g_test_results.f32_vals[1] = fr1;
+    g_test_results.f32_vals[2] = fr2;
+    g_test_results.f32_vals[3] = fr3;
+    g_test_results.f32_vals[4] = fr4;
+    g_test_results.f32_vals[5] = fr5;
+    g_test_results.f32_vals[6] = fr6;
+    g_test_results.f32_vals[7] = fr7;
+    g_test_results.mixed_f32[0] = fs0;
+    g_test_results.mixed_f32[1] = fs1;
+    g_test_results.mixed_f64[0] = fs2;
+}
+
+static void
+native_mixed_overflow(WASMExecEnv *exec_env, int r0, int r1, int r2, int r3,
+                      int r4, int r5, int r6, float fr0, float fr1, float fr2,
+                      float fr3, float fr4, float fr5, float fr6, float fr7,
+                      int s0, float fs0, int64 s1, double fs1)
+{
+    g_test_results.call_count++;
+    g_test_results.i32_vals[0] = r0;
+    g_test_results.i32_vals[1] = r1;
+    g_test_results.i32_vals[2] = r2;
+    g_test_results.i32_vals[3] = r3;
+    g_test_results.i32_vals[4] = r4;
+    g_test_results.i32_vals[5] = r5;
+    g_test_results.i32_vals[6] = r6;
+
+    g_test_results.f32_vals[0] = fr0;
+    g_test_results.f32_vals[1] = fr1;
+    g_test_results.f32_vals[2] = fr2;
+    g_test_results.f32_vals[3] = fr3;
+    g_test_results.f32_vals[4] = fr4;
+    g_test_results.f32_vals[5] = fr5;
+    g_test_results.f32_vals[6] = fr6;
+    g_test_results.f32_vals[7] = fr7;
+
+    g_test_results.mixed_i32[0] = s0;
+    g_test_results.mixed_f32[0] = fs0;
+    g_test_results.mixed_i64[0] = s1;
+    g_test_results.mixed_f64[0] = fs1;
+}
+
+static void
+native_i32_i64_alignment(WASMExecEnv *exec_env, int r0, int r1, int r2, int r3,
+                         int r4, int r5, int r6, int s0, int64 s1)
+{
+    g_test_results.call_count++;
+    g_test_results.mixed_i32[0] = s0;
+    g_test_results.mixed_i64[0] = s1;
+}
+
+static void
+native_unaligned_total_stack_size(WASMExecEnv *exec_env, int r0, int r1, int r2,
+                                  int r3, int r4, int r5, int r6, int s0,
+                                  int s1, int s2)
+{
+    g_test_results.call_count++;
+    g_test_results.mixed_i32[0] = s0;
+    g_test_results.mixed_i32[1] = s1;
+    g_test_results.mixed_i32[2] = s2;
+}
+
+static void
+native_float_double_alignment(WASMExecEnv *exec_env, float fr0, float fr1,
+                              float fr2, float fr3, float fr4, float fr5,
+                              float fr6, float fr7, float fs0, double fs1)
+{
+    g_test_results.call_count++;
+    g_test_results.mixed_f32[0] = fs0;
+    g_test_results.mixed_f64[0] = fs1;
+}
+
+static int32
+native_return_i32(WASMExecEnv *exec_env)
+{
+    return 0x12345678;
+}
+
+static int64
+native_return_i64(WASMExecEnv *exec_env)
+{
+    return 0x12345678ABCDEFFFll;
+}
+
+static float32
+native_return_f32(WASMExecEnv *exec_env)
+{
+    return 1234.5678f;
+}
+
+static float64
+native_return_f64(WASMExecEnv *exec_env)
+{
+    return 87654321.12345678;
+}
+
+static void
+run_generic_test(WASMExecEnv *exec_env, void *func_ptr, const TestVal *args,
+                 uint32 param_count, uint8 ret_type, uint32 *argv_out)
+{
+    uint32 argv[128];
+    uint32 *p = argv;
+    uint8 *param_types = NULL;
+
+    if (param_count > 0) {
+        param_types = malloc(param_count);
+        if (!param_types)
+            return;
+        for (uint32 i = 0; i < param_count; i++) {
+            param_types[i] = args[i].type;
+            if (args[i].type == VALUE_TYPE_I32) {
+                *p++ = (uint32)args[i].u.i32;
+            }
+            else if (args[i].type == VALUE_TYPE_I64) {
+                STORE_I64(p, args[i].u.i64);
+                p += 2;
+            }
+            else if (args[i].type == VALUE_TYPE_F32) {
+                *(float32 *)p++ = args[i].u.f32;
+            }
+            else if (args[i].type == VALUE_TYPE_F64) {
+                STORE_F64(p, args[i].u.f64);
+                p += 2;
+            }
+        }
+    }
+
+    WASMFuncType *func_type =
+        create_func_type(param_count, ret_type ? 1 : 0, param_types,
+                         ret_type ? &ret_type : NULL);
+    if (param_types) {
+        free(param_types);
+    }
+
+    if (!func_type)
+        return;
+
+    wasm_runtime_invoke_native(exec_env, func_ptr, func_type, NULL, NULL,
+                               param_count > 0 ? argv : NULL, p - argv, argv);
+
+    if (argv_out) {
+        memcpy(argv_out, argv, 8 * sizeof(uint32));
+    }
+
+    free(func_type);
+}
+
+static void
+run_test_i32_overflow(WASMExecEnv *exec_env)
+{
+    TestVal args[] = { T_I32(100), T_I32(101), T_I32(102), T_I32(103),
+                       T_I32(104), T_I32(105), T_I32(106), T_I32(107),
+                       T_I32(108), T_I32(109), T_I32(110) };
+
+    run_generic_test(exec_env, native_i32_overflow, args, 11, 0, NULL);
+
+    TEST_EQ(g_test_results.call_count, 1);
+    for (int i = 0; i < 11; i++) {
+        TEST_EQ(g_test_results.i32_vals[i], 100 + i);
+    }
+}
+
+static void
+run_test_i64_overflow(WASMExecEnv *exec_env)
+{
+    TestVal args[] = { T_I64(200), T_I64(201), T_I64(202), T_I64(203),
+                       T_I64(204), T_I64(205), T_I64(206), T_I64(207),
+                       T_I64(208), T_I64(209), T_I64(210) };
+
+    run_generic_test(exec_env, native_i64_overflow, args, 11, 0, NULL);
+
+    TEST_EQ(g_test_results.call_count, 1);
+    for (int i = 0; i < 11; i++) {
+        TEST_EQ(g_test_results.i64_vals[i], 200 + i);
+    }
+}
+
+static void
+run_test_i32_i32_i64_on_stack(WASMExecEnv *exec_env)
+{
+    TestVal args[] = { T_I32(300), T_I32(301),
+                       T_I32(302), T_I32(303),
+                       T_I32(304), T_I32(305),
+                       T_I32(306), T_I32(307),
+                       T_I32(308), T_I64(0x1122334455667788ll) };
+
+    run_generic_test(exec_env, native_i32_i32_i64_on_stack, args, 10, 0, NULL);
+
+    TEST_EQ(g_test_results.call_count, 1);
+    for (int i = 0; i < 9; i++) {
+        TEST_EQ(g_test_results.mixed_i32[i], 300 + i);
+    }
+    TEST_EQ(g_test_results.mixed_i64[0], 0x1122334455667788ll);
+}
+
+static void
+run_test_f32_overflow(WASMExecEnv *exec_env)
+{
+    TestVal args[] = { T_F32(400.0f), T_F32(401.0f), T_F32(402.0f),
+                       T_F32(403.0f), T_F32(404.0f), T_F32(405.0f),
+                       T_F32(406.0f), T_F32(407.0f), T_F32(408.0f),
+                       T_F32(409.0f), T_F32(410.0f), T_F32(411.0f) };
+
+    run_generic_test(exec_env, native_f32_overflow, args, 12, 0, NULL);
+
+    TEST_EQ(g_test_results.call_count, 1);
+    for (int i = 0; i < 12; i++) {
+        TEST_FLOAT_EQ(g_test_results.f32_vals[i], 400.0f + i);
+    }
+}
+
+static void
+run_test_f64_overflow(WASMExecEnv *exec_env)
+{
+    TestVal args[] = { T_F64(500.0), T_F64(501.0), T_F64(502.0), T_F64(503.0),
+                       T_F64(504.0), T_F64(505.0), T_F64(506.0), T_F64(507.0),
+                       T_F64(508.0), T_F64(509.0), T_F64(510.0), T_F64(511.0) };
+
+    run_generic_test(exec_env, native_f64_overflow, args, 12, 0, NULL);
+
+    TEST_EQ(g_test_results.call_count, 1);
+    for (int i = 0; i < 12; i++) {
+        TEST_FLOAT_EQ(g_test_results.f64_vals[i], 500.0 + i);
+    }
+}
+
+static void
+run_test_f32_f32_f64_on_stack(WASMExecEnv *exec_env)
+{
+    TestVal args[] = { T_F32(600.0f), T_F32(601.0f), T_F32(602.0f),
+                       T_F32(603.0f), T_F32(604.0f), T_F32(605.0f),
+                       T_F32(606.0f), T_F32(607.0f), T_F32(608.0f),
+                       T_F32(609.0f), T_F64(999.888) };
+
+    run_generic_test(exec_env, native_f32_f32_f64_on_stack, args, 11, 0, NULL);
+
+    TEST_EQ(g_test_results.call_count, 1);
+    for (int i = 0; i < 8; i++) {
+        TEST_FLOAT_EQ(g_test_results.f32_vals[i], 600.0f + i);
+    }
+    TEST_FLOAT_EQ(g_test_results.mixed_f32[0], 608.0f);
+    TEST_FLOAT_EQ(g_test_results.mixed_f32[1], 609.0f);
+    TEST_FLOAT_EQ(g_test_results.mixed_f64[0], 999.888);
+}
+
+static void
+run_test_mixed_overflow(WASMExecEnv *exec_env)
+{
+    TestVal args[] = {
+        T_I32(700),       T_I32(701),    T_I32(702),
+        T_I32(703),       T_I32(704),    T_I32(705),
+        T_I32(706),       T_F32(800.0f), T_F32(801.0f),
+        T_F32(802.0f),    T_F32(803.0f), T_F32(804.0f),
+        T_F32(805.0f),    T_F32(806.0f), T_F32(807.0f),
+        T_I32(707),       T_F32(808.0f), T_I64(0x5555666677778888ll),
+        T_F64(12345.6789)
+    };
+
+    run_generic_test(exec_env, native_mixed_overflow, args, 19, 0, NULL);
+
+    TEST_EQ(g_test_results.call_count, 1);
+    for (int i = 0; i < 7; i++) {
+        TEST_EQ(g_test_results.i32_vals[i], 700 + i);
+    }
+    for (int i = 0; i < 8; i++) {
+        TEST_FLOAT_EQ(g_test_results.f32_vals[i], 800.0f + i);
+    }
+    TEST_EQ(g_test_results.mixed_i32[0], 707);
+    TEST_FLOAT_EQ(g_test_results.mixed_f32[0], 808.0f);
+    TEST_EQ(g_test_results.mixed_i64[0], 0x5555666677778888ll);
+    TEST_FLOAT_EQ(g_test_results.mixed_f64[0], 12345.6789);
+}
+
+static void
+run_test_i32_i64_alignment(WASMExecEnv *exec_env)
+{
+    TestVal args[] = { T_I32(0), T_I32(1),  T_I32(2),
+                       T_I32(3), T_I32(4),  T_I32(5),
+                       T_I32(6), T_I32(42), T_I64(0xabcdef0123456789ll) };
+    run_generic_test(exec_env, native_i32_i64_alignment, args, 9, 0, NULL);
+    TEST_EQ(g_test_results.call_count, 1);
+    TEST_EQ(g_test_results.mixed_i32[0], 42);
+    TEST_EQ(g_test_results.mixed_i64[0], 0xabcdef0123456789ll);
+}
+
+static void
+run_test_unaligned_total_stack_size(WASMExecEnv *exec_env)
+{
+    TestVal args[] = { T_I32(0), T_I32(1), T_I32(2),  T_I32(3),  T_I32(4),
+                       T_I32(5), T_I32(6), T_I32(70), T_I32(71), T_I32(72) };
+    run_generic_test(exec_env, native_unaligned_total_stack_size, args, 10, 0,
+                     NULL);
+    TEST_EQ(g_test_results.call_count, 1);
+    TEST_EQ(g_test_results.mixed_i32[0], 70);
+    TEST_EQ(g_test_results.mixed_i32[1], 71);
+    TEST_EQ(g_test_results.mixed_i32[2], 72);
+}
+
+static void
+run_test_float_double_alignment(WASMExecEnv *exec_env)
+{
+    TestVal args[] = { T_F32(0.0f), T_F32(1.0f), T_F32(2.0f), T_F32(3.0f),
+                       T_F32(4.0f), T_F32(5.0f), T_F32(6.0f), T_F32(7.0f),
+                       T_F32(8.5f), T_F64(9.25) };
+    run_generic_test(exec_env, native_float_double_alignment, args, 10, 0,
+                     NULL);
+    TEST_EQ(g_test_results.call_count, 1);
+    TEST_FLOAT_EQ(g_test_results.mixed_f32[0], 8.5f);
+    TEST_FLOAT_EQ(g_test_results.mixed_f64[0], 9.25);
+}
+
+static void
+run_test_return_values(WASMExecEnv *exec_env)
+{
+    uint32 ret_buf[8];
+    uint8 type_i32 = I32;
+    uint8 type_i64 = I64;
+    uint8 type_f32 = F32;
+    uint8 type_f64 = F64;
+
+    /* i32 */
+    run_generic_test(exec_env, native_return_i32, NULL, 0, type_i32, ret_buf);
+    TEST_EQ(ret_buf[0], 0x12345678);
+
+    /* i64 */
+    run_generic_test(exec_env, native_return_i64, NULL, 0, type_i64, ret_buf);
+    TEST_EQ(*(int64 *)ret_buf, 0x12345678ABCDEFFFll);
+
+    /* f32 */
+    run_generic_test(exec_env, native_return_f32, NULL, 0, type_f32, ret_buf);
+    TEST_FLOAT_EQ(*(float32 *)ret_buf, 1234.5678f);
+
+    /* f64 */
+    run_generic_test(exec_env, native_return_f64, NULL, 0, type_f64, ret_buf);
+    TEST_FLOAT_EQ(*(float64 *)ret_buf, 87654321.12345678);
+}
+
+static void
+execute_test(const char *test_name, void (*test_func)(WASMExecEnv *),
+             WASMExecEnv *exec_env)
+{
+    printf("Running %s...\n", test_name);
+    g_test_failed = 0;
+    memset(&g_test_results, 0, sizeof(g_test_results));
+    test_func(exec_env);
+    if (g_test_failed) {
+        printf("RESULT: FAIL\n\n");
+        failed_tests++;
+    }
+    else {
+        printf("RESULT: PASS\n\n");
+        passed_tests++;
+    }
+}
+
+int
 test_invoke_native()
 {
-    uint32 argv[128], *p = argv;
-    WASMTypeTest func_type1 = { 20, 0, 0, 0, { I32, I64, F32, F64, I32,
-                                               I64, I64, I32, F64, F32,
-                                               I32, F64, F32, I64, I64,
-                                               F32, F64, I64, I64, F32 } };
-    WASMTypeTest func_type2 = { 19,
-                                0,
-                                0,
-                                0,
-                                { I64, F32, F64, I32, I64, I64, I32, F64, F32,
-                                  I32, F64, F32, I64, I64, F32, F64, I64, I64,
-                                  F32 } };
-    WASMTypeTest func_type_i32 = { 0, 1, 0, 0, { I32 } };
-    WASMTypeTest func_type_i64 = { 0, 1, 0, 0, { I64 } };
-    WASMTypeTest func_type_f32 = { 0, 1, 0, 0, { F32 } };
-    WASMTypeTest func_type_f64 = { 0, 1, 0, 0, { F64 } };
     WASMModuleInstance module_inst = { 0 };
     WASMExecEnv exec_env = { 0 };
+
+    passed_tests = 0;
+    failed_tests = 0;
 
     module_inst.module_type = Wasm_Module_Bytecode;
     exec_env.module_inst = (WASMModuleInstanceCommon *)&module_inst;
 
-    *p++ = 0x12345678;
-    STORE_I64(p, 0xFFFFFFFF87654321ll);
-    p += 2;
-    *(float32 *)p++ = 1234.5678f;
-    STORE_F64(p, 567890.1234);
-    p += 2;
+    printf("=========================================\n");
+    printf("Starting Native Invoke Tests...\n");
+    printf("=========================================\n");
 
-    *p++ = 0x11111111;
-    STORE_I64(p, 0xAAAAAAAABBBBBBBBll);
-    p += 2;
-    STORE_I64(p, 0x7788888899ll);
-    p += 2;
-    *p++ = 0x3456;
+    execute_test("run_test_i32_overflow", run_test_i32_overflow, &exec_env);
+    execute_test("run_test_i64_overflow", run_test_i64_overflow, &exec_env);
+    execute_test("run_test_i32_i32_i64_on_stack", run_test_i32_i32_i64_on_stack,
+                 &exec_env);
+    execute_test("run_test_f32_overflow", run_test_f32_overflow, &exec_env);
+    execute_test("run_test_f64_overflow", run_test_f64_overflow, &exec_env);
+    execute_test("run_test_f32_f32_f64_on_stack", run_test_f32_f32_f64_on_stack,
+                 &exec_env);
+    execute_test("run_test_mixed_overflow", run_test_mixed_overflow, &exec_env);
+    execute_test("run_test_i32_i64_alignment", run_test_i32_i64_alignment,
+                 &exec_env);
+    execute_test("run_test_unaligned_total_stack_size",
+                 run_test_unaligned_total_stack_size, &exec_env);
+    execute_test("run_test_float_double_alignment",
+                 run_test_float_double_alignment, &exec_env);
+    execute_test("run_test_return_values", run_test_return_values, &exec_env);
 
-    STORE_F64(p, 8888.7777);
-    p += 2;
-    *(float32 *)p++ = 7777.8888f;
-    *p++ = 0x66666;
-    STORE_F64(p, 999999.88888);
-    p += 2;
+    printf("=========================================\n");
+    printf("Tests Summary: Passed: %d, Failed: %d\n", passed_tests,
+           failed_tests);
+    printf("=========================================\n");
 
-    *(float32 *)p++ = 555555.22f;
-    STORE_I64(p, 0xBBBBBAAAAAAAAll);
-    p += 2;
-    STORE_I64(p, 0x3333AAAABBBBll);
-    p += 2;
-    *(float32 *)p++ = 88.77f;
-
-    STORE_F64(p, 9999.01234);
-    p += 2;
-    STORE_I64(p, 0x1111122222222ll);
-    p += 2;
-    STORE_I64(p, 0x444455555555ll);
-    p += 2;
-    *(float32 *)p++ = 77.88f;
-
-    wasm_runtime_invoke_native(&exec_env, test_native_args1,
-                               (WASMType *)&func_type1, NULL, NULL, argv,
-                               p - argv, argv);
-    printf("\n");
-
-    wasm_runtime_invoke_native(&exec_env, test_native_args2,
-                               (WASMType *)&func_type2, NULL, NULL, argv + 1,
-                               p - argv - 1, argv);
-    printf("\n");
-
-    wasm_runtime_invoke_native(&exec_env, test_return_i32,
-                               (WASMType *)&func_type_i32, NULL, NULL, NULL, 0,
-                               argv);
-    printf("test_return_i32: 0x%X\n\n", argv[0]);
-
-    wasm_runtime_invoke_native(&exec_env, test_return_i64,
-                               (WASMType *)&func_type_i64, NULL, NULL, NULL, 0,
-                               argv);
-    printf("test_return_i64: 0x%X%08X\n\n", (int32)((*(int64 *)argv) >> 32),
-           (int32)(*(int64 *)argv));
-
-    wasm_runtime_invoke_native(&exec_env, test_return_f32,
-                               (WASMType *)&func_type_f32, NULL, NULL, NULL, 0,
-                               argv);
-    printf("test_return_f32: %f\n\n", *(float32 *)argv);
-
-    wasm_runtime_invoke_native(&exec_env, test_return_f64,
-                               (WASMType *)&func_type_f64, NULL, NULL, NULL, 0,
-                               argv);
-    printf("test_return_f64: %f\n\n", *(float64 *)argv);
+    return failed_tests;
 }

--- a/tests/standalone/test-invoke-native/test_invoke_native.h
+++ b/tests/standalone/test-invoke-native/test_invoke_native.h
@@ -1,0 +1,4 @@
+#pragma once
+
+int
+test_invoke_native(void);


### PR DESCRIPTION
# Summary

Fixes https://github.com/bytecodealliance/wasm-micro-runtime/issues/4892.

On AArch64, Darwin uses a slightly different ABI from Linux for stack-passed arguments. In particular, Darwin sizes stack slots according to the actual argument size instead of always allocating 8-byte slots.

According to LLVM:
https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/AArch64/AArch64CallingConvention.td#L365-L368

```
// Darwin uses a calling convention which differs in only two ways
// from the standard one at this level:
//     + i128s (i.e. split i64s) don't need even registers.
//     + Stack slots are sized as needed rather than being at least 64-bit.
```

## Linux ABI

When the number of function arguments exceeds the available argument registers, the remaining arguments are passed on the stack. Each stack-passed argument occupies an 8-byte stack slot, even for 32-bit values:

```
+-----------------------------------+ <--- sp
|   s0 (i32) [occupies 4 bytes]     | \
|   Padding  [4 bytes]              |  }-- 8-byte stack slot
+-----------------------------------+ <--- sp + 8
|   s1 (i32) [occupies 4 bytes]     | \
|   Padding  [4 bytes]              |  }-- 8-byte stack slot
+-----------------------------------+ <--- sp + 16
|   s2 (i64) [occupies 8 bytes]     | \
|                                   |  }-- 8-byte stack slot
+-----------------------------------+ <--- sp + 24
```

## Darwin ABI

Darwin sizes stack slots according to the actual argument size, allowing adjacent 32-bit arguments to be packed without unnecessary padding:

```
+-----------------+-----------------+ <--- sp
|  s0 (i32) [4B]  |  s1 (i32) [4B]  |
+-----------------+-----------------+ <--- sp + 8
|  s2 (i64) [8B]                    |
|                                   |
+-----------------------------------+ <--- sp + 16
```


# Test Results

## before fix:

```
============> run test-invoke-native
=========================================
Starting Native Invoke Tests...
=========================================
Running run_test_i32_overflow...
  FAIL: line 374: expected 108, got 0
  FAIL: line 374: expected 109, got 108
  FAIL: line 374: expected 110, got 0
RESULT: FAIL

Running run_test_i64_overflow...
RESULT: PASS

Running run_test_i32_i32_i64_on_stack...
  FAIL: line 406: expected 308, got 0
  FAIL: line 408: expected 1234605616436508552, got 308
RESULT: FAIL

Running run_test_f32_overflow...
  FAIL: line 423: expected 409.000000, got 0.000000
  FAIL: line 423: expected 410.000000, got 409.000000
  FAIL: line 423: expected 411.000000, got 0.000000
RESULT: FAIL

Running run_test_f64_overflow...
RESULT: PASS

Running run_test_f32_f32_f64_on_stack...
  FAIL: line 457: expected 609.000000, got 0.000000
  FAIL: line 458: expected 999.888000, got 0.000000
RESULT: FAIL

Running run_test_mixed_overflow...
  FAIL: line 484: expected 808.000000, got 0.000000
  FAIL: line 485: expected 6148933456521300104, got 1145700352
  FAIL: line 486: expected 12345.678900, got 11982634940256485731267794306136873969953117937862608357662199969694965589666549254097237871668169277440.000000
RESULT: FAIL

Running run_test_i32_i64_alignment...
RESULT: PASS

Running run_test_unaligned_total_stack_size...
  FAIL: line 510: expected 71, got 0
  FAIL: line 511: expected 72, got 71
RESULT: FAIL

Running run_test_float_double_alignment...
RESULT: PASS

Running run_test_return_values...
RESULT: PASS

=========================================
Tests Summary: Passed: 5, Failed: 6
=========================================

```


## after fix:

```
============> run test-invoke-native
=========================================
Starting Native Invoke Tests...
=========================================
Running run_test_i32_overflow...
RESULT: PASS

Running run_test_i64_overflow...
RESULT: PASS

Running run_test_i32_i32_i64_on_stack...
RESULT: PASS

Running run_test_f32_overflow...
RESULT: PASS

Running run_test_f64_overflow...
RESULT: PASS

Running run_test_f32_f32_f64_on_stack...
RESULT: PASS

Running run_test_mixed_overflow...
RESULT: PASS

Running run_test_i32_i64_alignment...
RESULT: PASS

Running run_test_unaligned_total_stack_size...
RESULT: PASS

Running run_test_float_double_alignment...
RESULT: PASS

Running run_test_return_values...
RESULT: PASS

=========================================
Tests Summary: Passed: 11, Failed: 0
=========================================
```