### PR TITLE
fix(thumb): keep SP 8-byte aligned for native calls with >4 argv words

### DIFF
--- a/core/iwasm/common/arch/invokeNative_thumb.s
+++ b/core/iwasm/common/arch/invokeNative_thumb.s
@@ -61,12 +61,16 @@ _invokeNative:
 
         sub    r5, r5, #4       /* argc -= 4, now we have r0 ~ r3 */
 
-        /* Ensure address is 8 byte aligned */
+        /* Reserve stack for the remaining args, rounded up to 8 bytes so SP
+           stays 8-byte aligned at the blx below (AAPCS requires 8-byte SP
+           alignment at a public interface). SP is already 8-aligned here:
+           the prologue pushed r4-r7 + lr (20 bytes) and did sub sp,#4, i.e.
+           24 bytes (see .cfi_def_cfa_offset 24). The reservation must
+           therefore be a multiple of 8 and nothing more. */
         lsl     r6, r5, #2      /* r6 = argc * 4 */
         mov     r7, #7
         add     r6, r6, r7      /* r6 = (r6 + 7) & ~7 */
         bic     r6, r6, r7
-        add     r6, r6, #4      /* +4 because odd(5) registers are in stack */
         mov     r7, sp
         sub     r7, r7, r6      /* reserved stack space for left arguments */
         mov     sp, r7


### PR DESCRIPTION
## Summary
`invokeNative_thumb.s` leaves SP at 4 mod 8 at the native call for any native invoked with more than 4 packed argv words, violating AAPCS 8-byte stack alignment.

## Root cause
The stack reservation for arguments beyond r0–r3 is rounded up to a multiple of 8 (`add #7` / `bic #7`), then an unconditional `add r6, r6, #4` adds one more word. SP is already 8-byte aligned at that point — the prologue pushes r4–r7 + lr (20 bytes) and does `sub sp, #4`, 24 bytes total (`.cfi_def_cfa_offset 24`) — so the reservation must be a multiple of 8 and nothing more. The extra word makes SP `4 mod 8` at `blx ip` whenever `argc > 4`.

## Effect
An outgoing 8-byte argument (e.g. a vararg `i64`) is placed by the compiler at a slot it models as 8-aligned but whose real address is `4 mod 8`; the callee's `va_arg` realigns to the true boundary 4 bytes lower and reads the low word paired with a zero — so a `%lld` in such a native prints `value * 2^32`. The value itself arrives intact in r2:r3, which is why it looks correct at the register level.

## Fix
Remove the stray `add r6, r6, #4`. The restore path (`add sp, sp, r6`) is symmetric, so nothing else changes.

## Testing
- Assembles cleanly for `cortex-m33` (`arm-none-eabi-gcc -x assembler-with-cpp -mthumb -mcpu=cortex-m33`).
- Alignment verified against the prologue: the reservation is a multiple of 8, so SP is 0 mod 8 at `blx`.
- Reproduced on a Cortex-M33 target: a native taking >4 packed words with an `i64` vararg printed `value * 2^32` before this change, correct value after.